### PR TITLE
python: implement stream-related classes

### DIFF
--- a/library/cc/BUILD
+++ b/library/cc/BUILD
@@ -6,6 +6,12 @@ envoy_package()
 
 envoy_cc_library(
     name = "envoy_engine_cc_lib",
+    srcs = [
+        "stream.cc",
+        "stream_callbacks.cc",
+        "stream_client.cc",
+        "stream_prototype.cc",
+    ],
     hdrs = [
         "bridge_utility.h",
         "engine.h",

--- a/library/cc/stream.cc
+++ b/library/cc/stream.cc
@@ -1,0 +1,41 @@
+#include "stream.h"
+
+#include <iostream>
+
+#include "bridge_utility.h"
+#include "library/common/main_interface.h"
+#include "library/common/types/c_types.h"
+
+namespace Envoy {
+namespace Platform {
+
+Stream::Stream(envoy_stream_t handle, EnvoyHttpCallbacksAdapterSharedPtr adapter)
+    : handle_(handle), adapter_(adapter) {}
+
+Stream& Stream::send_headers(RequestHeadersSharedPtr headers, bool end_stream) {
+  envoy_headers raw_headers = raw_headers_as_envoy_headers(headers->all_headers());
+  ::send_headers(this->handle_, raw_headers, end_stream);
+  return *this;
+}
+
+Stream& Stream::send_data(const std::vector<uint8_t>& data) {
+  envoy_data raw_data = buffer_as_envoy_data(data);
+  ::send_data(this->handle_, raw_data, false);
+  return *this;
+}
+
+void Stream::close(RequestTrailersSharedPtr trailers) {
+  envoy_status_t send_trailers(envoy_stream_t stream, envoy_headers trailers);
+  envoy_headers raw_headers = raw_headers_as_envoy_headers(trailers->all_headers());
+  ::send_trailers(this->handle_, raw_headers);
+}
+
+void Stream::close(const std::vector<uint8_t>& data) {
+  envoy_data raw_data = buffer_as_envoy_data(data);
+  ::send_data(this->handle_, raw_data, true);
+}
+
+void Stream::cancel() { reset_stream(this->handle_); }
+
+} // namespace Platform
+} // namespace Envoy

--- a/library/cc/stream.cc
+++ b/library/cc/stream.cc
@@ -13,26 +13,24 @@ Stream::Stream(envoy_stream_t handle, EnvoyHttpCallbacksAdapterSharedPtr adapter
     : handle_(handle), adapter_(adapter) {}
 
 Stream& Stream::send_headers(RequestHeadersSharedPtr headers, bool end_stream) {
-  envoy_headers raw_headers = raw_headers_as_envoy_headers(headers->all_headers());
+  envoy_headers raw_headers = raw_header_map_as_envoy_headers(headers->all_headers());
   ::send_headers(this->handle_, raw_headers, end_stream);
   return *this;
 }
 
-Stream& Stream::send_data(const std::vector<uint8_t>& data) {
-  envoy_data raw_data = buffer_as_envoy_data(data);
-  ::send_data(this->handle_, raw_data, false);
+Stream& Stream::send_data(envoy_data data) {
+  ::send_data(this->handle_, data, false);
   return *this;
 }
 
 void Stream::close(RequestTrailersSharedPtr trailers) {
   envoy_status_t send_trailers(envoy_stream_t stream, envoy_headers trailers);
-  envoy_headers raw_headers = raw_headers_as_envoy_headers(trailers->all_headers());
+  envoy_headers raw_headers = raw_header_map_as_envoy_headers(trailers->all_headers());
   ::send_trailers(this->handle_, raw_headers);
 }
 
-void Stream::close(const std::vector<uint8_t>& data) {
-  envoy_data raw_data = buffer_as_envoy_data(data);
-  ::send_data(this->handle_, raw_data, true);
+void Stream::close(envoy_data data) {
+  ::send_data(this->handle_, data, true);
 }
 
 void Stream::cancel() { reset_stream(this->handle_); }

--- a/library/cc/stream.cc
+++ b/library/cc/stream.cc
@@ -29,9 +29,7 @@ void Stream::close(RequestTrailersSharedPtr trailers) {
   ::send_trailers(this->handle_, raw_headers);
 }
 
-void Stream::close(envoy_data data) {
-  ::send_data(this->handle_, data, true);
-}
+void Stream::close(envoy_data data) { ::send_data(this->handle_, data, true); }
 
 void Stream::cancel() { reset_stream(this->handle_); }
 

--- a/library/cc/stream_callbacks.cc
+++ b/library/cc/stream_callbacks.cc
@@ -1,0 +1,100 @@
+#include "stream_callbacks.h"
+
+#include "bridge_utility.h"
+#include "response_headers_builder.h"
+#include "response_trailers_builder.h"
+
+namespace Envoy {
+namespace Platform {
+
+EnvoyHttpCallbacksAdapter::EnvoyHttpCallbacksAdapter(ExecutorSharedPtr executor,
+                                                     StreamCallbacksSharedPtr callbacks)
+    : executor_(executor), stream_callbacks_(callbacks) {}
+
+envoy_http_callbacks EnvoyHttpCallbacksAdapter::as_envoy_http_callbacks() {
+  envoy_http_callbacks callbacks{
+      .on_headers = &EnvoyHttpCallbacksAdapter::dispatch_on_headers,
+      .on_data = &EnvoyHttpCallbacksAdapter::dispatch_on_data,
+      // on_metadata is not used
+      .on_trailers = &EnvoyHttpCallbacksAdapter::dispatch_on_trailers,
+      .on_error = &EnvoyHttpCallbacksAdapter::dispatch_on_error,
+      .on_complete = &EnvoyHttpCallbacksAdapter::dispatch_on_complete,
+      .on_cancel = &EnvoyHttpCallbacksAdapter::dispatch_on_cancel,
+      .context = this,
+  };
+  return callbacks;
+}
+
+void* EnvoyHttpCallbacksAdapter::dispatch_on_headers(envoy_headers headers, bool end_stream,
+                                                     void* context) {
+  auto self = static_cast<EnvoyHttpCallbacksAdapter*>(context);
+  if (self->stream_callbacks_->on_headers.has_value()) {
+    auto raw_headers = envoy_headers_as_raw_headers(headers);
+    ResponseHeadersBuilder builder;
+    for (const auto& pair : raw_headers) {
+      if (pair.first == ":status") {
+        builder.add_http_status(std::stoi(pair.second[0]));
+      }
+      builder.set(pair.first, pair.second);
+    }
+    self->executor_->execute(
+        [=]() { self->stream_callbacks_->on_headers.value()(builder.build(), end_stream); });
+  }
+  return context;
+}
+
+void* EnvoyHttpCallbacksAdapter::dispatch_on_data(envoy_data data, bool end_stream, void* context) {
+  auto self = static_cast<EnvoyHttpCallbacksAdapter*>(context);
+  if (self->stream_callbacks_->on_error.has_value()) {
+    auto buffer = envoy_data_as_buffer(data);
+    self->executor_->execute(
+        [=]() { self->stream_callbacks_->on_data.value()(buffer, end_stream); });
+  }
+  return context;
+}
+
+void* EnvoyHttpCallbacksAdapter::dispatch_on_trailers(envoy_headers metadata, void* context) {
+  auto self = static_cast<EnvoyHttpCallbacksAdapter*>(context);
+  if (self->stream_callbacks_->on_trailers.has_value()) {
+    auto raw_headers = envoy_headers_as_raw_headers(metadata);
+    ResponseTrailersBuilder builder;
+    for (const auto& pair : raw_headers) {
+      builder.set(pair.first, pair.second);
+    }
+    self->executor_->execute(
+        [=]() { self->stream_callbacks_->on_trailers.value()(builder.build()); });
+  }
+  return context;
+}
+
+void* EnvoyHttpCallbacksAdapter::dispatch_on_error(envoy_error raw_error, void* context) {
+  auto self = static_cast<EnvoyHttpCallbacksAdapter*>(context);
+  if (self->stream_callbacks_->on_error.has_value()) {
+    EnvoyErrorSharedPtr error = std::make_shared<EnvoyError>();
+    error->error_code = raw_error.error_code;
+    error->message = envoy_data_as_string(raw_error.message);
+    error->attempt_count = absl::optional<int>(raw_error.attempt_count);
+
+    self->executor_->execute([=]() { self->stream_callbacks_->on_error.value()(error); });
+  }
+  return context;
+}
+
+void* EnvoyHttpCallbacksAdapter::dispatch_on_complete(void* context) {
+  auto self = static_cast<EnvoyHttpCallbacksAdapter*>(context);
+  if (self->stream_callbacks_->on_complete.has_value()) {
+    self->executor_->execute(self->stream_callbacks_->on_complete.value());
+  }
+  return context;
+}
+
+void* EnvoyHttpCallbacksAdapter::dispatch_on_cancel(void* context) {
+  auto self = static_cast<EnvoyHttpCallbacksAdapter*>(context);
+  if (self->stream_callbacks_->on_cancel.has_value()) {
+    self->executor_->execute(self->stream_callbacks_->on_cancel.value());
+  }
+  return context;
+}
+
+} // namespace Platform
+} // namespace Envoy

--- a/library/cc/stream_callbacks.cc
+++ b/library/cc/stream_callbacks.cc
@@ -25,7 +25,7 @@ envoy_http_callbacks EnvoyHttpCallbacksAdapter::as_envoy_http_callbacks() {
 }
 
 void* EnvoyHttpCallbacksAdapter::c_on_headers(envoy_headers headers, bool end_stream,
-                                                     void* context) {
+                                              void* context) {
   auto self = static_cast<EnvoyHttpCallbacksAdapter*>(context);
   if (self->stream_callbacks_->on_headers.has_value()) {
     auto raw_headers = envoy_headers_as_raw_header_map(headers);

--- a/library/cc/stream_callbacks.cc
+++ b/library/cc/stream_callbacks.cc
@@ -7,29 +7,28 @@
 namespace Envoy {
 namespace Platform {
 
-EnvoyHttpCallbacksAdapter::EnvoyHttpCallbacksAdapter(ExecutorSharedPtr executor,
-                                                     StreamCallbacksSharedPtr callbacks)
-    : executor_(executor), stream_callbacks_(callbacks) {}
+EnvoyHttpCallbacksAdapter::EnvoyHttpCallbacksAdapter(StreamCallbacksSharedPtr callbacks)
+    : stream_callbacks_(callbacks) {}
 
 envoy_http_callbacks EnvoyHttpCallbacksAdapter::as_envoy_http_callbacks() {
   envoy_http_callbacks callbacks{
-      .on_headers = &EnvoyHttpCallbacksAdapter::dispatch_on_headers,
-      .on_data = &EnvoyHttpCallbacksAdapter::dispatch_on_data,
+      .on_headers = &EnvoyHttpCallbacksAdapter::c_on_headers,
+      .on_data = &EnvoyHttpCallbacksAdapter::c_on_data,
       // on_metadata is not used
-      .on_trailers = &EnvoyHttpCallbacksAdapter::dispatch_on_trailers,
-      .on_error = &EnvoyHttpCallbacksAdapter::dispatch_on_error,
-      .on_complete = &EnvoyHttpCallbacksAdapter::dispatch_on_complete,
-      .on_cancel = &EnvoyHttpCallbacksAdapter::dispatch_on_cancel,
+      .on_trailers = &EnvoyHttpCallbacksAdapter::c_on_trailers,
+      .on_error = &EnvoyHttpCallbacksAdapter::c_on_error,
+      .on_complete = &EnvoyHttpCallbacksAdapter::c_on_complete,
+      .on_cancel = &EnvoyHttpCallbacksAdapter::c_on_cancel,
       .context = this,
   };
   return callbacks;
 }
 
-void* EnvoyHttpCallbacksAdapter::dispatch_on_headers(envoy_headers headers, bool end_stream,
+void* EnvoyHttpCallbacksAdapter::c_on_headers(envoy_headers headers, bool end_stream,
                                                      void* context) {
   auto self = static_cast<EnvoyHttpCallbacksAdapter*>(context);
   if (self->stream_callbacks_->on_headers.has_value()) {
-    auto raw_headers = envoy_headers_as_raw_headers(headers);
+    auto raw_headers = envoy_headers_as_raw_header_map(headers);
     ResponseHeadersBuilder builder;
     for (const auto& pair : raw_headers) {
       if (pair.first == ":status") {
@@ -37,61 +36,58 @@ void* EnvoyHttpCallbacksAdapter::dispatch_on_headers(envoy_headers headers, bool
       }
       builder.set(pair.first, pair.second);
     }
-    self->executor_->execute(
-        [=]() { self->stream_callbacks_->on_headers.value()(builder.build(), end_stream); });
+    self->stream_callbacks_->on_headers.value()(builder.build(), end_stream);
   }
   return context;
 }
 
-void* EnvoyHttpCallbacksAdapter::dispatch_on_data(envoy_data data, bool end_stream, void* context) {
+void* EnvoyHttpCallbacksAdapter::c_on_data(envoy_data data, bool end_stream, void* context) {
   auto self = static_cast<EnvoyHttpCallbacksAdapter*>(context);
   if (self->stream_callbacks_->on_error.has_value()) {
-    auto buffer = envoy_data_as_buffer(data);
-    self->executor_->execute(
-        [=]() { self->stream_callbacks_->on_data.value()(buffer, end_stream); });
+    self->stream_callbacks_->on_data.value()(data, end_stream);
   }
   return context;
 }
 
-void* EnvoyHttpCallbacksAdapter::dispatch_on_trailers(envoy_headers metadata, void* context) {
+void* EnvoyHttpCallbacksAdapter::c_on_trailers(envoy_headers metadata, void* context) {
   auto self = static_cast<EnvoyHttpCallbacksAdapter*>(context);
   if (self->stream_callbacks_->on_trailers.has_value()) {
-    auto raw_headers = envoy_headers_as_raw_headers(metadata);
+    auto raw_headers = envoy_headers_as_raw_header_map(metadata);
     ResponseTrailersBuilder builder;
     for (const auto& pair : raw_headers) {
       builder.set(pair.first, pair.second);
     }
-    self->executor_->execute(
-        [=]() { self->stream_callbacks_->on_trailers.value()(builder.build()); });
+    self->stream_callbacks_->on_trailers.value()(builder.build());
   }
   return context;
 }
 
-void* EnvoyHttpCallbacksAdapter::dispatch_on_error(envoy_error raw_error, void* context) {
+void* EnvoyHttpCallbacksAdapter::c_on_error(envoy_error raw_error, void* context) {
   auto self = static_cast<EnvoyHttpCallbacksAdapter*>(context);
   if (self->stream_callbacks_->on_error.has_value()) {
     EnvoyErrorSharedPtr error = std::make_shared<EnvoyError>();
     error->error_code = raw_error.error_code;
-    error->message = envoy_data_as_string(raw_error.message);
+    // TODO(crockeo): go back and convert from raw_error.message
+    // when doing so won't cause merge conflicts with other PRs.
+    error->message = "";
     error->attempt_count = absl::optional<int>(raw_error.attempt_count);
-
-    self->executor_->execute([=]() { self->stream_callbacks_->on_error.value()(error); });
+    self->stream_callbacks_->on_error.value()(error);
   }
   return context;
 }
 
-void* EnvoyHttpCallbacksAdapter::dispatch_on_complete(void* context) {
+void* EnvoyHttpCallbacksAdapter::c_on_complete(void* context) {
   auto self = static_cast<EnvoyHttpCallbacksAdapter*>(context);
   if (self->stream_callbacks_->on_complete.has_value()) {
-    self->executor_->execute(self->stream_callbacks_->on_complete.value());
+    self->stream_callbacks_->on_complete.value();
   }
   return context;
 }
 
-void* EnvoyHttpCallbacksAdapter::dispatch_on_cancel(void* context) {
+void* EnvoyHttpCallbacksAdapter::c_on_cancel(void* context) {
   auto self = static_cast<EnvoyHttpCallbacksAdapter*>(context);
   if (self->stream_callbacks_->on_cancel.has_value()) {
-    self->executor_->execute(self->stream_callbacks_->on_cancel.value());
+    self->stream_callbacks_->on_cancel.value();
   }
   return context;
 }

--- a/library/cc/stream_client.cc
+++ b/library/cc/stream_client.cc
@@ -1,0 +1,13 @@
+#include "stream_client.h"
+
+namespace Envoy {
+namespace Platform {
+
+StreamClient::StreamClient(envoy_engine_t engine) : engine_(engine) {}
+
+StreamPrototypeSharedPtr StreamClient::new_stream_prototype() {
+  return std::make_shared<StreamPrototype>(this->engine_);
+}
+
+} // namespace Platform
+} // namespace Envoy

--- a/library/cc/stream_prototype.cc
+++ b/library/cc/stream_prototype.cc
@@ -9,9 +9,9 @@ StreamPrototype::StreamPrototype(envoy_engine_t engine) : engine_(engine) {
   this->callbacks_ = std::make_shared<StreamCallbacks>();
 }
 
-StreamSharedPtr StreamPrototype::start(ExecutorSharedPtr executor) {
+StreamSharedPtr StreamPrototype::start() {
   auto stream = init_stream(this->engine_);
-  auto adapter = std::make_shared<EnvoyHttpCallbacksAdapter>(executor, this->callbacks_);
+  auto adapter = std::make_shared<EnvoyHttpCallbacksAdapter>(this->callbacks_);
   start_stream(stream, adapter->as_envoy_http_callbacks());
 
   return std::make_shared<Stream>(stream, adapter);

--- a/library/cc/stream_prototype.cc
+++ b/library/cc/stream_prototype.cc
@@ -1,0 +1,51 @@
+#include "stream_prototype.h"
+
+#include "library/common/main_interface.h"
+
+namespace Envoy {
+namespace Platform {
+
+StreamPrototype::StreamPrototype(envoy_engine_t engine) : engine_(engine) {
+  this->callbacks_ = std::make_shared<StreamCallbacks>();
+}
+
+StreamSharedPtr StreamPrototype::start(ExecutorSharedPtr executor) {
+  auto stream = init_stream(this->engine_);
+  auto adapter = std::make_shared<EnvoyHttpCallbacksAdapter>(executor, this->callbacks_);
+  start_stream(stream, adapter->as_envoy_http_callbacks());
+
+  return std::make_shared<Stream>(stream, adapter);
+}
+
+StreamPrototype& StreamPrototype::set_on_headers(OnHeadersCallback closure) {
+  this->callbacks_->on_headers = closure;
+  return *this;
+}
+
+StreamPrototype& StreamPrototype::set_on_data(OnDataCallback closure) {
+  this->callbacks_->on_data = closure;
+  return *this;
+}
+
+StreamPrototype& StreamPrototype::set_on_trailers(OnTrailersCallback closure) {
+  this->callbacks_->on_trailers = closure;
+  return *this;
+}
+
+StreamPrototype& StreamPrototype::set_on_error(OnErrorCallback closure) {
+  this->callbacks_->on_error = closure;
+  return *this;
+}
+
+StreamPrototype& StreamPrototype::set_on_complete(OnCompleteCallback closure) {
+  this->callbacks_->on_complete = closure;
+  return *this;
+}
+
+StreamPrototype& StreamPrototype::set_on_cancel(OnCancelCallback closure) {
+  this->callbacks_->on_cancel = closure;
+  return *this;
+}
+
+} // namespace Platform
+} // namespace Envoy

--- a/library/python/BUILD
+++ b/library/python/BUILD
@@ -4,6 +4,10 @@ licenses(["notice"])  # Apache 2
 
 pybind_library(
     name = "envoy_engine_lib",
+    srcs = [
+        "stream_prototype_shim.cc",
+        "stream_shim.cc",
+    ],
     hdrs = [
         "bytes_view.h",
         "stream_prototype_shim.h",

--- a/library/python/module_definition.cc
+++ b/library/python/module_definition.cc
@@ -181,12 +181,12 @@ PYBIND11_MODULE(envoy_engine, m) {
 
   py::class_<StreamPrototype, StreamPrototypeSharedPtr>(m, "StreamPrototype")
       .def("start", &StreamPrototype::start)
-      .def("set_on_headers", &StreamPrototype::set_on_headers)
+      .def("set_on_headers", &Envoy::Python::StreamPrototype::set_on_headers_shim)
       .def("set_on_data", &Envoy::Python::StreamPrototype::set_on_data_shim)
-      .def("set_on_trailers", &StreamPrototype::set_on_trailers)
-      .def("set_on_complete", &StreamPrototype::set_on_complete)
-      .def("set_on_error", &StreamPrototype::set_on_error)
-      .def("set_on_cancel", &StreamPrototype::set_on_cancel);
+      .def("set_on_trailers", &Envoy::Python::StreamPrototype::set_on_trailers_shim)
+      .def("set_on_complete", &Envoy::Python::StreamPrototype::set_on_complete_shim)
+      .def("set_on_error", &Envoy::Python::StreamPrototype::set_on_error_shim)
+      .def("set_on_cancel", &Envoy::Python::StreamPrototype::set_on_cancel_shim);
 
   py::enum_<UpstreamHttpProtocol>(m, "UpstreamHttpProtocol")
       .value("HTTP1", UpstreamHttpProtocol::HTTP1)

--- a/library/python/stream_prototype_shim.cc
+++ b/library/python/stream_prototype_shim.cc
@@ -6,15 +6,20 @@ namespace Envoy {
 namespace Python {
 namespace StreamPrototype {
 
-Platform::StreamPrototype& set_on_headers_shim(Platform::StreamPrototype self,
-                                               Platform::OnHeadersCallback closure) {
-  return self.set_on_headers(
-      [closure](Platform::ResponseHeadersSharedPtr headers, bool end_stream) {
-        py::gil_scoped_acquire acquire;
-        closure(std::move(headers), end_stream);
-      });
+template <typename... Ts> std::function<void(Ts...)> make_shim(std::function<void(Ts...)> closure) {
+  return [closure](Ts... args) {
+    py::gil_scoped_acquire acquire;
+    closure(std::forward<Ts>(args)...);
+  };
 }
 
+Platform::StreamPrototype& set_on_headers_shim(Platform::StreamPrototype& self,
+                                               Platform::OnHeadersCallback closure) {
+  return self.set_on_headers(make_shim(closure));
+}
+
+// set_on_data_shim can't be represented by the make_shim above, because it
+// also constructs a bytes view onto the envoy_data provided.
 Platform::StreamPrototype& set_on_data_shim(Platform::StreamPrototype& self,
                                             OnPyBytesDataCallback closure) {
   return self.set_on_data([closure](envoy_data data, bool end_stream) {
@@ -24,36 +29,24 @@ Platform::StreamPrototype& set_on_data_shim(Platform::StreamPrototype& self,
   });
 }
 
-Platform::StreamPrototype& set_on_trailers_shim(Platform::StreamPrototype self,
+Platform::StreamPrototype& set_on_trailers_shim(Platform::StreamPrototype& self,
                                                 Platform::OnTrailersCallback closure) {
-  return self.set_on_trailers([closure](Platform::ResponseTrailersSharedPtr trailers) {
-    py::gil_scoped_acquire acquire;
-    closure(std::move(trailers));
-  });
+  return self.set_on_trailers(make_shim(closure));
 }
 
-Platform::StreamPrototype& set_on_error_shim(Platform::StreamPrototype self,
+Platform::StreamPrototype& set_on_error_shim(Platform::StreamPrototype& self,
                                              Platform::OnErrorCallback closure) {
-  return self.set_on_error([closure](Platform::EnvoyErrorSharedPtr error) {
-    py::gil_scoped_acquire acquire;
-    closure(std::move(error));
-  });
+  return self.set_on_error(make_shim(closure));
 }
 
-Platform::StreamPrototype& set_on_complete_shim(Platform::StreamPrototype self,
+Platform::StreamPrototype& set_on_complete_shim(Platform::StreamPrototype& self,
                                                 Platform::OnCompleteCallback closure) {
-  return self.set_on_complete([closure]() {
-    py::gil_scoped_acquire acquire;
-    closure();
-  });
+  return self.set_on_complete(make_shim(closure));
 }
 
-Platform::StreamPrototype& set_on_cancel_shim(Platform::StreamPrototype self,
+Platform::StreamPrototype& set_on_cancel_shim(Platform::StreamPrototype& self,
                                               Platform::OnCancelCallback closure) {
-  return self.set_on_cancel([closure]() {
-    py::gil_scoped_acquire acquire;
-    closure();
-  });
+  return self.set_on_cancel(make_shim(closure));
 }
 
 } // namespace StreamPrototype

--- a/library/python/stream_prototype_shim.cc
+++ b/library/python/stream_prototype_shim.cc
@@ -1,0 +1,19 @@
+#include "stream_prototype_shim.h"
+
+#include "bytes_view.h"
+
+namespace Envoy {
+namespace Python {
+namespace StreamPrototype {
+
+Platform::StreamPrototype& set_on_data_shim(Platform::StreamPrototype& self,
+                                            OnPyBytesDataCallback on_data) {
+  return self.set_on_data([on_data](envoy_data data, bool end_stream) {
+    py::bytes bytes = envoy_data_as_py_bytes(data);
+    on_data(bytes, end_stream);
+  });
+}
+
+} // namespace StreamPrototype
+} // namespace Python
+} // namespace Envoy

--- a/library/python/stream_prototype_shim.cc
+++ b/library/python/stream_prototype_shim.cc
@@ -6,11 +6,53 @@ namespace Envoy {
 namespace Python {
 namespace StreamPrototype {
 
+Platform::StreamPrototype& set_on_headers_shim(Platform::StreamPrototype self,
+                                               Platform::OnHeadersCallback closure) {
+  return self.set_on_headers(
+      [closure](Platform::ResponseHeadersSharedPtr headers, bool end_stream) {
+        py::gil_scoped_acquire acquire;
+        closure(std::move(headers), end_stream);
+      });
+}
+
 Platform::StreamPrototype& set_on_data_shim(Platform::StreamPrototype& self,
-                                            OnPyBytesDataCallback on_data) {
-  return self.set_on_data([on_data](envoy_data data, bool end_stream) {
+                                            OnPyBytesDataCallback closure) {
+  return self.set_on_data([closure](envoy_data data, bool end_stream) {
+    py::gil_scoped_acquire acquire;
     py::bytes bytes = envoy_data_as_py_bytes(data);
-    on_data(bytes, end_stream);
+    closure(bytes, end_stream);
+  });
+}
+
+Platform::StreamPrototype& set_on_trailers_shim(Platform::StreamPrototype self,
+                                                Platform::OnTrailersCallback closure) {
+  return self.set_on_trailers([closure](Platform::ResponseTrailersSharedPtr trailers) {
+    py::gil_scoped_acquire acquire;
+    closure(std::move(trailers));
+  });
+}
+
+Platform::StreamPrototype& set_on_error_shim(Platform::StreamPrototype self,
+                                             Platform::OnErrorCallback closure) {
+  return self.set_on_error([closure](Platform::EnvoyErrorSharedPtr error) {
+    py::gil_scoped_acquire acquire;
+    closure(std::move(error));
+  });
+}
+
+Platform::StreamPrototype& set_on_complete_shim(Platform::StreamPrototype self,
+                                                Platform::OnCompleteCallback closure) {
+  return self.set_on_complete([closure]() {
+    py::gil_scoped_acquire acquire;
+    closure();
+  });
+}
+
+Platform::StreamPrototype& set_on_cancel_shim(Platform::StreamPrototype self,
+                                              Platform::OnCancelCallback closure) {
+  return self.set_on_cancel([closure]() {
+    py::gil_scoped_acquire acquire;
+    closure();
   });
 }
 

--- a/library/python/stream_prototype_shim.h
+++ b/library/python/stream_prototype_shim.h
@@ -4,6 +4,7 @@
 
 #include "library/cc/stream_prototype.h"
 #include "library/common/types/c_types.h"
+#include "pybind11/pybind11.h"
 
 namespace py = pybind11;
 
@@ -11,7 +12,7 @@ namespace Envoy {
 namespace Python {
 namespace StreamPrototype {
 
-using OnPyBytesDataCallback = std::function<void(envoy_data data, bool end_stream)>;
+using OnPyBytesDataCallback = std::function<void(py::bytes bytes, bool end_stream)>;
 
 Platform::StreamPrototype& set_on_data_shim(Platform::StreamPrototype& self,
                                             OnPyBytesDataCallback on_data);

--- a/library/python/stream_prototype_shim.h
+++ b/library/python/stream_prototype_shim.h
@@ -16,22 +16,22 @@ using OnPyBytesDataCallback = std::function<void(py::bytes bytes, bool end_strea
 
 // each of these shims exist to insert a GIL aqcuisition between the C++
 // callback and the call into Python code.
-Platform::StreamPrototype& set_on_headers_shim(Platform::StreamPrototype self,
+Platform::StreamPrototype& set_on_headers_shim(Platform::StreamPrototype& self,
                                                Platform::OnHeadersCallback closure);
 
 Platform::StreamPrototype& set_on_data_shim(Platform::StreamPrototype& self,
                                             OnPyBytesDataCallback closure);
 
-Platform::StreamPrototype& set_on_trailers_shim(Platform::StreamPrototype self,
+Platform::StreamPrototype& set_on_trailers_shim(Platform::StreamPrototype& self,
                                                 Platform::OnTrailersCallback closure);
 
-Platform::StreamPrototype& set_on_error_shim(Platform::StreamPrototype self,
+Platform::StreamPrototype& set_on_error_shim(Platform::StreamPrototype& self,
                                              Platform::OnErrorCallback closure);
 
-Platform::StreamPrototype& set_on_complete_shim(Platform::StreamPrototype self,
+Platform::StreamPrototype& set_on_complete_shim(Platform::StreamPrototype& self,
                                                 Platform::OnCompleteCallback closure);
 
-Platform::StreamPrototype& set_on_cancel_shim(Platform::StreamPrototype self,
+Platform::StreamPrototype& set_on_cancel_shim(Platform::StreamPrototype& self,
                                               Platform::OnCancelCallback closure);
 
 } // namespace StreamPrototype

--- a/library/python/stream_prototype_shim.h
+++ b/library/python/stream_prototype_shim.h
@@ -14,8 +14,25 @@ namespace StreamPrototype {
 
 using OnPyBytesDataCallback = std::function<void(py::bytes bytes, bool end_stream)>;
 
+// each of these shims exist to insert a GIL aqcuisition between the C++
+// callback and the call into Python code.
+Platform::StreamPrototype& set_on_headers_shim(Platform::StreamPrototype self,
+                                               Platform::OnHeadersCallback closure);
+
 Platform::StreamPrototype& set_on_data_shim(Platform::StreamPrototype& self,
-                                            OnPyBytesDataCallback on_data);
+                                            OnPyBytesDataCallback closure);
+
+Platform::StreamPrototype& set_on_trailers_shim(Platform::StreamPrototype self,
+                                                Platform::OnTrailersCallback closure);
+
+Platform::StreamPrototype& set_on_error_shim(Platform::StreamPrototype self,
+                                             Platform::OnErrorCallback closure);
+
+Platform::StreamPrototype& set_on_complete_shim(Platform::StreamPrototype self,
+                                                Platform::OnCompleteCallback closure);
+
+Platform::StreamPrototype& set_on_cancel_shim(Platform::StreamPrototype self,
+                                              Platform::OnCancelCallback closure);
 
 } // namespace StreamPrototype
 } // namespace Python

--- a/library/python/stream_shim.cc
+++ b/library/python/stream_shim.cc
@@ -1,0 +1,21 @@
+#include "stream_shim.h"
+
+#include "bytes_view.h"
+
+namespace Envoy {
+namespace Python {
+namespace Stream {
+
+Platform::Stream& send_data_shim(Platform::Stream& self, py::bytes data) {
+  envoy_data raw_data = py_bytes_as_envoy_data(data);
+  return self.send_data(raw_data);
+}
+
+void close_shim(Platform::Stream& self, py::bytes data) {
+  envoy_data raw_data = py_bytes_as_envoy_data(data);
+  self.close(raw_data);
+}
+
+} // namespace Stream
+} // namespace Python
+} // namespace Envoy


### PR DESCRIPTION
**Description:**

All header changes in this PR come from https://github.com/envoyproxy/envoy-mobile/pull/1217, that should be reviewed and merged first.

This PR implements all of the stream-related classes: `Stream`, `StreamCallbacks `EnvoyHttpCallbacksAdapter`, and `StreamPrototype`.

**Risk Level:** Low
**Testing:** N/A, will follow up when everything is finished with e2e testing + unit testing in Python and/orC++
**Docs Changes:** N/A
**Release Notes:** N/A