### PR TITLE
java: avoid deserializing non-200 in demo

### DIFF
--- a/examples/java/hello_world/MainActivity.java
+++ b/examples/java/hello_world/MainActivity.java
@@ -75,7 +75,7 @@ public class MainActivity extends Activity {
         HttpURLConnection connection = (HttpURLConnection) url.openConnection();
         int status = connection.getResponseCode();
         if (status != 200) {
-            Log.d("MainActivity", "non 200 status: " + status);
+            throw new IOException("non 200 status: " + status);
         }
 
         List<String> serverHeaderField = connection.getHeaderFields().get("server");


### PR DESCRIPTION
Update to throw and avoid deserializing non-200 responses in the Java demo. This is the same behavior as Swift/Objective-C.

Signed-off-by: Michael Rebello <mrebello@lyft.com>