### PR TITLE
 filters: only access mutable buffer when iteration is stopped on current 

### DIFF
--- a/library/common/extensions/filters/http/platform_bridge/filter.cc
+++ b/library/common/extensions/filters/http/platform_bridge/filter.cc
@@ -559,6 +559,9 @@ void PlatformBridgeFilter::ResponseFilterBase::resumeIteration() {
 // this shortcut works for now.
 Buffer::Instance* PlatformBridgeFilter::RequestFilterBase::buffer() {
   Buffer::Instance* internal_buffer = nullptr;
+  // This only exists to provide a mutable buffer, and that buffer is only used when iteration is
+  // stopped. We check iteration state here before returning the buffer, to ensure this filter is
+  // the one that stopped iteration.
   if (iteration_state_ == IterationState::Stopped && parent_.decoder_callbacks_->decodingBuffer()) {
     parent_.decoder_callbacks_->modifyDecodingBuffer(
         [&internal_buffer](Buffer::Instance& mutable_buffer) {
@@ -573,6 +576,9 @@ Buffer::Instance* PlatformBridgeFilter::RequestFilterBase::buffer() {
 // this shortcut works for now.
 Buffer::Instance* PlatformBridgeFilter::ResponseFilterBase::buffer() {
   Buffer::Instance* internal_buffer = nullptr;
+  // This only exists to provide a mutable buffer, and that buffer is only used when iteration is
+  // stopped. We check iteration state here before returning the buffer, to ensure this filter is
+  // the one that stopped iteration.
   if (iteration_state_ == IterationState::Stopped && parent_.encoder_callbacks_->encodingBuffer()) {
     parent_.encoder_callbacks_->modifyEncodingBuffer(
         [&internal_buffer](Buffer::Instance& mutable_buffer) {

--- a/library/common/extensions/filters/http/platform_bridge/filter.cc
+++ b/library/common/extensions/filters/http/platform_bridge/filter.cc
@@ -559,7 +559,7 @@ void PlatformBridgeFilter::ResponseFilterBase::resumeIteration() {
 // this shortcut works for now.
 Buffer::Instance* PlatformBridgeFilter::RequestFilterBase::buffer() {
   Buffer::Instance* internal_buffer = nullptr;
-  if (parent_.decoder_callbacks_->decodingBuffer()) {
+  if (iteration_state_ == IterationState::Stopped && parent_.decoder_callbacks_->decodingBuffer()) {
     parent_.decoder_callbacks_->modifyDecodingBuffer(
         [&internal_buffer](Buffer::Instance& mutable_buffer) {
           internal_buffer = &mutable_buffer;
@@ -573,7 +573,7 @@ Buffer::Instance* PlatformBridgeFilter::RequestFilterBase::buffer() {
 // this shortcut works for now.
 Buffer::Instance* PlatformBridgeFilter::ResponseFilterBase::buffer() {
   Buffer::Instance* internal_buffer = nullptr;
-  if (parent_.encoder_callbacks_->encodingBuffer()) {
+  if (iteration_state_ == IterationState::Stopped && parent_.encoder_callbacks_->encodingBuffer()) {
     parent_.encoder_callbacks_->modifyEncodingBuffer(
         [&internal_buffer](Buffer::Instance& mutable_buffer) {
           internal_buffer = &mutable_buffer;

--- a/test/common/extensions/filters/http/platform_bridge/BUILD
+++ b/test/common/extensions/filters/http/platform_bridge/BUILD
@@ -22,3 +22,21 @@ envoy_extension_cc_test(
         "@envoy//test/test_common:utility_lib",
     ],
 )
+
+envoy_extension_cc_test(
+    name = "platform_bridge_filter_integration_test",
+    srcs = [
+        "platform_bridge_filter_integration_test.cc",
+    ],
+    extension_name = "envoy.filters.http.platform_bridge",
+    repository = "@envoy",
+    deps = [
+        "//library/common/api:external_api_lib",
+        "//library/common/extensions/filters/http/platform_bridge:config",
+        "//library/common/extensions/filters/http/platform_bridge:filter_cc_proto",
+        "@envoy//test/integration:http_integration_lib",
+        "@envoy//test/mocks/server:factory_context_mocks",
+        "@envoy//test/test_common:simulated_time_system_lib",
+        "@envoy//test/test_common:utility_lib",
+    ],
+)

--- a/test/common/extensions/filters/http/platform_bridge/platform_bridge_filter_integration_test.cc
+++ b/test/common/extensions/filters/http/platform_bridge/platform_bridge_filter_integration_test.cc
@@ -86,8 +86,7 @@ TEST_P(PlatformBridgeIntegrationTest, MultipleFilters) {
   };
   platform_filter_1.on_response_data = [](envoy_data c_data, bool,
                                           const void* context) -> envoy_filter_data_status {
-    filter_invocations* invocations =
-    static_cast<filter_invocations*>(const_cast<void*>(context));
+    filter_invocations* invocations = static_cast<filter_invocations*>(const_cast<void*>(context));
     invocations->on_response_data_calls++;
     return {kEnvoyFilterDataStatusContinue, c_data, nullptr};
   };
@@ -105,8 +104,7 @@ TEST_P(PlatformBridgeIntegrationTest, MultipleFilters) {
   };
   platform_filter_2.on_response_data = [](envoy_data c_data, bool end_stream,
                                           const void* context) -> envoy_filter_data_status {
-    filter_invocations* invocations =
-    static_cast<filter_invocations*>(const_cast<void*>(context));
+    filter_invocations* invocations = static_cast<filter_invocations*>(const_cast<void*>(context));
     invocations->on_response_data_calls++;
     if (!end_stream) {
       return {kEnvoyFilterDataStatusStopIterationAndBuffer, c_data, nullptr};
@@ -121,8 +119,7 @@ TEST_P(PlatformBridgeIntegrationTest, MultipleFilters) {
   auto response = codec_client_->makeHeaderOnlyRequest(default_request_headers_);
 
   // Wait for frames to arrive upstream.
-  ASSERT_TRUE(fake_upstreams_[0]->waitForHttpConnection(*dispatcher_,
-  fake_upstream_connection_));
+  ASSERT_TRUE(fake_upstreams_[0]->waitForHttpConnection(*dispatcher_, fake_upstream_connection_));
   ASSERT_TRUE(fake_upstream_connection_->waitForNewStream(*dispatcher_, upstream_request_));
   ASSERT_TRUE(upstream_request_->waitForEndStream(*dispatcher_));
 

--- a/test/common/extensions/filters/http/platform_bridge/platform_bridge_filter_integration_test.cc
+++ b/test/common/extensions/filters/http/platform_bridge/platform_bridge_filter_integration_test.cc
@@ -9,6 +9,7 @@
 
 namespace Envoy {
 
+// TODO: consolidate all instances of this function to one utility class.
 std::string to_string(envoy_data data) {
   return std::string(reinterpret_cast<const char*>(data.bytes), data.length);
 }
@@ -69,69 +70,70 @@ public:
   } filter_invocations;
 };
 
-INSTANTIATE_TEST_SUITE_P(IpVersions, PlatformBridgeIntegrationTest,
-                         testing::ValuesIn(TestEnvironment::getIpVersionsForTest()));
+// INSTANTIATE_TEST_SUITE_P(IpVersions, PlatformBridgeIntegrationTest,
+//                          testing::ValuesIn(TestEnvironment::getIpVersionsForTest()));
 
-TEST_P(PlatformBridgeIntegrationTest, MultipleFilters) {
-  envoy_http_filter platform_filter_1{};
-  filter_invocations invocations_1{};
-  platform_filter_1.static_context = &invocations_1;
-  platform_filter_1.init_filter = [](const void* context) -> const void* {
-    envoy_http_filter* c_filter = static_cast<envoy_http_filter*>(const_cast<void*>(context));
-    filter_invocations* invocations =
-        static_cast<filter_invocations*>(const_cast<void*>(c_filter->static_context));
-    invocations->init_filter_calls++;
-    return invocations;
-  };
-  platform_filter_1.on_response_data = [](envoy_data c_data, bool,
-                                          const void* context) -> envoy_filter_data_status {
-    filter_invocations* invocations = static_cast<filter_invocations*>(const_cast<void*>(context));
-    // EXPECT_EQ(to_string(c_data), "response body");
-    // EXPECT_TRUE(end_stream);
-    invocations->on_response_data_calls++;
-    return {kEnvoyFilterDataStatusContinue, c_data, nullptr};
-  };
-  platform_filter_1.release_filter = [](const void*) {};
+// TODO: uncomment to test fix for crash introduced when calling modify<Decoding/Encoding>Buffer
+// from a filter that did not stop iteration of the filter chain.
+// TEST_P(PlatformBridgeIntegrationTest, MultipleFilters) {
+//   envoy_http_filter platform_filter_1{};
+//   filter_invocations invocations_1{};
+//   platform_filter_1.static_context = &invocations_1;
+//   platform_filter_1.init_filter = [](const void* context) -> const void* {
+//     envoy_http_filter* c_filter = static_cast<envoy_http_filter*>(const_cast<void*>(context));
+//     filter_invocations* invocations =
+//         static_cast<filter_invocations*>(const_cast<void*>(c_filter->static_context));
+//     invocations->init_filter_calls++;
+//     return invocations;
+//   };
+//   platform_filter_1.on_response_data = [](envoy_data c_data, bool,
+//                                           const void* context) -> envoy_filter_data_status {
+//     filter_invocations* invocations =
+//     static_cast<filter_invocations*>(const_cast<void*>(context));
+//     invocations->on_response_data_calls++;
+//     return {kEnvoyFilterDataStatusContinue, c_data, nullptr};
+//   };
+//   platform_filter_1.release_filter = [](const void*) {};
 
-  envoy_http_filter platform_filter_2{};
-  filter_invocations invocations_2{};
-  platform_filter_2.static_context = &invocations_2;
-  platform_filter_2.init_filter = [](const void* context) -> const void* {
-    envoy_http_filter* c_filter = static_cast<envoy_http_filter*>(const_cast<void*>(context));
-    filter_invocations* invocations =
-        static_cast<filter_invocations*>(const_cast<void*>(c_filter->static_context));
-    invocations->init_filter_calls++;
-    return invocations;
-  };
-  platform_filter_2.on_response_data = [](envoy_data c_data, bool,
-                                          const void* context) -> envoy_filter_data_status {
-    filter_invocations* invocations = static_cast<filter_invocations*>(const_cast<void*>(context));
-    // EXPECT_EQ(to_string(c_data), "response body");
-    // EXPECT_TRUE(end_stream);
-    invocations->on_response_data_calls++;
-    return {kEnvoyFilterDataStatusStopIterationAndBuffer, c_data, nullptr};
-  };
-  platform_filter_2.release_filter = [](const void*) {};
+//   envoy_http_filter platform_filter_2{};
+//   filter_invocations invocations_2{};
+//   platform_filter_2.static_context = &invocations_2;
+//   platform_filter_2.init_filter = [](const void* context) -> const void* {
+//     envoy_http_filter* c_filter = static_cast<envoy_http_filter*>(const_cast<void*>(context));
+//     filter_invocations* invocations =
+//         static_cast<filter_invocations*>(const_cast<void*>(c_filter->static_context));
+//     invocations->init_filter_calls++;
+//     return invocations;
+//   };
+//   platform_filter_2.on_response_data = [](envoy_data c_data, bool,
+//                                           const void* context) -> envoy_filter_data_status {
+//     filter_invocations* invocations =
+//     static_cast<filter_invocations*>(const_cast<void*>(context));
+//     invocations->on_response_data_calls++;
+//     return {kEnvoyFilterDataStatusStopIterationAndBuffer, c_data, nullptr};
+//   };
+//   platform_filter_2.release_filter = [](const void*) {};
 
-  customInit(&platform_filter_1, &platform_filter_2);
+//   customInit(&platform_filter_1, &platform_filter_2);
 
-  auto response = codec_client_->makeHeaderOnlyRequest(default_request_headers_);
+//   auto response = codec_client_->makeHeaderOnlyRequest(default_request_headers_);
 
-  // Wait for frames to arrive upstream.
-  ASSERT_TRUE(fake_upstreams_[0]->waitForHttpConnection(*dispatcher_, fake_upstream_connection_));
-  ASSERT_TRUE(fake_upstream_connection_->waitForNewStream(*dispatcher_, upstream_request_));
-  ASSERT_TRUE(upstream_request_->waitForEndStream(*dispatcher_));
+//   // Wait for frames to arrive upstream.
+//   ASSERT_TRUE(fake_upstreams_[0]->waitForHttpConnection(*dispatcher_,
+//   fake_upstream_connection_));
+//   ASSERT_TRUE(fake_upstream_connection_->waitForNewStream(*dispatcher_, upstream_request_));
+//   ASSERT_TRUE(upstream_request_->waitForEndStream(*dispatcher_));
 
-  upstream_request_->encodeHeaders(Http::TestResponseHeaderMapImpl{{":status", "200"}}, false);
+//   upstream_request_->encodeHeaders(Http::TestResponseHeaderMapImpl{{":status", "200"}}, false);
 
-  upstream_request_->encodeData(100, false);
-  upstream_request_->encodeData(100, true);
+//   upstream_request_->encodeData(100, false);
+//   upstream_request_->encodeData(100, true);
 
-  // Wait for frames to arrive downstream.
-  response->waitForEndStream();
+//   // Wait for frames to arrive downstream.
+//   response->waitForEndStream();
 
-  EXPECT_TRUE(response->complete());
-  EXPECT_EQ("200", response->headers().Status()->value().getStringView());
-}
+//   EXPECT_TRUE(response->complete());
+//   EXPECT_EQ("200", response->headers().Status()->value().getStringView());
+// }
 
 } // namespace Envoy

--- a/test/common/extensions/filters/http/platform_bridge/platform_bridge_filter_integration_test.cc
+++ b/test/common/extensions/filters/http/platform_bridge/platform_bridge_filter_integration_test.cc
@@ -107,7 +107,8 @@ TEST_P(PlatformBridgeIntegrationTest, MultipleFilters) {
     filter_invocations* invocations = static_cast<filter_invocations*>(const_cast<void*>(context));
     invocations->on_response_data_calls++;
     if (!end_stream) {
-      return {kEnvoyFilterDataStatusStopIterationAndBuffer, c_data, nullptr};
+      c_data.release(c_data.context);
+      return {kEnvoyFilterDataStatusStopIterationAndBuffer, envoy_nodata, nullptr};
     } else {
       return {kEnvoyFilterDataStatusResumeIteration, c_data, nullptr};
     }

--- a/test/common/extensions/filters/http/platform_bridge/platform_bridge_filter_integration_test.cc
+++ b/test/common/extensions/filters/http/platform_bridge/platform_bridge_filter_integration_test.cc
@@ -1,0 +1,137 @@
+#include "common/http/header_map_impl.h"
+
+#include "test/integration/http_integration.h"
+#include "test/test_common/utility.h"
+
+#include "gtest/gtest.h"
+#include "library/common/api/external.h"
+#include "library/common/extensions/filters/http/platform_bridge/filter.h"
+
+namespace Envoy {
+
+std::string to_string(envoy_data data) {
+  return std::string(reinterpret_cast<const char*>(data.bytes), data.length);
+}
+
+class PlatformBridgeIntegrationTest : public testing::TestWithParam<Network::Address::IpVersion>,
+                                      public HttpIntegrationTest {
+public:
+  PlatformBridgeIntegrationTest()
+      : HttpIntegrationTest(Http::CodecClient::Type::HTTP2, GetParam()) {}
+
+  const std::string filter_config_1{R"EOF(
+      name: envoy.filters.http.platform_bridge
+      typed_config:
+        "@type": type.googleapis.com/envoymobile.extensions.filters.http.platform_bridge.PlatformBridge
+        platform_filter_name: filter_1
+    )EOF"};
+
+  const std::string filter_config_2{R"EOF(
+      name: envoy.filters.http.platform_bridge
+      typed_config:
+        "@type": type.googleapis.com/envoymobile.extensions.filters.http.platform_bridge.PlatformBridge
+        platform_filter_name: filter_2
+    )EOF"};
+
+  void customInit(envoy_http_filter* filter_1, envoy_http_filter* filter_2) {
+    setDownstreamProtocol(Http::CodecClient::Type::HTTP2);
+    setUpstreamProtocol(FakeHttpConnection::Type::HTTP2);
+
+    Api::External::registerApi("filter_1", filter_1);
+    Api::External::registerApi("filter_2", filter_2);
+
+    config_helper_.addFilter(filter_config_1);
+    config_helper_.addFilter(filter_config_2);
+
+    HttpIntegrationTest::initialize();
+    codec_client_ = makeHttpConnection(lookupPort("http"));
+  }
+
+  void TearDown() override {
+    HttpIntegrationTest::cleanupUpstreamAndDownstream();
+    codec_client_->close();
+    codec_client_.reset();
+  }
+
+  typedef struct {
+    unsigned int init_filter_calls;
+    unsigned int on_request_headers_calls;
+    unsigned int on_request_data_calls;
+    unsigned int on_request_trailers_calls;
+    unsigned int on_response_headers_calls;
+    unsigned int on_response_data_calls;
+    unsigned int on_response_trailers_calls;
+    unsigned int set_request_callbacks_calls;
+    unsigned int on_resume_request_calls;
+    unsigned int set_response_callbacks_calls;
+    unsigned int on_resume_response_calls;
+    unsigned int release_filter_calls;
+  } filter_invocations;
+};
+
+INSTANTIATE_TEST_SUITE_P(IpVersions, PlatformBridgeIntegrationTest,
+                         testing::ValuesIn(TestEnvironment::getIpVersionsForTest()));
+
+TEST_P(PlatformBridgeIntegrationTest, MultipleFilters) {
+  envoy_http_filter platform_filter_1{};
+  filter_invocations invocations_1{};
+  platform_filter_1.static_context = &invocations_1;
+  platform_filter_1.init_filter = [](const void* context) -> const void* {
+    envoy_http_filter* c_filter = static_cast<envoy_http_filter*>(const_cast<void*>(context));
+    filter_invocations* invocations =
+        static_cast<filter_invocations*>(const_cast<void*>(c_filter->static_context));
+    invocations->init_filter_calls++;
+    return invocations;
+  };
+  platform_filter_1.on_response_data = [](envoy_data c_data, bool,
+                                          const void* context) -> envoy_filter_data_status {
+    filter_invocations* invocations = static_cast<filter_invocations*>(const_cast<void*>(context));
+    // EXPECT_EQ(to_string(c_data), "response body");
+    // EXPECT_TRUE(end_stream);
+    invocations->on_response_data_calls++;
+    return {kEnvoyFilterDataStatusContinue, c_data, nullptr};
+  };
+  platform_filter_1.release_filter = [](const void*) {};
+
+  envoy_http_filter platform_filter_2{};
+  filter_invocations invocations_2{};
+  platform_filter_2.static_context = &invocations_2;
+  platform_filter_2.init_filter = [](const void* context) -> const void* {
+    envoy_http_filter* c_filter = static_cast<envoy_http_filter*>(const_cast<void*>(context));
+    filter_invocations* invocations =
+        static_cast<filter_invocations*>(const_cast<void*>(c_filter->static_context));
+    invocations->init_filter_calls++;
+    return invocations;
+  };
+  platform_filter_2.on_response_data = [](envoy_data c_data, bool,
+                                          const void* context) -> envoy_filter_data_status {
+    filter_invocations* invocations = static_cast<filter_invocations*>(const_cast<void*>(context));
+    // EXPECT_EQ(to_string(c_data), "response body");
+    // EXPECT_TRUE(end_stream);
+    invocations->on_response_data_calls++;
+    return {kEnvoyFilterDataStatusStopIterationAndBuffer, c_data, nullptr};
+  };
+  platform_filter_2.release_filter = [](const void*) {};
+
+  customInit(&platform_filter_1, &platform_filter_2);
+
+  auto response = codec_client_->makeHeaderOnlyRequest(default_request_headers_);
+
+  // Wait for frames to arrive upstream.
+  ASSERT_TRUE(fake_upstreams_[0]->waitForHttpConnection(*dispatcher_, fake_upstream_connection_));
+  ASSERT_TRUE(fake_upstream_connection_->waitForNewStream(*dispatcher_, upstream_request_));
+  ASSERT_TRUE(upstream_request_->waitForEndStream(*dispatcher_));
+
+  upstream_request_->encodeHeaders(Http::TestResponseHeaderMapImpl{{":status", "200"}}, false);
+
+  upstream_request_->encodeData(100, false);
+  upstream_request_->encodeData(100, true);
+
+  // Wait for frames to arrive downstream.
+  response->waitForEndStream();
+
+  EXPECT_TRUE(response->complete());
+  EXPECT_EQ("200", response->headers().Status()->value().getStringView());
+}
+
+} // namespace Envoy

--- a/test/common/extensions/filters/http/platform_bridge/platform_bridge_filter_integration_test.cc
+++ b/test/common/extensions/filters/http/platform_bridge/platform_bridge_filter_integration_test.cc
@@ -70,70 +70,68 @@ public:
   } filter_invocations;
 };
 
-// INSTANTIATE_TEST_SUITE_P(IpVersions, PlatformBridgeIntegrationTest,
-//                          testing::ValuesIn(TestEnvironment::getIpVersionsForTest()));
+INSTANTIATE_TEST_SUITE_P(IpVersions, PlatformBridgeIntegrationTest,
+                         testing::ValuesIn(TestEnvironment::getIpVersionsForTest()));
 
-// TODO: uncomment to test fix for crash introduced when calling modify<Decoding/Encoding>Buffer
-// from a filter that did not stop iteration of the filter chain.
-// TEST_P(PlatformBridgeIntegrationTest, MultipleFilters) {
-//   envoy_http_filter platform_filter_1{};
-//   filter_invocations invocations_1{};
-//   platform_filter_1.static_context = &invocations_1;
-//   platform_filter_1.init_filter = [](const void* context) -> const void* {
-//     envoy_http_filter* c_filter = static_cast<envoy_http_filter*>(const_cast<void*>(context));
-//     filter_invocations* invocations =
-//         static_cast<filter_invocations*>(const_cast<void*>(c_filter->static_context));
-//     invocations->init_filter_calls++;
-//     return invocations;
-//   };
-//   platform_filter_1.on_response_data = [](envoy_data c_data, bool,
-//                                           const void* context) -> envoy_filter_data_status {
-//     filter_invocations* invocations =
-//     static_cast<filter_invocations*>(const_cast<void*>(context));
-//     invocations->on_response_data_calls++;
-//     return {kEnvoyFilterDataStatusContinue, c_data, nullptr};
-//   };
-//   platform_filter_1.release_filter = [](const void*) {};
+TEST_P(PlatformBridgeIntegrationTest, MultipleFilters) {
+  envoy_http_filter platform_filter_1{};
+  filter_invocations invocations_1{};
+  platform_filter_1.static_context = &invocations_1;
+  platform_filter_1.init_filter = [](const void* context) -> const void* {
+    envoy_http_filter* c_filter = static_cast<envoy_http_filter*>(const_cast<void*>(context));
+    filter_invocations* invocations =
+        static_cast<filter_invocations*>(const_cast<void*>(c_filter->static_context));
+    invocations->init_filter_calls++;
+    return invocations;
+  };
+  platform_filter_1.on_response_data = [](envoy_data c_data, bool,
+                                          const void* context) -> envoy_filter_data_status {
+    filter_invocations* invocations =
+    static_cast<filter_invocations*>(const_cast<void*>(context));
+    invocations->on_response_data_calls++;
+    return {kEnvoyFilterDataStatusContinue, c_data, nullptr};
+  };
+  platform_filter_1.release_filter = [](const void*) {};
 
-//   envoy_http_filter platform_filter_2{};
-//   filter_invocations invocations_2{};
-//   platform_filter_2.static_context = &invocations_2;
-//   platform_filter_2.init_filter = [](const void* context) -> const void* {
-//     envoy_http_filter* c_filter = static_cast<envoy_http_filter*>(const_cast<void*>(context));
-//     filter_invocations* invocations =
-//         static_cast<filter_invocations*>(const_cast<void*>(c_filter->static_context));
-//     invocations->init_filter_calls++;
-//     return invocations;
-//   };
-//   platform_filter_2.on_response_data = [](envoy_data c_data, bool,
-//                                           const void* context) -> envoy_filter_data_status {
-//     filter_invocations* invocations =
-//     static_cast<filter_invocations*>(const_cast<void*>(context));
-//     invocations->on_response_data_calls++;
-//     return {kEnvoyFilterDataStatusStopIterationAndBuffer, c_data, nullptr};
-//   };
-//   platform_filter_2.release_filter = [](const void*) {};
+  envoy_http_filter platform_filter_2{};
+  filter_invocations invocations_2{};
+  platform_filter_2.static_context = &invocations_2;
+  platform_filter_2.init_filter = [](const void* context) -> const void* {
+    envoy_http_filter* c_filter = static_cast<envoy_http_filter*>(const_cast<void*>(context));
+    filter_invocations* invocations =
+        static_cast<filter_invocations*>(const_cast<void*>(c_filter->static_context));
+    invocations->init_filter_calls++;
+    return invocations;
+  };
+  platform_filter_2.on_response_data = [](envoy_data c_data, bool,
+                                          const void* context) -> envoy_filter_data_status {
+    filter_invocations* invocations =
+    static_cast<filter_invocations*>(const_cast<void*>(context));
+    invocations->on_response_data_calls++;
+    return {kEnvoyFilterDataStatusStopIterationAndBuffer, c_data, nullptr};
+  };
+  platform_filter_2.release_filter = [](const void*) {};
 
-//   customInit(&platform_filter_1, &platform_filter_2);
+  customInit(&platform_filter_1, &platform_filter_2);
 
-//   auto response = codec_client_->makeHeaderOnlyRequest(default_request_headers_);
+  auto response = codec_client_->makeHeaderOnlyRequest(default_request_headers_);
 
-//   // Wait for frames to arrive upstream.
-//   ASSERT_TRUE(fake_upstreams_[0]->waitForHttpConnection(*dispatcher_,
-//   fake_upstream_connection_));
-//   ASSERT_TRUE(fake_upstream_connection_->waitForNewStream(*dispatcher_, upstream_request_));
-//   ASSERT_TRUE(upstream_request_->waitForEndStream(*dispatcher_));
+  // Wait for frames to arrive upstream.
+  ASSERT_TRUE(fake_upstreams_[0]->waitForHttpConnection(*dispatcher_,
+  fake_upstream_connection_));
+  ASSERT_TRUE(fake_upstream_connection_->waitForNewStream(*dispatcher_, upstream_request_));
+  ASSERT_TRUE(upstream_request_->waitForEndStream(*dispatcher_));
 
-//   upstream_request_->encodeHeaders(Http::TestResponseHeaderMapImpl{{":status", "200"}}, false);
+  upstream_request_->encodeHeaders(Http::TestResponseHeaderMapImpl{{":status", "200"}}, false);
 
-//   upstream_request_->encodeData(100, false);
-//   upstream_request_->encodeData(100, true);
+  upstream_request_->encodeData(100, false);
+  upstream_request_->encodeData(100, true);
 
-//   // Wait for frames to arrive downstream.
-//   response->waitForEndStream();
+  // Wait for frames to arrive downstream.
+  response->waitForEndStream();
 
-//   EXPECT_TRUE(response->complete());
-//   EXPECT_EQ("200", response->headers().Status()->value().getStringView());
-// }
+  EXPECT_TRUE(response->complete());
+  EXPECT_EQ("200", response->headers().Status()->value().getStringView());
+}
 
 } // namespace Envoy

--- a/test/common/extensions/filters/http/platform_bridge/platform_bridge_filter_integration_test.cc
+++ b/test/common/extensions/filters/http/platform_bridge/platform_bridge_filter_integration_test.cc
@@ -103,12 +103,16 @@ TEST_P(PlatformBridgeIntegrationTest, MultipleFilters) {
     invocations->init_filter_calls++;
     return invocations;
   };
-  platform_filter_2.on_response_data = [](envoy_data c_data, bool,
+  platform_filter_2.on_response_data = [](envoy_data c_data, bool end_stream,
                                           const void* context) -> envoy_filter_data_status {
     filter_invocations* invocations =
     static_cast<filter_invocations*>(const_cast<void*>(context));
     invocations->on_response_data_calls++;
-    return {kEnvoyFilterDataStatusStopIterationAndBuffer, c_data, nullptr};
+    if (!end_stream) {
+      return {kEnvoyFilterDataStatusStopIterationAndBuffer, c_data, nullptr};
+    } else {
+      return {kEnvoyFilterDataStatusResumeIteration, c_data, nullptr};
+    }
   };
   platform_filter_2.release_filter = [](const void*) {};
 

--- a/test/common/extensions/filters/http/platform_bridge/platform_bridge_filter_test.cc
+++ b/test/common/extensions/filters/http/platform_bridge/platform_bridge_filter_test.cc
@@ -431,10 +431,10 @@ TEST_F(PlatformBridgeFilterTest, StopAndBufferOnRequestData) {
 
   Buffer::OwnedImpl decoding_buffer;
   EXPECT_CALL(decoder_callbacks_, decodingBuffer())
-      .Times(3)
+      .Times(2)
       .WillRepeatedly(Return(&decoding_buffer));
   EXPECT_CALL(decoder_callbacks_, modifyDecodingBuffer(_))
-      .Times(3)
+      .Times(2)
       .WillRepeatedly(Invoke([&](std::function<void(Buffer::Instance&)> callback) -> void {
         callback(decoding_buffer);
       }));
@@ -505,10 +505,10 @@ TEST_F(PlatformBridgeFilterTest, StopAndBufferThenResumeOnRequestData) {
 
   Buffer::OwnedImpl decoding_buffer;
   EXPECT_CALL(decoder_callbacks_, decodingBuffer())
-      .Times(2)
+      .Times(1)
       .WillRepeatedly(Return(&decoding_buffer));
   EXPECT_CALL(decoder_callbacks_, modifyDecodingBuffer(_))
-      .Times(2)
+      .Times(1)
       .WillRepeatedly(Invoke([&](std::function<void(Buffer::Instance&)> callback) -> void {
         callback(decoding_buffer);
       }));
@@ -1228,10 +1228,10 @@ TEST_F(PlatformBridgeFilterTest, StopAndBufferOnResponseData) {
 
   Buffer::OwnedImpl encoding_buffer;
   EXPECT_CALL(encoder_callbacks_, encodingBuffer())
-      .Times(3)
+      .Times(2)
       .WillRepeatedly(Return(&encoding_buffer));
   EXPECT_CALL(encoder_callbacks_, modifyEncodingBuffer(_))
-      .Times(3)
+      .Times(2)
       .WillRepeatedly(Invoke([&](std::function<void(Buffer::Instance&)> callback) -> void {
         callback(encoding_buffer);
       }));
@@ -1302,10 +1302,10 @@ TEST_F(PlatformBridgeFilterTest, StopAndBufferThenResumeOnResponseData) {
 
   Buffer::OwnedImpl encoding_buffer;
   EXPECT_CALL(encoder_callbacks_, encodingBuffer())
-      .Times(2)
+      .Times(1)
       .WillRepeatedly(Return(&encoding_buffer));
   EXPECT_CALL(encoder_callbacks_, modifyEncodingBuffer(_))
-      .Times(2)
+      .Times(1)
       .WillRepeatedly(Invoke([&](std::function<void(Buffer::Instance&)> callback) -> void {
         callback(encoding_buffer);
       }));


### PR DESCRIPTION
Description: A previous change caused the pointer to the mutable buffer to be retrieved regardless of iteration state which trips an internal assertion in Envoy.
Risk Level: Low
Testing: New integration test