### PR TITLE
filters: add support for data and trailers injection

### DIFF
--- a/library/common/extensions/filters/http/platform_bridge/filter.cc
+++ b/library/common/extensions/filters/http/platform_bridge/filter.cc
@@ -534,11 +534,11 @@ void PlatformBridgeFilter::ResponseFilterBase::addTrailers(envoy_headers trailer
 }
 
 void PlatformBridgeFilter::RequestFilterBase::resumeIteration() {
-  parent_.encoder_callbacks_->continueEncoding();
+  parent_.decoder_callbacks_->continueDecoding();
 }
 
 void PlatformBridgeFilter::ResponseFilterBase::resumeIteration() {
-  parent_.decoder_callbacks_->continueDecoding();
+  parent_.encoder_callbacks_->continueEncoding();
 }
 
 // Technically-speaking to align with Envoy's internal API this method should take

--- a/library/common/extensions/filters/http/platform_bridge/filter.cc
+++ b/library/common/extensions/filters/http/platform_bridge/filter.cc
@@ -58,26 +58,11 @@ PlatformBridgeFilterConfig::PlatformBridgeFilterConfig(
       platform_filter_(static_cast<envoy_http_filter*>(
           Api::External::retrieveApi(proto_config.platform_filter_name()))) {}
 
-PlatformBridgeFilter::FilterBase
-PlatformBridgeFilter::FilterBase::createRequestBase(PlatformBridgeFilter& parent) {
-  return FilterBase{
-      parent, parent.platform_filter_.on_request_headers, parent.platform_filter_.on_request_data,
-      parent.platform_filter_.on_request_trailers, parent.platform_filter_.on_resume_request};
-}
-
-PlatformBridgeFilter::FilterBase
-PlatformBridgeFilter::FilterBase::createResponseBase(PlatformBridgeFilter& parent) {
-  return FilterBase{
-      parent, parent.platform_filter_.on_response_headers, parent.platform_filter_.on_response_data,
-      parent.platform_filter_.on_response_trailers, parent.platform_filter_.on_resume_response};
-}
-
 PlatformBridgeFilter::PlatformBridgeFilter(PlatformBridgeFilterConfigSharedPtr config,
                                            Event::Dispatcher& dispatcher)
     : dispatcher_(dispatcher), filter_name_(config->filter_name()),
-      platform_filter_(*config->platform_filter()),
-      request_filter_base_(FilterBase::createRequestBase(*this)),
-      response_filter_base_(FilterBase::createResponseBase(*this)) {
+      platform_filter_(*config->platform_filter()), request_filter_base_(RequestFilterBase{*this}),
+      response_filter_base_(ResponseFilterBase{*this}) {
   // The initialization above sets platform_filter_ to a copy of the struct stored on the config.
   // In the typical case, this will represent a filter implementation that needs to be intantiated.
   // static_context will contain the necessary platform-specific mechanism to produce a filter
@@ -186,8 +171,7 @@ Http::FilterHeadersStatus PlatformBridgeFilter::FilterBase::onHeaders(Http::Head
 }
 
 Http::FilterDataStatus PlatformBridgeFilter::FilterBase::onData(Buffer::Instance& data,
-                                                                bool end_stream,
-                                                                Buffer::Instance* internal_buffer) {
+                                                                bool end_stream) {
   stream_complete_ = end_stream;
 
   // Allow nullptr to act as no-op.
@@ -195,6 +179,7 @@ Http::FilterDataStatus PlatformBridgeFilter::FilterBase::onData(Buffer::Instance
     return Http::FilterDataStatus::Continue;
   }
 
+  auto internal_buffer = buffer();
   envoy_data in_data;
 
   // Decide whether to preemptively buffer data to present aggregate to platform.
@@ -276,9 +261,7 @@ Http::FilterDataStatus PlatformBridgeFilter::FilterBase::onData(Buffer::Instance
   NOT_REACHED_GCOVR_EXCL_LINE;
 }
 
-Http::FilterTrailersStatus
-PlatformBridgeFilter::FilterBase::onTrailers(Http::HeaderMap& trailers,
-                                             Buffer::Instance* internal_buffer) {
+Http::FilterTrailersStatus PlatformBridgeFilter::FilterBase::onTrailers(Http::HeaderMap& trailers) {
   stream_complete_ = true;
 
   // Allow nullptr to act as no-op.
@@ -286,6 +269,7 @@ PlatformBridgeFilter::FilterBase::onTrailers(Http::HeaderMap& trailers,
     return Http::FilterTrailersStatus::Continue;
   }
 
+  auto internal_buffer = buffer();
   envoy_headers in_trailers = Http::Utility::toBridgeHeaders(trailers);
   ENVOY_LOG(trace, "PlatformBridgeFilter({})->on_*_trailers", parent_.filter_name_);
   envoy_filter_trailers_status result =
@@ -340,6 +324,8 @@ Http::FilterHeadersStatus PlatformBridgeFilter::decodeHeaders(Http::RequestHeade
                                                               bool end_stream) {
   ENVOY_LOG(trace, "PlatformBridgeFilter({})::decodeHeaders(end_stream:{})", filter_name_,
             end_stream);
+
+  // Delegate to base implementation for request and response path.
   return request_filter_base_.onHeaders(headers, end_stream);
 }
 
@@ -378,6 +364,7 @@ Http::FilterHeadersStatus PlatformBridgeFilter::encodeHeaders(Http::ResponseHead
     return Http::FilterHeadersStatus::Continue;
   }
 
+  // Delegate to base implementation for request and response path.
   return response_filter_base_.onHeaders(headers, end_stream);
 }
 
@@ -385,16 +372,8 @@ Http::FilterDataStatus PlatformBridgeFilter::decodeData(Buffer::Instance& data, 
   ENVOY_LOG(trace, "PlatformBridgeFilter({})::decodeData(length:{}, end_stream:{})", filter_name_,
             data.length(), end_stream);
 
-  // Delegate to shared implementation for request and response path.
-  Buffer::Instance* internal_buffer = nullptr;
-  if (request_filter_base_.iteration_state_ == IterationState::Stopped &&
-      decoder_callbacks_->decodingBuffer()) {
-    decoder_callbacks_->modifyDecodingBuffer([&internal_buffer](Buffer::Instance& mutable_buffer) {
-      internal_buffer = &mutable_buffer;
-    });
-  }
-
-  return request_filter_base_.onData(data, end_stream, internal_buffer);
+  // Delegate to base implementation for request and response path.
+  return request_filter_base_.onData(data, end_stream);
 }
 
 Http::FilterDataStatus PlatformBridgeFilter::encodeData(Buffer::Instance& data, bool end_stream) {
@@ -406,31 +385,15 @@ Http::FilterDataStatus PlatformBridgeFilter::encodeData(Buffer::Instance& data, 
     return Http::FilterDataStatus::Continue;
   }
 
-  // Delegate to shared implementation for request and response path.
-  Buffer::Instance* internal_buffer = nullptr;
-  if (response_filter_base_.iteration_state_ == IterationState::Stopped &&
-      encoder_callbacks_->encodingBuffer()) {
-    encoder_callbacks_->modifyEncodingBuffer([&internal_buffer](Buffer::Instance& mutable_buffer) {
-      internal_buffer = &mutable_buffer;
-    });
-  }
-
-  return response_filter_base_.onData(data, end_stream, internal_buffer);
+  // Delegate to base implementation for request and response path.
+  return response_filter_base_.onData(data, end_stream);
 }
 
 Http::FilterTrailersStatus PlatformBridgeFilter::decodeTrailers(Http::RequestTrailerMap& trailers) {
   ENVOY_LOG(trace, "PlatformBridgeFilter({})::decodeTrailers", filter_name_);
 
-  // Delegate to shared implementation for request and response path.
-  Buffer::Instance* internal_buffer = nullptr;
-  if (request_filter_base_.iteration_state_ == IterationState::Stopped &&
-      decoder_callbacks_->decodingBuffer()) {
-    decoder_callbacks_->modifyDecodingBuffer([&internal_buffer](Buffer::Instance& mutable_buffer) {
-      internal_buffer = &mutable_buffer;
-    });
-  }
-
-  return request_filter_base_.onTrailers(trailers, internal_buffer);
+  // Delegate to base implementation for request and response path.
+  return request_filter_base_.onTrailers(trailers);
 }
 
 Http::FilterTrailersStatus
@@ -442,16 +405,8 @@ PlatformBridgeFilter::encodeTrailers(Http::ResponseTrailerMap& trailers) {
     return Http::FilterTrailersStatus::Continue;
   }
 
-  // Delegate to shared implementation for request and response path.
-  Buffer::Instance* internal_buffer = nullptr;
-  if (response_filter_base_.iteration_state_ == IterationState::Stopped &&
-      encoder_callbacks_->encodingBuffer()) {
-    encoder_callbacks_->modifyEncodingBuffer([&internal_buffer](Buffer::Instance& mutable_buffer) {
-      internal_buffer = &mutable_buffer;
-    });
-  }
-
-  return response_filter_base_.onTrailers(trailers, internal_buffer);
+  // Delegate to base implementation for request and response path.
+  return response_filter_base_.onTrailers(trailers);
 }
 
 void PlatformBridgeFilter::resumeDecoding() {
@@ -467,15 +422,8 @@ void PlatformBridgeFilter::resumeDecoding() {
   // Relevant: https://github.com/lyft/envoy-mobile/issues/332
   dispatcher_.post([weak_self]() -> void {
     if (auto self = weak_self.lock()) {
-      Buffer::Instance* internal_buffer = nullptr;
-      if (self->decoder_callbacks_->decodingBuffer()) {
-        self->decoder_callbacks_->modifyDecodingBuffer(
-            [&internal_buffer](Buffer::Instance& mutable_buffer) {
-              internal_buffer = &mutable_buffer;
-            });
-      }
-      self->request_filter_base_.onResume(
-          internal_buffer, [&self]() { self->decoder_callbacks_->continueDecoding(); });
+      // Delegate to base implementation for request and response path.
+      self->request_filter_base_.onResume();
     }
   });
 }
@@ -486,27 +434,20 @@ void PlatformBridgeFilter::resumeEncoding() {
   auto weak_self = weak_from_this();
   dispatcher_.post([weak_self]() -> void {
     if (auto self = weak_self.lock()) {
-      Buffer::Instance* internal_buffer = nullptr;
-      if (self->encoder_callbacks_->encodingBuffer()) {
-        self->encoder_callbacks_->modifyEncodingBuffer(
-            [&internal_buffer](Buffer::Instance& mutable_buffer) {
-              internal_buffer = &mutable_buffer;
-            });
-      }
-      self->response_filter_base_.onResume(
-          internal_buffer, [&self]() { self->encoder_callbacks_->continueEncoding(); });
+      // Delegate to base implementation for request and response path.
+      self->response_filter_base_.onResume();
     }
   });
 }
 
-void PlatformBridgeFilter::FilterBase::onResume(Buffer::Instance* internal_buffer,
-                                                std::function<void()> resume_call) {
+void PlatformBridgeFilter::FilterBase::onResume() {
   ENVOY_LOG(trace, "PlatformBridgeFilter({})::onResume", parent_.filter_name_);
 
   if (iteration_state_ == IterationState::Ongoing) {
     return;
   }
 
+  auto internal_buffer = buffer();
   envoy_headers bridged_headers;
   envoy_data bridged_data;
   envoy_headers bridged_trailers;
@@ -551,9 +492,9 @@ void PlatformBridgeFilter::FilterBase::onResume(Buffer::Instance* internal_buffe
     internal_buffer->addBufferFragment(
         *Buffer::BridgeFragment::createBridgeFragment(*result.pending_data));
     free(result.pending_data);
-  } else {
-    RELEASE_ASSERT(!result.pending_data,
-                   "invalid filter state: data injection is unsupported at present");
+  } else if (result.pending_data) {
+    addData(*result.pending_data);
+    free(result.pending_data);
   }
 
   if (pending_trailers_) {
@@ -562,9 +503,70 @@ void PlatformBridgeFilter::FilterBase::onResume(Buffer::Instance* internal_buffe
     replaceHeaders(*pending_trailers_, *result.pending_trailers);
     pending_trailers_ = nullptr;
     free(result.pending_trailers);
+  } else if (result.pending_trailers) {
+    addTrailers(*result.pending_trailers);
   }
+
   iteration_state_ = IterationState::Ongoing;
-  resume_call();
+  resumeIteration();
+}
+
+void PlatformBridgeFilter::RequestFilterBase::addData(envoy_data data) {
+  Buffer::OwnedImpl inject_data;
+  inject_data.addBufferFragment(*Buffer::BridgeFragment::createBridgeFragment(data));
+  parent_.decoder_callbacks_->addDecodedData(inject_data, /* watermark */ false);
+}
+
+void PlatformBridgeFilter::ResponseFilterBase::addData(envoy_data data) {
+  Buffer::OwnedImpl inject_data;
+  inject_data.addBufferFragment(*Buffer::BridgeFragment::createBridgeFragment(data));
+  parent_.encoder_callbacks_->addEncodedData(inject_data, /* watermark */ false);
+}
+
+void PlatformBridgeFilter::RequestFilterBase::addTrailers(envoy_headers trailers) {
+  Http::HeaderMap& inject_trailers = parent_.decoder_callbacks_->addDecodedTrailers();
+  replaceHeaders(inject_trailers, trailers);
+}
+
+void PlatformBridgeFilter::ResponseFilterBase::addTrailers(envoy_headers trailers) {
+  Http::HeaderMap& inject_trailers = parent_.encoder_callbacks_->addEncodedTrailers();
+  replaceHeaders(inject_trailers, trailers);
+}
+
+void PlatformBridgeFilter::RequestFilterBase::resumeIteration() {
+  parent_.encoder_callbacks_->continueEncoding();
+}
+
+void PlatformBridgeFilter::ResponseFilterBase::resumeIteration() {
+  parent_.decoder_callbacks_->continueDecoding();
+}
+
+// Technically-speaking to align with Envoy's internal API this method should take
+// a closure to execute with the available buffer, but since we control all usage,
+// this shortcut works for now.
+Buffer::Instance* PlatformBridgeFilter::RequestFilterBase::buffer() {
+  Buffer::Instance* internal_buffer = nullptr;
+  if (parent_.decoder_callbacks_->decodingBuffer()) {
+    parent_.decoder_callbacks_->modifyDecodingBuffer(
+        [&internal_buffer](Buffer::Instance& mutable_buffer) {
+          internal_buffer = &mutable_buffer;
+        });
+  }
+  return internal_buffer;
+}
+
+// Technically-speaking to align with Envoy's internal API this method should take
+// a closure to execute with the available buffer, but since we control all usage,
+// this shortcut works for now.
+Buffer::Instance* PlatformBridgeFilter::ResponseFilterBase::buffer() {
+  Buffer::Instance* internal_buffer = nullptr;
+  if (parent_.encoder_callbacks_->encodingBuffer()) {
+    parent_.encoder_callbacks_->modifyEncodingBuffer(
+        [&internal_buffer](Buffer::Instance& mutable_buffer) {
+          internal_buffer = &mutable_buffer;
+        });
+  }
+  return internal_buffer;
 }
 
 } // namespace PlatformBridge

--- a/library/common/extensions/filters/http/platform_bridge/filter.h
+++ b/library/common/extensions/filters/http/platform_bridge/filter.h
@@ -90,12 +90,11 @@ private:
         : iteration_state_(IterationState::Ongoing), parent_(parent), on_headers_(on_headers),
           on_data_(on_data), on_trailers_(on_trailers), on_resume_(on_resume) {}
 
-    virtual ~FilterBase() PURE;
+    virtual ~FilterBase() = default;
 
+    // Common handling for both request and response path.
     Http::FilterHeadersStatus onHeaders(Http::HeaderMap& headers, bool end_stream);
-
     Http::FilterDataStatus onData(Buffer::Instance& data, bool end_stream);
-
     Http::FilterTrailersStatus onTrailers(Http::HeaderMap& trailers);
 
     // Scheduled on the dispatcher when resumeDecoding/Encoding is called from platform
@@ -104,12 +103,10 @@ private:
     // entities before resuming iteration.
     void onResume();
 
+    // Directional (request/response) helper methods.
     virtual void addData(envoy_data data) PURE;
-
     virtual void addTrailers(envoy_headers trailers) PURE;
-
     virtual void resumeIteration() PURE;
-
     virtual Buffer::Instance* buffer() PURE;
 
     IterationState iteration_state_;
@@ -129,8 +126,6 @@ private:
                      parent.platform_filter_.on_request_data,
                      parent.platform_filter_.on_request_trailers,
                      parent.platform_filter_.on_resume_request) {}
-
-    // override ~RequestFilterBase();
 
     // FilterBase
     void addData(envoy_data data) override;

--- a/library/common/extensions/filters/http/platform_bridge/filter.h
+++ b/library/common/extensions/filters/http/platform_bridge/filter.h
@@ -90,23 +90,27 @@ private:
         : iteration_state_(IterationState::Ongoing), parent_(parent), on_headers_(on_headers),
           on_data_(on_data), on_trailers_(on_trailers), on_resume_(on_resume) {}
 
-    static FilterBase createRequestBase(PlatformBridgeFilter& parent);
-
-    static FilterBase createResponseBase(PlatformBridgeFilter& parent);
+    virtual ~FilterBase() PURE;
 
     Http::FilterHeadersStatus onHeaders(Http::HeaderMap& headers, bool end_stream);
 
-    Http::FilterDataStatus onData(Buffer::Instance& data, bool end_stream,
-                                  Buffer::Instance* internal_buffer);
+    Http::FilterDataStatus onData(Buffer::Instance& data, bool end_stream);
 
-    Http::FilterTrailersStatus onTrailers(Http::HeaderMap& trailers,
-                                          Buffer::Instance* internal_buffer);
+    Http::FilterTrailersStatus onTrailers(Http::HeaderMap& trailers);
 
-    // Scheduled on the dispatcher when resume* is called from platform
+    // Scheduled on the dispatcher when resumeDecoding/Encoding is called from platform
     // filter callbacks. Provides a snapshot of pending HTTP stream state to the
     // platform filter, and consumes invocation results to modify pending HTTP
     // entities before resuming iteration.
-    void onResume(Buffer::Instance* internal_buffer, std::function<void()> resume_call);
+    void onResume();
+
+    virtual void addData(envoy_data data) PURE;
+
+    virtual void addTrailers(envoy_headers trailers) PURE;
+
+    virtual void resumeIteration() PURE;
+
+    virtual Buffer::Instance* buffer() PURE;
 
     IterationState iteration_state_;
     PlatformBridgeFilter& parent_;
@@ -119,11 +123,41 @@ private:
     Http::HeaderMap* pending_trailers_{};
   };
 
+  struct RequestFilterBase : FilterBase {
+    RequestFilterBase(PlatformBridgeFilter& parent)
+        : FilterBase(parent, parent.platform_filter_.on_request_headers,
+                     parent.platform_filter_.on_request_data,
+                     parent.platform_filter_.on_request_trailers,
+                     parent.platform_filter_.on_resume_request) {}
+
+    // override ~RequestFilterBase();
+
+    // FilterBase
+    void addData(envoy_data data) override;
+    void addTrailers(envoy_headers trailers) override;
+    void resumeIteration() override;
+    Buffer::Instance* buffer() override;
+  };
+
+  struct ResponseFilterBase : FilterBase {
+    ResponseFilterBase(PlatformBridgeFilter& parent)
+        : FilterBase(parent, parent.platform_filter_.on_response_headers,
+                     parent.platform_filter_.on_response_data,
+                     parent.platform_filter_.on_response_trailers,
+                     parent.platform_filter_.on_resume_response) {}
+
+    // FilterBase
+    void addData(envoy_data data) override;
+    void addTrailers(envoy_headers trailers) override;
+    void resumeIteration() override;
+    Buffer::Instance* buffer() override;
+  };
+
   Event::Dispatcher& dispatcher_;
   const std::string filter_name_;
   envoy_http_filter platform_filter_;
-  FilterBase request_filter_base_;
-  FilterBase response_filter_base_;
+  RequestFilterBase request_filter_base_;
+  ResponseFilterBase response_filter_base_;
   envoy_http_filter_callbacks platform_request_callbacks_{};
   envoy_http_filter_callbacks platform_response_callbacks_{};
   bool error_response_{};

--- a/test/common/extensions/filters/http/platform_bridge/platform_bridge_filter_test.cc
+++ b/test/common/extensions/filters/http/platform_bridge/platform_bridge_filter_test.cc
@@ -417,10 +417,10 @@ TEST_F(PlatformBridgeFilterTest, StopAndBufferOnRequestData) {
 
   Buffer::OwnedImpl decoding_buffer;
   EXPECT_CALL(decoder_callbacks_, decodingBuffer())
-      .Times(2)
+      .Times(3)
       .WillRepeatedly(Return(&decoding_buffer));
   EXPECT_CALL(decoder_callbacks_, modifyDecodingBuffer(_))
-      .Times(2)
+      .Times(3)
       .WillRepeatedly(Invoke([&](std::function<void(Buffer::Instance&)> callback) -> void {
         callback(decoding_buffer);
       }));
@@ -489,10 +489,10 @@ TEST_F(PlatformBridgeFilterTest, StopAndBufferThenResumeOnRequestData) {
 
   Buffer::OwnedImpl decoding_buffer;
   EXPECT_CALL(decoder_callbacks_, decodingBuffer())
-      .Times(1)
+      .Times(2)
       .WillRepeatedly(Return(&decoding_buffer));
   EXPECT_CALL(decoder_callbacks_, modifyDecodingBuffer(_))
-      .Times(1)
+      .Times(2)
       .WillRepeatedly(Invoke([&](std::function<void(Buffer::Instance&)> callback) -> void {
         callback(decoding_buffer);
       }));
@@ -1190,10 +1190,10 @@ TEST_F(PlatformBridgeFilterTest, StopAndBufferOnResponseData) {
 
   Buffer::OwnedImpl encoding_buffer;
   EXPECT_CALL(encoder_callbacks_, encodingBuffer())
-      .Times(2)
+      .Times(3)
       .WillRepeatedly(Return(&encoding_buffer));
   EXPECT_CALL(encoder_callbacks_, modifyEncodingBuffer(_))
-      .Times(2)
+      .Times(3)
       .WillRepeatedly(Invoke([&](std::function<void(Buffer::Instance&)> callback) -> void {
         callback(encoding_buffer);
       }));
@@ -1262,10 +1262,10 @@ TEST_F(PlatformBridgeFilterTest, StopAndBufferThenResumeOnResponseData) {
 
   Buffer::OwnedImpl encoding_buffer;
   EXPECT_CALL(encoder_callbacks_, encodingBuffer())
-      .Times(1)
+      .Times(2)
       .WillRepeatedly(Return(&encoding_buffer));
   EXPECT_CALL(encoder_callbacks_, modifyEncodingBuffer(_))
-      .Times(1)
+      .Times(2)
       .WillRepeatedly(Invoke([&](std::function<void(Buffer::Instance&)> callback) -> void {
         callback(encoding_buffer);
       }));


### PR DESCRIPTION
Description: Adds support for injecting data and/or trailers specifically during onResume() callbacks when resuming filter iteration asynchronously. This is accomplished by passing back data and/or trailers where none were originally present at the point of resumption.
Risk Level: Moderate
Testing: Pending

Signed-off-by: Mike Schore <mike.schore@gmail.com>