### PR TITLE
ios: fix formatting warnings

### DIFF
--- a/library/objective-c/EnvoyConfiguration.m
+++ b/library/objective-c/EnvoyConfiguration.m
@@ -23,9 +23,11 @@
 - (nullable NSString *)resolveTemplate:(NSString *)templateYAML {
   NSDictionary<NSString *, NSString *> *templateKeysToValues = @{
     @"domain" : self.domain,
-    @"connect_timeout" : [NSString stringWithFormat:@"%is", self.connectTimeoutSeconds],
-    @"dns_refresh_rate" : [NSString stringWithFormat:@"%is", self.dnsRefreshSeconds],
-    @"stats_flush_interval" : [NSString stringWithFormat:@"%is", self.statsFlushSeconds]
+    @"connect_timeout" :
+        [NSString stringWithFormat:@"%lu", (unsigned long)self.connectTimeoutSeconds],
+    @"dns_refresh_rate" : [NSString stringWithFormat:@"%lu", (unsigned long)self.dnsRefreshSeconds],
+    @"stats_flush_interval" :
+        [NSString stringWithFormat:@"%lu", (unsigned long)self.statsFlushSeconds]
   };
 
   for (NSString *templateKey in templateKeysToValues) {


### PR DESCRIPTION
Fixes the following warnings:

```
library/objective-c/EnvoyConfiguration.m:26:61: warning: values of type 'UInt32' should not be used as format arguments; add an explicit cast to 'unsigned int' instead [-Wformat]
    @"connect_timeout" : [NSString stringWithFormat:@"%is", self.connectTimeoutSeconds],
                                                      ~~    ^~~~~~~~~~~~~~~~~~~~~~~~~~
                                                      %u    (unsigned int)
library/objective-c/EnvoyConfiguration.m:27:62: warning: values of type 'UInt32' should not be used as format arguments; add an explicit cast to 'unsigned int' instead [-Wformat]
    @"dns_refresh_rate" : [NSString stringWithFormat:@"%is", self.dnsRefreshSeconds],
                                                       ~~    ^~~~~~~~~~~~~~~~~~~~~~
                                                       %u    (unsigned int)
library/objective-c/EnvoyConfiguration.m:28:66: warning: values of type 'UInt32' should not be used as format arguments; add an explicit cast to 'unsigned int' instead [-Wformat]
    @"stats_flush_interval" : [NSString stringWithFormat:@"%is", self.statsFlushSeconds]
                                                           ~~    ^~~~~~~~~~~~~~~~~~~~~~
                                                           %u    (unsigned int)
```

Signed-off-by: Michael Rebello <me@michaelrebello.com>