### PR TITLE
java: update demo request time interval

### DIFF
--- a/examples/java/hello_world/MainActivity.java
+++ b/examples/java/hello_world/MainActivity.java
@@ -65,7 +65,7 @@ public class MainActivity extends Activity {
                     Log.d("MainActivity", "exception making request.", e);
                 }
                 // Make a call again
-                handler.postDelayed(this, TimeUnit.SECONDS.toMillis(10));
+                handler.postDelayed(this, TimeUnit.SECONDS.toMillis(1));
             }
         }, 0);
     }


### PR DESCRIPTION
Change the interval from `10s` to `1s` for parity with Swift/Objective-C and so that the demo doesn't _appear_ to hang on launch.

Signed-off-by: Michael Rebello <mrebello@lyft.com>