### PR TITLE
stats: avoid string join during stats reporting

### DIFF
--- a/library/kotlin/src/io/envoyproxy/envoymobile/stats/CounterImpl.kt
+++ b/library/kotlin/src/io/envoyproxy/envoymobile/stats/CounterImpl.kt
@@ -8,17 +8,15 @@ import java.lang.ref.WeakReference
  */
 internal class CounterImpl : Counter {
   internal val envoyEngine: WeakReference<EnvoyEngine>
-  internal val elements: List<Element>
+  private val series: String
 
   internal constructor(engine: EnvoyEngine, elements: List<Element>) {
     this.envoyEngine = WeakReference<EnvoyEngine>(engine)
-    this.elements = elements
+    this.series = elements.joinToString(separator = ".") { it.value }
   }
 
   // TODO: potentially raise error to platform if the operation is not successful.
   override fun increment(count: Int) {
-    envoyEngine.get()?.recordCounterInc(
-      elements.joinToString(separator = ".") { it.value }, count
-    )
+    envoyEngine.get()?.recordCounterInc(series, count)
   }
 }

--- a/library/kotlin/src/io/envoyproxy/envoymobile/stats/GaugeImpl.kt
+++ b/library/kotlin/src/io/envoyproxy/envoymobile/stats/GaugeImpl.kt
@@ -8,28 +8,22 @@ import java.lang.ref.WeakReference
  */
 internal class GaugeImpl : Gauge {
   internal val envoyEngine: WeakReference<EnvoyEngine>
-  internal val elements: List<Element>
+  internal val series: String
 
   internal constructor(engine: EnvoyEngine, elements: List<Element>) {
     this.envoyEngine = WeakReference<EnvoyEngine>(engine)
-    this.elements = elements
+    this.series = elements.joinToString(separator = ".") { it.value }
   }
 
   override fun set(value: Int) {
-    envoyEngine.get()?.recordGaugeSet(
-      elements.joinToString(separator = ".") { it.value }, value
-    )
+    envoyEngine.get()?.recordGaugeSet(series, value)
   }
 
   override fun add(amount: Int) {
-    envoyEngine.get()?.recordGaugeAdd(
-      elements.joinToString(separator = ".") { it.value }, amount
-    )
+    envoyEngine.get()?.recordGaugeAdd(series, amount)
   }
 
   override fun sub(amount: Int) {
-    envoyEngine.get()?.recordGaugeSub(
-      elements.joinToString(separator = ".") { it.value }, amount
-    )
+    envoyEngine.get()?.recordGaugeSub(series, amount)
   }
 }


### PR DESCRIPTION
Description: construct the stats name in constructor, avoid string join during stats reporting (inc, set, etc.)
Risk Level: low
Testing: unit, ci

Signed-off-by: Jingwei Hao <jingweih@lyft.com>