### PR TITLE
coverage: integration test for LocalErrorFilter when using gRPC

### DIFF
--- a/library/swift/test/HttpBridgeTests/BUILD
+++ b/library/swift/test/HttpBridgeTests/BUILD
@@ -36,6 +36,17 @@ envoy_mobile_swift_test(
 )
 
 envoy_mobile_swift_test(
+    name = "grpc_receive_error_test",
+    srcs = [
+        "DemoFilter.swift",
+        "GRPCReceiveErrorTest.swift",
+    ],
+    deps = [
+        "//library/objective-c:envoy_engine_objc_lib",
+    ],
+)
+
+envoy_mobile_swift_test(
     name = "send_data_test",
     srcs = [
         "DemoFilter.swift",

--- a/library/swift/test/HttpBridgeTests/GRPCReceiveErrorTest.swift
+++ b/library/swift/test/HttpBridgeTests/GRPCReceiveErrorTest.swift
@@ -1,0 +1,112 @@
+import Envoy
+import EnvoyEngine
+import Foundation
+import XCTest
+
+private let kGRPCMessage = Data([1, 2, 3, 4, 5])
+
+final class ReceiveErrorTests: XCTestCase {
+  func testReceiveError() throws {
+    // swiftlint:disable:next line_length
+    let hcmType = "type.googleapis.com/envoy.extensions.filters.network.http_connection_manager.v3.HttpConnectionManager"
+    // swiftlint:disable:next line_length
+    let pbfType = "type.googleapis.com/envoymobile.extensions.filters.http.platform_bridge.PlatformBridge"
+    // swiftlint:disable:next line_length
+    let localErrorFilterType = "type.googleapis.com/envoymobile.extensions.filters.http.local_error.LocalError"
+    let config =
+    """
+    static_resources:
+      listeners:
+      - name: base_api_listener
+        address:
+          socket_address: { protocol: TCP, address: 0.0.0.0, port_value: 10000 }
+        api_listener:
+          api_listener:
+            "@type": \(hcmType)
+            stat_prefix: hcm
+            route_config:
+              name: api_router
+              virtual_hosts:
+              - name: api
+                domains: ["*"]
+                routes:
+                - match: { prefix: "/" }
+                  direct_response: { status: 503 }
+            http_filters:
+            - name: envoy.filters.http.platform_bridge
+              typed_config:
+                "@type": \(pbfType)
+                platform_filter_name: error_validation_filter
+            - name: envoy.filters.http.local_error
+              typed_config:
+                "@type": \(localErrorFilterType)
+            - name: envoy.router
+              typed_config:
+                "@type": type.googleapis.com/envoy.extensions.filters.http.router.v3.Router
+    """
+
+    struct ErrorValidationFilter: ResponseFilter {
+      let expectation: XCTestExpectation
+
+      func onResponseHeaders(_ headers: ResponseHeaders, endStream: Bool)
+        -> FilterHeadersStatus<ResponseHeaders>
+      {
+        return .continue(headers: headers)
+      }
+
+      func onResponseData(_ body: Data, endStream: Bool) -> FilterDataStatus<ResponseHeaders> {
+        return .continue(data: body)
+      }
+
+      func onResponseTrailers(_ trailers: ResponseTrailers)
+          -> FilterTrailersStatus<ResponseHeaders, ResponseTrailers> {
+        return .continue(trailers: trailers)
+      }
+
+      func onError(_ error: EnvoyError) {
+        XCTAssertEqual(error.errorCode, 2) // 503/Connection Failure
+        self.expectation.fulfill()
+      }
+
+      func onCancel() {}
+    }
+
+    let runExpectation = self.expectation(description: "Run called with expected error")
+    let filterExpectation = self.expectation(description: "Filter called with expected error")
+
+    let httpStreamClient = try EngineBuilder(yaml: config)
+      .addLogLevel(.trace)
+      .addPlatformFilter(
+        name: "error_validation_filter",
+        factory: { ErrorValidationFilter(expectation: filterExpectation) }
+      )
+      .build()
+      .streamClient()
+
+    let client = Envoy.GRPCClient(streamClient: httpStreamClient)
+
+    let requestHeaders = GRPCRequestHeadersBuilder(scheme: "https", authority: "example.com",
+                                                   path: "/pb.api.v1.Foo/GetBar").build()
+
+    client
+      .newGRPCStreamPrototype()
+      .newStreamPrototype()
+      .setOnResponseHeaders { _, _ in
+        XCTFail("Headers received instead of expected error")
+      }
+      .setOnResponseMessage { _, _ in
+        XCTFail("Message received instead of expected error")
+      }
+      // The unmatched expecation will cause a local reply which gets translated in Envoy Mobile to
+      // an error.
+      .setOnError { error in
+         XCTAssertEqual(error.errorCode, 2) // 503/Connection Failure
+         runExpectation.fulfill()
+      }
+      .start()
+      .sendHeaders(requestHeaders, endStream: true)
+      .sendMessage(kGRPCMessage)
+
+    XCTAssertEqual(XCTWaiter.wait(for: [filterExpectation, runExpectation], timeout: 1), .completed)
+  }
+}

--- a/library/swift/test/HttpBridgeTests/GRPCReceiveErrorTest.swift
+++ b/library/swift/test/HttpBridgeTests/GRPCReceiveErrorTest.swift
@@ -90,11 +90,10 @@ final class ReceiveErrorTests: XCTestCase {
 
     client
       .newGRPCStreamPrototype()
-      .newStreamPrototype()
       .setOnResponseHeaders { _, _ in
         XCTFail("Headers received instead of expected error")
       }
-      .setOnResponseMessage { _, _ in
+      .setOnResponseMessage { _ in
         XCTFail("Message received instead of expected error")
       }
       // The unmatched expecation will cause a local reply which gets translated in Envoy Mobile to

--- a/library/swift/test/HttpBridgeTests/GRPCReceiveErrorTest.swift
+++ b/library/swift/test/HttpBridgeTests/GRPCReceiveErrorTest.swift
@@ -87,7 +87,6 @@ final class ReceiveErrorTests: XCTestCase {
                                                    path: "/pb.api.v1.Foo/GetBar").build()
     let message = Data([1, 2, 3, 4, 5])
 
-
     client
       .newGRPCStreamPrototype()
       .setOnResponseHeaders { _, _ in

--- a/library/swift/test/HttpBridgeTests/GRPCReceiveErrorTest.swift
+++ b/library/swift/test/HttpBridgeTests/GRPCReceiveErrorTest.swift
@@ -3,8 +3,6 @@ import EnvoyEngine
 import Foundation
 import XCTest
 
-private let kGRPCMessage = Data([1, 2, 3, 4, 5])
-
 final class ReceiveErrorTests: XCTestCase {
   func testReceiveError() throws {
     // swiftlint:disable:next line_length
@@ -87,6 +85,8 @@ final class ReceiveErrorTests: XCTestCase {
 
     let requestHeaders = GRPCRequestHeadersBuilder(scheme: "https", authority: "example.com",
                                                    path: "/pb.api.v1.Foo/GetBar").build()
+    let message = Data([1, 2, 3, 4, 5])
+
 
     client
       .newGRPCStreamPrototype()
@@ -104,7 +104,7 @@ final class ReceiveErrorTests: XCTestCase {
       }
       .start()
       .sendHeaders(requestHeaders, endStream: true)
-      .sendMessage(kGRPCMessage)
+      .sendMessage(message)
 
     XCTAssertEqual(XCTWaiter.wait(for: [filterExpectation, runExpectation], timeout: 1), .completed)
   }


### PR DESCRIPTION
Description: This test covers the case where the LocalErrorFilter transforms a locally generated response for a gRPC request to an error.

Note: Kotlin tests can be added once we have #1263.
Risk Level: Low
Testing: This commit adds coverage.

Signed-off-by: Mike Schore <mike.schore@gmail.com>