### PR TITLE
size: update docs and bazel target

### DIFF
--- a/docs/root/development/performance/binary_size.rst
+++ b/docs/root/development/performance/binary_size.rst
@@ -49,6 +49,17 @@ necessary tools::
   make -j6
   cp bloaty /usr/local/bin/bloaty
 
+.. attention::
+
+    After this `change <https://github.com/envoyproxy/envoy/pull/12569>`_ Envoy starting
+    using split DWARF capabilities to reduce link time and binary size when compiling debug symbols.
+    However, Bloaty (the analysis tool described below)
+    does not support using ``.dwp`` files as a source for debug symbols
+    (tracked in this  `issue <https://github.com/google/bloaty/issues/156>`_). Therefore, a patch
+    `like this <https://github.com/envoyproxy/envoy-mobile/issues/1274#issuecomment-788345216>`_
+    must be applied to the Envoy submodule before compiling the binary described
+    below.
+
 The binary being compiled is ``//test/performance:test_binary_size``.
 The binary is getting built with the following build command::
 

--- a/docs/root/development/performance/binary_size.rst
+++ b/docs/root/development/performance/binary_size.rst
@@ -51,11 +51,11 @@ necessary tools::
 
 .. attention::
 
-    After this `change <https://github.com/envoyproxy/envoy/pull/12569>`_ Envoy starting
+    After this `change <https://github.com/envoyproxy/envoy/pull/12569>`_ Envoy started
     using split DWARF capabilities to reduce link time and binary size when compiling debug symbols.
     However, Bloaty (the analysis tool described below)
     does not support using ``.dwp`` files as a source for debug symbols
-    (tracked in this  `issue <https://github.com/google/bloaty/issues/156>`_). Therefore, a patch
+    (tracked in this `issue <https://github.com/google/bloaty/issues/156>`_). Therefore, a patch
     `like this <https://github.com/envoyproxy/envoy-mobile/issues/1274#issuecomment-788345216>`_
     must be applied to the Envoy submodule before compiling the binary described
     below.

--- a/test/performance/BUILD
+++ b/test/performance/BUILD
@@ -8,5 +8,6 @@ envoy_cc_binary(
     name = "test_binary_size",
     srcs = ["test_binary_size.cc"],
     repository = "@envoy",
+    stamped = True,
     deps = ["//library/common:envoy_main_interface_lib"],
 )


### PR DESCRIPTION
Description: fixing bazel target with explicit stamp. Also updating docs with information about debug symbols.
Risk Level: low
Testing: local binary size analysis
Docs Changes: updated relevant docs.

Signed-off-by: Jose Nino <jnino@lyft.com>