### PR TITLE
swift/kotlin: enforce unsigned :status code values

### DIFF
--- a/examples/swift/hello_world/ViewController.swift
+++ b/examples/swift/hello_world/ViewController.swift
@@ -70,7 +70,7 @@ final class ViewController: UITableViewController {
     streamClient
       .newStreamPrototype()
       .setOnResponseHeaders { [weak self] headers, _ in
-        let statusCode = headers.httpStatus ?? -1
+        let statusCode = headers.httpStatus.map(String.init) ?? "nil"
         let message = "received headers with status \(statusCode)"
 
         let headerMessage = headers.allHeaders()

--- a/library/kotlin/src/io/envoyproxy/envoymobile/ResponseHeaders.kt
+++ b/library/kotlin/src/io/envoyproxy/envoymobile/ResponseHeaders.kt
@@ -15,7 +15,7 @@ class ResponseHeaders : Headers {
    * HTTP status code received with the response.
    */
   val httpStatus: Int? by lazy {
-    value(":status")?.first()?.toIntOrNull().takeIf { it >= 0 }
+    value(":status")?.first()?.toIntOrNull()?.takeIf { it >= 0 }
   }
 
   /**

--- a/library/kotlin/src/io/envoyproxy/envoymobile/ResponseHeaders.kt
+++ b/library/kotlin/src/io/envoyproxy/envoymobile/ResponseHeaders.kt
@@ -14,7 +14,9 @@ class ResponseHeaders : Headers {
   /**
    * HTTP status code received with the response.
    */
-  val httpStatus: Int? by lazy { value(":status")?.first()?.toIntOrNull() }
+  val httpStatus: Int? by lazy {
+    value(":status")?.first()?.toIntOrNull().takeIf { it >= 0 }
+  }
 
   /**
    * Convert the headers back to a builder for mutation.

--- a/library/kotlin/src/io/envoyproxy/envoymobile/ResponseHeadersBuilder.kt
+++ b/library/kotlin/src/io/envoyproxy/envoymobile/ResponseHeadersBuilder.kt
@@ -39,13 +39,16 @@ class ResponseHeadersBuilder : HeadersBuilder {
   }
 
   /**
-   * Add an HTTP status to the response headers.
+   * Add an HTTP status to the response headers. Must be a positive integer.
    *
    * @param status: The HTTP status to add.
    *
    * @return ResponseHeadersBuilder, This builder.
    */
   fun addHttpStatus(status: Int): ResponseHeadersBuilder {
+    if (status < 0) {
+      return this
+    }
     internalSet(":status", mutableListOf("$status"))
     return this
   }

--- a/library/kotlin/test/io/envoyproxy/envoymobile/ResponseHeadersTest.kt
+++ b/library/kotlin/test/io/envoyproxy/envoymobile/ResponseHeadersTest.kt
@@ -11,8 +11,14 @@ class ResponseHeadersTest {
   }
 
   @Test
-  fun `parsing invalid status code returns null`() {
+  fun `parsing invalid status string returns null`() {
     val headers = ResponseHeaders(mapOf(":status" to listOf("invalid"), "other" to listOf("1")))
+    assertThat(headers.httpStatus).isNull()
+  }
+
+  @Test
+  fun `parsing negative status returns null`() {
+    val headers = ResponseHeaders(mapOf(":status" to listOf("-123"), "other" to listOf("1")))
     assertThat(headers.httpStatus).isNull()
   }
 
@@ -28,5 +34,13 @@ class ResponseHeadersTest {
       .addHttpStatus(200)
       .build()
     assertThat(headers.value(":status")).containsExactly("200")
+  }
+
+  @Test
+  fun `adding negative HTTP status code no-ops`() {
+    val headers = ResponseHeadersBuilder()
+      .addHttpStatus(-123)
+      .build()
+    assertThat(headers.value(":status")).isNull()
   }
 }

--- a/library/swift/src/ResponseHeaders.swift
+++ b/library/swift/src/ResponseHeaders.swift
@@ -4,8 +4,8 @@ import Foundation
 @objcMembers
 public final class ResponseHeaders: Headers {
   /// HTTP status code received with the response.
-  public private(set) lazy var httpStatus: Int? =
-    self.value(forName: ":status")?.first.flatMap(Int.init)
+  public private(set) lazy var httpStatus: UInt? =
+    self.value(forName: ":status")?.first.flatMap(UInt.init)
 
   /// Convert the headers back to a builder for mutation.
   ///

--- a/library/swift/src/ResponseHeadersBuilder.swift
+++ b/library/swift/src/ResponseHeadersBuilder.swift
@@ -13,7 +13,7 @@ public final class ResponseHeadersBuilder: HeadersBuilder {
   /// - parameter status: The HTTP status to add.
   ///
   /// - returns: This builder.
-  public func addHttpStatus(_ status: Int) -> ResponseHeadersBuilder {
+  public func addHttpStatus(_ status: UInt) -> ResponseHeadersBuilder {
     self.internalSet(name: ":status", value: ["\(status)"])
     return self
   }

--- a/library/swift/test/ResponseHeadersTests.swift
+++ b/library/swift/test/ResponseHeadersTests.swift
@@ -7,8 +7,13 @@ final class ResponseHeadersTests: XCTestCase {
     XCTAssertEqual(204, ResponseHeaders(headers: headers).httpStatus)
   }
 
-  func testParsingInvalidStatusCodeReturnsNil() {
+  func testParsingInvalidStatusStringReturnsNil() {
     let headers = [":status": ["invalid"], "other": ["1"]]
+    XCTAssertNil(ResponseHeaders(headers: headers).httpStatus)
+  }
+
+  func testParsingNegativeStatusReturnsNil() {
+    let headers = [":status": ["-123"], "other": ["1"]]
     XCTAssertNil(ResponseHeaders(headers: headers).httpStatus)
   }
 


### PR DESCRIPTION
We can prevent an [assert from being hit within Envoy](https://github.com/envoyproxy/envoy/blob/17e815122ff53d0ac6cb2d64cdbf1bfc547bb7e8/source/common/http/utility.cc#L441-L448) if the end consumer attempts to set a negative status code via these platform interfaces.

Signed-off-by: Michael Rebello <me@michaelrebello.com>