### PR TITLE
jni load investigation

### DIFF
--- a/library/java/src/io/envoyproxy/envoymobile/engine/AndroidEngineImpl.java
+++ b/library/java/src/io/envoyproxy/envoymobile/engine/AndroidEngineImpl.java
@@ -1,6 +1,7 @@
 package io.envoyproxy.envoymobile.engine;
 
 import android.app.Application;
+import android.util.Log;
 import io.envoyproxy.envoymobile.engine.types.EnvoyHTTPCallbacks;
 import io.envoyproxy.envoymobile.engine.types.EnvoyOnEngineRunning;
 
@@ -11,9 +12,22 @@ public class AndroidEngineImpl implements EnvoyEngine {
 
   public AndroidEngineImpl(Application application) {
     this.application = application;
-    this.envoyEngine = new EnvoyEngineImpl();
+    long jniStart = System.currentTimeMillis();
+    JniLibrary.load();
+    long jniEnd = System.currentTimeMillis();
+    long handle = JniLibrary.initEngine();
+    long engineInitEnd = System.currentTimeMillis();
+    this.envoyEngine = new EnvoyEngineImpl(handle);
+    long envoyEngineImplEnd = System.currentTimeMillis();
     AndroidJniLibrary.load(application.getBaseContext());
+    long androidJniLoad = System.currentTimeMillis();
     AndroidNetworkMonitor.load(application.getBaseContext());
+    long androidNetworkMonitorLoad = System.currentTimeMillis();
+    Log.d("AndroidEngineImpl","~~~ jniStart " + (jniEnd - jniStart));
+    Log.d("AndroidEngineImpl","~~~ engineInitEnd " + (engineInitEnd - jniEnd));
+    Log.d("AndroidEngineImpl","~~~ envoyEngineImplEnd " + (envoyEngineImplEnd - engineInitEnd));
+    Log.d("AndroidEngineImpl","~~~ androidJniLoad " + (androidJniLoad - envoyEngineImplEnd));
+    Log.d("AndroidEngineImpl","~~~ androidNetworkMonitorLoad " + (androidNetworkMonitorLoad - androidJniLoad));
   }
 
   @Override

--- a/library/java/src/io/envoyproxy/envoymobile/engine/EnvoyEngineImpl.java
+++ b/library/java/src/io/envoyproxy/envoymobile/engine/EnvoyEngineImpl.java
@@ -18,6 +18,10 @@ public class EnvoyEngineImpl implements EnvoyEngine {
     this.engineHandle = JniLibrary.initEngine();
   }
 
+  public EnvoyEngineImpl(long engineHandle) {
+    this.engineHandle = engineHandle;
+  }
+
   /**
    * Creates a new stream with the provided callbacks.
    *

--- a/library/java/src/io/envoyproxy/envoymobile/engine/JniLibrary.java
+++ b/library/java/src/io/envoyproxy/envoymobile/engine/JniLibrary.java
@@ -18,17 +18,17 @@ class JniLibrary {
 
   // Load and initialize Envoy and its dependencies, but only once.
   public static void load() {
-    if (loader != null) {
-      return;
-    }
-
-    synchronized (JavaLoader.class) {
-      if (loader != null) {
-        return;
-      }
-
+//    if (loader != null) {
+//      return;
+//    }
+//
+//    synchronized (JavaLoader.class) {
+//      if (loader != null) {
+//        return;
+//      }
+//
       loader = new JavaLoader();
-    }
+//    }
   }
 
   // Private helper class used by the load method to ensure the native library and

--- a/library/kotlin/src/io/envoyproxy/envoymobile/AndroidEngineBuilder.kt
+++ b/library/kotlin/src/io/envoyproxy/envoymobile/AndroidEngineBuilder.kt
@@ -1,6 +1,7 @@
 package io.envoyproxy.envoymobile
 
 import android.app.Application
+import android.util.Log
 import io.envoyproxy.envoymobile.engine.AndroidEngineImpl
 
 class AndroidEngineBuilder @JvmOverloads constructor(
@@ -8,6 +9,15 @@ class AndroidEngineBuilder @JvmOverloads constructor(
   baseConfiguration: BaseConfiguration = Standard()
 ) : EngineBuilder(baseConfiguration) {
   init {
-    addEngineType { AndroidEngineImpl(application) }
+    val start = System.currentTimeMillis()
+    addEngineType {
+      val s = System.currentTimeMillis()
+      val androidEngineImpl = AndroidEngineImpl(application)
+      val e = System.currentTimeMillis()
+      Log.d("AndroidEngineBuilder","~~~ init ${e-s}")
+      androidEngineImpl
+    }
+    val end = System.currentTimeMillis()
+    Log.d("AndroidEngineBuilder","~~~ ${end-start}")
   }
 }


### PR DESCRIPTION
Not intended to be checked in


On the Lyft App:
```
2020-11-06 14:38:02.109 29127-29462/me.lyft.android.dev D/AndroidEngineBuilder: ~~~ 0
2020-11-06 14:38:05.715 29127-29462/me.lyft.android.dev D/AndroidEngineImpl: ~~~ jniStart 3557
2020-11-06 14:38:05.716 29127-29462/me.lyft.android.dev D/AndroidEngineImpl: ~~~ engineInitEnd 0
2020-11-06 14:38:05.716 29127-29462/me.lyft.android.dev D/AndroidEngineImpl: ~~~ envoyEngineImplEnd 1
2020-11-06 14:38:05.716 29127-29462/me.lyft.android.dev D/AndroidEngineImpl: ~~~ androidJniLoad 15
2020-11-06 14:38:05.716 29127-29462/me.lyft.android.dev D/AndroidEngineImpl: ~~~ androidNetworkMonitorLoad 21
2020-11-06 14:38:05.716 29127-29462/me.lyft.android.dev D/AndroidEngineBuilder: ~~~ init 3599
```
Signed-off-by: Alan Chiu <achiu@lyft.com>