### PR TITLE
test: set up objc unit tests

### DIFF
--- a/bazel/apple_test.bzl
+++ b/bazel/apple_test.bzl
@@ -44,9 +44,7 @@ def envoy_mobile_objc_test(name, srcs, data = [], deps = []):
         name = test_lib_name,
         srcs = srcs,
         data = data,
-        deps = [
-            "//library/swift:ios_framework_archive",
-        ] + deps,
+        deps = deps,
         visibility = ["//visibility:private"],
     )
 

--- a/bazel/apple_test.bzl
+++ b/bazel/apple_test.bzl
@@ -1,5 +1,6 @@
 load("@build_bazel_rules_apple//apple:ios.bzl", "ios_unit_test")
 load("@build_bazel_rules_swift//swift:swift.bzl", "swift_library")
+load("@rules_cc//cc:defs.bzl", "objc_library")
 
 # Macro providing a way to easily/consistently define Swift unit test targets.
 #
@@ -8,7 +9,7 @@ load("@build_bazel_rules_swift//swift:swift.bzl", "swift_library")
 # - Sets default visibility and OS requirements
 #
 # Usage example:
-# load("@envoy_mobile//bazel:swift_test.bzl", "envoy_mobile_swift_test")
+# load("@envoy_mobile//bazel:apple_test.bzl", "envoy_mobile_swift_test")
 #
 # envoy_mobile_swift_test(
 #     name = "sample_test",
@@ -27,6 +28,25 @@ def envoy_mobile_swift_test(name, srcs, data = [], deps = []):
             "//library/swift:ios_framework_archive",
         ] + deps,
         linkopts = ["-lresolv.9"],
+        visibility = ["//visibility:private"],
+    )
+
+    ios_unit_test(
+        name = name,
+        data = data,
+        deps = [test_lib_name],
+        minimum_os_version = "11.0",
+    )
+
+def envoy_mobile_objc_test(name, srcs, data = [], deps = []):
+    test_lib_name = name + "_lib"
+    objc_library(
+        name = test_lib_name,
+        srcs = srcs,
+        data = data,
+        deps = [
+            "//library/swift:ios_framework_archive",
+        ] + deps,
         visibility = ["//visibility:private"],
     )
 

--- a/experimental/swift/BUILD
+++ b/experimental/swift/BUILD
@@ -1,4 +1,4 @@
-load("@envoy_mobile//bazel:swift_test.bzl", "envoy_mobile_swift_test")
+load("@envoy_mobile//bazel:apple_test.bzl", "envoy_mobile_swift_test")
 
 licenses(["notice"])  # Apache 2
 

--- a/library/objective-c/BUILD
+++ b/library/objective-c/BUILD
@@ -40,6 +40,7 @@ objc_library(
 objc_library(
     name = "envoy_objc_bridge_lib",
     hdrs = ["EnvoyBridgeUtility.h"],
+    visibility = ["//visibility:public"],
     deps = [
         "//library/common/types:c_types_lib",
     ],

--- a/test/objective-c/BUILD
+++ b/test/objective-c/BUILD
@@ -1,0 +1,13 @@
+load("@envoy_mobile//bazel:apple_test.bzl", "envoy_mobile_objc_test")
+
+licenses(["notice"])  # Apache 2
+
+envoy_mobile_objc_test(
+    name = "envoy_bridge_utility_test",
+    srcs = [
+        "EnvoyBridgeUtilityTest.m",
+    ],
+    deps = [
+        "//library/objective-c:envoy_objc_bridge_lib"
+    ],
+)

--- a/test/objective-c/BUILD
+++ b/test/objective-c/BUILD
@@ -8,6 +8,6 @@ envoy_mobile_objc_test(
         "EnvoyBridgeUtilityTest.m",
     ],
     deps = [
-        "//library/objective-c:envoy_objc_bridge_lib"
+        "//library/objective-c:envoy_objc_bridge_lib",
     ],
 )

--- a/test/objective-c/EnvoyBridgeUtilityTest.m
+++ b/test/objective-c/EnvoyBridgeUtilityTest.m
@@ -1,0 +1,20 @@
+#import <XCTest/XCTest.h>
+
+@interface EnvoyBridgeUtilityTest : XCTestCase
+@end
+
+@implementation EnvoyBridgeUtilityTest
+
+- (void)setUp {
+  [super setUp];
+}
+
+- (void)tearDown {
+  [super tearDown];
+}
+
+- (void)testExample {
+  XCTFail(@"This should fail");
+}
+
+@end

--- a/test/objective-c/EnvoyBridgeUtilityTest.m
+++ b/test/objective-c/EnvoyBridgeUtilityTest.m
@@ -1,5 +1,11 @@
 #import <XCTest/XCTest.h>
 
+typedef NSDictionary<NSString *, NSArray<NSString *> *> EnvoyHeaders;
+
+typedef NSDictionary<NSString *, NSString *> EnvoyTags;
+
+#import "library/objective-c/EnvoyBridgeUtility.h"
+
 @interface EnvoyBridgeUtilityTest : XCTestCase
 @end
 
@@ -13,8 +19,11 @@
   [super tearDown];
 }
 
-- (void)testExample {
-  XCTFail(@"This should fail");
+- (void)testToNativeData {
+  NSString *testString = @"abc";
+  NSData *testData = [testString dataUsingEncoding:NSUTF8StringEncoding];
+  envoy_data nativeData = toNativeData(testData);
+  XCTAssertTrue(memcmp(nativeData.bytes, testData.bytes, 3) == 0);
 }
 
 @end

--- a/test/objective-c/EnvoyBridgeUtilityTest.m
+++ b/test/objective-c/EnvoyBridgeUtilityTest.m
@@ -11,19 +11,11 @@ typedef NSDictionary<NSString *, NSString *> EnvoyTags;
 
 @implementation EnvoyBridgeUtilityTest
 
-- (void)setUp {
-  [super setUp];
-}
-
-- (void)tearDown {
-  [super tearDown];
-}
-
 - (void)testToNativeData {
   NSString *testString = @"abc";
   NSData *testData = [testString dataUsingEncoding:NSUTF8StringEncoding];
   envoy_data nativeData = toNativeData(testData);
-  XCTAssertTrue(memcmp(nativeData.bytes, testData.bytes, 3) == 0);
+  XCTAssertEqual(memcmp(nativeData.bytes, testData.bytes, 3), 0);
 }
 
 @end

--- a/test/swift/BUILD
+++ b/test/swift/BUILD
@@ -1,4 +1,4 @@
-load("@envoy_mobile//bazel:swift_test.bzl", "envoy_mobile_swift_test")
+load("@envoy_mobile//bazel:apple_test.bzl", "envoy_mobile_swift_test")
 
 licenses(["notice"])  # Apache 2
 

--- a/test/swift/integration/BUILD
+++ b/test/swift/integration/BUILD
@@ -1,4 +1,4 @@
-load("@envoy_mobile//bazel:swift_test.bzl", "envoy_mobile_swift_test")
+load("@envoy_mobile//bazel:apple_test.bzl", "envoy_mobile_swift_test")
 
 licenses(["notice"])  # Apache 2
 

--- a/test/swift/stats/BUILD
+++ b/test/swift/stats/BUILD
@@ -1,4 +1,4 @@
-load("@envoy_mobile//bazel:swift_test.bzl", "envoy_mobile_swift_test")
+load("@envoy_mobile//bazel:apple_test.bzl", "envoy_mobile_swift_test")
 
 licenses(["notice"])  # Apache 2
 


### PR DESCRIPTION
Description: Adds requisite setup for objective-c unit tests, and a single example for EnvoyBridgeUtility. Fixes #1280
Risk Level: Low
Testing: Local and CI

Signed-off-by: Mike Schore <mike.schore@gmail.com>
