### PR TITLE
config: experiment with tighter keepalive configuration

### DIFF
--- a/library/common/config_template.cc
+++ b/library/common/config_template.cc
@@ -105,9 +105,9 @@ static_resources:
                               R"(
     upstream_connection_options: &upstream_opts
       tcp_keepalive:
-        keepalive_interval: 10
+        keepalive_interval: 8
         keepalive_probes: 1
-        keepalive_time: 5
+        keepalive_time: 2
     circuit_breakers: &circuit_breakers_settings
       thresholds:
         - priority: DEFAULT


### PR DESCRIPTION
Description: This change will result in faster dead connection cycling at the expense of much busier connections once keepalive triggers. It's probably not an appropriate setting in all cases, but supports an experiment we're running with connection behavior on preferred interface switchovers. Applications can still override this to meet their specific requirements until we land a reasonable default. Augmenting this with h2 pings will give us quite a bit more flexibility.
Risk Level: Low
Testing: CI

Signed-off-by: Mike Schore <mike.schore@gmail.com>
