### PR TITLE
python: implement bridge utilities

### DIFF
--- a/library/cc/BUILD
+++ b/library/cc/BUILD
@@ -6,6 +6,9 @@ envoy_package()
 
 envoy_cc_library(
     name = "envoy_engine_cc_lib",
+    srcs = [
+        "bridge_utility.cc",
+    ],
     hdrs = [
         "bridge_utility.h",
         "engine.h",

--- a/library/cc/bridge_utility.cc
+++ b/library/cc/bridge_utility.cc
@@ -1,0 +1,70 @@
+#include "bridge_utility.h"
+
+#include <sstream>
+
+namespace Envoy {
+namespace Platform {
+
+// TODO(crockeo): we always copy memory across boundaries; consider allowing for moves and/or
+// shared ownership w/ reference counting via envoy-mobile's release callbacks
+
+envoy_data string_as_envoy_data(const std::string& str) {
+  uint8_t* bytes = static_cast<uint8_t*>(safe_malloc(str.size()));
+  memcpy(bytes, &str[0], str.size());
+  return envoy_data{
+      .length = str.size(),
+      .bytes = bytes,
+      .release = envoy_noop_release,
+      .context = nullptr,
+  };
+}
+
+std::string envoy_data_as_string(envoy_data data) {
+  std::string str;
+  str.resize(data.length);
+  memcpy(&str[0], data.bytes, data.length);
+  return str;
+}
+
+envoy_headers raw_header_map_as_envoy_headers(const RawHeaderMap& headers) {
+  size_t header_count = 0;
+  for (const auto& pair : headers) {
+    header_count += pair.second.size();
+  }
+
+  envoy_header* headers_list =
+      static_cast<envoy_header*>(safe_malloc(sizeof(envoy_header) * header_count));
+
+  size_t i = 0;
+  for (const auto& pair : headers) {
+    const auto& key = pair.first;
+    for (const auto& value : pair.second) {
+      envoy_header& header = headers_list[i++];
+      header.key = string_as_envoy_data(key);
+      header.value = string_as_envoy_data(value);
+    }
+  }
+
+  envoy_headers raw_headers{
+      .length = static_cast<envoy_header_size_t>(header_count),
+      .headers = headers_list,
+  };
+  return raw_headers;
+}
+
+RawHeaderMap envoy_headers_as_raw_headers(envoy_headers raw_headers) {
+  RawHeaderMap headers;
+  for (auto i = 0; i < raw_headers.length; i++) {
+    auto key = envoy_data_as_string(raw_headers.headers[i].key);
+    auto value = envoy_data_as_string(raw_headers.headers[i].value);
+
+    if (!headers.contains(key)) {
+      headers.emplace(key, std::vector<std::string>());
+    }
+    headers[key].push_back(value);
+  }
+  return headers;
+}
+
+} // namespace Platform
+} // namespace Envoy

--- a/library/cc/bridge_utility.cc
+++ b/library/cc/bridge_utility.cc
@@ -14,7 +14,7 @@ envoy_data string_as_envoy_data(const std::string& str) {
   return envoy_data{
       .length = str.size(),
       .bytes = bytes,
-      .release = envoy_noop_release,
+      .release = free,
       .context = nullptr,
   };
 }
@@ -23,6 +23,7 @@ std::string envoy_data_as_string(envoy_data data) {
   std::string str;
   str.resize(data.length);
   memcpy(&str[0], data.bytes, data.length);
+  data.release(data.context);
   return str;
 }
 

--- a/library/cc/bridge_utility.cc
+++ b/library/cc/bridge_utility.cc
@@ -64,6 +64,7 @@ RawHeaderMap envoy_headers_as_raw_headers(envoy_headers raw_headers) {
     }
     headers[key].push_back(value);
   }
+  release_envoy_headers(raw_headers);
   return headers;
 }
 

--- a/library/cc/bridge_utility.cc
+++ b/library/cc/bridge_utility.cc
@@ -15,7 +15,7 @@ envoy_data string_as_envoy_data(const std::string& str) {
       .length = str.size(),
       .bytes = bytes,
       .release = free,
-      .context = nullptr,
+      .context = bytes,
   };
 }
 

--- a/library/python/BUILD
+++ b/library/python/BUILD
@@ -4,6 +4,9 @@ licenses(["notice"])  # Apache 2
 
 pybind_library(
     name = "envoy_engine_lib",
+    srcs = [
+        "bytes_view.cc",
+    ],
     hdrs = [
         "bytes_view.h",
         "stream_prototype_shim.h",

--- a/library/python/bytes_view.cc
+++ b/library/python/bytes_view.cc
@@ -1,0 +1,38 @@
+#include "bytes_view.h"
+
+namespace Envoy {
+namespace Python {
+
+struct EnvoyDataViewContext {
+  const py::bytes& handle;
+};
+
+static void release_envoy_data_view(void* context) {
+  auto envoy_data_view_context = static_cast<EnvoyDataViewContext*>(context);
+  envoy_data_view_context->handle.dec_ref();
+}
+
+envoy_data py_bytes_as_envoy_data(const py::bytes& bytes) {
+  auto context = new EnvoyDataViewContext{
+      .handle = bytes,
+  };
+  bytes.inc_ref();
+
+  py::buffer_info info(py::buffer(bytes).request());
+  return envoy_data{
+      .length = static_cast<size_t>(info.itemsize * info.size),
+      .bytes = static_cast<uint8_t*>(info.ptr),
+      .release = release_envoy_data_view,
+      .context = static_cast<void*>(context),
+  };
+}
+
+// we cannot extend the lifetime of an envoy_data like we can a py::bytes
+// so instead of providing a view onto the underlying data
+// we just copy it over to python-land.
+py::bytes envoy_data_as_py_bytes(envoy_data data) {
+  return py::bytes((const char*)data.bytes, data.length);
+}
+
+} // namespace Python
+} // namespace Envoy

--- a/library/python/bytes_view.cc
+++ b/library/python/bytes_view.cc
@@ -31,7 +31,9 @@ envoy_data py_bytes_as_envoy_data(const py::bytes& bytes) {
 // so instead of providing a view onto the underlying data
 // we just copy it over to python-land.
 py::bytes envoy_data_as_py_bytes(envoy_data data) {
-  return py::bytes((const char*)data.bytes, data.length);
+  auto bytes = py::bytes((const char*)data.bytes, data.length);
+  data.release(data.context);
+  return bytes;
 }
 
 } // namespace Python


### PR DESCRIPTION
**Description:**

All header changes in this PR come from https://github.com/envoyproxy/envoy-mobile/pull/1217, that should be reviewed and merged first.

This implements all of the util functions used to convert between envoy-mobile types and cc-lib types. Note that right now it copies _all_ data at the border between envoy-mobile and the cc-lib, which is inefficient. As noted in the TODO, this is going to be a good place for optimization.

**Risk Level:** Low
**Testing:** N/A, will follow up with testing in only C++, since this won't be exposed into the Python layer.
**Docs Changes:** N/A
**Release Notes:** N/A