### PR TITLE
swift: clean up some stats types

### DIFF
--- a/library/swift/src/stats/Counter.swift
+++ b/library/swift/src/stats/Counter.swift
@@ -9,7 +9,7 @@ public protocol Counter: AnyObject {
 
 extension Counter {
   /// Increment the counter by 1.
-  public func increment(){
+  public func increment() {
     self.increment(count: 1)
   }
 }

--- a/library/swift/src/stats/CounterImpl.swift
+++ b/library/swift/src/stats/CounterImpl.swift
@@ -3,7 +3,7 @@ import Foundation
 
 /// The implementation of time series counter.
 @objcMembers
-class CounterImpl: NSObject, Counter {
+final class CounterImpl: NSObject, Counter {
   private let series: String
   private weak var engine: EnvoyEngine?
 
@@ -14,12 +14,8 @@ class CounterImpl: NSObject, Counter {
   }
 
   /// Increment the counter by the given count.
-  /// TODO: potentially raise error to platform if the operation is not successful.
   func increment(count: Int) {
-    guard let engine = self.engine else {
-      return
-    }
-
-    engine.recordCounterInc(self.series, count: numericCast(count))
+    // TODO(jingwei99) potentially surface error up if engine is nil.
+    self.engine?.recordCounterInc(self.series, count: numericCast(count))
   }
 }

--- a/library/swift/src/stats/DistributionImpl.swift
+++ b/library/swift/src/stats/DistributionImpl.swift
@@ -3,7 +3,7 @@ import Foundation
 
 /// The implementation of distribution tracking quantile/sum/average stats
 @objcMembers
-class DistributionImpl: NSObject, Distribution {
+final class DistributionImpl: NSObject, Distribution {
   private let series: String
   private weak var engine: EnvoyEngine?
 
@@ -14,12 +14,8 @@ class DistributionImpl: NSObject, Distribution {
   }
 
   /// Record a new int value for the distribution.
-  /// TODO: potentially raise error to platform if the operation is not successful.
   func recordValue(value: Int) {
-    guard let engine = self.engine else {
-      return
-    }
-
-    engine.recordHistogramValue(self.series, value: numericCast(value))
+    // TODO(jingwei99) potentially surface error up if engine is nil.
+    self.engine?.recordHistogramValue(self.series, value: numericCast(value))
   }
 }

--- a/library/swift/src/stats/GaugeImpl.swift
+++ b/library/swift/src/stats/GaugeImpl.swift
@@ -3,7 +3,7 @@ import Foundation
 
 /// The implementation of time series gauge.
 @objcMembers
-class GaugeImpl: NSObject, Gauge {
+final class GaugeImpl: NSObject, Gauge {
   private let series: String
   private weak var engine: EnvoyEngine?
 
@@ -14,32 +14,20 @@ class GaugeImpl: NSObject, Gauge {
   }
 
   /// Set the gauge with the given value.
-  /// TODO: potentially raise error to platform if the operation is not successful.
   func set(value: Int) {
-    guard let engine = self.engine else {
-      return
-    }
-
-    engine.recordGaugeSet(self.series, value: numericCast(value))
+    // TODO(jingwei99) potentially surface error up if engine is nil.
+    self.engine?.recordGaugeSet(self.series, value: numericCast(value))
   }
 
   /// Add the given amount to the gauge.
-  /// TODO: potentially raise error to platform if the operation is not successful.
   func add(amount: Int) {
-    guard let engine = self.engine else {
-      return
-    }
-
-    engine.recordGaugeAdd(self.series, amount: numericCast(amount))
+    // TODO(jingwei99) potentially surface error up if engine is nil.
+    self.engine?.recordGaugeAdd(self.series, amount: numericCast(amount))
   }
 
   /// Subtract the given amount from the gauge.
-  /// TODO: potentially raise error to platform if the operation is not successful.
   func sub(amount: Int) {
-    guard let engine = self.engine else {
-      return
-    }
-
-    engine.recordGaugeSub(self.series, amount: numericCast(amount))
+    // TODO(jingwei99) potentially surface error up if engine is nil.
+    self.engine?.recordGaugeSub(self.series, amount: numericCast(amount))
   }
 }

--- a/library/swift/src/stats/TimerImpl.swift
+++ b/library/swift/src/stats/TimerImpl.swift
@@ -3,7 +3,7 @@ import Foundation
 
 /// The implementation of timer that can be used to track a distribution of time durations
 @objcMembers
-class TimerImpl: NSObject, Timer {
+final class TimerImpl: NSObject, Timer {
   private let series: String
   private weak var engine: EnvoyEngine?
 
@@ -14,12 +14,8 @@ class TimerImpl: NSObject, Timer {
   }
 
   /// Record a new duration value for the distribution.
-  /// TODO: potentially raise error to platform if the operation is not successful.
   func completeWithDuration(durationMs: Int) {
-    guard let engine = self.engine else {
-      return
-    }
-
-    engine.recordHistogramDuration(self.series, durationMs: numericCast(durationMs))
+    // TODO(jingwei99) potentially surface error up if engine is nil.
+    self.engine?.recordHistogramDuration(self.series, durationMs: numericCast(durationMs))
   }
 }


### PR DESCRIPTION
- Make some classes final since they are not intended to be subclassed
- Use optional chaining to simplify guard statements
- Move todos into functions to avoid them showing up in documentation

Signed-off-by: Michael Rebello <me@michaelrebello.com>