### PR TITLE
ci: skip go install

### DIFF
--- a/ci/mac_ci_setup.sh
+++ b/ci/mac_ci_setup.sh
@@ -42,6 +42,7 @@ if [ -n "$CIRCLECI" ]; then
 fi
 
 echo "Installing go"
+brew unlink go || true
 brew reinstall --force go
 if ! brew link --overwrite go; then
     echo "Failed to install and link go"

--- a/ci/mac_ci_setup.sh
+++ b/ci/mac_ci_setup.sh
@@ -29,7 +29,7 @@ function install {
 #    exit 1
 #fi
 
-DEPS="automake cmake coreutils go libtool wget ninja"
+DEPS="automake cmake coreutils libtool wget ninja"
 for DEP in ${DEPS}
 do
     is_installed "${DEP}" || install "${DEP}"
@@ -40,6 +40,14 @@ if [ -n "$CIRCLECI" ]; then
     # convert https://github.com to ssh://git@github.com, which jgit does not support.
     mv ~/.gitconfig ~/.gitconfig_save
 fi
+
+echo "Installing go"
+brew reinstall --force go
+if ! brew link --overwrite go; then
+    echo "Failed to install and link go"
+    exit 1
+fi
+
 
 # Required as bazel and a foreign bazelisk are installed in the latest macos vm image, we have
 # to unlink/overwrite them to install bazelisk

--- a/ci/mac_ci_setup.sh
+++ b/ci/mac_ci_setup.sh
@@ -41,15 +41,6 @@ if [ -n "$CIRCLECI" ]; then
     mv ~/.gitconfig ~/.gitconfig_save
 fi
 
-echo "Installing go"
-brew unlink go || true
-brew reinstall --force go
-if ! brew link --overwrite go; then
-    echo "Failed to install and link go"
-    exit 1
-fi
-
-
 # Required as bazel and a foreign bazelisk are installed in the latest macos vm image, we have
 # to unlink/overwrite them to install bazelisk
 echo "Installing bazelisk"


### PR DESCRIPTION
Description: Fixes CI. MacOS images seem to have a "good enough" version of go pre-installed now.
Risk Level: Low
Testing: CI

Signed-off-by: Mike Schore <mike.schore@gmail.com>