### PR TITLE
tooling: allow for target path to be passed to check_format.py

### DIFF
--- a/tools/check_format.sh
+++ b/tools/check_format.sh
@@ -8,10 +8,12 @@ if [ -z "$ENVOY_FORMAT_ACTION" ]; then
   ENVOY_FORMAT_ACTION="check"
 fi
 
+TARGET_PATH="$2"
+
 # TODO(mattklein123): WORKSPACE is excluded due to warning about @bazel_tools reference. Fix here
 #                     or in the upstream checker.
 ENVOY_BAZEL_PREFIX=@envoy envoy/tools/code_format/check_format.py \
     --add-excluded-prefixes ./envoy/ ./envoy_build_config/extensions_build_config.bzl ./WORKSPACE ./dist/Envoy.framework/ ./library/common/config_template.cc ./bazel/envoy_mobile_swift_bazel_support.bzl ./bazel/envoy_mobile_repositories.bzl \
-    --skip_envoy_build_rule_check "$ENVOY_FORMAT_ACTION" \
+    --skip_envoy_build_rule_check "$ENVOY_FORMAT_ACTION" $TARGET_PATH \
     --namespace_check_excluded_paths ./examples/ ./library/java/ ./library/kotlin ./library/objective-c \
     --build_fixer_check_excluded_paths ./BUILD ./dist ./examples ./library/java ./library/kotlin ./library/objective-c ./library/swift ./library/common/extensions


### PR DESCRIPTION
Description: Allows the target path parameter to be passed through to `check_format.py`

Risk Level: Low

Testing:

- Manual testing, a la `./tools/check_format.sh check` and `./tools/check_format.sh check library/common` to check that it works with and w/o a path
- Will be run as part of normal format check during PR, so any incompatibilities w/ CI setup will be bubbled up

Docs Changes: N/A

Release Notes: N/A