### PR TITLE
filters: wire JVM/Android on-cancel and on-error pathways

### DIFF
--- a/library/common/jni/jni_interface.cc
+++ b/library/common/jni/jni_interface.cc
@@ -593,6 +593,14 @@ static void* jvm_on_cancel(void* context) {
   return result;
 }
 
+static void jvm_http_filter_on_error(envoy_error error, const void* context) {
+  jvm_on_error(error, const_cast<void*>(context));
+}
+
+static void jvm_http_filter_on_cancel(const void* context) {
+  jvm_on_cancel(const_cast<void*>(context));
+}
+
 // JvmFilterFactoryContext
 
 static const void* jvm_http_filter_init(const void* context) {
@@ -692,6 +700,8 @@ Java_io_envoyproxy_envoymobile_engine_JniLibrary_registerFilterFactory(JNIEnv* e
   api->on_resume_request = jvm_http_filter_on_resume_request;
   api->set_response_callbacks = jvm_http_filter_set_response_callbacks;
   api->on_resume_response = jvm_http_filter_on_resume_response;
+  api->on_cancel = jvm_http_filter_on_cancel;
+  api->on_error = jvm_http_filter_on_error;
   api->release_filter = jni_delete_const_global_ref;
   api->static_context = retained_context;
   api->instance_context = NULL;

--- a/library/java/src/io/envoyproxy/envoymobile/engine/JvmFilterContext.java
+++ b/library/java/src/io/envoyproxy/envoymobile/engine/JvmFilterContext.java
@@ -190,7 +190,7 @@ class JvmFilterContext {
     filter.setResponseFilterCallbacks(EnvoyHTTPFilterCallbacksImpl.create(callbackHandle));
   }
 
-   /**
+  /**
    * Dispatches error received from the JNI layer up to the platform.
    *
    * @param errorCode,    the error code.

--- a/library/java/src/io/envoyproxy/envoymobile/engine/JvmFilterContext.java
+++ b/library/java/src/io/envoyproxy/envoymobile/engine/JvmFilterContext.java
@@ -190,6 +190,30 @@ class JvmFilterContext {
     filter.setResponseFilterCallbacks(EnvoyHTTPFilterCallbacksImpl.create(callbackHandle));
   }
 
+   /**
+   * Dispatches error received from the JNI layer up to the platform.
+   *
+   * @param errorCode,    the error code.
+   * @param message,      the error message.
+   * @param attemptCount, the number of times an operation was attempted before firing this error.
+   * @return Object,      not used in HTTP filters.
+   */
+  public Object onError(int errorCode, byte[] message, int attemptCount) {
+    String errorMessage = new String(message);
+    filter.onError(errorCode, errorMessage, attemptCount);
+    return null;
+  }
+
+  /**
+   * Dispatches cancellation notice up to the platform.
+   *
+   * @return Object, not used in HTTP filters.
+   */
+  public Object onCancel() {
+    filter.onCancel();
+    return null;
+  }
+
   private static byte[][] toJniHeaders(Object headers) {
     return JniBridgeUtility.toJniHeaders((Map<String, List<String>>)headers);
   }

--- a/library/java/src/io/envoyproxy/envoymobile/engine/types/EnvoyHTTPFilter.java
+++ b/library/java/src/io/envoyproxy/envoymobile/engine/types/EnvoyHTTPFilter.java
@@ -87,4 +87,21 @@ public interface EnvoyHTTPFilter {
    */
   Object[] onResumeResponse(Map<String, List<String>> headers, ByteBuffer data,
                             Map<String, List<String>> trailers, boolean endStream);
+
+  /**
+   * Called when the async HTTP stream has an error.
+   *
+   * @param errorCode,    the error code.
+   * @param message,      the error message.
+   * @param attemptCount, the number of times an operation was attempted before firing this error.
+   *                      -1 is used in scenarios where it does not make sense to have an attempt
+   *                      count for an error. This is different from 0, which intentionally conveys
+   *                      that the action was _not_ executed.
+   */
+  void onError(int errorCode, String message, int attemptCount);
+
+  /**
+   * Called when the async HTTP stream is canceled.
+   */
+  void onCancel();
 }

--- a/library/kotlin/src/io/envoyproxy/envoymobile/filters/Filter.kt
+++ b/library/kotlin/src/io/envoyproxy/envoymobile/filters/Filter.kt
@@ -97,6 +97,18 @@ internal class EnvoyHTTPFilterAdapter(
     return arrayOf(0, trailers)
   }
 
+  override fun onError(errorCode: Int, message: String, attemptCount: Int) {
+    (filter as? ResponseFilter)?.let { responseFilter ->
+      responseFilter.onError(EnvoyError(errorCode, message, attemptCount))
+    }
+  }
+
+  override fun onCancel() {
+    (filter as? ResponseFilter)?.let { responseFilter ->
+      responseFilter.onCancel()
+    }
+  }
+
   override fun setRequestFilterCallbacks(callbacks: EnvoyHTTPFilterCallbacks) {
     (filter as? AsyncRequestFilter)?.let { asyncRequestFilter ->
       asyncRequestFilter.setRequestFilterCallbacks(RequestFilterCallbacksImpl(callbacks))


### PR DESCRIPTION
Description: Adds JVM/Android wiring for on-cancel and on-error filter invocations.
Risk Level: Moderate
Testing: Pending

Signed-off-by: Mike Schore <mike.schore@gmail.com>