### PR TITLE
jni: fix local ref leaks

### DIFF
--- a/library/common/jni/jni_interface.cc
+++ b/library/common/jni/jni_interface.cc
@@ -142,7 +142,6 @@ static void pass_headers(const char* method, envoy_headers headers, jobject j_co
   JNIEnv* env = get_env();
   jclass jcls_JvmCallbackContext = env->GetObjectClass(j_context);
   jmethodID jmid_passHeader = env->GetMethodID(jcls_JvmCallbackContext, method, "([B[BZ)V");
-  env->PushLocalFrame(headers.length * 2);
   jboolean start_headers = JNI_TRUE;
 
   for (envoy_header_size_t i = 0; i < headers.length; i++) {
@@ -172,13 +171,14 @@ static void pass_headers(const char* method, envoy_headers headers, jobject j_co
 
     // Pass this header pair to the platform
     env->CallVoidMethod(j_context, jmid_passHeader, key, value, start_headers);
+    env->DeleteLocalRef(key);
+    env->DeleteLocalRef(value);
 
     // We don't release local refs currently because we've pushed a large enough frame, but we could
     // consider this and/or periodically popping the frame.
     start_headers = JNI_FALSE;
   }
 
-  env->PopLocalFrame(nullptr);
   env->DeleteLocalRef(jcls_JvmCallbackContext);
   release_envoy_headers(headers);
 }

--- a/library/common/jni/jni_utility.cc
+++ b/library/common/jni/jni_utility.cc
@@ -69,6 +69,7 @@ envoy_data buffer_to_native_data(JNIEnv* env, jobject j_data) {
     jmethodID jmid_array = env->GetMethodID(jcls_ByteBuffer, "array", "()[B");
     jbyteArray array = static_cast<jbyteArray>(env->CallObjectMethod(j_data, jmid_array));
     env->DeleteLocalRef(jcls_ByteBuffer);
+    env->DeleteLocalRef(array);
     return array_to_native_data(env, array);
   }
 

--- a/library/common/jni/jni_utility.cc
+++ b/library/common/jni/jni_utility.cc
@@ -69,8 +69,10 @@ envoy_data buffer_to_native_data(JNIEnv* env, jobject j_data) {
     jmethodID jmid_array = env->GetMethodID(jcls_ByteBuffer, "array", "()[B");
     jbyteArray array = static_cast<jbyteArray>(env->CallObjectMethod(j_data, jmid_array));
     env->DeleteLocalRef(jcls_ByteBuffer);
+
+    envoy_data native_data = array_to_native_data(env, array);
     env->DeleteLocalRef(array);
-    return array_to_native_data(env, array);
+    return native_data;
   }
 
   envoy_data native_data;

--- a/library/common/jni/jni_utility.cc
+++ b/library/common/jni/jni_utility.cc
@@ -45,6 +45,7 @@ void jni_delete_const_global_ref(const void* context) {
 int unbox_integer(JNIEnv* env, jobject boxedInteger) {
   jclass jcls_Integer = env->FindClass("java/lang/Integer");
   jmethodID jmid_intValue = env->GetMethodID(jcls_Integer, "intValue", "()I");
+  env->DeleteLocalRef(jcls_Integer);
   return env->CallIntMethod(boxedInteger, jmid_intValue);
 }
 
@@ -67,6 +68,7 @@ envoy_data buffer_to_native_data(JNIEnv* env, jobject j_data) {
     // implemented in the JVM layer.
     jmethodID jmid_array = env->GetMethodID(jcls_ByteBuffer, "array", "()[B");
     jbyteArray array = static_cast<jbyteArray>(env->CallObjectMethod(j_data, jmid_array));
+    env->DeleteLocalRef(jcls_ByteBuffer);
     return array_to_native_data(env, array);
   }
 
@@ -125,6 +127,8 @@ envoy_headers to_native_headers(JNIEnv* env, jobjectArray headers) {
     envoy_data header_value = {value_length, native_value, free, native_value};
 
     header_array[i / 2] = {header_key, header_value};
+    env->DeleteLocalRef(j_key);
+    env->DeleteLocalRef(j_value);
   }
 
   envoy_headers native_headers = {length / 2, header_array};


### PR DESCRIPTION
Description: These caused an almost immediate crash on a Galaxy S8 for some reason, but are a problem regardless.
Risk Level: Low
Testing: Device

Co-authored-by: Alan Chiu <achiu@lyft.com>
Signed-off-by: Mike Schore <mike.schore@gmail.com>