### PR TITLE
ios: allow engine to be run with custom yaml template

### DIFF
--- a/library/objective-c/EnvoyEngine.h
+++ b/library/objective-c/EnvoyEngine.h
@@ -302,15 +302,17 @@ extern const int kEnvoyFailure;
 /**
  Run the Envoy engine with the provided yaml string and log level.
 
- @param configYAML The configuration yaml with which to start Envoy.
+ @param template The configuration template with which to start Envoy.
+ @param config The EnvoyConfiguration used to start Envoy.
  @param logLevel The log level to use when starting Envoy.
  @param onEngineRunning Closure called when the engine finishes its async startup and begins
  running.
  @return A status indicating if the action was successful.
  */
-- (int)runWithConfigYAML:(NSString *)configYAML
-                logLevel:(NSString *)logLevel
-         onEngineRunning:(nullable void (^)())onEngineRunning;
+- (int)runWithTemplate:(NSString *)yaml
+                config:(EnvoyConfiguration *)config
+              logLevel:(NSString *)logLevel
+       onEngineRunning:(nullable void (^)())onEngineRunning;
 
 /**
  Opens a new HTTP stream attached to this engine.

--- a/library/objective-c/EnvoyEngine.h
+++ b/library/objective-c/EnvoyEngine.h
@@ -302,7 +302,7 @@ extern const int kEnvoyFailure;
 /**
  Run the Envoy engine with the provided yaml string and log level.
 
- @param template The configuration template with which to start Envoy.
+ @param yaml The configuration template with which to start Envoy.
  @param config The EnvoyConfiguration used to start Envoy.
  @param logLevel The log level to use when starting Envoy.
  @param onEngineRunning Closure called when the engine finishes its async startup and begins

--- a/library/objective-c/EnvoyEngineImpl.m
+++ b/library/objective-c/EnvoyEngineImpl.m
@@ -286,7 +286,7 @@ static void ios_http_filter_release(const void *context) {
     return kEnvoyFailure;
   }
 
-  for (EnvoyHTTPFilterFactory *filterFactory in config.httpFilterFactories) {
+  for (EnvoyHTTPFilterFactory *filterFactory in config.httpPlatformFilterFactories) {
     [self registerFilterFactory:filterFactory];
   }
 

--- a/library/objective-c/EnvoyEngineImpl.m
+++ b/library/objective-c/EnvoyEngineImpl.m
@@ -277,6 +277,22 @@ static void ios_http_filter_release(const void *context) {
   return [self runWithConfigYAML:resolvedYAML logLevel:logLevel onEngineRunning:onEngineRunning];
 }
 
+- (int)runWithTemplate:(NSString *)yaml
+                config:(EnvoyConfiguration *)config
+              logLevel:(NSString *)logLevel
+       onEngineRunning:(nullable void (^)())onEngineRunning {
+  NSString *resolvedYAML = [config resolveTemplate:yaml];
+  if (resolvedYAML == nil) {
+    return kEnvoyFailure;
+  }
+
+  for (EnvoyHTTPFilterFactory *filterFactory in config.httpFilterFactories) {
+    [self registerFilterFactory:filterFactory];
+  }
+
+  return [self runWithConfigYAML:resolvedYAML logLevel:logLevel onEngineRunning:onEngineRunning];
+}
+
 - (int)runWithConfigYAML:(NSString *)configYAML
                 logLevel:(NSString *)logLevel
          onEngineRunning:(nullable void (^)())onEngineRunning {

--- a/library/swift/src/EngineBuilder.swift
+++ b/library/swift/src/EngineBuilder.swift
@@ -191,12 +191,7 @@ public final class EngineBuilder: NSObject {
   /// - returns: A new instance of Envoy.
   public func build() throws -> Engine {
     let engine = self.engineType.init()
-    switch self.base {
-    case .custom(let yaml):
-      return EngineImpl(configYAML: yaml, logLevel: self.logLevel, engine: engine,
-                        onEngineRunning: self.onEngineRunning)
-    case .standard:
-      let config = EnvoyConfiguration(
+    let config = EnvoyConfiguration(
         statsDomain: self.statsDomain,
         connectTimeoutSeconds: self.connectTimeoutSeconds,
         dnsRefreshSeconds: self.dnsRefreshSeconds,
@@ -208,6 +203,12 @@ public final class EngineBuilder: NSObject {
         virtualClusters: self.virtualClusters,
         nativeFilterChain: self.nativeFilterChain,
         platformFilterChain: self.platformFilterChain)
+
+    switch self.base {
+    case .custom(let yaml):
+      return EngineImpl(yaml: yaml, config: config, logLevel: self.logLevel, engine: engine,
+                        onEngineRunning: self.onEngineRunning)
+    case .standard:
       return EngineImpl(config: config, logLevel: self.logLevel, engine: engine,
                         onEngineRunning: self.onEngineRunning)
     }

--- a/library/swift/src/EngineImpl.swift
+++ b/library/swift/src/EngineImpl.swift
@@ -9,8 +9,8 @@ final class EngineImpl: NSObject {
   private let streamClientImpl: StreamClientImpl
 
   private enum ConfigurationType {
-    case yaml(String)
-    case typed(EnvoyConfiguration)
+    case custom(String, EnvoyConfiguration)
+    case standard(EnvoyConfiguration)
   }
 
   private init(configType: ConfigurationType, logLevel: LogLevel, engine: EnvoyEngine,
@@ -22,10 +22,10 @@ final class EngineImpl: NSObject {
     super.init()
 
     switch configType {
-    case .yaml(let configYAML):
-      self.engine.run(withConfigYAML: configYAML, logLevel: logLevel.stringValue,
+    case .custom(let yaml, let config):
+      self.engine.run(withTemplate: yaml, config: config, logLevel: logLevel.stringValue,
                       onEngineRunning: onEngineRunning)
-    case .typed(let config):
+    case .standard(let config):
       self.engine.run(withConfig: config, logLevel: logLevel.stringValue,
                       onEngineRunning: onEngineRunning)
     }
@@ -41,7 +41,7 @@ final class EngineImpl: NSObject {
   convenience init(config: EnvoyConfiguration, logLevel: LogLevel = .info, engine: EnvoyEngine,
                    onEngineRunning: (() -> Void)?)
   {
-    self.init(configType: .typed(config), logLevel: logLevel, engine: engine,
+    self.init(configType: .standard(config), logLevel: logLevel, engine: engine,
               onEngineRunning: onEngineRunning)
   }
 
@@ -52,10 +52,10 @@ final class EngineImpl: NSObject {
   /// - parameter engine:          The underlying engine to use for starting Envoy.
   /// - parameter onEngineRunning: Closure called when the engine finishes its async
   ///                              initialization/startup.
-  convenience init(configYAML: String, logLevel: LogLevel = .info, engine: EnvoyEngine,
+  convenience init(yaml: String, config: EnvoyConfiguration, logLevel: LogLevel = .info, engine: EnvoyEngine,
                    onEngineRunning: (() -> Void)?)
   {
-    self.init(configType: .yaml(configYAML), logLevel: logLevel, engine: engine,
+    self.init(configType: .custom(yaml, config), logLevel: logLevel, engine: engine,
               onEngineRunning: onEngineRunning)
   }
 }

--- a/library/swift/src/EngineImpl.swift
+++ b/library/swift/src/EngineImpl.swift
@@ -9,8 +9,8 @@ final class EngineImpl: NSObject {
   private let streamClientImpl: StreamClientImpl
 
   private enum ConfigurationType {
-    case custom(String, EnvoyConfiguration)
-    case standard(EnvoyConfiguration)
+    case custom(yaml: String, config: EnvoyConfiguration)
+    case standard(config: EnvoyConfiguration)
   }
 
   private init(configType: ConfigurationType, logLevel: LogLevel, engine: EnvoyEngine,
@@ -41,13 +41,14 @@ final class EngineImpl: NSObject {
   convenience init(config: EnvoyConfiguration, logLevel: LogLevel = .info, engine: EnvoyEngine,
                    onEngineRunning: (() -> Void)?)
   {
-    self.init(configType: .standard(config), logLevel: logLevel, engine: engine,
+    self.init(configType: .standard(config: config), logLevel: logLevel, engine: engine,
               onEngineRunning: onEngineRunning)
   }
 
   /// Initialize a new Envoy instance using a string configuration.
   ///
-  /// - parameter configYAML:      Configuration yaml to use for starting Envoy.
+  /// - parameter yaml:            Template yaml to use as basis for configuration.
+  /// - parameter config:          Configuration to use for starting Envoy.
   /// - parameter logLevel:        Log level to use for this instance.
   /// - parameter engine:          The underlying engine to use for starting Envoy.
   /// - parameter onEngineRunning: Closure called when the engine finishes its async
@@ -55,7 +56,7 @@ final class EngineImpl: NSObject {
   convenience init(yaml: String, config: EnvoyConfiguration, logLevel: LogLevel = .info,
                    engine: EnvoyEngine, onEngineRunning: (() -> Void)?)
   {
-    self.init(configType: .custom(yaml, config), logLevel: logLevel, engine: engine,
+    self.init(configType: .custom(yaml: yaml, config: config), logLevel: logLevel, engine: engine,
               onEngineRunning: onEngineRunning)
   }
 }

--- a/library/swift/src/EngineImpl.swift
+++ b/library/swift/src/EngineImpl.swift
@@ -52,8 +52,8 @@ final class EngineImpl: NSObject {
   /// - parameter engine:          The underlying engine to use for starting Envoy.
   /// - parameter onEngineRunning: Closure called when the engine finishes its async
   ///                              initialization/startup.
-  convenience init(yaml: String, config: EnvoyConfiguration, logLevel: LogLevel = .info, engine: EnvoyEngine,
-                   onEngineRunning: (() -> Void)?)
+  convenience init(yaml: String, config: EnvoyConfiguration, logLevel: LogLevel = .info,
+                   engine: EnvoyEngine, onEngineRunning: (() -> Void)?)
   {
     self.init(configType: .custom(yaml, config), logLevel: logLevel, engine: engine,
               onEngineRunning: onEngineRunning)

--- a/library/swift/src/mocks/MockEnvoyEngine.swift
+++ b/library/swift/src/mocks/MockEnvoyEngine.swift
@@ -6,7 +6,7 @@ final class MockEnvoyEngine: NSObject {
   /// Closure called when `run(withConfig:)` is called.
   static var onRunWithConfig: ((_ config: EnvoyConfiguration, _ logLevel: String?) -> Void)?
   /// Closure called when `run(withConfigYAML:)` is called.
-  static var onRunWithYAML: ((_ configYAML: String, _ logLevel: String?) -> Void)?
+  static var onRunWithTemplate: ((_ template: String, _ config: EnvoyConfiguration, _ logLevel: String?) -> Void)?
   /// Closure called when `recordCounterInc(_:count:)` is called.
   static var onRecordCounter: ((_ elements: String, _ count: UInt) -> Void)?
   /// Closure called when `recordGaugeSet(_:value:)` is called.
@@ -25,10 +25,10 @@ extension MockEnvoyEngine: EnvoyEngine {
     return kEnvoySuccess
   }
 
-  func run(withConfigYAML configYAML: String, logLevel: String,
+  func run(withTemplate template: String, config: EnvoyConfiguration, logLevel: String,
            onEngineRunning: (() -> Void)?) -> Int32
   {
-    MockEnvoyEngine.onRunWithYAML?(configYAML, logLevel)
+    MockEnvoyEngine.onRunWithTemplate?(template, config, logLevel)
     return kEnvoySuccess
   }
 

--- a/library/swift/src/mocks/MockEnvoyEngine.swift
+++ b/library/swift/src/mocks/MockEnvoyEngine.swift
@@ -6,7 +6,11 @@ final class MockEnvoyEngine: NSObject {
   /// Closure called when `run(withConfig:)` is called.
   static var onRunWithConfig: ((_ config: EnvoyConfiguration, _ logLevel: String?) -> Void)?
   /// Closure called when `run(withConfigYAML:)` is called.
-  static var onRunWithTemplate: ((_ template: String, _ config: EnvoyConfiguration, _ logLevel: String?) -> Void)?
+  static var onRunWithTemplate: ((
+    _ template: String,
+    _ config: EnvoyConfiguration,
+    _ logLevel: String?
+  ) -> Void)?
   /// Closure called when `recordCounterInc(_:count:)` is called.
   static var onRecordCounter: ((_ elements: String, _ count: UInt) -> Void)?
   /// Closure called when `recordGaugeSet(_:value:)` is called.

--- a/library/swift/test/EngineBuilderTests.swift
+++ b/library/swift/test/EngineBuilderTests.swift
@@ -28,12 +28,12 @@ final class EngineBuilderTests: XCTestCase {
   override func tearDown() {
     super.tearDown()
     MockEnvoyEngine.onRunWithConfig = nil
-    MockEnvoyEngine.onRunWithYAML = nil
+    MockEnvoyEngine.onRunWithTemplate = nil
   }
 
-  func testCustomConfigYAMLUsesSpecifiedYAMLWhenRunningEnvoy() throws {
+  func testCustomConfigTemplateUsesSpecifiedYAMLWhenRunningEnvoy() throws {
     let expectation = self.expectation(description: "Run called with expected data")
-    MockEnvoyEngine.onRunWithYAML = { yaml, _ in
+    MockEnvoyEngine.onRunWithTemplate = { yaml, _, _ in
       XCTAssertEqual("foobar", yaml)
       expectation.fulfill()
     }


### PR DESCRIPTION
Description: Custom yaml will be treated as a configuration template, rather than a fixed set of configuration. It's still possible to pass fixed configuration, simply by not including any tokens for interpolation. This usage was already present and appeared supported by the API (e.g. see HttpBridgeTests), but simply wouldn't work, without any indication that it wouldn't.
Risk Level: Low
Testing: Local & CI

Signed-off-by: Mike Schore <mike.schore@gmail.com>