### PR TITLE
core: create LocalErrorFilter to map responses to errors

### DIFF
--- a/envoy_build_config/BUILD
+++ b/envoy_build_config/BUILD
@@ -26,6 +26,7 @@ envoy_cc_library(
         "@envoy//source/extensions/transport_sockets/tls:config",
         "@envoy//source/extensions/upstreams/http/generic:config",
         "@envoy_mobile//library/common/extensions/filters/http/assertion:config",
+        "@envoy_mobile//library/common/extensions/filters/http/local_error:config",
         "@envoy_mobile//library/common/extensions/filters/http/platform_bridge:config",
     ],
 )

--- a/envoy_build_config/extension_registry.cc
+++ b/envoy_build_config/extension_registry.cc
@@ -28,6 +28,7 @@ void ExtensionRegistry::registerFactories() {
   Envoy::Extensions::HttpFilters::BufferFilter::forceRegisterBufferFilterFactory();
   Envoy::Extensions::HttpFilters::DynamicForwardProxy::
       forceRegisterDynamicForwardProxyFilterFactory();
+  Envoy::Extensions::HttpFilters::LocalError::forceRegisterLocalErrorFilterFactory();
   Envoy::Extensions::HttpFilters::PlatformBridge::forceRegisterPlatformBridgeFilterFactory();
   Envoy::Extensions::HttpFilters::RouterFilter::forceRegisterRouterFilterConfig();
   Envoy::Extensions::NetworkFilters::HttpConnectionManager::

--- a/envoy_build_config/extension_registry.h
+++ b/envoy_build_config/extension_registry.h
@@ -15,6 +15,7 @@
 #include "extensions/upstreams/http/generic/config.h"
 
 #include "library/common/extensions/filters/http/assertion/config.h"
+#include "library/common/extensions/filters/http/local_error/config.h"
 #include "library/common/extensions/filters/http/platform_bridge/config.h"
 
 namespace Envoy {

--- a/envoy_build_config/extensions_build_config.bzl
+++ b/envoy_build_config/extensions_build_config.bzl
@@ -6,6 +6,7 @@ EXTENSIONS = {
     "envoy.filters.http.assertion":                   "@envoy_mobile//library/common/extensions/filters/http/assertion:config",
     "envoy.filters.http.buffer":                      "//source/extensions/filters/http/buffer:config",
     "envoy.filters.http.dynamic_forward_proxy":       "//source/extensions/filters/http/dynamic_forward_proxy:config",
+    "envoy.filters.http.local_error":                 "@envoy_mobile//library/common/extensions/filters/http/local_error:config",
     "envoy.filters.http.platform_bridge":             "@envoy_mobile//library/common/extensions/filters/http/platform_bridge:config",
     "envoy.filters.http.router":                      "//source/extensions/filters/http/router:config",
     "envoy.filters.network.http_connection_manager":  "//source/extensions/filters/network/http_connection_manager:config",

--- a/library/common/buffer/utility.cc
+++ b/library/common/buffer/utility.cc
@@ -1,5 +1,7 @@
 #include "library/common/buffer/utility.h"
 
+#include <stdlib.h>
+
 #include "common/buffer/buffer_impl.h"
 
 #include "library/common/buffer/bridge_fragment.h"
@@ -23,6 +25,17 @@ envoy_data toBridgeData(Buffer::Instance& data) {
   bridge_data.bytes = static_cast<uint8_t*>(safe_malloc(sizeof(uint8_t) * bridge_data.length));
   data.copyOut(0, bridge_data.length, const_cast<uint8_t*>(bridge_data.bytes));
   data.drain(bridge_data.length);
+  bridge_data.release = free;
+  bridge_data.context = const_cast<uint8_t*>(bridge_data.bytes);
+  return bridge_data;
+}
+
+envoy_data copyToBridgeData(absl::string_view str) {
+  envoy_data bridge_data;
+  bridge_data.length = str.length();
+  void* buffer = safe_malloc(sizeof(uint8_t) * bridge_data.length);
+  memcpy(buffer, str.data(), str.length());
+  bridge_data.bytes = static_cast<uint8_t*>(buffer);
   bridge_data.release = free;
   bridge_data.context = const_cast<uint8_t*>(bridge_data.bytes);
   return bridge_data;

--- a/library/common/buffer/utility.h
+++ b/library/common/buffer/utility.h
@@ -23,6 +23,13 @@ Buffer::InstancePtr toInternalData(envoy_data data);
 envoy_data toBridgeData(Buffer::Instance&);
 
 /**
+ * Copy from string to envoy_data.
+ * @param str, the string to copy.
+ * @return envoy_data, the copy produced of the original string.
+ */
+envoy_data copyToBridgeData(absl::string_view);
+
+/**
  * Copy from Buffer::Instance to envoy_data.
  * @param data, the Buffer::Instance to copy.
  * @return envoy_data, the copy produced from the Buffer::Instance param.

--- a/library/common/extensions/filters/http/local_error/BUILD
+++ b/library/common/extensions/filters/http/local_error/BUILD
@@ -1,0 +1,39 @@
+load("@envoy//bazel:envoy_build_system.bzl", "envoy_cc_library")
+load("@envoy_api//bazel:api_build_system.bzl", "api_proto_package")
+
+licenses(["notice"])  # Apache 2
+
+package(default_visibility = ["//visibility:public"])
+
+api_proto_package()
+
+envoy_cc_library(
+    name = "local_error_filter_lib",
+    srcs = ["filter.cc"],
+    hdrs = ["filter.h"],
+    repository = "@envoy",
+    deps = [
+        ":pkg_cc_proto",
+        "//library/common/http:internal_headers_lib",
+        "//library/common/types:c_types_lib",
+        "@envoy//include/envoy/http:codes_interface",
+        "@envoy//include/envoy/http:filter_interface",
+        "@envoy//source/common/http:codes_lib",
+        "@envoy//source/common/http:header_map_lib",
+        "@envoy//source/common/http:headers_lib",
+        "@envoy//source/common/http:utility_lib",
+        "@envoy//source/extensions/filters/http/common:pass_through_filter_lib",
+    ],
+)
+
+envoy_cc_library(
+    name = "config",
+    srcs = ["config.cc"],
+    hdrs = ["config.h"],
+    repository = "@envoy",
+    deps = [
+        ":local_error_filter_lib",
+        ":pkg_cc_proto",
+        "@envoy//source/extensions/filters/http/common:factory_base_lib",
+    ],
+)

--- a/library/common/extensions/filters/http/local_error/config.cc
+++ b/library/common/extensions/filters/http/local_error/config.cc
@@ -8,8 +8,8 @@ namespace HttpFilters {
 namespace LocalError {
 
 Http::FilterFactoryCb LocalErrorFilterFactory::createFilterFactoryFromProtoTyped(
-    const envoymobile::extensions::filters::http::local_error::LocalError&,
-    const std::string&, Server::Configuration::FactoryContext&) {
+    const envoymobile::extensions::filters::http::local_error::LocalError&, const std::string&,
+    Server::Configuration::FactoryContext&) {
 
   return [](Http::FilterChainFactoryCallbacks& callbacks) -> void {
     callbacks.addStreamEncoderFilter(std::make_shared<LocalErrorFilter>());

--- a/library/common/extensions/filters/http/local_error/config.cc
+++ b/library/common/extensions/filters/http/local_error/config.cc
@@ -8,13 +8,11 @@ namespace HttpFilters {
 namespace LocalError {
 
 Http::FilterFactoryCb LocalErrorFilterFactory::createFilterFactoryFromProtoTyped(
-    const envoymobile::extensions::filters::http::local_error::LocalError& proto_config,
+    const envoymobile::extensions::filters::http::local_error::LocalError&,
     const std::string&, Server::Configuration::FactoryContext&) {
 
-  LocalErrorFilterConfigSharedPtr filter_config =
-      std::make_shared<LocalErrorFilterConfig>(proto_config);
-  return [filter_config](Http::FilterChainFactoryCallbacks& callbacks) -> void {
-    callbacks.addStreamEncoderFilter(std::make_shared<LocalErrorFilter>(filter_config));
+  return [](Http::FilterChainFactoryCallbacks& callbacks) -> void {
+    callbacks.addStreamEncoderFilter(std::make_shared<LocalErrorFilter>());
   };
 }
 

--- a/library/common/extensions/filters/http/local_error/config.cc
+++ b/library/common/extensions/filters/http/local_error/config.cc
@@ -1,0 +1,29 @@
+#include "library/common/extensions/filters/http/local_error/config.h"
+
+#include "library/common/extensions/filters/http/local_error/filter.h"
+
+namespace Envoy {
+namespace Extensions {
+namespace HttpFilters {
+namespace LocalError {
+
+Http::FilterFactoryCb LocalErrorFilterFactory::createFilterFactoryFromProtoTyped(
+    const envoymobile::extensions::filters::http::local_error::LocalError& proto_config,
+    const std::string&, Server::Configuration::FactoryContext&) {
+
+  LocalErrorFilterConfigSharedPtr filter_config =
+      std::make_shared<LocalErrorFilterConfig>(proto_config);
+  return [filter_config](Http::FilterChainFactoryCallbacks& callbacks) -> void {
+    callbacks.addStreamEncoderFilter(std::make_shared<LocalErrorFilter>(filter_config));
+  };
+}
+
+/**
+ * Static registration for the LocalError filter. @see NamedHttpFilterConfigFactory.
+ */
+REGISTER_FACTORY(LocalErrorFilterFactory, Server::Configuration::NamedHttpFilterConfigFactory);
+
+} // namespace LocalError
+} // namespace HttpFilters
+} // namespace Extensions
+} // namespace Envoy

--- a/library/common/extensions/filters/http/local_error/config.h
+++ b/library/common/extensions/filters/http/local_error/config.h
@@ -1,0 +1,32 @@
+#include <string>
+
+#include "extensions/filters/http/common/factory_base.h"
+
+#include "library/common/extensions/filters/http/local_error/filter.pb.h"
+#include "library/common/extensions/filters/http/local_error/filter.pb.validate.h"
+
+namespace Envoy {
+namespace Extensions {
+namespace HttpFilters {
+namespace LocalError {
+
+/**
+ * Config registration for the local_error filter. @see NamedHttpFilterConfigFactory.
+ */
+class LocalErrorFilterFactory
+    : public Common::FactoryBase<envoymobile::extensions::filters::http::local_error::LocalError> {
+public:
+  LocalErrorFilterFactory() : FactoryBase("local_error") {}
+
+private:
+  Http::FilterFactoryCb createFilterFactoryFromProtoTyped(
+      const envoymobile::extensions::filters::http::local_error::LocalError& config,
+      const std::string& stats_prefix, Server::Configuration::FactoryContext& context) override;
+};
+
+DECLARE_FACTORY(LocalErrorFilterFactory);
+
+} // namespace LocalError
+} // namespace HttpFilters
+} // namespace Extensions
+} // namespace Envoy

--- a/library/common/extensions/filters/http/local_error/filter.cc
+++ b/library/common/extensions/filters/http/local_error/filter.cc
@@ -1,0 +1,88 @@
+#include "library/common/extensions/filters/http/local_error/filter.h"
+
+#include "envoy/http/codes.h"
+#include "envoy/server/filter_config.h"
+
+#include "common/http/codes.h"
+#include "common/http/header_map_impl.h"
+#include "common/http/utility.h"
+
+#include "library/common/http/headers.h"
+#include "library/common/types/c_types.h"
+
+namespace Envoy {
+namespace Extensions {
+namespace HttpFilters {
+namespace LocalError {
+
+LocalErrorFilterConfig::LocalErrorFilterConfig(
+    const envoymobile::extensions::filters::http::local_error::LocalError& proto_config)
+    : enabled_(proto_config.enabled()) {}
+
+LocalErrorFilter::LocalErrorFilter(LocalErrorFilterConfigSharedPtr config) : config_(config) {}
+
+Http::FilterHeadersStatus LocalErrorFilter::encodeHeaders(Http::ResponseHeaderMap& headers,
+                                                          bool end_stream) {
+  uint64_t response_status = Http::Utility::getResponseStatus(headers);
+  bool success = Http::CodeUtility::is2xx(response_status);
+
+  // TODO: ***HACK*** currently Envoy sends local replies in cases where an error ought to be
+  // surfaced via the error path. There are ways we can clean up Envoy's local reply path to
+  // make this possible, but nothing expedient. For the immediate term this is our only real
+  // option. See https://github.com/lyft/envoy-mobile/issues/460
+
+  // Absence of EnvoyUpstreamServiceTime header implies this is a local reply, which we treat as
+  // a stream error.
+  if (!success && headers.get(Http::Headers::get().EnvoyUpstreamServiceTime).empty()) {
+    ENVOY_LOG(debug, "intercepted local response");
+    processingError_ = true;
+    headers_ = &headers;
+    mapLocalResponseToError(headers);
+    return end_stream ? Http::FilterHeadersStatus::Continue
+                      : Http::FilterHeadersStatus::StopIteration;
+  }
+
+  return Http::FilterHeadersStatus::Continue;
+}
+
+Http::FilterDataStatus LocalErrorFilter::encodeData(Buffer::Instance& data, bool end_stream) {
+  if (processingError_) {
+    // We assume the first (and assumed only) data chunk will be a contextual error message.
+    ASSERT(end_stream,
+           "Local responses must end the stream with a single data frame. If Envoy changes "
+           "this expectation, this code needs to be updated.");
+    headers_->addCopy(Http::InternalHeaders::get().ErrorMessage, data.toString());
+    return Http::FilterDataStatus::Continue;
+  }
+
+  return Http::FilterDataStatus::Continue;
+}
+
+void LocalErrorFilter::mapLocalResponseToError(Http::ResponseHeaderMap& headers) {
+  // Envoy Mobile surfaces non-200 local responses as errors via callbacks rather than an HTTP
+  // response. Here that response's "real" status code is mapped to an Envoy Mobile error code
+  // which is passed through the response chain as a header. The status code is updated with
+  // the sentinel value, 218 ("This is fine").
+  switch (Http::Utility::getResponseStatus(headers)) {
+  case 408:
+    headers.addCopy(Http::InternalHeaders::get().ErrorCode, std::to_string(ENVOY_REQUEST_TIMEOUT));
+    break;
+  case 413:
+    headers.addCopy(Http::InternalHeaders::get().ErrorCode,
+                    std::to_string(ENVOY_BUFFER_LIMIT_EXCEEDED));
+    break;
+  case 503:
+    headers.addCopy(Http::InternalHeaders::get().ErrorCode,
+                    std::to_string(ENVOY_CONNECTION_FAILURE));
+    break;
+  default:
+    headers.addCopy(Http::InternalHeaders::get().ErrorCode, std::to_string(ENVOY_UNDEFINED_ERROR));
+  }
+
+  headers.setStatus(218);
+}
+
+} // namespace LocalError
+} // namespace HttpFilters
+} // namespace Extensions
+} // namespace Envoy

--- a/library/common/extensions/filters/http/local_error/filter.cc
+++ b/library/common/extensions/filters/http/local_error/filter.cc
@@ -15,11 +15,7 @@ namespace Extensions {
 namespace HttpFilters {
 namespace LocalError {
 
-LocalErrorFilterConfig::LocalErrorFilterConfig(
-    const envoymobile::extensions::filters::http::local_error::LocalError& proto_config)
-    : enabled_(proto_config.enabled()) {}
-
-LocalErrorFilter::LocalErrorFilter(LocalErrorFilterConfigSharedPtr config) : config_(config) {}
+LocalErrorFilter::LocalErrorFilter() {}
 
 Http::FilterHeadersStatus LocalErrorFilter::encodeHeaders(Http::ResponseHeaderMap& headers,
                                                           bool end_stream) {

--- a/library/common/extensions/filters/http/local_error/filter.h
+++ b/library/common/extensions/filters/http/local_error/filter.h
@@ -13,24 +13,13 @@ namespace Extensions {
 namespace HttpFilters {
 namespace LocalError {
 
-class LocalErrorFilterConfig {
-public:
-  LocalErrorFilterConfig(
-      const envoymobile::extensions::filters::http::local_error::LocalError& proto_config);
-
-private:
-  const bool enabled_;
-};
-
-typedef std::shared_ptr<LocalErrorFilterConfig> LocalErrorFilterConfigSharedPtr;
-
 /**
  * Filter to assert expectations on HTTP requests.
  */
 class LocalErrorFilter final : public Http::PassThroughEncoderFilter,
                                public Logger::Loggable<Logger::Id::filter> {
 public:
-  LocalErrorFilter(LocalErrorFilterConfigSharedPtr config);
+  LocalErrorFilter();
 
   // StreamEncoderFilter
   Http::FilterHeadersStatus encodeHeaders(Http::ResponseHeaderMap& headers,
@@ -40,7 +29,6 @@ public:
 private:
   void mapLocalResponseToError(Http::ResponseHeaderMap& headers);
 
-  const LocalErrorFilterConfigSharedPtr config_;
   Http::ResponseHeaderMap* headers_{};
   bool processingError_{};
 };

--- a/library/common/extensions/filters/http/local_error/filter.h
+++ b/library/common/extensions/filters/http/local_error/filter.h
@@ -1,0 +1,51 @@
+#pragma once
+
+#include "envoy/http/filter.h"
+
+#include "common/common/logger.h"
+
+#include "extensions/filters/http/common/pass_through_filter.h"
+
+#include "library/common/extensions/filters/http/local_error/filter.pb.h"
+
+namespace Envoy {
+namespace Extensions {
+namespace HttpFilters {
+namespace LocalError {
+
+class LocalErrorFilterConfig {
+public:
+  LocalErrorFilterConfig(
+      const envoymobile::extensions::filters::http::local_error::LocalError& proto_config);
+
+private:
+  const bool enabled_;
+};
+
+typedef std::shared_ptr<LocalErrorFilterConfig> LocalErrorFilterConfigSharedPtr;
+
+/**
+ * Filter to assert expectations on HTTP requests.
+ */
+class LocalErrorFilter final : public Http::PassThroughEncoderFilter,
+                               public Logger::Loggable<Logger::Id::filter> {
+public:
+  LocalErrorFilter(LocalErrorFilterConfigSharedPtr config);
+
+  // StreamEncoderFilter
+  Http::FilterHeadersStatus encodeHeaders(Http::ResponseHeaderMap& headers,
+                                          bool end_stream) override;
+  Http::FilterDataStatus encodeData(Buffer::Instance& data, bool end_stream) override;
+
+private:
+  void mapLocalResponseToError(Http::ResponseHeaderMap& headers);
+
+  const LocalErrorFilterConfigSharedPtr config_;
+  Http::ResponseHeaderMap* headers_{};
+  bool processingError_{};
+};
+
+} // namespace LocalError
+} // namespace HttpFilters
+} // namespace Extensions
+} // namespace Envoy

--- a/library/common/extensions/filters/http/local_error/filter.proto
+++ b/library/common/extensions/filters/http/local_error/filter.proto
@@ -1,0 +1,7 @@
+syntax = "proto3";
+
+package envoymobile.extensions.filters.http.local_error;
+
+message LocalError {
+  bool enabled = 1;
+}

--- a/library/common/extensions/filters/http/local_error/filter.proto
+++ b/library/common/extensions/filters/http/local_error/filter.proto
@@ -3,5 +3,4 @@ syntax = "proto3";
 package envoymobile.extensions.filters.http.local_error;
 
 message LocalError {
-  bool enabled = 1;
 }

--- a/library/common/http/BUILD
+++ b/library/common/http/BUILD
@@ -13,6 +13,7 @@ envoy_cc_library(
     deps = [
         "//library/common/buffer:bridge_fragment_lib",
         "//library/common/buffer:utility_lib",
+        "//library/common/extensions/filters/http/local_error:local_error_filter_lib",
         "//library/common/http:header_utility_lib",
         "//library/common/network:synthetic_address_lib",
         "//library/common/thread:lock_guard_lib",
@@ -46,5 +47,16 @@ envoy_cc_library(
         "@envoy//include/envoy/buffer:buffer_interface",
         "@envoy//include/envoy/http:header_map_interface",
         "@envoy//source/common/http:header_map_lib",
+    ],
+)
+
+envoy_cc_library(
+    name = "internal_headers_lib",
+    hdrs = ["headers.h"],
+    repository = "@envoy",
+    deps = [
+        "@envoy//include/envoy/http:header_map_interface",
+        "@envoy//source/common/singleton:const_singleton",
+        "@envoy//source/common/singleton:threadsafe_singleton",
     ],
 )

--- a/library/common/http/dispatcher.cc
+++ b/library/common/http/dispatcher.cc
@@ -9,6 +9,7 @@
 #include "library/common/buffer/bridge_fragment.h"
 #include "library/common/buffer/utility.h"
 #include "library/common/http/header_utility.h"
+#include "library/common/http/headers.h"
 #include "library/common/network/synthetic_address_impl.h"
 #include "library/common/thread/lock_guard.h"
 
@@ -35,32 +36,39 @@ void Dispatcher::DirectStreamCallbacks::encodeHeaders(const ResponseHeaderMap& h
             direct_stream_.stream_handle_, end_stream, headers);
 
   ASSERT(http_dispatcher_.getStream(direct_stream_.stream_handle_));
-
-  uint64_t response_status = Utility::getResponseStatus(headers);
-  // Track success for later bookkeeping (stream could still be reset).
-  success_ = CodeUtility::is2xx(response_status);
-
   if (end_stream) {
     closeStream();
   }
 
-  // TODO: ***HACK*** currently Envoy sends local replies in cases where an error ought to be
-  // surfaced via the error path. There are ways we can clean up Envoy's local reply path to
-  // make this possible, but nothing expedient. For the immediate term this is our only real
-  // option. See https://github.com/lyft/envoy-mobile/issues/460
+  uint64_t response_status = Utility::getResponseStatus(headers);
 
-  // Error path: missing EnvoyUpstreamServiceTime implies this is a local reply, which we treat as
-  // a stream error.
-  if (!success_ && headers.get(Headers::get().EnvoyUpstreamServiceTime).empty()) {
-    ENVOY_LOG(debug, "[S{}] intercepted local response", direct_stream_.stream_handle_);
-    mapLocalResponseToError(headers);
-    if (end_stream) {
-      onError();
+  // Presence of internal error header indicates an error that should be surfaced as an
+  // error callback (rather than an HTTP response).
+  const auto error_code_header = headers.get(InternalHeaders::get().ErrorCode);
+  if (!error_code_header.empty()) {
+    envoy_error_code_t error_code;
+    bool check = absl::SimpleAtoi(error_code_header[0]->value().getStringView(), &error_code);
+    RELEASE_ASSERT(check, "parse error reading error code");
+    error_code_ = error_code;
+
+    const auto error_message_header = headers.get(InternalHeaders::get().ErrorMessage);
+    if (!error_message_header.empty()) {
+      error_message_ =
+          Buffer::Utility::copyToBridgeData(error_message_header[0]->value().getStringView());
     }
+
+    uint32_t attempt_count;
+    if (headers.EnvoyAttemptCount() &&
+        absl::SimpleAtoi(headers.EnvoyAttemptCount()->value().getStringView(), &attempt_count)) {
+      error_attempt_count_ = attempt_count;
+    }
+
+    onError();
     return;
   }
 
-  // Normal response path.
+  // Track success for later bookkeeping (stream could still be reset).
+  success_ = CodeUtility::is2xx(response_status);
 
   // Testing hook.
   http_dispatcher_.synchronizer_.syncPoint("dispatch_encode_headers");
@@ -74,26 +82,6 @@ void Dispatcher::DirectStreamCallbacks::encodeHeaders(const ResponseHeaderMap& h
   }
 }
 
-void Dispatcher::DirectStreamCallbacks::mapLocalResponseToError(const ResponseHeaderMap& headers) {
-  // Deal with a local response based on the HTTP status code received. Envoy Mobile treats
-  // successful local responses as actual success. Envoy Mobile surfaces non-200 local responses as
-  // errors via callbacks rather than an HTTP response. This is inline with behaviour of other
-  // mobile networking libraries.
-  switch (Utility::getResponseStatus(headers)) {
-  case 503:
-    error_code_ = ENVOY_CONNECTION_FAILURE;
-    break;
-  default:
-    error_code_ = ENVOY_UNDEFINED_ERROR;
-  }
-
-  uint32_t attempt_count;
-  if (headers.EnvoyAttemptCount() &&
-      absl::SimpleAtoi(headers.EnvoyAttemptCount()->value().getStringView(), &attempt_count)) {
-    error_attempt_count_ = attempt_count;
-  }
-}
-
 void Dispatcher::DirectStreamCallbacks::encodeData(Buffer::Instance& data, bool end_stream) {
   ENVOY_LOG(debug, "[S{}] response data for stream (length={} end_stream={})",
             direct_stream_.stream_handle_, data.length(), end_stream);
@@ -102,18 +90,6 @@ void Dispatcher::DirectStreamCallbacks::encodeData(Buffer::Instance& data, bool 
   if (end_stream) {
     closeStream();
   }
-
-  // Error path.
-  if (error_code_.has_value()) {
-    ASSERT(end_stream,
-           "local response has to end the stream with a single data frame. If Envoy changes "
-           "this expectation, this code needs to be updated.");
-    error_message_ = Buffer::Utility::toBridgeData(data);
-    onError();
-    return;
-  }
-
-  // Normal path.
 
   // Testing hook.
   if (end_stream) {

--- a/library/common/http/dispatcher.cc
+++ b/library/common/http/dispatcher.cc
@@ -63,7 +63,9 @@ void Dispatcher::DirectStreamCallbacks::encodeHeaders(const ResponseHeaderMap& h
       error_attempt_count_ = attempt_count;
     }
 
-    onError();
+    if (end_stream) {
+      onError();
+    }
     return;
   }
 
@@ -89,6 +91,11 @@ void Dispatcher::DirectStreamCallbacks::encodeData(Buffer::Instance& data, bool 
   ASSERT(http_dispatcher_.getStream(direct_stream_.stream_handle_));
   if (end_stream) {
     closeStream();
+  }
+
+  if (error_code_) {
+    onError();
+    return;
   }
 
   // Testing hook.

--- a/library/common/http/dispatcher.h
+++ b/library/common/http/dispatcher.h
@@ -127,7 +127,6 @@ private:
     void onComplete();
     void onCancel();
     void onError();
-    void mapLocalResponseToError(const ResponseHeaderMap& headers);
 
     // ResponseEncoder
     void encodeHeaders(const ResponseHeaderMap& headers, bool end_stream) override;

--- a/library/common/http/headers.h
+++ b/library/common/http/headers.h
@@ -1,0 +1,20 @@
+#pragma once
+
+#include "envoy/http/header_map.h"
+
+namespace Envoy {
+namespace Http {
+
+/**
+ * Constant HTTP headers used internally for in-band signalling in the request/response path.
+ */
+class InternalHeaderValues {
+public:
+  const LowerCaseString ErrorCode{"x-internal-error-code"};
+  const LowerCaseString ErrorMessage{"x-internal-error-message"};
+};
+
+using InternalHeaders = ConstSingleton<InternalHeaderValues>;
+
+} // namespace Http
+} // namespace Envoy

--- a/library/common/types/c_types.h
+++ b/library/common/types/c_types.h
@@ -39,7 +39,9 @@ extern const int kEnvoyFailure;
 typedef enum {
   ENVOY_UNDEFINED_ERROR,
   ENVOY_STREAM_RESET,
-  ENVOY_CONNECTION_FAILURE
+  ENVOY_CONNECTION_FAILURE,
+  ENVOY_BUFFER_LIMIT_EXCEEDED,
+  ENVOY_REQUEST_TIMEOUT,
 } envoy_error_code_t;
 
 /**

--- a/library/java/src/io/envoyproxy/envoymobile/engine/types/EnvoyHTTPFilterCallbacks.java
+++ b/library/java/src/io/envoyproxy/envoymobile/engine/types/EnvoyHTTPFilterCallbacks.java
@@ -1,3 +1,5 @@
 package io.envoyproxy.envoymobile.engine.types;
 
-public interface EnvoyHTTPFilterCallbacks { void resumeIteration(); }
+public interface EnvoyHTTPFilterCallbacks {
+  void resumeIteration();
+}

--- a/library/java/src/io/envoyproxy/envoymobile/engine/types/EnvoyHTTPFilterCallbacks.java
+++ b/library/java/src/io/envoyproxy/envoymobile/engine/types/EnvoyHTTPFilterCallbacks.java
@@ -1,5 +1,3 @@
 package io.envoyproxy.envoymobile.engine.types;
 
-public interface EnvoyHTTPFilterCallbacks {
-  void resumeIteration();
-}
+public interface EnvoyHTTPFilterCallbacks { void resumeIteration(); }

--- a/library/java/src/io/envoyproxy/envoymobile/engine/types/EnvoyOnEngineRunning.java
+++ b/library/java/src/io/envoyproxy/envoymobile/engine/types/EnvoyOnEngineRunning.java
@@ -1,4 +1,6 @@
 package io.envoyproxy.envoymobile.engine.types;
 
 /* Interface used to support lambdas being passed from Kotlin for engine setup completion. */
-public interface EnvoyOnEngineRunning { Object invokeOnEngineRunning(); }
+public interface EnvoyOnEngineRunning {
+  Object invokeOnEngineRunning();
+}

--- a/library/java/src/io/envoyproxy/envoymobile/engine/types/EnvoyOnEngineRunning.java
+++ b/library/java/src/io/envoyproxy/envoymobile/engine/types/EnvoyOnEngineRunning.java
@@ -1,6 +1,4 @@
 package io.envoyproxy.envoymobile.engine.types;
 
 /* Interface used to support lambdas being passed from Kotlin for engine setup completion. */
-public interface EnvoyOnEngineRunning {
-  Object invokeOnEngineRunning();
-}
+public interface EnvoyOnEngineRunning { Object invokeOnEngineRunning(); }

--- a/library/swift/test/HttpBridgeTests/ReceiveDataTest.swift
+++ b/library/swift/test/HttpBridgeTests/ReceiveDataTest.swift
@@ -74,6 +74,9 @@ final class ReceiveDataTests: XCTestCase {
         XCTAssertEqual("response_body", responseBody)
         dataExpectation.fulfill()
       }
+      .setOnError { _ in
+        XCTFail()
+      }
       .start()
       .sendHeaders(requestHeaders, endStream: true)
 

--- a/library/swift/test/HttpBridgeTests/ReceiveDataTest.swift
+++ b/library/swift/test/HttpBridgeTests/ReceiveDataTest.swift
@@ -75,7 +75,7 @@ final class ReceiveDataTests: XCTestCase {
         dataExpectation.fulfill()
       }
       .setOnError { _ in
-        XCTFail()
+        XCTFail("Unexpected error")
       }
       .start()
       .sendHeaders(requestHeaders, endStream: true)

--- a/library/swift/test/HttpBridgeTests/ReceiveErrorTest.swift
+++ b/library/swift/test/HttpBridgeTests/ReceiveErrorTest.swift
@@ -8,7 +8,7 @@ final class ReceiveErrorTests: XCTestCase {
     // swiftlint:disable:next line_length
     let apiListenerType = "type.googleapis.com/envoy.extensions.filters.network.http_connection_manager.v3.HttpConnectionManager"
     // swiftlint:disable:next line_length
-    let assertionFilterType = "type.googleapis.com/envoymobile.extensions.filters.http.assertion.Assertion"
+    let localErrorFilterType = "type.googleapis.com/envoymobile.extensions.filters.http.local_error.LocalError"
     let config =
     """
     static_resources:
@@ -35,13 +35,10 @@ final class ReceiveErrorTests: XCTestCase {
                       direct_response:
                         status: 503
             http_filters:
-              - name: envoy.filters.http.assertion
+              - name: envoy.filters.http.local_error
                 typed_config:
-                  "@type": \(assertionFilterType)
-                  match_config:
-                    http_request_generic_body_match:
-                      patterns:
-                        - string_match: match_me
+                  "@type": \(localErrorFilterType)
+                  enabled: true
               - name: envoy.router
                 typed_config:
                   "@type": type.googleapis.com/envoy.extensions.filters.http.router.v3.Router
@@ -59,13 +56,21 @@ final class ReceiveErrorTests: XCTestCase {
       .build()
     client
       .newStreamPrototype()
+      .setOnResponseHeaders { _, _ in
+        XCTFail()
+      }
+      .setOnResponseData { _, _ in
+        XCTFail()
+      }
       // The unmatched expecation will cause a local reply which gets translated in Envoy Mobile to
       // an error.
-      .setOnError { _ in
+      .setOnError { error in
+         XCTAssertEqual(error.errorCode, 2) // 503/Connection Failure
          expectation.fulfill()
       }
       .start()
       .sendHeaders(requestHeaders, endStream: true)
+
     XCTAssertEqual(XCTWaiter.wait(for: [expectation], timeout: 1), .completed)
   }
 }

--- a/library/swift/test/HttpBridgeTests/ReceiveErrorTest.swift
+++ b/library/swift/test/HttpBridgeTests/ReceiveErrorTest.swift
@@ -57,10 +57,10 @@ final class ReceiveErrorTests: XCTestCase {
     client
       .newStreamPrototype()
       .setOnResponseHeaders { _, _ in
-        XCTFail()
+        XCTFail("Headers received instead of expected error")
       }
       .setOnResponseData { _, _ in
-        XCTFail()
+        XCTFail("Data received instead of expected error")
       }
       // The unmatched expecation will cause a local reply which gets translated in Envoy Mobile to
       // an error.

--- a/library/swift/test/HttpBridgeTests/ReceiveErrorTest.swift
+++ b/library/swift/test/HttpBridgeTests/ReceiveErrorTest.swift
@@ -38,7 +38,6 @@ final class ReceiveErrorTests: XCTestCase {
               - name: envoy.filters.http.local_error
                 typed_config:
                   "@type": \(localErrorFilterType)
-                  enabled: true
               - name: envoy.router
                 typed_config:
                   "@type": type.googleapis.com/envoy.extensions.filters.http.router.v3.Router

--- a/library/swift/test/HttpBridgeTests/SendDataTest.swift
+++ b/library/swift/test/HttpBridgeTests/SendDataTest.swift
@@ -71,7 +71,7 @@ final class SendDataTests: XCTestCase {
          expectation.fulfill()
       }
       .setOnError { _ in
-        XCTFail()
+        XCTFail("Unexpected error")
       }
       .start()
       .sendHeaders(requestHeaders, endStream: false)

--- a/library/swift/test/HttpBridgeTests/SendDataTest.swift
+++ b/library/swift/test/HttpBridgeTests/SendDataTest.swift
@@ -65,9 +65,13 @@ final class SendDataTests: XCTestCase {
 
     client
       .newStreamPrototype()
-      .setOnResponseHeaders { responseHeaders, _ in
+      .setOnResponseHeaders { responseHeaders, endStream in
          XCTAssertEqual(200, responseHeaders.httpStatus)
+         XCTAssertTrue(endStream)
          expectation.fulfill()
+      }
+      .setOnError { _ in
+        XCTFail()
       }
       .start()
       .sendHeaders(requestHeaders, endStream: false)

--- a/library/swift/test/HttpBridgeTests/SendHeadersTest.swift
+++ b/library/swift/test/HttpBridgeTests/SendHeadersTest.swift
@@ -66,7 +66,7 @@ final class SendHeadersTests: XCTestCase {
          expectation.fulfill()
       }
       .setOnError { _ in
-        XCTFail()
+        XCTFail("Unexpected error")
       }
       .start()
       .sendHeaders(requestHeaders, endStream: true)

--- a/library/swift/test/HttpBridgeTests/SendHeadersTest.swift
+++ b/library/swift/test/HttpBridgeTests/SendHeadersTest.swift
@@ -60,9 +60,13 @@ final class SendHeadersTests: XCTestCase {
       .build()
     client
       .newStreamPrototype()
-      .setOnResponseHeaders { responseHeaders, _ in
+      .setOnResponseHeaders { responseHeaders, endStream in
          XCTAssertEqual(200, responseHeaders.httpStatus)
+         XCTAssertTrue(endStream)
          expectation.fulfill()
+      }
+      .setOnError { _ in
+        XCTFail()
       }
       .start()
       .sendHeaders(requestHeaders, endStream: true)

--- a/library/swift/test/HttpBridgeTests/SendTrailersTest.swift
+++ b/library/swift/test/HttpBridgeTests/SendTrailersTest.swift
@@ -73,6 +73,9 @@ final class SendTrailersTests: XCTestCase {
          XCTAssertEqual(200, responseHeaders.httpStatus)
          expectation.fulfill()
       }
+      .setOnError { _ in
+        XCTFail()
+      }
       .start()
       .sendHeaders(requestHeaders, endStream: false)
       .sendData(body)

--- a/library/swift/test/HttpBridgeTests/SendTrailersTest.swift
+++ b/library/swift/test/HttpBridgeTests/SendTrailersTest.swift
@@ -74,7 +74,7 @@ final class SendTrailersTests: XCTestCase {
          expectation.fulfill()
       }
       .setOnError { _ in
-        XCTFail()
+        XCTFail("Unexpected error")
       }
       .start()
       .sendHeaders(requestHeaders, endStream: false)

--- a/test/common/buffer/utility_test.cc
+++ b/test/common/buffer/utility_test.cc
@@ -47,5 +47,26 @@ TEST(DataConstructorTest, FromCppToC) {
   c_data.release(c_data.context);
 }
 
+TEST(DataConstructorTest, CopyFromCppToC) {
+  std::string s = "test string";
+  OwnedImpl cpp_data = OwnedImpl(absl::string_view(s));
+
+  envoy_data c_data = Utility::copyToBridgeData(cpp_data);
+
+  ASSERT_EQ(c_data.length, s.size());
+  ASSERT_EQ(Http::Utility::convertToString(c_data), s);
+  c_data.release(c_data.context);
+}
+
+TEST(DataConstructorTest, CopyStringFromCppToC) {
+  std::string s = "test string";
+
+  envoy_data c_data = Utility::copyToBridgeData(s);
+
+  ASSERT_EQ(c_data.length, s.size());
+  ASSERT_EQ(Http::Utility::convertToString(c_data), s);
+  c_data.release(c_data.context);
+}
+
 } // namespace Buffer
 } // namespace Envoy

--- a/test/common/http/dispatcher_test.cc
+++ b/test/common/http/dispatcher_test.cc
@@ -917,8 +917,7 @@ TEST_F(DispatcherTest, EnvoyResponseWithErrorCode) {
   envoy_http_callbacks bridge_callbacks;
   callbacks_called cc = {0, 0, 0, 0, 0, 0};
   bridge_callbacks.context = &cc;
-  bridge_callbacks.on_headers = [](envoy_headers c_headers, bool,
-                                   void* context) -> void* {
+  bridge_callbacks.on_headers = [](envoy_headers c_headers, bool, void* context) -> void* {
     ResponseHeaderMapPtr response_headers = toResponseHeaders(c_headers);
     EXPECT_EQ(response_headers->Status()->value().getStringView(), "218");
     callbacks_called* cc = static_cast<callbacks_called*>(context);
@@ -977,10 +976,10 @@ TEST_F(DispatcherTest, EnvoyResponseWithErrorCode) {
   EXPECT_CALL(event_dispatcher_, isThreadSafe()).Times(1).WillRepeatedly(Return(true));
   EXPECT_CALL(event_dispatcher_, deferredDelete_(_)).Times(1);
   TestResponseHeaderMapImpl response_headers{
-    {":status", "218"},
-    {"x-internal-error-code", std::to_string(ENVOY_CONNECTION_FAILURE)},
-    {"x-internal-error-message", "no internet"},
-    {"x-envoy-attempt-count", "123"},
+      {":status", "218"},
+      {"x-internal-error-code", std::to_string(ENVOY_CONNECTION_FAILURE)},
+      {"x-internal-error-message", "no internet"},
+      {"x-envoy-attempt-count", "123"},
   };
   response_encoder_->encodeHeaders(response_headers, true);
   ASSERT_EQ(cc.on_headers_calls, 0);

--- a/test/common/http/dispatcher_test.cc
+++ b/test/common/http/dispatcher_test.cc
@@ -773,7 +773,7 @@ TEST_F(DispatcherTest, MultipleStreams) {
   ASSERT_EQ(cc.on_complete_calls, 1);
 }
 
-TEST_F(DispatcherTest, EnvoyLocalReply) {
+TEST_F(DispatcherTest, EnvoyLocalReplyNotAnError) {
   ready();
 
   envoy_stream_t stream = 1;
@@ -781,9 +781,21 @@ TEST_F(DispatcherTest, EnvoyLocalReply) {
   envoy_http_callbacks bridge_callbacks;
   callbacks_called cc = {0, 0, 0, 0, 0, 0};
   bridge_callbacks.context = &cc;
-  bridge_callbacks.on_error = [](envoy_error error, void* context) -> void* {
-    EXPECT_EQ(error.error_code, ENVOY_CONNECTION_FAILURE);
-    EXPECT_EQ(error.attempt_count, -1);
+  bridge_callbacks.on_headers = [](envoy_headers c_headers, bool end_stream,
+                                   void* context) -> void* {
+    EXPECT_TRUE(end_stream);
+    ResponseHeaderMapPtr response_headers = toResponseHeaders(c_headers);
+    EXPECT_EQ(response_headers->Status()->value().getStringView(), "503");
+    callbacks_called* cc = static_cast<callbacks_called*>(context);
+    cc->on_headers_calls++;
+    return nullptr;
+  };
+  bridge_callbacks.on_complete = [](void* context) -> void* {
+    callbacks_called* cc = static_cast<callbacks_called*>(context);
+    cc->on_complete_calls++;
+    return nullptr;
+  };
+  bridge_callbacks.on_error = [](envoy_error, void* context) -> void* {
     callbacks_called* cc = static_cast<callbacks_called*>(context);
     cc->on_error_calls++;
     return nullptr;
@@ -823,13 +835,13 @@ TEST_F(DispatcherTest, EnvoyLocalReply) {
   EXPECT_CALL(event_dispatcher_, deferredDelete_(_)).Times(1);
   TestResponseHeaderMapImpl response_headers{{":status", "503"}};
   response_encoder_->encodeHeaders(response_headers, true);
-  ASSERT_EQ(cc.on_headers_calls, 0);
   // Ensure that the callbacks on the bridge_callbacks were called.
-  ASSERT_EQ(cc.on_complete_calls, 0);
-  ASSERT_EQ(cc.on_error_calls, 1);
+  ASSERT_EQ(cc.on_headers_calls, 1);
+  ASSERT_EQ(cc.on_complete_calls, 1);
+  ASSERT_EQ(cc.on_error_calls, 0);
 }
 
-TEST_F(DispatcherTest, EnvoyLocalReplyNon503) {
+TEST_F(DispatcherTest, EnvoyLocalReplyNon503NotAnError) {
   ready();
 
   envoy_stream_t stream = 1;
@@ -837,9 +849,21 @@ TEST_F(DispatcherTest, EnvoyLocalReplyNon503) {
   envoy_http_callbacks bridge_callbacks;
   callbacks_called cc = {0, 0, 0, 0, 0, 0};
   bridge_callbacks.context = &cc;
-  bridge_callbacks.on_error = [](envoy_error error, void* context) -> void* {
-    EXPECT_EQ(error.error_code, ENVOY_UNDEFINED_ERROR);
-    EXPECT_EQ(error.attempt_count, -1);
+  bridge_callbacks.on_headers = [](envoy_headers c_headers, bool end_stream,
+                                   void* context) -> void* {
+    EXPECT_TRUE(end_stream);
+    ResponseHeaderMapPtr response_headers = toResponseHeaders(c_headers);
+    EXPECT_EQ(response_headers->Status()->value().getStringView(), "504");
+    callbacks_called* cc = static_cast<callbacks_called*>(context);
+    cc->on_headers_calls++;
+    return nullptr;
+  };
+  bridge_callbacks.on_complete = [](void* context) -> void* {
+    callbacks_called* cc = static_cast<callbacks_called*>(context);
+    cc->on_complete_calls++;
+    return nullptr;
+  };
+  bridge_callbacks.on_error = [](envoy_error, void* context) -> void* {
     callbacks_called* cc = static_cast<callbacks_called*>(context);
     cc->on_error_calls++;
     return nullptr;
@@ -879,13 +903,13 @@ TEST_F(DispatcherTest, EnvoyLocalReplyNon503) {
   EXPECT_CALL(event_dispatcher_, deferredDelete_(_)).Times(1);
   TestResponseHeaderMapImpl response_headers{{":status", "504"}};
   response_encoder_->encodeHeaders(response_headers, true);
-  ASSERT_EQ(cc.on_headers_calls, 0);
   // Ensure that the callbacks on the bridge_callbacks were called.
-  ASSERT_EQ(cc.on_complete_calls, 0);
-  ASSERT_EQ(cc.on_error_calls, 1);
+  ASSERT_EQ(cc.on_headers_calls, 1);
+  ASSERT_EQ(cc.on_complete_calls, 1);
+  ASSERT_EQ(cc.on_error_calls, 0);
 }
 
-TEST_F(DispatcherTest, EnvoyLocalReplyWithData) {
+TEST_F(DispatcherTest, EnvoyResponseWithErrorCode) {
   ready();
 
   envoy_stream_t stream = 1;
@@ -893,68 +917,25 @@ TEST_F(DispatcherTest, EnvoyLocalReplyWithData) {
   envoy_http_callbacks bridge_callbacks;
   callbacks_called cc = {0, 0, 0, 0, 0, 0};
   bridge_callbacks.context = &cc;
-  bridge_callbacks.on_error = [](envoy_error error, void* context) -> void* {
-    EXPECT_EQ(error.error_code, ENVOY_CONNECTION_FAILURE);
-    EXPECT_EQ(Http::Utility::convertToString(error.message), "error message");
-    EXPECT_EQ(error.attempt_count, -1);
+  bridge_callbacks.on_headers = [](envoy_headers c_headers, bool,
+                                   void* context) -> void* {
+    ResponseHeaderMapPtr response_headers = toResponseHeaders(c_headers);
+    EXPECT_EQ(response_headers->Status()->value().getStringView(), "218");
     callbacks_called* cc = static_cast<callbacks_called*>(context);
-    cc->on_error_calls++;
-    error.message.release(error.message.context);
+    cc->on_headers_calls++;
     return nullptr;
   };
-
-  // Build a set of request headers.
-  TestRequestHeaderMapImpl headers;
-  HttpTestUtility::addDefaultHeaders(headers);
-  envoy_headers c_headers = Utility::toBridgeHeaders(headers);
-
-  // Create a stream.
-  Event::PostCb start_stream_post_cb;
-  EXPECT_CALL(event_dispatcher_, post(_)).WillOnce(SaveArg<0>(&start_stream_post_cb));
-  EXPECT_EQ(http_dispatcher_.startStream(stream, bridge_callbacks), ENVOY_SUCCESS);
-
-  // Grab the response encoder in order to dispatch responses on the stream.
-  // Return the request decoder to make sure calls are dispatched to the decoder via the dispatcher
-  // API.
-  EXPECT_CALL(api_listener_, newStream(_, _))
-      .WillOnce(Invoke([&](ResponseEncoder& encoder, bool) -> RequestDecoder& {
-        response_encoder_ = &encoder;
-        return request_decoder_;
-      }));
-  start_stream_post_cb();
-
-  // Send request headers.
-  Event::PostCb send_headers_post_cb;
-  EXPECT_CALL(event_dispatcher_, post(_)).WillOnce(SaveArg<0>(&send_headers_post_cb));
-  http_dispatcher_.sendHeaders(stream, c_headers, true);
-
-  EXPECT_CALL(request_decoder_, decodeHeaders_(_, true));
-  send_headers_post_cb();
-
-  // Encode response headers. A non-200 code triggers an on_error callback chain. In particular, a
-  // 503 should have an ENVOY_CONNECTION_FAILURE error code. However, do not end the stream yet.
-  TestResponseHeaderMapImpl response_headers{{":status", "503"}};
-  response_encoder_->encodeHeaders(response_headers, false);
-  ASSERT_EQ(cc.on_headers_calls, 0);
-
-  EXPECT_CALL(event_dispatcher_, isThreadSafe()).Times(1).WillRepeatedly(Return(true));
-  EXPECT_CALL(event_dispatcher_, deferredDelete_(_)).Times(1);
-  Buffer::InstancePtr response_data{new Buffer::OwnedImpl("error message")};
-  response_encoder_->encodeData(*response_data, true);
-  ASSERT_EQ(cc.on_data_calls, 0);
-  // Ensure that the callbacks on the bridge_callbacks were called.
-  ASSERT_EQ(cc.on_complete_calls, 0);
-  ASSERT_EQ(cc.on_error_calls, 1);
-}
-
-TEST_F(DispatcherTest, EnvoyLocalReplyWithAttemptCount) {
-  ready();
-
-  envoy_stream_t stream = 1;
-  // Setup bridge_callbacks to handle the response headers.
-  envoy_http_callbacks bridge_callbacks;
-  callbacks_called cc = {0, 0, 0, 0, 0, 0};
-  bridge_callbacks.context = &cc;
+  bridge_callbacks.on_data = [](envoy_data c_data, bool, void* context) -> void* {
+    callbacks_called* cc = static_cast<callbacks_called*>(context);
+    cc->on_data_calls++;
+    c_data.release(c_data.context);
+    return nullptr;
+  };
+  bridge_callbacks.on_complete = [](void* context) -> void* {
+    callbacks_called* cc = static_cast<callbacks_called*>(context);
+    cc->on_complete_calls++;
+    return nullptr;
+  };
   bridge_callbacks.on_error = [](envoy_error error, void* context) -> void* {
     EXPECT_EQ(error.error_code, ENVOY_CONNECTION_FAILURE);
     EXPECT_EQ(error.attempt_count, 123);
@@ -995,7 +976,12 @@ TEST_F(DispatcherTest, EnvoyLocalReplyWithAttemptCount) {
   // 503 should have an ENVOY_CONNECTION_FAILURE error code.
   EXPECT_CALL(event_dispatcher_, isThreadSafe()).Times(1).WillRepeatedly(Return(true));
   EXPECT_CALL(event_dispatcher_, deferredDelete_(_)).Times(1);
-  TestResponseHeaderMapImpl response_headers{{":status", "503"}, {"x-envoy-attempt-count", "123"}};
+  TestResponseHeaderMapImpl response_headers{
+    {":status", "218"},
+    {"x-internal-error-code", std::to_string(ENVOY_CONNECTION_FAILURE)},
+    {"x-internal-error-message", "no internet"},
+    {"x-envoy-attempt-count", "123"},
+  };
   response_encoder_->encodeHeaders(response_headers, true);
   ASSERT_EQ(cc.on_headers_calls, 0);
   // Ensure that the callbacks on the bridge_callbacks were called.

--- a/test/common/http/dispatcher_test.cc
+++ b/test/common/http/dispatcher_test.cc
@@ -940,6 +940,7 @@ TEST_F(DispatcherTest, EnvoyResponseWithErrorCode) {
     EXPECT_EQ(error.attempt_count, 123);
     callbacks_called* cc = static_cast<callbacks_called*>(context);
     cc->on_error_calls++;
+    error.message.release(error.message.context);
     return nullptr;
   };
 

--- a/test/integration/BUILD
+++ b/test/integration/BUILD
@@ -9,6 +9,8 @@ envoy_cc_test(
     srcs = ["dispatcher_integration_test.cc"],
     repository = "@envoy",
     deps = [
+        "//library/common/extensions/filters/http/local_error:config",
+        "//library/common/extensions/filters/http/local_error:pkg_cc_proto",
         "//library/common/http:dispatcher_lib",
         "//library/common/http:header_utility_lib",
         "//library/common/types:c_types_lib",

--- a/test/integration/dispatcher_integration_test.cc
+++ b/test/integration/dispatcher_integration_test.cc
@@ -268,8 +268,7 @@ TEST_P(DispatcherIntegrationTest, BasicReset) {
   ConditionalInitializer terminal_callback;
   callbacks_called cc = {0, 0, 0, 0, 0, &terminal_callback};
   bridge_callbacks.context = &cc;
-  bridge_callbacks.on_headers = [](envoy_headers c_headers, bool,
-                                   void*) -> void* {
+  bridge_callbacks.on_headers = [](envoy_headers c_headers, bool, void*) -> void* {
     release_envoy_headers(c_headers);
     ADD_FAILURE() << "unexpected call to on_headers";
     return nullptr;

--- a/test/integration/dispatcher_integration_test.cc
+++ b/test/integration/dispatcher_integration_test.cc
@@ -97,6 +97,10 @@ api_listener:
         domains: "*"
       name: route_config_0
     http_filters:
+      - name: envoy.filters.http.local_error
+        typed_config:
+          "@type": type.googleapis.com/envoymobile.extensions.filters.http.local_error.LocalError"
+          enabled: true
       - name: envoy.router
         typed_config:
           "@type": type.googleapis.com/envoy.extensions.filters.http.router.v3.Router

--- a/test/integration/dispatcher_integration_test.cc
+++ b/test/integration/dispatcher_integration_test.cc
@@ -100,7 +100,6 @@ api_listener:
       - name: envoy.filters.http.local_error
         typed_config:
           "@type": type.googleapis.com/envoymobile.extensions.filters.http.local_error.LocalError
-          enabled: true
       - name: envoy.router
         typed_config:
           "@type": type.googleapis.com/envoy.extensions.filters.http.router.v3.Router


### PR DESCRIPTION
Description: Creates a filter to handle mapping local responses to errors, instead of baking the logic into the dispatcher. This additionally allows platform filters to receive onError callbacks.
Risk Level: Moderate
Testing: Dispatcher integration, Swift integration, unit and manual

Signed-off-by: Mike Schore <mike.schore@gmail.com>