### PR TITLE
Update envoy to b1caeb3

### DIFF
--- a/library/common/extensions/filters/http/assertion/BUILD
+++ b/library/common/extensions/filters/http/assertion/BUILD
@@ -21,6 +21,7 @@ envoy_cc_extension(
     name = "assertion_filter_lib",
     srcs = ["filter.cc"],
     hdrs = ["filter.h"],
+    category = "envoy.filters.http",
     repository = "@envoy",
     security_posture = "requires_trusted_downstream_and_upstream",
     deps = [
@@ -37,6 +38,7 @@ envoy_cc_extension(
     name = "config",
     srcs = ["config.cc"],
     hdrs = ["config.h"],
+    category = "envoy.filters.http",
     repository = "@envoy",
     security_posture = "requires_trusted_downstream_and_upstream",
     deps = [

--- a/library/common/extensions/filters/http/local_error/BUILD
+++ b/library/common/extensions/filters/http/local_error/BUILD
@@ -18,6 +18,7 @@ envoy_cc_extension(
     name = "local_error_filter_lib",
     srcs = ["filter.cc"],
     hdrs = ["filter.h"],
+    category = "envoy.filters.http",
     repository = "@envoy",
     security_posture = "requires_trusted_downstream_and_upstream",
     deps = [
@@ -40,6 +41,7 @@ envoy_cc_extension(
     name = "config",
     srcs = ["config.cc"],
     hdrs = ["config.h"],
+    category = "envoy.filters.http",
     repository = "@envoy",
     security_posture = "requires_trusted_downstream_and_upstream",
     deps = [

--- a/library/common/extensions/filters/http/platform_bridge/BUILD
+++ b/library/common/extensions/filters/http/platform_bridge/BUILD
@@ -24,6 +24,7 @@ envoy_cc_extension(
         "c_types.h",
         "filter.h",
     ],
+    category = "envoy.filters.http",
     repository = "@envoy",
     security_posture = "requires_trusted_downstream_and_upstream",
     deps = [
@@ -43,6 +44,7 @@ envoy_cc_extension(
     name = "config",
     srcs = ["config.cc"],
     hdrs = ["config.h"],
+    category = "envoy.filters.http",
     repository = "@envoy",
     security_posture = "requires_trusted_downstream_and_upstream",
     deps = [

--- a/library/common/extensions/stat_sinks/metrics_service/BUILD
+++ b/library/common/extensions/stat_sinks/metrics_service/BUILD
@@ -32,6 +32,7 @@ envoy_cc_extension(
     name = "mobile_grpc_streamer",
     srcs = ["mobile_grpc_streamer.cc"],
     hdrs = ["mobile_grpc_streamer.h"],
+    category = "envoy.filters.http",
     repository = "@envoy",
     security_posture = "requires_trusted_downstream_and_upstream",
     deps = [
@@ -45,6 +46,7 @@ envoy_cc_extension(
     name = "config",
     srcs = ["config.cc"],
     hdrs = ["config.h"],
+    category = "envoy.filters.http",
     repository = "@envoy",
     security_posture = "requires_trusted_downstream_and_upstream",
     deps = [


### PR DESCRIPTION
Updating upstream to include: https://github.com/envoyproxy/envoy/pull/14945

Update includes adding extension categories for `envoy_cc_extension`

Signed-off-by: Alan Chiu <achiu@lyft.com>

For an explanation of how to fill out the fields, please see the relevant section
in [PULL_REQUESTS.md](https://github.com/envoyproxy/envoy/blob/master/PULL_REQUESTS.md)

Description: Updating upstream to include: https://github.com/envoyproxy/envoy/pull/14945
Risk Level: low
Testing: CI
Docs Changes: N/A
Release Notes: N/A
[Optional Fixes #Issue]
[Optional Deprecated:]
