### PR TITLE
docs: update commands to reference bazelisk

### DIFF
--- a/docs/root/development/performance/binary_size.rst
+++ b/docs/root/development/performance/binary_size.rst
@@ -52,7 +52,7 @@ necessary tools::
 The binary being compiled is ``//test/performance:test_binary_size``.
 The binary is getting built with the following build command::
 
-  bazel build //test/performance:test_binary_size --config=sizeopt --copt=-ggdb3 --linkopt=-fuse-ld=lld
+  bazelisk build //test/performance:test_binary_size --config=sizeopt --copt=-ggdb3 --linkopt=-fuse-ld=lld
 
 Thus the binary is compiled with the following flags pertinent to reducing
 binary size:

--- a/docs/root/development/performance/cpu_battery_impact.rst
+++ b/docs/root/development/performance/cpu_battery_impact.rst
@@ -86,7 +86,7 @@ Modified versions of the "hello world" example apps were used to run these exper
 
 Getting the build:
 
-1. Build the library using ``bazel build android_dist --config=android --fat_apk_cpu=armeabi-v7a``
+1. Build the library using ``bazelisk build android_dist --config=android --fat_apk_cpu=armeabi-v7a``
 2. Control: ``bazel mobile-install //examples/kotlin/control:hello_control_kt``
 3. Envoy: ``bazel mobile-install //examples/kotlin/hello_world:hello_envoy_kt --fat_apk_cpu=armeabi-v7a``
 

--- a/docs/root/development/performance/device_connectivity.rst
+++ b/docs/root/development/performance/device_connectivity.rst
@@ -72,7 +72,7 @@ Android configuration
 
 2. Build and run the example app:
 
-``bazel mobile-install //examples/kotlin/hello_world:hello_envoy_kt --fat_apk_cpu=armeabi-v7a``
+``bazelisk mobile-install //examples/kotlin/hello_world:hello_envoy_kt --fat_apk_cpu=armeabi-v7a``
 
 ~~~~~~~~~~~
 Open issues

--- a/docs/root/development/testing/testing.rst
+++ b/docs/root/development/testing/testing.rst
@@ -26,7 +26,7 @@ Java tests
 
 To run the entire Java unit test suite locally, use the following Bazel command:
 
-``bazel test --test_output=all --build_tests_only //library/java/test/...``
+``bazelisk test --test_output=all --build_tests_only //library/java/test/...``
 
 ------------
 Kotlin tests
@@ -34,7 +34,7 @@ Kotlin tests
 
 To run the entire Kotlin unit test suite locally, use the following Bazel command:
 
-``bazel test --test_output=all --build_tests_only //library/kotlin/test/...``
+``bazelisk test --test_output=all --build_tests_only //library/kotlin/test/...``
 
 -----------
 Swift tests
@@ -42,4 +42,4 @@ Swift tests
 
 To run the entire Swift unit test suite locally, use the following Bazel command:
 
-``bazel test --test_output=all --build_tests_only //library/swift/test/...``
+``bazelisk test --test_output=all --build_tests_only //library/swift/test/...``

--- a/docs/root/start/building/building.rst
+++ b/docs/root/start/building/building.rst
@@ -51,7 +51,7 @@ Android AAR
 Envoy Mobile can be compiled into an ``.aar`` file for use with Android apps.
 This command is defined in the main :repo:`BUILD <BUILD>` file of the repo, and may be run locally:
 
-``bazel build android_dist --config=android --fat_apk_cpu=<arch1,arch2>``
+``bazelisk build android_dist --config=android --fat_apk_cpu=<arch1,arch2>``
 
 Upon completion of the build, you'll see an ``envoy.aar`` file at :repo:`dist/envoy.aar <dist>`.
 
@@ -64,7 +64,7 @@ an example of how this artifact may be used.
 **When building the artifact for release** (usage outside of development), be sure to include the
 ``--config=release-android`` option, along with the architectures for which the artifact is being built:
 
-``bazel build android_dist --config=release-android --fat_apk_cpu=x86,armeabi-v7a,arm64-v8a``
+``bazelisk build android_dist --config=release-android --fat_apk_cpu=x86,armeabi-v7a,arm64-v8a``
 
 For a demo of a working app using this artifact, see the :ref:`hello_world` example.
 
@@ -77,7 +77,7 @@ iOS static framework
 Envoy Mobile supports being compiled into a ``.framework`` for consumption by iOS apps.
 This command is defined in the main :repo:`BUILD <BUILD>` file of the repo, and may be run locally:
 
-``bazel build ios_dist --config=ios``
+``bazelisk build ios_dist --config=ios``
 
 Upon completion of the build, you'll see a ``Envoy.framework`` directory at
 :repo:`dist/Envoy.framework <dist>`.
@@ -91,7 +91,7 @@ example of how this artifact may be used.
 **When building the artifact for release** (usage outside of development), be sure to include the
 ``--config=release-ios`` option, along with the architectures for which the artifact is being built:
 
-``bazel build ios_dist --config=release-ios --ios_multi_cpus=i386,x86_64,armv7,arm64``
+``bazelisk build ios_dist --config=release-ios --ios_multi_cpus=i386,x86_64,armv7,arm64``
 
 For a demo of a working app using this artifact, see the :ref:`hello_world` example.
 

--- a/docs/root/start/examples/hello_world.rst
+++ b/docs/root/start/examples/hello_world.rst
@@ -23,7 +23,7 @@ Next, make sure you have an Android simulator running.
 
 Run the :repo:`sample app <examples/java/hello_world>` using the following Bazel build rule:
 
-``bazel mobile-install //examples/java/hello_world:hello_envoy --fat_apk_cpu=<arch1,arch2>``
+``bazelisk mobile-install //examples/java/hello_world:hello_envoy --fat_apk_cpu=<arch1,arch2>``
 
 You should see a new app installed on your simulator called ``Hello Envoy``.
 Open it up, and requests will start flowing!
@@ -38,7 +38,7 @@ Next, make sure you have an Android simulator running.
 
 Run the :repo:`sample app <examples/kotlin/hello_world>` using the following Bazel build rule:
 
-``bazel mobile-install //examples/kotlin/hello_world:hello_envoy_kt --fat_apk_cpu=<arch1,arch2>``
+``bazelisk mobile-install //examples/kotlin/hello_world:hello_envoy_kt --fat_apk_cpu=<arch1,arch2>``
 
 You should see a new app installed on your simulator called ``Hello Envoy Kotlin``.
 Open it up, and requests will start flowing!
@@ -51,7 +51,7 @@ First, build the :ref:`ios_framework` artifact.
 
 Next, run the :repo:`sample app <examples/objective-c/hello_world>` using the following Bazel build rule:
 
-``bazel run //examples/objective-c/hello_world:app --config=ios``
+``bazelisk run //examples/objective-c/hello_world:app --config=ios``
 
 This will start a simulator and open a new app. You should see requests start flowing!
 
@@ -63,6 +63,6 @@ First, build the :ref:`ios_framework` artifact.
 
 Next, run the :repo:`sample app <examples/swift/hello_world>` using the following Bazel build rule:
 
-``bazel run //examples/swift/hello_world:app --config=ios``
+``bazelisk run //examples/swift/hello_world:app --config=ios``
 
 This will start a simulator and open a new app. You should see requests start flowing!


### PR DESCRIPTION
Description: bazelisk is the default and preferred way to build to ensure consistency as much as possible. This change updates the project's docs to refer to bazelisk when providing example build commands.

Signed-off-by: Mike Schore <mike.schore@gmail.com>