### PR TITLE
python: implement e2e test

### DIFF
--- a/library/cc/BUILD
+++ b/library/cc/BUILD
@@ -7,12 +7,14 @@ envoy_package()
 envoy_cc_library(
     name = "envoy_engine_cc_lib",
     hdrs = [
+        "bridge_utility.h",
         "engine.h",
         "engine_builder.h",
         "envoy_error.h",
         "executor.h",
         "headers.h",
         "headers_builder.h",
+        "log_level.h",
         "pulse_client.h",
         "request_headers.h",
         "request_headers_builder.h",

--- a/library/cc/bridge_utility.h
+++ b/library/cc/bridge_utility.h
@@ -1,0 +1,21 @@
+#pragma once
+
+#include <string>
+#include <vector>
+
+#include "headers.h"
+#include "library/common/types/c_types.h"
+
+namespace Envoy {
+namespace Platform {
+
+envoy_data buffer_as_envoy_data(const std::vector<uint8_t>& data);
+envoy_data string_as_envoy_data(const std::string& data);
+envoy_headers raw_headers_as_envoy_headers(const RawHeaders& headers);
+
+std::vector<uint8_t> envoy_data_as_buffer(envoy_data raw_data);
+std::string envoy_data_as_string(envoy_data raw_data);
+RawHeaders envoy_headers_as_raw_headers(envoy_headers raw_headers);
+
+} // namespace Platform
+} // namespace Envoy

--- a/library/cc/engine.h
+++ b/library/cc/engine.h
@@ -1,29 +1,40 @@
 #pragma once
 
-// NOLINT(namespace-envoy)
-
-#include "common/common/base_logger.h"
+#include <functional>
 
 #include "executor.h"
 #include "library/common/types/c_types.h"
+#include "log_level.h"
 #include "pulse_client.h"
 #include "stream_client.h"
 
+namespace Envoy {
+namespace Platform {
+
 class Engine {
 public:
+  ~Engine();
+
   StreamClientSharedPtr stream_client();
   PulseClientSharedPtr pulse_client();
 
 private:
-  Engine(envoy_engine_t engine, const std::string& configuration,
-         Envoy::Logger::Logger::Levels log_level, std::function<void()> on_engine_running,
-         ExecutorSharedPtr executor_);
+  Engine(envoy_engine_t engine, const std::string& configuration, LogLevel log_level,
+         std::function<void()> on_engine_running, ExecutorSharedPtr executor);
+
+  static void dispatch_on_engine_running(void* context);
+  static void dispatch_on_exit(void* context);
 
   friend class EngineBuilder;
 
+  envoy_engine_t engine_;
+  std::function<void()> on_engine_running_;
+  ExecutorSharedPtr executor_;
   StreamClientSharedPtr stream_client_;
   PulseClientSharedPtr pulse_client_;
-  ExecutorSharedPtr executor_;
 };
 
 using EngineSharedPtr = std::shared_ptr<Engine>;
+
+} // namespace Platform
+} // namespace Envoy

--- a/library/cc/engine_builder.h
+++ b/library/cc/engine_builder.h
@@ -1,20 +1,20 @@
 #pragma once
 
-// NOLINT(namespace-envoy)
-
 #include <memory>
 #include <string>
 
-#include "common/common/base_logger.h"
-
 #include "engine.h"
 #include "executor.h"
+#include "log_level.h"
+
+namespace Envoy {
+namespace Platform {
 
 class EngineBuilder {
 public:
   EngineBuilder();
 
-  EngineBuilder& add_log_level(Envoy::Logger::Logger::Levels log_level);
+  EngineBuilder& add_log_level(LogLevel log_level);
   EngineBuilder& set_on_engine_running(std::function<void()> closure);
 
   EngineBuilder& add_stats_domain(const std::string& stats_domain);
@@ -35,15 +35,15 @@ public:
   // EnvoyStringAccessor): EngineBuilder {
 
 private:
-  Envoy::Logger::Logger::Levels log_level_;
+  LogLevel log_level_ = LogLevel::info;
   std::function<void()> on_engine_running_;
 
   std::string stats_domain_ = "0.0.0.0";
   int connect_timeout_seconds_ = 30;
   int dns_refresh_seconds_ = 60;
-  int dns_failure_refresh_seconds_base = 2;
-  int dns_failure_refresh_seconds_max = 10;
-  int stats_flush_seconds = 60;
+  int dns_failure_refresh_seconds_base_ = 2;
+  int dns_failure_refresh_seconds_max_ = 10;
+  int stats_flush_seconds_ = 60;
   std::string app_version_ = "unspecified";
   std::string app_id_ = "unspecified";
   std::string virtual_clusters_ = "[]";
@@ -55,3 +55,6 @@ private:
 };
 
 using EngineBuilderSharedPtr = std::shared_ptr<EngineBuilder>;
+
+} // namespace Platform
+} // namespace Envoy

--- a/library/cc/envoy_error.h
+++ b/library/cc/envoy_error.h
@@ -1,7 +1,5 @@
 #pragma once
 
-// NOLINT(namespace-envoy)
-
 #include <exception>
 #include <memory>
 #include <optional>
@@ -9,11 +7,17 @@
 
 #include "absl/types/optional.h"
 
+namespace Envoy {
+namespace Platform {
+
 struct EnvoyError {
   int error_code;
   std::string message;
   absl::optional<int> attempt_count;
-  std::exception cause;
+  absl::optional<std::exception> cause;
 };
 
 using EnvoyErrorSharedPtr = std::shared_ptr<EnvoyError>;
+
+} // namespace Platform
+} // namespace Envoy

--- a/library/cc/executor.h
+++ b/library/cc/executor.h
@@ -1,15 +1,19 @@
 #pragma once
 
-// NOLINT(namespace-envoy)
-
 #include <functional>
 #include <memory>
 
+namespace Envoy {
+namespace Platform {
+
 class Executor {
 public:
-  virtual ~Executor();
+  virtual ~Executor() {}
 
   virtual void execute(std::function<void()> closure) = 0;
 };
 
 using ExecutorSharedPtr = std::shared_ptr<Executor>;
+
+} // namespace Platform
+} // namespace Envoy

--- a/library/cc/headers.h
+++ b/library/cc/headers.h
@@ -1,11 +1,12 @@
 #pragma once
 
-// NOLINT(namespace-envoy)
-
 #include <string>
 #include <vector>
 
 #include "absl/container/flat_hash_map.h"
+
+namespace Envoy {
+namespace Platform {
 
 using RawHeaders = absl::flat_hash_map<std::string, std::vector<std::string>>;
 
@@ -15,6 +16,7 @@ public:
 
   const std::vector<std::string>& operator[](const std::string& key) const;
   const RawHeaders& all_headers() const;
+  bool contains(const std::string& key) const;
 
 protected:
   Headers(const RawHeaders& headers);
@@ -22,3 +24,6 @@ protected:
 private:
   RawHeaders headers_;
 };
+
+} // namespace Platform
+} // namespace Envoy

--- a/library/cc/headers_builder.h
+++ b/library/cc/headers_builder.h
@@ -1,21 +1,28 @@
 #pragma once
 
-// NOLINT(namespace-envoy)
-
 #include "headers.h"
+
+namespace Envoy {
+namespace Platform {
 
 class HeadersBuilder {
 public:
+  virtual ~HeadersBuilder() {}
+
   HeadersBuilder& add(const std::string& name, const std::string& value);
   HeadersBuilder& set(const std::string& name, const std::vector<std::string>& values);
   HeadersBuilder& remove(const std::string& name);
 
 protected:
   HeadersBuilder();
-  HeadersBuilder& internal_set(const std::string&, const std::vector<std::string>& values);
+  HeadersBuilder& internal_set(const std::string& name, const std::vector<std::string>& values);
+  const RawHeaders& all_headers() const;
 
 private:
   bool is_restricted_header_(const std::string& name) const;
 
   RawHeaders headers_;
 };
+
+} // namespace Platform
+} // namespace Envoy

--- a/library/cc/log_level.h
+++ b/library/cc/log_level.h
@@ -1,0 +1,16 @@
+#pragma once
+
+#include <string>
+
+#include "common/common/base_logger.h"
+
+namespace Envoy {
+namespace Platform {
+
+using LogLevel = Envoy::Logger::Logger::Levels;
+
+std::string log_level_to_string(LogLevel method);
+LogLevel log_level_from_string(const std::string& str);
+
+} // namespace Platform
+} // namespace Envoy

--- a/library/cc/pulse_client.h
+++ b/library/cc/pulse_client.h
@@ -1,15 +1,12 @@
 #pragma once
 
-// NOLINT(namespace-envoy)
-
 #include <memory>
+
+namespace Envoy {
+namespace Platform {
 
 // TODO(crockeo): although this is stubbed out since it's in the main directory, it depends on
 // objects defined under stats. this will not be fully stubbed until stats is stubbed
-
-// #include "stats/counter.h"
-// #include "stats/element.h"
-// #include "stats/gauge.h"
 
 class PulseClient {
 public:
@@ -18,3 +15,6 @@ public:
 };
 
 using PulseClientSharedPtr = std::shared_ptr<PulseClient>;
+
+} // namespace Platform
+} // namespace Envoy

--- a/library/cc/request_headers.h
+++ b/library/cc/request_headers.h
@@ -1,7 +1,5 @@
 #pragma once
 
-// NOLINT(namespace-envoy)
-
 #include <optional>
 
 #include "absl/types/optional.h"
@@ -11,14 +9,19 @@
 #include "retry_policy.h"
 #include "upstream_http_protocol.h"
 
+namespace Envoy {
+namespace Platform {
+
+class RequestHeadersBuilder;
+
 class RequestHeaders : public Headers {
 public:
   RequestMethod request_method() const;
   const std::string& scheme() const;
   const std::string& authority() const;
   const std::string& path() const;
-  const absl::optional<RetryPolicy> retry_policy() const;
-  UpstreamHttpProtocol upstream_http_protocol() const;
+  absl::optional<RetryPolicy> retry_policy() const;
+  absl::optional<UpstreamHttpProtocol> upstream_http_protocol() const;
 
   RequestHeadersBuilder to_request_headers_builder() const;
 
@@ -29,3 +32,6 @@ private:
 };
 
 using RequestHeadersSharedPtr = std::shared_ptr<RequestHeaders>;
+
+} // namespace Platform
+} // namespace Envoy

--- a/library/cc/request_headers_builder.h
+++ b/library/cc/request_headers_builder.h
@@ -1,7 +1,5 @@
 #pragma once
 
-// NOLINT(namespace-envoy)
-
 #include <string>
 
 #include "headers_builder.h"
@@ -10,7 +8,11 @@
 #include "retry_policy.h"
 #include "upstream_http_protocol.h"
 
+namespace Envoy {
+namespace Platform {
+
 class RequestHeaders;
+struct RetryPolicy;
 
 class RequestHeadersBuilder : public HeadersBuilder {
 public:
@@ -24,3 +26,6 @@ public:
 };
 
 using RequestHeadersBuilderSharedPtr = std::shared_ptr<RequestHeadersBuilder>;
+
+} // namespace Platform
+} // namespace Envoy

--- a/library/cc/request_method.h
+++ b/library/cc/request_method.h
@@ -1,6 +1,9 @@
 #pragma once
 
-// NOLINT(namespace-envoy)
+#include <string>
+
+namespace Envoy {
+namespace Platform {
 
 enum RequestMethod {
   DELETE,
@@ -12,3 +15,9 @@ enum RequestMethod {
   PUT,
   TRACE,
 };
+
+std::string request_method_to_string(RequestMethod method);
+RequestMethod request_method_from_string(const std::string& str);
+
+} // namespace Platform
+} // namespace Envoy

--- a/library/cc/request_trailers.h
+++ b/library/cc/request_trailers.h
@@ -1,9 +1,12 @@
 #pragma once
 
-// NOLINT(namespace-envoy)
-
 #include "request_trailers_builder.h"
 #include "trailers.h"
+
+namespace Envoy {
+namespace Platform {
+
+class RequestTrailersBuilder;
 
 class RequestTrailers : public Trailers {
 public:
@@ -16,3 +19,6 @@ private:
 };
 
 using RequestTrailersSharedPtr = std::shared_ptr<RequestTrailers>;
+
+} // namespace Platform
+} // namespace Envoy

--- a/library/cc/request_trailers_builder.h
+++ b/library/cc/request_trailers_builder.h
@@ -1,9 +1,10 @@
 #pragma once
 
-// NOLINT(namespace-envoy)
-
 #include "headers_builder.h"
 #include "request_trailers.h"
+
+namespace Envoy {
+namespace Platform {
 
 class RequestTrailers;
 
@@ -15,3 +16,6 @@ public:
 };
 
 using RequestTrailersBuilderSharedPtr = std::shared_ptr<RequestTrailersBuilder>;
+
+} // namespace Platform
+} // namespace Envoy

--- a/library/cc/response_headers.h
+++ b/library/cc/response_headers.h
@@ -1,9 +1,12 @@
 #pragma once
 
-// NOLINT(namespace-envoy)
-
 #include "headers.h"
 #include "response_headers_builder.h"
+
+namespace Envoy {
+namespace Platform {
+
+class ResponseHeadersBuilder;
 
 class ResponseHeaders : public Headers {
 public:
@@ -18,3 +21,6 @@ private:
 };
 
 using ResponseHeadersSharedPtr = std::shared_ptr<ResponseHeaders>;
+
+} // namespace Platform
+} // namespace Envoy

--- a/library/cc/response_headers_builder.h
+++ b/library/cc/response_headers_builder.h
@@ -1,18 +1,23 @@
 #pragma once
 
-// NOLINT(namespace-envoy)
-
 #include "headers_builder.h"
 #include "response_headers.h"
 
+namespace Envoy {
+namespace Platform {
+
 class ResponseHeaders;
+using ResponseHeadersSharedPtr = std::shared_ptr<ResponseHeaders>;
 
 class ResponseHeadersBuilder : public HeadersBuilder {
 public:
   ResponseHeadersBuilder() {}
 
   ResponseHeadersBuilder& add_http_status(int status);
-  ResponseHeaders build() const;
+  ResponseHeadersSharedPtr build() const;
 };
 
 using ResponseHeadersBuilderSharedPtr = std::shared_ptr<ResponseHeadersBuilder>;
+
+} // namespace Platform
+} // namespace Envoy

--- a/library/cc/response_trailers.h
+++ b/library/cc/response_trailers.h
@@ -1,9 +1,12 @@
 #pragma once
 
-// NOLINT(namespace-envoy)
-
 #include "response_trailers_builder.h"
 #include "trailers.h"
+
+namespace Envoy {
+namespace Platform {
+
+class ResponseTrailersBuilder;
 
 class ResponseTrailers : public Trailers {
 public:
@@ -16,3 +19,6 @@ private:
 };
 
 using ResponseTrailersSharedPtr = std::shared_ptr<ResponseTrailers>;
+
+} // namespace Platform
+} // namespace Envoy

--- a/library/cc/response_trailers_builder.h
+++ b/library/cc/response_trailers_builder.h
@@ -1,17 +1,22 @@
 #pragma once
 
-// NOLINT(namespace-envoy)
-
 #include "headers_builder.h"
 #include "response_trailers.h"
 
+namespace Envoy {
+namespace Platform {
+
 class ResponseTrailers;
+using ResponseTrailersSharedPtr = std::shared_ptr<ResponseTrailers>;
 
 class ResponseTrailersBuilder : public HeadersBuilder {
 public:
   ResponseTrailersBuilder() {}
 
-  ResponseTrailers build() const;
+  ResponseTrailersSharedPtr build() const;
 };
 
 using ResponseTrailersBuilderSharedPtr = std::shared_ptr<ResponseTrailersBuilder>;
+
+} // namespace Platform
+} // namespace Envoy

--- a/library/cc/retry_policy.h
+++ b/library/cc/retry_policy.h
@@ -1,7 +1,5 @@
 #pragma once
 
-// NOLINT(namespace-envoy)
-
 #include <optional>
 #include <vector>
 
@@ -9,17 +7,23 @@
 #include "headers.h"
 #include "request_headers.h"
 
+namespace Envoy {
+namespace Platform {
+
 class RequestHeaders;
 
 enum RetryRule {
   Status5xx,
-  GatewayFailure,
+  GatewayError,
   ConnectFailure,
   RefusedStream,
   Retriable4xx,
   RetriableHeaders,
   Reset,
 };
+
+std::string retry_rule_to_string(RetryRule retry_rule);
+RetryRule retry_rule_from_string(const std::string& str);
 
 struct RetryPolicy {
   int max_retry_count;
@@ -28,8 +32,11 @@ struct RetryPolicy {
   absl::optional<int> per_try_timeout_ms;
   absl::optional<int> total_upstream_timeout_ms;
 
-  RawHeaders output_headers() const;
-  static RetryPolicy from(const RequestHeaders& headers);
+  RawHeaders as_raw_headers() const;
+  static RetryPolicy from_raw_headers(const RawHeaders& headers);
 };
 
 using RetryPolicySharedPtr = std::shared_ptr<RetryPolicy>;
+
+} // namespace Platform
+} // namespace Envoy

--- a/library/cc/stream.h
+++ b/library/cc/stream.h
@@ -1,16 +1,18 @@
 #pragma once
 
-// NOLINT(namespace-envoy)
-
 #include <vector>
 
 #include "library/common/types/c_types.h"
 #include "request_headers.h"
 #include "request_trailers.h"
+#include "stream_callbacks.h"
+
+namespace Envoy {
+namespace Platform {
 
 class Stream {
 public:
-  Stream(envoy_stream_t handle);
+  Stream(envoy_stream_t handle, EnvoyHttpCallbacksAdapterSharedPtr adapter);
 
   Stream& send_headers(RequestHeadersSharedPtr headers, bool end_stream);
   Stream& send_data(const std::vector<uint8_t>& data);
@@ -20,6 +22,10 @@ public:
 
 private:
   envoy_stream_t handle_;
+  EnvoyHttpCallbacksAdapterSharedPtr adapter_;
 };
 
 using StreamSharedPtr = std::shared_ptr<Stream>;
+
+} // namespace Platform
+} // namespace Envoy

--- a/library/cc/stream_callbacks.h
+++ b/library/cc/stream_callbacks.h
@@ -1,7 +1,5 @@
 #pragma once
 
-// NOLINT(namespace-envoy)
-
 #include <memory>
 #include <optional>
 #include <vector>
@@ -9,21 +7,27 @@
 #include "absl/types/optional.h"
 #include "envoy_error.h"
 #include "executor.h"
+#include "library/common/types/c_types.h"
 #include "response_headers.h"
 #include "response_trailers.h"
+
+namespace Envoy {
+namespace Platform {
 
 using OnHeadersCallback = std::function<void(ResponseHeadersSharedPtr headers, bool end_stream)>;
 using OnDataCallback = std::function<void(std::vector<uint8_t> data, bool end_stream)>;
 using OnTrailersCallback = std::function<void(ResponseTrailersSharedPtr trailers)>;
-using OnCancelCallback = std::function<void()>;
 using OnErrorCallback = std::function<void(EnvoyErrorSharedPtr error)>;
+using OnCompleteCallback = std::function<void()>;
+using OnCancelCallback = std::function<void()>;
 
 struct StreamCallbacks {
   absl::optional<OnHeadersCallback> on_headers;
   absl::optional<OnDataCallback> on_data;
   absl::optional<OnTrailersCallback> on_trailers;
-  absl::optional<OnCancelCallback> on_cancel;
   absl::optional<OnErrorCallback> on_error;
+  absl::optional<OnCompleteCallback> on_complete;
+  absl::optional<OnCancelCallback> on_cancel;
 };
 
 using StreamCallbacksSharedPtr = std::shared_ptr<StreamCallbacks>;
@@ -32,9 +36,21 @@ class EnvoyHttpCallbacksAdapter {
 public:
   EnvoyHttpCallbacksAdapter(ExecutorSharedPtr executor, StreamCallbacksSharedPtr callbacks);
 
+  envoy_http_callbacks as_envoy_http_callbacks();
+
 private:
+  static void* dispatch_on_headers(envoy_headers headers, bool end_stream, void* context);
+  static void* dispatch_on_data(envoy_data data, bool end_stream, void* context);
+  static void* dispatch_on_trailers(envoy_headers metadata, void* context);
+  static void* dispatch_on_error(envoy_error raw_error, void* context);
+  static void* dispatch_on_complete(void* context);
+  static void* dispatch_on_cancel(void* context);
+
   ExecutorSharedPtr executor_;
   StreamCallbacksSharedPtr stream_callbacks_;
 };
 
 using EnvoyHttpCallbacksAdapterSharedPtr = std::shared_ptr<EnvoyHttpCallbacksAdapter>;
+
+} // namespace Platform
+} // namespace Envoy

--- a/library/cc/stream_client.h
+++ b/library/cc/stream_client.h
@@ -1,14 +1,23 @@
 #pragma once
 
-// NOLINT(namespace-envoy)
-
 #include <memory>
 
 #include "stream_prototype.h"
 
+namespace Envoy {
+namespace Platform {
+
 class StreamClient {
 public:
-  StreamPrototype new_stream_prototype();
+  StreamClient(envoy_engine_t engine);
+
+  StreamPrototypeSharedPtr new_stream_prototype();
+
+private:
+  envoy_engine_t engine_;
 };
 
 using StreamClientSharedPtr = std::shared_ptr<StreamClient>;
+
+} // namespace Platform
+} // namespace Envoy

--- a/library/cc/stream_prototype.h
+++ b/library/cc/stream_prototype.h
@@ -1,36 +1,37 @@
 #pragma once
 
-// NOLINT(namespace-envoy)
-
-#include <cstddef>
-#include <functional>
 #include <memory>
 
-#include "engine.h"
 #include "envoy_error.h"
 #include "executor.h"
+#include "library/common/types/c_types.h"
 #include "response_headers.h"
 #include "response_trailers.h"
 #include "stream.h"
 #include "stream_callbacks.h"
 
-class Engine;
+namespace Envoy {
+namespace Platform {
 
 class StreamPrototype {
 public:
-  StreamPrototype(Engine engine);
+  StreamPrototype(envoy_engine_t engine);
 
-  Stream start(Executor& executor);
+  StreamSharedPtr start(ExecutorSharedPtr executor);
 
-  StreamPrototype& set_on_response_headers(OnHeadersCallback closure);
-  StreamPrototype& set_on_response_data(OnDataCallback closure);
-  StreamPrototype& set_on_response_trailers(OnTrailersCallback closure);
+  StreamPrototype& set_on_headers(OnHeadersCallback closure);
+  StreamPrototype& set_on_data(OnDataCallback closure);
+  StreamPrototype& set_on_trailers(OnTrailersCallback closure);
   StreamPrototype& set_on_error(OnErrorCallback closure);
+  StreamPrototype& set_on_complete(OnCompleteCallback closure);
   StreamPrototype& set_on_cancel(OnCancelCallback closure);
 
 private:
-  StreamCallbacks callbacks_;
-  EnvoyHttpCallbacksAdapter adapter_;
+  envoy_engine_t engine_;
+  StreamCallbacksSharedPtr callbacks_;
 };
 
 using StreamPrototypeSharedPtr = std::shared_ptr<StreamPrototype>;
+
+} // namespace Platform
+} // namespace Envoy

--- a/library/cc/trailers.h
+++ b/library/cc/trailers.h
@@ -1,10 +1,14 @@
 #pragma once
 
-// NOLINT(namespace-envoy)
-
 #include "headers.h"
+
+namespace Envoy {
+namespace Platform {
 
 class Trailers : public Headers {
 public:
   Trailers(const RawHeaders& headers) : Headers(headers) {}
 };
+
+} // namespace Platform
+} // namespace Envoy

--- a/library/cc/upstream_http_protocol.h
+++ b/library/cc/upstream_http_protocol.h
@@ -1,8 +1,17 @@
 #pragma once
 
-// NOLINT(namespace-envoy)
+#include <string>
+
+namespace Envoy {
+namespace Platform {
 
 enum UpstreamHttpProtocol {
   HTTP1,
   HTTP2,
 };
+
+std::string upstream_http_protocol_to_string(UpstreamHttpProtocol method);
+UpstreamHttpProtocol upstream_http_protocol_from_string(const std::string& str);
+
+} // namespace Platform
+} // namespace Envoy

--- a/library/python/BUILD
+++ b/library/python/BUILD
@@ -1,6 +1,16 @@
+load("@rules_python//python:defs.bzl", "py_binary")
 load("@pybind11_bazel//:build_defs.bzl", "pybind_extension")
 
 licenses(["notice"])  # Apache 2
+
+py_binary(
+    name = "e2e_test",
+    srcs = [":e2e_test.py"],
+    data = [
+        ":envoy_engine.so",
+    ],
+    main = "e2e_test.py",
+)
 
 pybind_extension(
     name = "envoy_engine",

--- a/library/python/e2e_test.py
+++ b/library/python/e2e_test.py
@@ -1,0 +1,136 @@
+import threading
+from typing import Callable
+from typing import Generic
+from typing import List
+from typing import TypeVar
+
+import gevent
+from gevent.event import Event
+from gevent.pool import Group
+
+from library.python import envoy_engine
+
+
+def main():
+    on_engine_running_evt = Event()
+    on_stream_complete_evt = Event()
+
+    def on_engine_running():
+        on_engine_running_evt.set()
+
+    executor = GeventExecutor()
+    engine = (
+        envoy_engine.EngineBuilder()
+        .add_log_level(envoy_engine.LogLevel.Warn)
+        .set_on_engine_running(on_engine_running)
+        .build(executor)
+    )
+    on_engine_running_evt.wait()
+
+    def on_headers(headers: envoy_engine.ResponseHeaders, end_stream: bool):
+        print("on_headers", headers, end_stream)
+
+    def on_data(data: List[int], end_stream: bool):
+        print("on_data", bytes(data[:60]), "...", end_stream)
+
+    def on_trailers(trailers: envoy_engine.ResponseTrailers):
+        print("on_trailers", trailers)
+
+    def on_error(error: envoy_engine.EnvoyError):
+        print("on_error")
+        on_stream_complete_evt.set()
+
+    def on_complete():
+        print("on_complete")
+        on_stream_complete_evt.set()
+
+    def on_cancel():
+        print("on_cancel")
+        on_stream_complete_evt.set()
+
+    stream_client = engine.stream_client()
+    stream_prototype = (
+        stream_client.new_stream_prototype()
+        .set_on_headers(on_headers)
+        .set_on_data(on_data)
+        .set_on_trailers(on_trailers)
+        .set_on_error(on_error)
+        .set_on_complete(on_complete)
+        .set_on_cancel(on_cancel)
+    )
+    stream = stream_prototype.start(executor)
+    stream.send_headers(
+       envoy_engine.RequestHeadersBuilder(
+           envoy_engine.RequestMethod.GET,
+           "https",
+           "www.google.com",
+           "/",
+        )
+        .build(),
+        True,
+    )
+    on_stream_complete_evt.wait()
+    # engine.terminate()
+
+T = TypeVar("T")
+
+class ThreadsafeChannel(Generic[T]):
+    """
+    gevent doesn't play well with multiple real threads. There is no documented canonical way to
+    move work across threads, a la asyncio.loop.call_soon_threadsafe. Also, if the main thread is
+    waiting on work from another thread, it will raise a LoopExit causing the program to exit.
+    This class solves both of those problems by creating a thread-safe way to move data across
+    threads that binds with gevent.
+    """
+
+    def __init__(self):
+        self.hub = gevent.get_hub()
+        self.watcher = self.hub.loop.async_()
+        self.lock = threading.Lock()
+        self.values: List[T] = []
+
+    def put(self, value: T) -> None:
+        """
+        put enqueues a value and notifies and greenlets waiting on a value that one is available.
+        """
+        with self.lock:
+            self.values.append(value)
+            self.watcher.send()
+
+    def get(self) -> T:
+        """
+        get retrieves an enqueued value. If none exists it waits until notified that such a value is
+        available.
+        """
+        self.lock.acquire()
+        while len(self.values) == 0:
+            self.lock.release()
+            self.hub.wait(self.watcher)
+            self.lock.acquire()
+
+        value: T = self.values.pop(0)
+        self.lock.release()
+        return value
+
+
+class GeventExecutor(envoy_engine.Executor):
+    def __init__(self):
+        super().__init__()
+        self.group = Group()
+        self.channel: ThreadsafeChannel[Callable[[], None]] = ThreadsafeChannel()
+        self.spawn_work_greenlet = gevent.spawn(self._spawn_work)
+
+    def __del__(self):
+        super().__del__()
+        self.spawn_work_greenlet.kill()
+
+    def execute(self, func: Callable[[], None]):
+        self.channel.put(func)
+
+    def _spawn_work(self):
+        while True:
+            self.group.spawn(self.channel.get())
+
+
+if __name__ == "__main__":
+    main()

--- a/library/python/module_definition.cc
+++ b/library/python/module_definition.cc
@@ -5,6 +5,7 @@
 #include "pybind11/functional.h"
 #include "pybind11/pybind11.h"
 #include "pybind11/stl.h"
+#include "pybind11/complex.h"
 
 #include "common/common/base_logger.h"
 #include "common/http/headers.h"
@@ -14,6 +15,7 @@
 #include "library/cc/envoy_error.h"
 #include "library/cc/executor.h"
 #include "library/cc/pulse_client.h"
+#include "library/cc/log_level.h"
 #include "library/cc/request_headers.h"
 #include "library/cc/request_headers_builder.h"
 #include "library/cc/request_method.h"
@@ -31,6 +33,7 @@
 #include "library/cc/upstream_http_protocol.h"
 
 namespace py = pybind11;
+using namespace Envoy::Platform;
 
 // This is what pybind11 calls a "trampoline" class.
 // It represents a bridge between the Python and C++ layers,
@@ -53,6 +56,7 @@ PYBIND11_MODULE(envoy_engine, m) {
       .def("pulse_client", &Engine::pulse_client);
 
   py::class_<EngineBuilder, EngineBuilderSharedPtr>(m, "EngineBuilder")
+      .def(py::init<>())
       .def("add_log_level", &EngineBuilder::add_log_level)
       .def("set_on_engine_running", &EngineBuilder::set_on_engine_running)
       .def("add_stats_domain", &EngineBuilder::add_stats_domain)
@@ -79,14 +83,14 @@ PYBIND11_MODULE(envoy_engine, m) {
       .def(py::init<>())
       .def("execute", &Executor::execute);
 
-  py::enum_<Envoy::Logger::Logger::Levels>(m, "LogLevel")
-      .value("Trace", Envoy::Logger::Logger::Levels::trace)
-      .value("Debug", Envoy::Logger::Logger::Levels::debug)
-      .value("Info", Envoy::Logger::Logger::Levels::info)
-      .value("Warn", Envoy::Logger::Logger::Levels::warn)
-      .value("Error", Envoy::Logger::Logger::Levels::error)
-      .value("Critical", Envoy::Logger::Logger::Levels::critical)
-      .value("Off", Envoy::Logger::Logger::Levels::off);
+  py::enum_<LogLevel>(m, "LogLevel")
+      .value("Trace", LogLevel::trace)
+      .value("Debug", LogLevel::debug)
+      .value("Info", LogLevel::info)
+      .value("Warn", LogLevel::warn)
+      .value("Error", LogLevel::error)
+      .value("Critical", LogLevel::critical)
+      .value("Off", LogLevel::off);
 
   py::class_<RequestHeaders, RequestHeadersSharedPtr>(m, "RequestHeaders")
       .def("__getitem__", &RequestHeaders::operator[])
@@ -100,6 +104,7 @@ PYBIND11_MODULE(envoy_engine, m) {
       .def("to_request_headers_builder", &RequestHeaders::to_request_headers_builder);
 
   py::class_<RequestHeadersBuilder, RequestHeadersBuilderSharedPtr>(m, "RequestHeadersBuilder")
+      .def(py::init<RequestMethod, const std::string&, const std::string&, const std::string&>())
       .def("add", &RequestHeadersBuilder::add)
       .def("set", &RequestHeadersBuilder::set)
       .def("remove", &RequestHeadersBuilder::remove)
@@ -155,7 +160,7 @@ PYBIND11_MODULE(envoy_engine, m) {
 
   py::enum_<RetryRule>(m, "RetryRule")
       .value("Status5xx", RetryRule::Status5xx)
-      .value("GatewayFailure", RetryRule::GatewayFailure)
+      .value("GatewayError", RetryRule::GatewayError)
       .value("ConnectFailure", RetryRule::ConnectFailure)
       .value("RefusedStream", RetryRule::RefusedStream)
       .value("Retriable4xx", RetryRule::Retriable4xx)
@@ -163,8 +168,6 @@ PYBIND11_MODULE(envoy_engine, m) {
       .value("Reset", RetryRule::Reset);
 
   py::class_<RetryPolicy, RetryPolicySharedPtr>(m, "RetryPolicy")
-      .def("output_headers", &RetryPolicy::output_headers)
-      .def("from", &RetryPolicy::from)
       .def_readwrite("max_retry_count", &RetryPolicy::max_retry_count)
       .def_readwrite("retry_on", &RetryPolicy::retry_on)
       .def_readwrite("retry_status_codes", &RetryPolicy::retry_status_codes)
@@ -193,9 +196,10 @@ PYBIND11_MODULE(envoy_engine, m) {
 
   py::class_<StreamPrototype, StreamPrototypeSharedPtr>(m, "StreamPrototype")
       .def("start", &StreamPrototype::start)
-      .def("set_on_response_headers", &StreamPrototype::set_on_response_headers)
-      .def("set_on_response_data", &StreamPrototype::set_on_response_data)
-      .def("set_on_response_trailers", &StreamPrototype::set_on_response_trailers)
+      .def("set_on_headers", &StreamPrototype::set_on_headers)
+      .def("set_on_data", &StreamPrototype::set_on_data)
+      .def("set_on_trailers", &StreamPrototype::set_on_trailers)
+      .def("set_on_complete", &StreamPrototype::set_on_complete)
       .def("set_on_error", &StreamPrototype::set_on_error)
       .def("set_on_cancel", &StreamPrototype::set_on_cancel);
 


### PR DESCRIPTION
**Description:**

All header changes in this PR come from https://github.com/envoyproxy/envoy-mobile/pull/1217, that should be reviewed and merged first.

This PR implements a e2e test that can be run in Python using the envoy_engine module as defined in #1217. Currently it's just a py_binary that you can run to check everything is working, but I'd like to translate it over to a minimal example + test once the core implementation is complete.

**Risk Level:** Low
**Testing:** This is the test! 🙂 Unfortunately, this will fail until all of the other impl PRs are in.
**Docs Changes:** N/A
**Release Notes:** N/A