### PR TITLE
android: split comma-delimited header values when creating platform representation

### DIFF
--- a/library/java/src/io/envoyproxy/envoymobile/engine/JvmBridgeUtility.java
+++ b/library/java/src/io/envoyproxy/envoymobile/engine/JvmBridgeUtility.java
@@ -53,8 +53,7 @@ class JvmBridgeUtility {
     }
 
     // By convention, these headers disregard the RFC and contain commas single values.
-    if (headerKey.equals("set-cookie") ||
-        headerKey.equals("www-authenticate") ||
+    if (headerKey.equals("set-cookie") || headerKey.equals("www-authenticate") ||
         headerKey.equals("proxy-authenticate")) {
       values.add(headerValue);
     } else {

--- a/library/java/src/io/envoyproxy/envoymobile/engine/JvmBridgeUtility.java
+++ b/library/java/src/io/envoyproxy/envoymobile/engine/JvmBridgeUtility.java
@@ -45,12 +45,26 @@ class JvmBridgeUtility {
       throw new RuntimeException(e);
     }
 
+    // Ensure list is present in dictionary value
     List<String> values = headerAccumulator.get(headerKey);
     if (values == null) {
       values = new ArrayList(1);
       headerAccumulator.put(headerKey, values);
     }
-    values.add(headerValue);
+
+    // By convention, these headers disregard the RFC and contain commas single values.
+    if (headerKey.equals("set-cookie") ||
+        headerKey.equals("www-authenticate") ||
+        headerKey.equals("proxy-authenticate")) {
+      values.add(headerValue);
+    } else {
+      // Add trimmed, comma-separated values as individual members of the list.
+      String[] newValues = headerValue.split(",");
+      for (int i = 0; i < newValues.length; i++) {
+        values.add(newValues[i].trim());
+      }
+    }
+
     headerCount++;
   }
 

--- a/library/java/src/io/envoyproxy/envoymobile/engine/JvmBridgeUtility.java
+++ b/library/java/src/io/envoyproxy/envoymobile/engine/JvmBridgeUtility.java
@@ -52,9 +52,9 @@ class JvmBridgeUtility {
       headerAccumulator.put(headerKey, values);
     }
 
-    // By convention, these headers disregard the RFC and contain commas single values.
-    if (headerKey.equals("set-cookie") || headerKey.equals("www-authenticate") ||
-        headerKey.equals("proxy-authenticate")) {
+    // These headers may contain commas in single values, in contravention of the RFC.
+    if (headerKey.equals("cookie") || headerKey.equals("proxy-authenticate") ||
+        headerKey.equals("set-cookie") || headerKey.equals("www-authenticate")) {
       values.add(headerValue);
     } else {
       // Add trimmed, comma-separated values as individual members of the list.

--- a/library/java/test/io/envoyproxy/envoymobile/engine/JvmBridgeUtilityTest.kt
+++ b/library/java/test/io/envoyproxy/envoymobile/engine/JvmBridgeUtilityTest.kt
@@ -24,6 +24,23 @@ class JvmBridgeUtilityTest {
   }
 
   @Test
+  fun `retrieveHeaders splits list-encoded header values when producing the Map`() {
+    val utility = JvmBridgeUtility()
+    utility.passHeader("test-0".toByteArray(), "value-0".toByteArray(), true)
+    utility.passHeader("test-1".toByteArray(), "value-1, value-2".toByteArray(), false)
+
+    val headers = utility.retrieveHeaders()
+    val expectedHeaders = mapOf(
+      "test-0" to listOf("value-0"),
+      "test-1" to listOf("value-1", "value-2")
+    )
+
+    assertThat(headers)
+      .hasSize(2) // Two keys / header name
+      .usingRecursiveComparison().isEqualTo(expectedHeaders)
+  }
+
+  @Test
   fun `validateCount checks if the expected number of header values in the map matches the actual`() {
     val utility = JvmBridgeUtility()
     assertThat(utility.validateCount(1)).isFalse()


### PR DESCRIPTION
Description: Splits list-formatted header value on creation of header maps.  Per RFC 7230, does not perform this parsing on "set-cookie" headers, and additionally skips it on "www-authenticate" and "proxy-authenticate", due to their potential to contain commas in contravention of the spec.
Risk Level: Low
Testing: Pending

Signed-off-by: Mike Schore <mike.schore@gmail.com>
