### PR TITLE
stats: adds metrics sink with ack

### DIFF
--- a/envoy_build_config/BUILD
+++ b/envoy_build_config/BUILD
@@ -26,5 +26,6 @@ envoy_cc_library(
         "@envoy//source/extensions/upstreams/http/generic:config",
         "@envoy_mobile//library/common/extensions/filters/http/assertion:config",
         "@envoy_mobile//library/common/extensions/filters/http/platform_bridge:config",
+        "@envoy_mobile//library/common/extensions/stat_sinks/metrics_service:config",
     ],
 )

--- a/envoy_build_config/extension_registry.cc
+++ b/envoy_build_config/extension_registry.cc
@@ -16,7 +16,8 @@ void ExtensionRegistry::registerFactories() {
   Envoy::Extensions::HttpFilters::RouterFilter::forceRegisterRouterFilterConfig();
   Envoy::Extensions::NetworkFilters::HttpConnectionManager::
       forceRegisterHttpConnectionManagerFilterConfigFactory();
-  Envoy::Extensions::StatSinks::MetricsService::forceRegisterMetricsServiceSinkFactory();
+  Envoy::Extensions::StatSinks::EnvoyMobileMetricsService::
+      forceRegisterEnvoyMobileMetricsServiceSinkFactory();
   Envoy::Extensions::TransportSockets::Tls::forceRegisterUpstreamSslSocketFactory();
   Envoy::Extensions::Upstreams::Http::Generic::forceRegisterGenericGenericConnPoolFactory();
   Envoy::Upstream::forceRegisterLogicalDnsClusterFactory();

--- a/envoy_build_config/extension_registry.h
+++ b/envoy_build_config/extension_registry.h
@@ -9,12 +9,12 @@
 #include "extensions/filters/http/dynamic_forward_proxy/config.h"
 #include "extensions/filters/http/router/config.h"
 #include "extensions/filters/network/http_connection_manager/config.h"
-#include "extensions/stat_sinks/metrics_service/config.h"
 #include "extensions/transport_sockets/tls/config.h"
 #include "extensions/upstreams/http/generic/config.h"
 
 #include "library/common/extensions/filters/http/assertion/config.h"
 #include "library/common/extensions/filters/http/platform_bridge/config.h"
+#include "library/common/extensions/stat_sinks/metrics_service/config.h"
 
 namespace Envoy {
 class ExtensionRegistry {

--- a/envoy_build_config/extensions_build_config.bzl
+++ b/envoy_build_config/extensions_build_config.bzl
@@ -9,7 +9,7 @@ EXTENSIONS = {
     "envoy.filters.http.platform_bridge":             "@envoy_mobile//library/common/extensions/filters/http/platform_bridge:config",
     "envoy.filters.http.router":                      "//source/extensions/filters/http/router:config",
     "envoy.filters.network.http_connection_manager":  "//source/extensions/filters/network/http_connection_manager:config",
-    "envoy.stat_sinks.metrics_service":               "//source/extensions/stat_sinks/metrics_service:config",
+    "envoymobile.stat_sinks.metrics_service":         "@envoy_mobile//library/common/extensions/stat_sinks/metrics_service:config",
     "envoy.transport_sockets.tls":                    "//source/extensions/transport_sockets/tls:config",
 }
 WINDOWS_EXTENSIONS = {}

--- a/library/common/extensions/stat_sinks/metrics_service/BUILD
+++ b/library/common/extensions/stat_sinks/metrics_service/BUILD
@@ -1,0 +1,39 @@
+load("@envoy//bazel:envoy_build_system.bzl", "envoy_cc_library")
+load("@envoy_api//bazel:api_build_system.bzl", "api_proto_package")
+
+licenses(["notice"])  # Apache 2
+
+package(default_visibility = ["//visibility:public"])
+
+api_proto_package(
+    has_services = True,
+    deps = [
+        "@envoy_api//envoy/config/core/v3:pkg",
+        "@prometheus_metrics_model//:client_model",
+    ],
+)
+
+envoy_cc_library(
+    name = "metrics_service_with_response",
+    srcs = ["metrics_service_with_response_impl.cc"],
+    hdrs = ["metrics_service_with_response.h"],
+    repository = "@envoy",
+    deps = [
+        ":pkg_cc_proto",
+        "@envoy//source/common/common:minimal_logger_lib",
+        "@envoy//source/extensions/stat_sinks/metrics_service:metrics_service_grpc_lib",
+    ],
+)
+
+envoy_cc_library(
+    name = "config",
+    srcs = ["config.cc"],
+    hdrs = ["config.h"],
+    repository = "@envoy",
+    deps = [
+        ":metrics_service_with_response",
+        "@envoy//source/common/grpc:async_client_lib",
+        "@envoy//source/extensions/stat_sinks/metrics_service:metrics_service_grpc_lib",
+        "@envoy//source/server:configuration_lib",
+    ],
+)

--- a/library/common/extensions/stat_sinks/metrics_service/config.cc
+++ b/library/common/extensions/stat_sinks/metrics_service/config.cc
@@ -1,0 +1,59 @@
+#include "library/common/extensions/stat_sinks/metrics_service/config.h"
+
+#include "common/grpc/async_client_impl.h"
+
+#include "extensions/stat_sinks/metrics_service/grpc_metrics_service_impl.h"
+
+#include "library/common/extensions/stat_sinks/metrics_service/metrics_service_config.pb.h"
+#include "library/common/extensions/stat_sinks/metrics_service/metrics_service_config.pb.validate.h"
+#include "library/common/extensions/stat_sinks/metrics_service/metrics_service_with_response.h"
+
+namespace Envoy {
+namespace Extensions {
+namespace StatSinks {
+namespace EnvoyMobileMetricsService {
+
+Stats::SinkPtr EnvoyMobileMetricsServiceSinkFactory::createStatsSink(
+    const Protobuf::Message& config, Server::Configuration::ServerFactoryContext& server) {
+  const auto& sink_config =
+      MessageUtil::downcastAndValidate<const envoymobile::extensions::config::StatSinks::
+                                           MetricsService::EnvoyMobileMetricsServiceConfig&>(
+          config, server.messageValidationContext().staticValidationVisitor());
+  const auto& grpc_service = sink_config.grpc_service();
+  ENVOY_LOG(debug, "Metrics Service gRPC service configuration: {}", grpc_service.DebugString());
+
+  std::shared_ptr<MetricsService::GrpcMetricsStreamer<
+      envoymobile::extensions::StatSinks::MetricsService::EnvoyMobileStreamMetricsMessage,
+          envoymobile::extensions::StatSinks::MetricsService::EnvoyMobileStreamMetricsResponse>>
+      grpc_metrics_streamer = std::make_shared<GrpcMetricsEnvoyMobileStreamerImpl>(
+          server.clusterManager().grpcAsyncClientManager().factoryForGrpcService(
+              grpc_service, server.scope(), false),
+          server.localInfo(), server.api().randomGenerator());
+
+  return std::make_unique<MetricsService::MetricsServiceSink<
+      envoymobile::extensions::StatSinks::MetricsService::EnvoyMobileStreamMetricsMessage,
+          envoymobile::extensions::StatSinks::MetricsService::EnvoyMobileStreamMetricsResponse>>(
+      grpc_metrics_streamer,
+      PROTOBUF_GET_WRAPPED_OR_DEFAULT(sink_config, report_counters_as_deltas, false));
+}
+
+ProtobufTypes::MessagePtr EnvoyMobileMetricsServiceSinkFactory::createEmptyConfigProto() {
+  return std::unique_ptr<
+      envoymobile::extensions::config::StatSinks::MetricsService::EnvoyMobileMetricsServiceConfig>(
+      std::make_unique<envoymobile::extensions::config::StatSinks::MetricsService::
+                           EnvoyMobileMetricsServiceConfig>());
+}
+
+std::string EnvoyMobileMetricsServiceSinkFactory::name() const {
+  return "envoymobile.stat_sinks.metrics_service";
+}
+
+/**
+ * Static registration for the this sink factory. @see RegisterFactory.
+ */
+REGISTER_FACTORY(EnvoyMobileMetricsServiceSinkFactory, Server::Configuration::StatsSinkFactory);
+
+} // namespace EnvoyMobileMetricsService
+} // namespace StatSinks
+} // namespace Extensions
+} // namespace Envoy

--- a/library/common/extensions/stat_sinks/metrics_service/config.h
+++ b/library/common/extensions/stat_sinks/metrics_service/config.h
@@ -1,0 +1,29 @@
+#pragma once
+
+#include "server/configuration_impl.h"
+
+namespace Envoy {
+namespace Extensions {
+namespace StatSinks {
+namespace EnvoyMobileMetricsService {
+
+/**
+ * Config registration for the EnvoyMobileMetricsService stats sink. @see StatsSinkFactory.
+ */
+class EnvoyMobileMetricsServiceSinkFactory : Logger::Loggable<Logger::Id::config>,
+                                             public Server::Configuration::StatsSinkFactory {
+public:
+  Stats::SinkPtr createStatsSink(const Protobuf::Message& config,
+                                 Server::Configuration::ServerFactoryContext& server) override;
+
+  ProtobufTypes::MessagePtr createEmptyConfigProto() override;
+
+  std::string name() const override;
+};
+
+DECLARE_FACTORY(EnvoyMobileMetricsServiceSinkFactory);
+
+} // namespace EnvoyMobileMetricsService
+} // namespace StatSinks
+} // namespace Extensions
+} // namespace Envoy

--- a/library/common/extensions/stat_sinks/metrics_service/metrics_service.proto
+++ b/library/common/extensions/stat_sinks/metrics_service/metrics_service.proto
@@ -1,0 +1,34 @@
+syntax = "proto3";
+
+package envoymobile.extensions.StatSinks.MetricsService;
+
+import "envoy/config/core/v3/base.proto";
+import "metrics.proto";
+import "validate/validate.proto";
+
+service EnvoyMobileMetricsService {
+  rpc EnvoyMobileStreamMetrics(stream EnvoyMobileStreamMetricsMessage)
+      returns (stream EnvoyMobileStreamMetricsResponse) {
+  }
+}
+
+message EnvoyMobileStreamMetricsResponse {
+  string batch_id = 1;
+}
+
+message EnvoyMobileStreamMetricsMessage {
+
+  message Identifier {
+    // The node sending metrics over the stream.
+    envoy.config.core.v3.Node node = 1 [(validate.rules).message = {required: true}];
+  }
+
+  // Identifier data effectively is a structured metadata. As a performance optimization this will
+  // only be sent in the first message on the stream.
+  Identifier identifier = 1;
+
+  // A list of metric entries
+  repeated io.prometheus.client.MetricFamily envoy_metrics = 2;
+
+  string batch_id = 3;
+}

--- a/library/common/extensions/stat_sinks/metrics_service/metrics_service_config.proto
+++ b/library/common/extensions/stat_sinks/metrics_service/metrics_service_config.proto
@@ -1,0 +1,19 @@
+syntax = "proto3";
+
+package envoymobile.extensions.config.StatSinks.MetricsService;
+
+import "envoy/config/core/v3/grpc_service.proto";
+
+import "validate/validate.proto";
+
+import "google/protobuf/wrappers.proto";
+
+message EnvoyMobileMetricsServiceConfig {
+
+  // The upstream gRPC cluster that hosts the metrics service.
+  envoy.config.core.v3.GrpcService grpc_service = 1 [(validate.rules).message = {required: true}];
+
+  // If true, counters are reported as the delta between flushing intervals. Otherwise, the current
+  // counter value is reported. Defaults to false.
+  google.protobuf.BoolValue report_counters_as_deltas = 2;
+}

--- a/library/common/extensions/stat_sinks/metrics_service/metrics_service_with_response.h
+++ b/library/common/extensions/stat_sinks/metrics_service/metrics_service_with_response.h
@@ -1,0 +1,57 @@
+#pragma once
+
+#include <memory>
+
+#include "envoy/common/random_generator.h"
+#include "envoy/grpc/async_client.h"
+#include "envoy/local_info/local_info.h"
+#include "envoy/network/connection.h"
+#include "envoy/service/metrics/v3/metrics_service.pb.h"
+#include "envoy/stats/sink.h"
+#include "envoy/upstream/cluster_manager.h"
+
+#include "library/common/extensions/stat_sinks/metrics_service/metrics_service.pb.h"
+
+namespace Envoy {
+namespace Extensions {
+namespace StatSinks {
+namespace EnvoyMobileMetricsService {
+
+/**
+ * EnvoyMobile implementation of GrpcMetrics\Streamer
+ */
+class GrpcMetricsEnvoyMobileStreamerImpl
+    : public Singleton::Instance,
+      public Logger::Loggable<Logger::Id::filter>,
+      public MetricsService::GrpcMetricsStreamer<
+          envoymobile::extensions::StatSinks::MetricsService::EnvoyMobileStreamMetricsMessage,
+          envoymobile::extensions::StatSinks::MetricsService::EnvoyMobileStreamMetricsResponse> {
+public:
+  GrpcMetricsEnvoyMobileStreamerImpl(Grpc::AsyncClientFactoryPtr&& factory,
+                                     const LocalInfo::LocalInfo& local_info,
+                                     Random::RandomGenerator& random_generator);
+
+  void send(MetricsService::MetricsPtr&& metrics) override;
+
+  void onReceiveMessage(
+      std::unique_ptr<
+          envoymobile::extensions::StatSinks::MetricsService::EnvoyMobileStreamMetricsResponse>&&
+          response) override {
+    ENVOY_LOG(debug, "EnvoyMobile streamer received batch_id: {}", response->batch_id());
+  }
+
+  // Grpc::AsyncStreamCallbacks
+  void onRemoteClose(Grpc::Status::GrpcStatus, const std::string&) override { stream_ = nullptr; }
+
+private:
+  const LocalInfo::LocalInfo& local_info_;
+  Random::RandomGenerator& random_generator_;
+  const Protobuf::MethodDescriptor& service_method_;
+};
+
+using GrpcMetricsEnvoyMobileStreamerImplPtr = std::unique_ptr<GrpcMetricsEnvoyMobileStreamerImpl>;
+
+} // namespace EnvoyMobileMetricsService
+} // namespace StatSinks
+} // namespace Extensions
+} // namespace Envoy

--- a/library/common/extensions/stat_sinks/metrics_service/metrics_service_with_response_impl.cc
+++ b/library/common/extensions/stat_sinks/metrics_service/metrics_service_with_response_impl.cc
@@ -1,0 +1,42 @@
+#include "extensions/stat_sinks/metrics_service/grpc_metrics_service_impl.h"
+
+#include "metrics_service_with_response.h"
+
+namespace Envoy {
+namespace Extensions {
+namespace StatSinks {
+namespace EnvoyMobileMetricsService {
+
+GrpcMetricsEnvoyMobileStreamerImpl::GrpcMetricsEnvoyMobileStreamerImpl(
+    Grpc::AsyncClientFactoryPtr&& factory, const LocalInfo::LocalInfo& local_info,
+    Random::RandomGenerator& random_generator)
+    : GrpcMetricsStreamer<
+          envoymobile::extensions::StatSinks::MetricsService::EnvoyMobileStreamMetricsMessage,
+          envoymobile::extensions::StatSinks::MetricsService::EnvoyMobileStreamMetricsResponse>(
+          std::move(factory)),
+      local_info_(local_info), random_generator_(random_generator),
+      service_method_(*Protobuf::DescriptorPool::generated_pool()->FindMethodByName(
+          "envoymobile.extensions.StatSinks.MetricsService.EnvoyMobileMetricsService."
+          "EnvoyMobileStreamMetrics")) {}
+
+void GrpcMetricsEnvoyMobileStreamerImpl::send(MetricsService::MetricsPtr&& metrics) {  
+  envoymobile::extensions::StatSinks::MetricsService::EnvoyMobileStreamMetricsMessage message;
+  message.mutable_envoy_metrics()->Reserve(metrics->size());
+  message.mutable_envoy_metrics()->MergeFrom(*metrics);
+  std::string uuid = random_generator_.uuid();
+  message.set_batch_id(uuid);
+  if (stream_ == nullptr) {
+    stream_ = client_->start(service_method_, *this, Http::AsyncClient::StreamOptions());
+    // for perf reasons, the identifier is only sent on establishing the stream.
+    auto* identifier = message.mutable_identifier();
+    *identifier->mutable_node() = local_info_.node();
+  }
+  if (stream_ != nullptr) {
+    stream_->sendMessage(message, false);
+  }
+}
+
+} // namespace EnvoyMobileMetricsService
+} // namespace StatSinks
+} // namespace Extensions
+} // namespace Envoy

--- a/test/common/extensions/stat_sinks/BUILD
+++ b/test/common/extensions/stat_sinks/BUILD
@@ -1,0 +1,40 @@
+load("@envoy//bazel:envoy_build_system.bzl", "envoy_package")
+load(
+    "@envoy//test/extensions:extensions_build_system.bzl",
+    "envoy_extension_cc_test",
+)
+
+licenses(["notice"])  # Apache 2
+
+envoy_package()
+
+envoy_extension_cc_test(
+    name = "metrics_service_with_response_test",
+    srcs = ["metrics_service_with_response_test.cc"],
+    extension_name = "envoymobile.stat_sinks.metrics_service",
+    repository = "@envoy",
+    deps = [
+        "//library/common/extensions/stat_sinks/metrics_service:config",
+        "//library/common/extensions/stat_sinks/metrics_service:pkg_cc_proto",
+        "@envoy//test/mocks/grpc:grpc_mocks",
+        "@envoy//test/mocks/local_info:local_info_mocks",
+        "@envoy//test/mocks/thread_local:thread_local_mocks",
+    ],
+)
+
+envoy_extension_cc_test(
+    name = "metrics_service_with_response_integration_test",
+    srcs = ["metrics_service_with_response_integration_test.cc"],
+    extension_name = "envoymobile.stat_sinks.metrics_service",
+    repository = "@envoy",
+    deps = [
+        "//library/common/extensions/stat_sinks/metrics_service:config",
+        "//library/common/extensions/stat_sinks/metrics_service:pkg_cc_proto",
+        "@envoy//test/integration:http_integration_lib",
+        "@envoy//test/mocks/grpc:grpc_mocks",
+        "@envoy//test/mocks/local_info:local_info_mocks",
+        "@envoy//test/mocks/thread_local:thread_local_mocks",
+        "@envoy//test/test_common:utility_lib",
+        "@envoy_api//envoy/config/bootstrap/v3:pkg_cc_proto",
+    ],
+)

--- a/test/common/extensions/stat_sinks/metrics_service_with_response_integration_test.cc
+++ b/test/common/extensions/stat_sinks/metrics_service_with_response_integration_test.cc
@@ -1,0 +1,186 @@
+#include "envoy/config/bootstrap/v3/bootstrap.pb.h"
+
+#include "common/grpc/codec.h"
+#include "common/grpc/common.h"
+#include "common/stats/histogram_impl.h"
+
+#include "test/integration/http_integration.h"
+
+#include "gtest/gtest.h"
+#include "library/common/extensions/stat_sinks/metrics_service/metrics_service.pb.h"
+#include "library/common/extensions/stat_sinks/metrics_service/metrics_service_config.pb.h"
+
+using testing::AssertionResult;
+
+namespace Envoy {
+namespace {
+
+class EnvoyMobileMetricsServiceIntegrationTest
+    : public Grpc::VersionedGrpcClientIntegrationParamTest,
+      public HttpIntegrationTest {
+public:
+  EnvoyMobileMetricsServiceIntegrationTest()
+      : HttpIntegrationTest(Http::CodecClient::Type::HTTP1, ipVersion()) {}
+
+  void createUpstreams() override {
+    HttpIntegrationTest::createUpstreams();
+    addFakeUpstream(FakeHttpConnection::Type::HTTP2);
+  }
+
+  void initialize() override {
+    config_helper_.addConfigModifier([this](envoy::config::bootstrap::v3::Bootstrap& bootstrap) {
+      // metrics_service cluster for Envoy gRPC.
+      auto* metrics_service_cluster = bootstrap.mutable_static_resources()->add_clusters();
+      metrics_service_cluster->MergeFrom(bootstrap.static_resources().clusters()[0]);
+      metrics_service_cluster->set_name("metrics_service");
+      metrics_service_cluster->mutable_http2_protocol_options();
+      // metrics_service gRPC service definition.
+      auto* metrics_sink = bootstrap.add_stats_sinks();
+      metrics_sink->set_name("envoymobile.stat_sinks.metrics_service");
+      envoymobile::extensions::config::StatSinks::MetricsService::EnvoyMobileMetricsServiceConfig
+          config;
+      setGrpcService(*config.mutable_grpc_service(), "metrics_service",
+                     fake_upstreams_.back()->localAddress());
+      metrics_sink->mutable_typed_config()->PackFrom(config);
+      // Shrink reporting period down to 1s to make test not take forever.
+      bootstrap.mutable_stats_flush_interval()->CopyFrom(
+          Protobuf::util::TimeUtil::MillisecondsToDuration(100));
+    });
+
+    HttpIntegrationTest::initialize();
+  }
+
+  ABSL_MUST_USE_RESULT
+  AssertionResult waitForMetricsServiceConnection() {
+    return fake_upstreams_[1]->waitForHttpConnection(*dispatcher_,
+                                                     fake_metrics_service_connection_);
+  }
+
+  ABSL_MUST_USE_RESULT
+  AssertionResult waitForMetricsStream() {
+    return fake_metrics_service_connection_->waitForNewStream(*dispatcher_,
+                                                              metrics_service_request_);
+  }
+
+  ABSL_MUST_USE_RESULT
+  AssertionResult waitForMetricsRequest() {
+    bool known_summary_exists = false;
+    bool known_histogram_exists = false;
+    bool known_counter_exists = false;
+    bool known_gauge_exists = false;
+
+    // Sometimes stats do not come in the first flush cycle, this loop ensures that we wait till
+    // required stats are flushed.
+    // TODO(ramaraochavali): Figure out a more robust way to find out all required stats have been
+    // flushed.
+    while (!(known_counter_exists && known_gauge_exists && known_histogram_exists)) {
+      envoymobile::extensions::StatSinks::MetricsService::EnvoyMobileStreamMetricsMessage
+          request_msg;
+      VERIFY_ASSERTION(metrics_service_request_->waitForGrpcMessage(*dispatcher_, request_msg));
+      EXPECT_EQ("POST", metrics_service_request_->headers().getMethodValue());
+      EXPECT_EQ("/envoymobile.extensions.StatSinks.MetricsService.EnvoyMobileMetricsService/"
+                "EnvoyMobileStreamMetrics",
+                metrics_service_request_->headers().getPathValue());
+      EXPECT_EQ("application/grpc", metrics_service_request_->headers().getContentTypeValue());
+      EXPECT_TRUE(request_msg.envoy_metrics_size() > 0);
+      const Protobuf::RepeatedPtrField<::io::prometheus::client::MetricFamily>& envoy_metrics =
+          request_msg.envoy_metrics();
+
+      int64_t previous_time_stamp = 0;
+      for (const ::io::prometheus::client::MetricFamily& metrics_family : envoy_metrics) {
+        if (metrics_family.name() == "cluster.cluster_0.membership_change" &&
+            metrics_family.type() == ::io::prometheus::client::MetricType::COUNTER) {
+          known_counter_exists = true;
+          EXPECT_EQ(1, metrics_family.metric(0).counter().value());
+        }
+        if (metrics_family.name() == "cluster.cluster_0.membership_total" &&
+            metrics_family.type() == ::io::prometheus::client::MetricType::GAUGE) {
+          known_gauge_exists = true;
+          EXPECT_EQ(1, metrics_family.metric(0).gauge().value());
+        }
+        if (metrics_family.name() == "cluster.cluster_0.upstream_rq_time" &&
+            metrics_family.type() == ::io::prometheus::client::MetricType::SUMMARY) {
+          known_summary_exists = true;
+          Stats::HistogramStatisticsImpl empty_statistics;
+          EXPECT_EQ(metrics_family.metric(0).summary().quantile_size(),
+                    empty_statistics.supportedQuantiles().size());
+        }
+        if (metrics_family.name() == "cluster.cluster_0.upstream_rq_time" &&
+            metrics_family.type() == ::io::prometheus::client::MetricType::HISTOGRAM) {
+          known_histogram_exists = true;
+          EXPECT_EQ(metrics_family.metric(0).histogram().bucket_size(),
+                    Stats::HistogramSettingsImpl::defaultBuckets().size());
+        }
+        ASSERT(metrics_family.metric(0).has_timestamp_ms());
+        // Validate that all metrics have the same timestamp.
+        if (previous_time_stamp > 0) {
+          EXPECT_EQ(previous_time_stamp, metrics_family.metric(0).timestamp_ms());
+        }
+        previous_time_stamp = metrics_family.metric(0).timestamp_ms();
+        if (known_counter_exists && known_gauge_exists && known_histogram_exists) {
+          break;
+        }
+      }
+    }
+    EXPECT_TRUE(known_counter_exists);
+    EXPECT_TRUE(known_gauge_exists);
+    EXPECT_TRUE(known_summary_exists);
+    EXPECT_TRUE(known_histogram_exists);
+
+    return AssertionSuccess();
+  }
+
+  void cleanup() {
+    if (fake_metrics_service_connection_ != nullptr) {
+      AssertionResult result = fake_metrics_service_connection_->close();
+      RELEASE_ASSERT(result, result.message());
+      result = fake_metrics_service_connection_->waitForDisconnect();
+      RELEASE_ASSERT(result, result.message());
+    }
+  }
+
+  FakeHttpConnectionPtr fake_metrics_service_connection_;
+  FakeStreamPtr metrics_service_request_;
+};
+
+INSTANTIATE_TEST_SUITE_P(IpVersionsClientType, EnvoyMobileMetricsServiceIntegrationTest,
+                         VERSIONED_GRPC_CLIENT_INTEGRATION_PARAMS);
+
+// Test a basic metric service flow.
+TEST_P(EnvoyMobileMetricsServiceIntegrationTest, BasicFlow) {
+  initialize();
+  // Send an empty request so that histogram values merged for cluster_0.
+  codec_client_ = makeHttpConnection(makeClientConnection(lookupPort("http")));
+  Http::TestRequestHeaderMapImpl request_headers{{":method", "GET"},
+                                                 {":path", "/test/long/url"},
+                                                 {":scheme", "http"},
+                                                 {":authority", "host"},
+                                                 {"x-lyft-user-id", "123"}};
+  sendRequestAndWaitForResponse(request_headers, 0, default_response_headers_, 0);
+
+  ASSERT_TRUE(waitForMetricsServiceConnection());
+  ASSERT_TRUE(waitForMetricsStream());
+  ASSERT_TRUE(waitForMetricsRequest());
+
+  // Send an empty response and end the stream. This should never happen but make sure nothing
+  // breaks and we make a new stream on a follow up request.
+  metrics_service_request_->startGrpcStream();
+  envoymobile::extensions::StatSinks::MetricsService::EnvoyMobileStreamMetricsResponse response_msg;
+  metrics_service_request_->sendGrpcMessage(response_msg);
+  metrics_service_request_->finishGrpcStream(Grpc::Status::Ok);
+
+  switch (clientType()) {
+  case Grpc::ClientType::EnvoyGrpc:
+    test_server_->waitForGaugeEq("cluster.metrics_service.upstream_rq_active", 0);
+    break;
+  case Grpc::ClientType::GoogleGrpc:
+    test_server_->waitForCounterGe("grpc.metrics_service.streams_closed_0", 1);
+    break;
+  default:
+    NOT_REACHED_GCOVR_EXCL_LINE;
+  }
+  cleanup();
+}
+
+} // namespace
+} // namespace Envoy

--- a/test/common/extensions/stat_sinks/metrics_service_with_response_test.cc
+++ b/test/common/extensions/stat_sinks/metrics_service_with_response_test.cc
@@ -1,0 +1,108 @@
+#include "extensions/stat_sinks/metrics_service/grpc_metrics_service_impl.h"
+
+#include "test/mocks/common.h"
+#include "test/mocks/grpc/mocks.h"
+#include "test/mocks/local_info/mocks.h"
+#include "test/mocks/stats/mocks.h"
+#include "test/mocks/thread_local/mocks.h"
+#include "test/test_common/simulated_time_system.h"
+
+#include "library/common/extensions/stat_sinks/metrics_service/metrics_service.pb.h"
+#include "library/common/extensions/stat_sinks/metrics_service/metrics_service_with_response.h"
+
+using testing::_;
+using testing::InSequence;
+using testing::Invoke;
+using testing::NiceMock;
+
+namespace Envoy {
+namespace Extensions {
+namespace StatSinks {
+namespace EnvoyMobileMetricsService {
+namespace {
+
+class GrpcMetricsEnvoyMobileStreamerImplTest : public testing::Test {
+public:
+  using MockMetricsStream = Grpc::MockAsyncStream;
+  using MetricsServiceCallbacks = Grpc::AsyncStreamCallbacks<
+      envoymobile::extensions::StatSinks::MetricsService::EnvoyMobileStreamMetricsResponse>;
+
+  GrpcMetricsEnvoyMobileStreamerImplTest() {
+    EXPECT_CALL(*factory_, create()).WillOnce(Invoke([this] {
+      return Grpc::RawAsyncClientPtr{async_client_};
+    }));
+
+    streamer_ = std::make_unique<GrpcMetricsEnvoyMobileStreamerImpl>(
+        Grpc::AsyncClientFactoryPtr{factory_}, local_info_, random_generator);
+  }
+
+  void expectStreamStart(MockMetricsStream& stream, MetricsServiceCallbacks** callbacks_to_set) {
+    EXPECT_CALL(*async_client_, startRaw(_, _, _, _))
+        .WillOnce(Invoke([&stream, callbacks_to_set](absl::string_view, absl::string_view,
+                                                     Grpc::RawAsyncStreamCallbacks& callbacks,
+                                                     const Http::AsyncClient::StreamOptions&) {
+          *callbacks_to_set = dynamic_cast<MetricsServiceCallbacks*>(&callbacks);
+          return &stream;
+        }));
+  }
+
+  NiceMock<Random::MockRandomGenerator> random_generator;
+  LocalInfo::MockLocalInfo local_info_;
+  Grpc::MockAsyncClient* async_client_{new NiceMock<Grpc::MockAsyncClient>};
+  Grpc::MockAsyncClientFactory* factory_{new Grpc::MockAsyncClientFactory};
+  GrpcMetricsEnvoyMobileStreamerImplPtr streamer_;
+};
+
+// Test basic metrics streaming flow.
+TEST_F(GrpcMetricsEnvoyMobileStreamerImplTest, BasicFlow) {
+  InSequence s;
+
+  // Start a stream and send first message.
+  
+  MockMetricsStream stream1;
+  MetricsServiceCallbacks* callbacks1;
+  expectStreamStart(stream1, &callbacks1);
+  EXPECT_CALL(local_info_, node());
+  EXPECT_CALL(stream1, sendMessageRaw_(_, false));
+  
+  auto metrics =
+      std::make_unique<Envoy::Protobuf::RepeatedPtrField<io::prometheus::client::MetricFamily>>();
+  
+  streamer_->send(std::move(metrics));
+  // Verify that sending an empty response message doesn't do anything bad.
+  callbacks1->onReceiveMessage(
+      std::make_unique<
+          envoymobile::extensions::StatSinks::MetricsService::EnvoyMobileStreamMetricsResponse>());
+}
+
+// Test that stream failure is handled correctly.
+TEST_F(GrpcMetricsEnvoyMobileStreamerImplTest, StreamFailure) {
+  InSequence s;
+
+  EXPECT_CALL(*async_client_, startRaw(_, _, _, _))
+      .WillOnce(
+          Invoke([](absl::string_view, absl::string_view, Grpc::RawAsyncStreamCallbacks& callbacks,
+                    const Http::AsyncClient::StreamOptions&) {
+            callbacks.onRemoteClose(Grpc::Status::Internal, "bad");
+            return nullptr;
+          }));
+  EXPECT_CALL(local_info_, node());
+  auto metrics =
+      std::make_unique<Envoy::Protobuf::RepeatedPtrField<io::prometheus::client::MetricFamily>>();
+  streamer_->send(std::move(metrics));
+}
+
+class MockGrpcMetricsStreamer
+    : MetricsService::GrpcMetricsStreamer<
+          envoymobile::extensions::StatSinks::MetricsService::EnvoyMobileStreamMetricsMessage,
+          envoymobile::extensions::StatSinks::MetricsService::EnvoyMobileStreamMetricsResponse> {
+public:
+  // GrpcMetricsStreamer
+  MOCK_METHOD(void, send, (MetricsService::MetricsPtr&& metrics));
+};
+
+} // namespace
+} // namespace EnvoyMobileMetricsService
+} // namespace StatSinks
+} // namespace Extensions
+} // namespace Envoy


### PR DESCRIPTION
Description: Replace the metrics sink from the envoy one to a custom one. The custom metrics sink comes with ack function on the grpc stream.
Risk Level: High
Testing: Local and ci unit tests and integration tests

Co-authored-by: Jose Nino <jnino@lyft.com>
Signed-off-by: Jingwei Hao <jingwei.hao@gmail.com>