### PR TITLE
ios: split comma-delimited header values when creating platform representation

### DIFF
--- a/library/objective-c/EnvoyBridgeUtility.h
+++ b/library/objective-c/EnvoyBridgeUtility.h
@@ -91,8 +91,7 @@ static inline EnvoyHeaders *to_ios_headers(envoy_headers headers) {
     }
 
     // By convention, these headers disregard the RFC and contain commas single values.
-    if (headerKey == @"set-cookie" ||
-        headerKey == @"www-authenticate" ||
+    if (headerKey == @"set-cookie" || headerKey == @"www-authenticate" ||
         headerKey == @"proxy-authenticate") {
       [headerValueList addObject:headerValue];
     } else {
@@ -100,7 +99,7 @@ static inline EnvoyHeaders *to_ios_headers(envoy_headers headers) {
       NSArray *newValueList = [headerValue componentsSeparatedByString:@","];
       for (NSString *value in newValueList) {
         NSString *trimmedValue =
-          [value stringByTrimmingCharactersInSet:[NSCharacterSet whitespaceCharacterSet]];
+            [value stringByTrimmingCharactersInSet:[NSCharacterSet whitespaceCharacterSet]];
         [headerValueList addObject:trimmedValue];
       }
     }

--- a/library/objective-c/EnvoyBridgeUtility.h
+++ b/library/objective-c/EnvoyBridgeUtility.h
@@ -90,9 +90,11 @@ static inline EnvoyHeaders *to_ios_headers(envoy_headers headers) {
       headerDict[headerKey] = headerValueList;
     }
 
-    // By convention, these headers disregard the RFC and contain commas single values.
-    if (headerKey == @"set-cookie" || headerKey == @"www-authenticate" ||
-        headerKey == @"proxy-authenticate") {
+    // These headers may contain commas in single values, in contravention of the RFC.
+    if ([headerKey caseInsensitiveCompare:@"cookie"] == NSOrderedSame ||
+        [headerKey caseInsensitiveCompare:@"proxy-authenticate"] == NSOrderedSame ||
+        [headerKey caseInsensitiveCompare:@"set-cookie"] == NSOrderedSame ||
+        [headerKey caseInsensitiveCompare:@"www-authenticate"] == NSOrderedSame) {
       [headerValueList addObject:headerValue];
     } else {
       // Add trimmed, comma-separated values as individual members of the list.


### PR DESCRIPTION
Description: Splits list-formatted header value on creation of header maps.  Per RFC 7230, does not perform this parsing on "set-cookie" headers, and additionally skips it on "www-authenticate" and "proxy-authenticate", due to their potential to contain commas in contravention of the spec.
Risk Level: Low
Testing: Pending

Signed-off-by: Mike Schore <mike.schore@gmail.com>