### PR TITLE
filters: dispatch on-error invocations from PlatformBridgeFilter

### DIFF
--- a/library/common/extensions/filters/http/platform_bridge/BUILD
+++ b/library/common/extensions/filters/http/platform_bridge/BUILD
@@ -23,6 +23,7 @@ envoy_cc_library(
         "//library/common/api:external_api_lib",
         "//library/common/buffer:utility_lib",
         "//library/common/http:header_utility_lib",
+        "//library/common/http:internal_headers_lib",
         "//library/common/types:c_types_lib",
         "@envoy//include/envoy/http:filter_interface",
         "@envoy//source/common/common:minimal_logger_lib",

--- a/library/common/extensions/filters/http/platform_bridge/filter.cc
+++ b/library/common/extensions/filters/http/platform_bridge/filter.cc
@@ -351,7 +351,8 @@ Http::FilterHeadersStatus PlatformBridgeFilter::encodeHeaders(Http::ResponseHead
     }
 
     if (platform_filter_.on_error) {
-      platform_filter_.on_error({error_code, error_message, attempt_count}, platform_filter_.instance_context);
+      platform_filter_.on_error({error_code, error_message, attempt_count},
+                                platform_filter_.instance_context);
     }
     error_response_ = true;
     return Http::FilterHeadersStatus::Continue;

--- a/library/common/extensions/filters/http/platform_bridge/filter.cc
+++ b/library/common/extensions/filters/http/platform_bridge/filter.cc
@@ -11,6 +11,7 @@
 #include "library/common/buffer/utility.h"
 #include "library/common/extensions/filters/http/platform_bridge/c_type_definitions.h"
 #include "library/common/http/header_utility.h"
+#include "library/common/http/headers.h"
 
 namespace Envoy {
 namespace Extensions {
@@ -327,6 +328,35 @@ Http::FilterHeadersStatus PlatformBridgeFilter::encodeHeaders(Http::ResponseHead
                                                               bool end_stream) {
   ENVOY_LOG(trace, "PlatformBridgeFilter({})::encodeHeaders", filter_name_);
 
+  // Presence of internal error header indicates an error that should be surfaced as an
+  // error callback (rather than an HTTP response).
+  const auto error_code_header = headers.get(Http::InternalHeaders::get().ErrorCode);
+  if (!error_code_header.empty()) {
+    envoy_error_code_t error_code;
+    bool parsed_code = absl::SimpleAtoi(error_code_header[0]->value().getStringView(), &error_code);
+    RELEASE_ASSERT(parsed_code, "parse error reading error code");
+
+    envoy_data error_message = envoy_nodata;
+    const auto error_message_header = headers.get(Http::InternalHeaders::get().ErrorMessage);
+    if (!error_message_header.empty()) {
+      error_message =
+          Buffer::Utility::copyToBridgeData(error_message_header[0]->value().getStringView());
+    }
+
+    int32_t attempt_count;
+    if (headers.EnvoyAttemptCount()) {
+      bool parsed_attempts =
+          absl::SimpleAtoi(headers.EnvoyAttemptCount()->value().getStringView(), &attempt_count);
+      RELEASE_ASSERT(parsed_attempts, "parse error reading attempt count");
+    }
+
+    if (platform_filter_.on_error) {
+      platform_filter_.on_error({error_code, error_message, attempt_count}, platform_filter_.instance_context);
+    }
+    error_response_ = true;
+    return Http::FilterHeadersStatus::Continue;
+  }
+
   // Delegate to shared implementation for request and response path.
   auto status = onHeaders(headers, end_stream, platform_filter_.on_response_headers);
   if (status == Http::FilterHeadersStatus::StopIteration) {
@@ -355,6 +385,11 @@ Http::FilterDataStatus PlatformBridgeFilter::decodeData(Buffer::Instance& data, 
 
 Http::FilterDataStatus PlatformBridgeFilter::encodeData(Buffer::Instance& data, bool end_stream) {
   ENVOY_LOG(trace, "PlatformBridgeFilter({})::encodeData", filter_name_);
+
+  // Pass through if already mapped to error response.
+  if (error_response_) {
+    return Http::FilterDataStatus::Continue;
+  }
 
   // Delegate to shared implementation for request and response path.
   Buffer::Instance* internal_buffer = nullptr;
@@ -393,6 +428,11 @@ Http::FilterTrailersStatus PlatformBridgeFilter::decodeTrailers(Http::RequestTra
 Http::FilterTrailersStatus
 PlatformBridgeFilter::encodeTrailers(Http::ResponseTrailerMap& trailers) {
   ENVOY_LOG(trace, "PlatformBridgeFilter({})::encodeTrailers", filter_name_);
+
+  // Pass through if already mapped to error response.
+  if (error_response_) {
+    return Http::FilterTrailersStatus::Continue;
+  }
 
   // Delegate to shared implementation for request and response path.
   Buffer::Instance* internal_buffer = nullptr;

--- a/library/common/extensions/filters/http/platform_bridge/filter.h
+++ b/library/common/extensions/filters/http/platform_bridge/filter.h
@@ -113,6 +113,7 @@ private:
   envoy_http_filter platform_filter_;
   envoy_http_filter_callbacks platform_request_callbacks_{};
   envoy_http_filter_callbacks platform_response_callbacks_{};
+  bool error_response_{};
   bool request_complete_{};
   bool response_complete_{};
 };

--- a/library/swift/test/HttpBridgeTests/ReceiveErrorTest.swift
+++ b/library/swift/test/HttpBridgeTests/ReceiveErrorTest.swift
@@ -6,7 +6,9 @@ import XCTest
 final class ReceiveErrorTests: XCTestCase {
   func testReceiveError() throws {
     // swiftlint:disable:next line_length
-    let apiListenerType = "type.googleapis.com/envoy.extensions.filters.network.http_connection_manager.v3.HttpConnectionManager"
+    let hcmType = "type.googleapis.com/envoy.extensions.filters.network.http_connection_manager.v3.HttpConnectionManager"
+    // swiftlint:disable:next line_length
+    let pbfType = "type.googleapis.com/envoymobile.extensions.filters.http.platform_bridge.PlatformBridge"
     // swiftlint:disable:next line_length
     let localErrorFilterType = "type.googleapis.com/envoymobile.extensions.filters.http.local_error.LocalError"
     let config =
@@ -15,37 +17,67 @@ final class ReceiveErrorTests: XCTestCase {
       listeners:
       - name: base_api_listener
         address:
-          socket_address:
-            protocol: TCP
-            address: 0.0.0.0
-            port_value: 10000
+          socket_address: { protocol: TCP, address: 0.0.0.0, port_value: 10000 }
         api_listener:
           api_listener:
-            "@type": \(apiListenerType)
+            "@type": \(hcmType)
             stat_prefix: hcm
             route_config:
               name: api_router
               virtual_hosts:
-                - name: api
-                  domains:
-                    - "*"
-                  routes:
-                    - match:
-                        prefix: "/"
-                      direct_response:
-                        status: 503
+              - name: api
+                domains: ["*"]
+                routes:
+                - match: { prefix: "/" }
+                  direct_response: { status: 503 }
             http_filters:
-              - name: envoy.filters.http.local_error
-                typed_config:
-                  "@type": \(localErrorFilterType)
-              - name: envoy.router
-                typed_config:
-                  "@type": type.googleapis.com/envoy.extensions.filters.http.router.v3.Router
+            - name: envoy.filters.http.platform_bridge
+              typed_config:
+                "@type": \(pbfType)
+                platform_filter_name: error_validation_filter
+            - name: envoy.filters.http.local_error
+              typed_config:
+                "@type": \(localErrorFilterType)
+            - name: envoy.router
+              typed_config:
+                "@type": type.googleapis.com/envoy.extensions.filters.http.router.v3.Router
     """
-    let expectation = self.expectation(description: "Run called with expected error")
+
+    struct ErrorValidationFilter: ResponseFilter {
+      let expectation: XCTestExpectation
+
+      func onResponseHeaders(_ headers: ResponseHeaders, endStream: Bool)
+        -> FilterHeadersStatus<ResponseHeaders>
+      {
+        return .continue(headers: headers)
+      }
+
+      func onResponseData(_ body: Data, endStream: Bool) -> FilterDataStatus<ResponseHeaders> {
+        return .continue(data: body)
+      }
+
+      func onResponseTrailers(_ trailers: ResponseTrailers)
+          -> FilterTrailersStatus<ResponseHeaders, ResponseTrailers> {
+        return .continue(trailers: trailers)
+      }
+
+      func onError(_ error: EnvoyError) {
+        XCTAssertEqual(error.errorCode, 2) // 503/Connection Failure
+        self.expectation.fulfill()
+      }
+
+      func onCancel() {}
+    }
+
+    let runExpectation = self.expectation(description: "Run called with expected error")
+    let filterExpectation = self.expectation(description: "Filter called with expected error")
+
     let client = try EngineBuilder(yaml: config)
-      .addLogLevel(.debug)
-      .addPlatformFilter(factory: DemoFilter.init)
+      .addLogLevel(.trace)
+      .addPlatformFilter(
+        name: "error_validation_filter",
+        factory: { ErrorValidationFilter(expectation: filterExpectation) }
+      )
       .build()
       .streamClient()
 
@@ -53,6 +85,7 @@ final class ReceiveErrorTests: XCTestCase {
                                                authority: "example.com", path: "/test")
       .addUpstreamHttpProtocol(.http2)
       .build()
+
     client
       .newStreamPrototype()
       .setOnResponseHeaders { _, _ in
@@ -65,11 +98,11 @@ final class ReceiveErrorTests: XCTestCase {
       // an error.
       .setOnError { error in
          XCTAssertEqual(error.errorCode, 2) // 503/Connection Failure
-         expectation.fulfill()
+         runExpectation.fulfill()
       }
       .start()
       .sendHeaders(requestHeaders, endStream: true)
 
-    XCTAssertEqual(XCTWaiter.wait(for: [expectation], timeout: 1), .completed)
+    XCTAssertEqual(XCTWaiter.wait(for: [filterExpectation, runExpectation], timeout: 1), .completed)
   }
 }


### PR DESCRIPTION
Description: Leverages the LocalErrorFilter to provide on-error invocations for platform filters.
Risk Level: Moderate
Testing: Integration test & manual

Signed-off-by: Mike Schore <mike.schore@gmail.com>
