### PR TITLE
docs: fix pull request template

### DIFF
--- a/PULL_REQUEST_TEMPLATE.md
+++ b/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,10 @@
+For an explanation of how to fill out the fields, please see the relevant section
+in [PULL_REQUESTS.md](https://github.com/envoyproxy/envoy/blob/master/PULL_REQUESTS.md)
+
+Description:
+Risk Level:
+Testing:
+Docs Changes:
+Release Notes:
+[Optional Fixes #Issue]
+[Optional Deprecated:]


### PR DESCRIPTION
Turns out that the symlink here doesn't actually work properly when opening PRs on GitHub. Replacing the symlink with an actual file.