### PR TITLE
stats: unregister custom stats sink

### DIFF
--- a/envoy_build_config/extension_registry.cc
+++ b/envoy_build_config/extension_registry.cc
@@ -34,8 +34,6 @@ void ExtensionRegistry::registerFactories() {
   Envoy::Extensions::NetworkFilters::HttpConnectionManager::
       forceRegisterHttpConnectionManagerFilterConfigFactory();
   Envoy::Extensions::StatSinks::MetricsService::forceRegisterMetricsServiceSinkFactory();
-  Envoy::Extensions::StatSinks::EnvoyMobileMetricsService::
-      forceRegisterEnvoyMobileMetricsServiceSinkFactory();
   Envoy::Extensions::TransportSockets::RawBuffer::forceRegisterUpstreamRawBufferSocketFactory();
   Envoy::Extensions::TransportSockets::Tls::forceRegisterUpstreamSslSocketFactory();
   Envoy::Extensions::Upstreams::Http::Generic::forceRegisterGenericGenericConnPoolFactory();

--- a/envoy_build_config/extension_registry.h
+++ b/envoy_build_config/extension_registry.h
@@ -17,7 +17,6 @@
 #include "library/common/extensions/filters/http/assertion/config.h"
 #include "library/common/extensions/filters/http/local_error/config.h"
 #include "library/common/extensions/filters/http/platform_bridge/config.h"
-#include "library/common/extensions/stat_sinks/metrics_service/config.h"
 
 namespace Envoy {
 class ExtensionRegistry {

--- a/envoy_build_config/extensions_build_config.bzl
+++ b/envoy_build_config/extensions_build_config.bzl
@@ -11,7 +11,6 @@ EXTENSIONS = {
     "envoy.filters.http.router":                      "//source/extensions/filters/http/router:config",
     "envoy.filters.network.http_connection_manager":  "//source/extensions/filters/network/http_connection_manager:config",
     "envoy.stat_sinks.metrics_service":               "//source/extensions/stat_sinks/metrics_service:config",
-    "envoy.stat_sinks.metrics_service.mobile":        "@envoy_mobile//library/common/extensions/stat_sinks/metrics_service:config",
     "envoy.transport_sockets.raw_buffer":             "//source/extensions/transport_sockets/raw_buffer:config",
     "envoy.transport_sockets.tls":                    "//source/extensions/transport_sockets/tls:config",
 }

--- a/library/common/config_template.cc
+++ b/library/common/config_template.cc
@@ -207,13 +207,6 @@ stats_sinks:
       grpc_service:
         envoy_grpc:
           cluster_name: stats
-  - name: envoy.stat_sinks.metrics_service.mobile
-    typed_config:
-      "@type": type.googleapis.com/envoymobile.extensions.stat_sinks.metrics_service.EnvoyMobileMetricsServiceConfig
-      report_counters_as_deltas: true
-      grpc_service:
-        envoy_grpc:
-          cluster_name: stats
 stats_config:
   stats_matcher:
     inclusion_list:


### PR DESCRIPTION
Description: unregister custom stats sink until the backend service is ready
Risk Level: low
Testing: ci/unit

Signed-off-by: Jingwei Hao <jingweih@lyft.com>
