### PR TITLE
bridge: rename envoy_headers to envoy_map for generalized usage

### DIFF
--- a/library/cc/bridge_utility.cc
+++ b/library/cc/bridge_utility.cc
@@ -33,21 +33,21 @@ envoy_headers raw_header_map_as_envoy_headers(const RawHeaderMap& headers) {
     header_count += pair.second.size();
   }
 
-  envoy_data_map_entry* headers_list =
-      static_cast<envoy_data_map_entry*>(safe_malloc(sizeof(envoy_data_map_entry) * header_count));
+  envoy_map_entry* headers_list =
+      static_cast<envoy_map_entry*>(safe_malloc(sizeof(envoy_map_entry) * header_count));
 
   size_t i = 0;
   for (const auto& pair : headers) {
     const auto& key = pair.first;
     for (const auto& value : pair.second) {
-      envoy_data_map_entry& header = headers_list[i++];
+      envoy_map_entry& header = headers_list[i++];
       header.key = string_as_envoy_data(key);
       header.value = string_as_envoy_data(value);
     }
   }
 
   envoy_headers raw_headers{
-      .length = static_cast<envoy_data_map_size_t>(header_count),
+      .length = static_cast<envoy_map_size_t>(header_count),
       .entries = headers_list,
   };
   return raw_headers;

--- a/library/cc/bridge_utility.cc
+++ b/library/cc/bridge_utility.cc
@@ -33,22 +33,22 @@ envoy_headers raw_header_map_as_envoy_headers(const RawHeaderMap& headers) {
     header_count += pair.second.size();
   }
 
-  envoy_header* headers_list =
-      static_cast<envoy_header*>(safe_malloc(sizeof(envoy_header) * header_count));
+  envoy_data_map_entry* headers_list =
+      static_cast<envoy_data_map_entry*>(safe_malloc(sizeof(envoy_data_map_entry) * header_count));
 
   size_t i = 0;
   for (const auto& pair : headers) {
     const auto& key = pair.first;
     for (const auto& value : pair.second) {
-      envoy_header& header = headers_list[i++];
+      envoy_data_map_entry& header = headers_list[i++];
       header.key = string_as_envoy_data(key);
       header.value = string_as_envoy_data(value);
     }
   }
 
   envoy_headers raw_headers{
-      .length = static_cast<envoy_header_size_t>(header_count),
-      .headers = headers_list,
+      .length = static_cast<envoy_data_map_size_t>(header_count),
+      .entries = headers_list,
   };
   return raw_headers;
 }
@@ -56,8 +56,8 @@ envoy_headers raw_header_map_as_envoy_headers(const RawHeaderMap& headers) {
 RawHeaderMap envoy_headers_as_raw_headers(envoy_headers raw_headers) {
   RawHeaderMap headers;
   for (auto i = 0; i < raw_headers.length; i++) {
-    auto key = envoy_data_as_string(raw_headers.headers[i].key);
-    auto value = envoy_data_as_string(raw_headers.headers[i].value);
+    auto key = envoy_data_as_string(raw_headers.entries[i].key);
+    auto value = envoy_data_as_string(raw_headers.entries[i].value);
 
     if (!headers.contains(key)) {
       headers.emplace(key, std::vector<std::string>());

--- a/library/common/extensions/filters/http/platform_bridge/filter.cc
+++ b/library/common/extensions/filters/http/platform_bridge/filter.cc
@@ -19,11 +19,12 @@ namespace HttpFilters {
 namespace PlatformBridge {
 
 namespace {
+// TODO: https://github.com/envoyproxy/envoy-mobile/issues/1287
 void replaceHeaders(Http::HeaderMap& headers, envoy_headers c_headers) {
   headers.clear();
-  for (envoy_header_size_t i = 0; i < c_headers.length; i++) {
-    headers.addCopy(Http::LowerCaseString(Http::Utility::convertToString(c_headers.headers[i].key)),
-                    Http::Utility::convertToString(c_headers.headers[i].value));
+  for (envoy_data_map_size_t i = 0; i < c_headers.length; i++) {
+    headers.addCopy(Http::LowerCaseString(Http::Utility::convertToString(c_headers.entries[i].key)),
+                    Http::Utility::convertToString(c_headers.entries[i].value));
   }
   // The C envoy_headers struct can be released now because the headers have been copied.
   release_envoy_headers(c_headers);
@@ -172,7 +173,7 @@ Http::FilterHeadersStatus PlatformBridgeFilter::FilterBase::onHeaders(Http::Head
   case kEnvoyFilterHeadersStatusStopIteration:
     pending_headers_ = &headers;
     iteration_state_ = IterationState::Stopped;
-    ASSERT(result.headers.length == 0 && result.headers.headers == NULL);
+    ASSERT(result.headers.length == 0 && result.headers.entries == NULL);
     return Http::FilterHeadersStatus::StopIteration;
 
   default:
@@ -298,7 +299,7 @@ Http::FilterTrailersStatus PlatformBridgeFilter::FilterBase::onTrailers(Http::He
   case kEnvoyFilterTrailersStatusStopIteration:
     pending_trailers_ = &trailers;
     iteration_state_ = IterationState::Stopped;
-    ASSERT(result.trailers.length == 0 && result.trailers.headers == NULL);
+    ASSERT(result.trailers.length == 0 && result.trailers.entries == NULL);
     return Http::FilterTrailersStatus::StopIteration;
 
   // Resume previously-stopped iteration, possibly forwarding headers and data if iteration was

--- a/library/common/extensions/filters/http/platform_bridge/filter.cc
+++ b/library/common/extensions/filters/http/platform_bridge/filter.cc
@@ -22,7 +22,7 @@ namespace {
 // TODO: https://github.com/envoyproxy/envoy-mobile/issues/1287
 void replaceHeaders(Http::HeaderMap& headers, envoy_headers c_headers) {
   headers.clear();
-  for (envoy_data_map_size_t i = 0; i < c_headers.length; i++) {
+  for (envoy_map_size_t i = 0; i < c_headers.length; i++) {
     headers.addCopy(Http::LowerCaseString(Http::Utility::convertToString(c_headers.entries[i].key)),
                     Http::Utility::convertToString(c_headers.entries[i].value));
   }

--- a/library/common/http/header_utility.cc
+++ b/library/common/http/header_utility.cc
@@ -12,7 +12,7 @@ std::string convertToString(envoy_data s) {
 
 RequestHeaderMapPtr toRequestHeaders(envoy_headers headers) {
   RequestHeaderMapPtr transformed_headers = RequestHeaderMapImpl::create();
-  for (envoy_data_map_size_t i = 0; i < headers.length; i++) {
+  for (envoy_map_size_t i = 0; i < headers.length; i++) {
     transformed_headers->addCopy(LowerCaseString(convertToString(headers.entries[i].key)),
                                  convertToString(headers.entries[i].value));
   }
@@ -23,7 +23,7 @@ RequestHeaderMapPtr toRequestHeaders(envoy_headers headers) {
 
 RequestTrailerMapPtr toRequestTrailers(envoy_headers trailers) {
   RequestTrailerMapPtr transformed_trailers = RequestTrailerMapImpl::create();
-  for (envoy_data_map_size_t i = 0; i < trailers.length; i++) {
+  for (envoy_map_size_t i = 0; i < trailers.length; i++) {
     transformed_trailers->addCopy(LowerCaseString(convertToString(trailers.entries[i].key)),
                                   convertToString(trailers.entries[i].value));
   }
@@ -33,8 +33,8 @@ RequestTrailerMapPtr toRequestTrailers(envoy_headers trailers) {
 }
 
 envoy_headers toBridgeHeaders(const HeaderMap& header_map) {
-  envoy_data_map_entry* headers = static_cast<envoy_data_map_entry*>(
-      safe_malloc(sizeof(envoy_data_map_entry) * header_map.size()));
+  envoy_map_entry* headers =
+      static_cast<envoy_map_entry*>(safe_malloc(sizeof(envoy_map_entry) * header_map.size()));
   envoy_headers transformed_headers;
   transformed_headers.length = 0;
   transformed_headers.entries = headers;

--- a/library/common/http/header_utility.cc
+++ b/library/common/http/header_utility.cc
@@ -12,9 +12,9 @@ std::string convertToString(envoy_data s) {
 
 RequestHeaderMapPtr toRequestHeaders(envoy_headers headers) {
   RequestHeaderMapPtr transformed_headers = RequestHeaderMapImpl::create();
-  for (envoy_header_size_t i = 0; i < headers.length; i++) {
-    transformed_headers->addCopy(LowerCaseString(convertToString(headers.headers[i].key)),
-                                 convertToString(headers.headers[i].value));
+  for (envoy_data_map_size_t i = 0; i < headers.length; i++) {
+    transformed_headers->addCopy(LowerCaseString(convertToString(headers.entries[i].key)),
+                                 convertToString(headers.entries[i].value));
   }
   // The C envoy_headers struct can be released now because the headers have been copied.
   release_envoy_headers(headers);
@@ -23,9 +23,9 @@ RequestHeaderMapPtr toRequestHeaders(envoy_headers headers) {
 
 RequestTrailerMapPtr toRequestTrailers(envoy_headers trailers) {
   RequestTrailerMapPtr transformed_trailers = RequestTrailerMapImpl::create();
-  for (envoy_header_size_t i = 0; i < trailers.length; i++) {
-    transformed_trailers->addCopy(LowerCaseString(convertToString(trailers.headers[i].key)),
-                                  convertToString(trailers.headers[i].value));
+  for (envoy_data_map_size_t i = 0; i < trailers.length; i++) {
+    transformed_trailers->addCopy(LowerCaseString(convertToString(trailers.entries[i].key)),
+                                  convertToString(trailers.entries[i].value));
   }
   // The C envoy_headers struct can be released now because the headers have been copied.
   release_envoy_headers(trailers);
@@ -33,11 +33,11 @@ RequestTrailerMapPtr toRequestTrailers(envoy_headers trailers) {
 }
 
 envoy_headers toBridgeHeaders(const HeaderMap& header_map) {
-  envoy_header* headers =
-      static_cast<envoy_header*>(safe_malloc(sizeof(envoy_header) * header_map.size()));
+  envoy_data_map_entry* headers = static_cast<envoy_data_map_entry*>(
+      safe_malloc(sizeof(envoy_data_map_entry) * header_map.size()));
   envoy_headers transformed_headers;
   transformed_headers.length = 0;
-  transformed_headers.headers = headers;
+  transformed_headers.entries = headers;
 
   header_map.iterate([&transformed_headers](const HeaderEntry& header) -> HeaderMap::Iterate {
     const absl::string_view header_key = header.key().getStringView();
@@ -48,7 +48,7 @@ envoy_headers toBridgeHeaders(const HeaderMap& header_map) {
     envoy_data value =
         copy_envoy_data(header_value.size(), reinterpret_cast<const uint8_t*>(header_value.data()));
 
-    transformed_headers.headers[transformed_headers.length] = {key, value};
+    transformed_headers.entries[transformed_headers.length] = {key, value};
     transformed_headers.length++;
 
     return HeaderMap::Iterate::Continue;

--- a/library/common/jni/jni_interface.cc
+++ b/library/common/jni/jni_interface.cc
@@ -144,7 +144,7 @@ static void pass_headers(const char* method, envoy_headers headers, jobject j_co
   jmethodID jmid_passHeader = env->GetMethodID(jcls_JvmCallbackContext, method, "([B[BZ)V");
   jboolean start_headers = JNI_TRUE;
 
-  for (envoy_header_size_t i = 0; i < headers.length; i++) {
+  for (envoy_data_map_size_t i = 0; i < headers.length; i++) {
     // Note this is just an initial implementation, and we will pass a more optimized structure in
     // the future.
 
@@ -152,21 +152,21 @@ static void pass_headers(const char* method, envoy_headers headers, jobject j_co
     // requires a null-terminated *modified* UTF-8 string.
 
     // Create platform byte array for header key
-    jbyteArray key = env->NewByteArray(headers.headers[i].key.length);
+    jbyteArray key = env->NewByteArray(headers.entries[i].key.length);
     // TODO: check if copied via isCopy.
     // TODO: check for NULL.
     // https://github.com/lyft/envoy-mobile/issues/758
     void* critical_key = env->GetPrimitiveArrayCritical(key, nullptr);
-    memcpy(critical_key, headers.headers[i].key.bytes, headers.headers[i].key.length);
+    memcpy(critical_key, headers.entries[i].key.bytes, headers.entries[i].key.length);
     // Here '0' (for which there is no named constant) indicates we want to commit the changes back
     // to the JVM and free the c array, where applicable.
     env->ReleasePrimitiveArrayCritical(key, critical_key, 0);
 
     // Create platform byte array for header value
-    jbyteArray value = env->NewByteArray(headers.headers[i].value.length);
+    jbyteArray value = env->NewByteArray(headers.entries[i].value.length);
     // TODO: check for NULL.
     void* critical_value = env->GetPrimitiveArrayCritical(value, nullptr);
-    memcpy(critical_value, headers.headers[i].value.bytes, headers.headers[i].value.length);
+    memcpy(critical_value, headers.entries[i].value.bytes, headers.entries[i].value.length);
     env->ReleasePrimitiveArrayCritical(value, critical_value, 0);
 
     // Pass this header pair to the platform

--- a/library/common/jni/jni_interface.cc
+++ b/library/common/jni/jni_interface.cc
@@ -144,7 +144,7 @@ static void pass_headers(const char* method, envoy_headers headers, jobject j_co
   jmethodID jmid_passHeader = env->GetMethodID(jcls_JvmCallbackContext, method, "([B[BZ)V");
   jboolean start_headers = JNI_TRUE;
 
-  for (envoy_data_map_size_t i = 0; i < headers.length; i++) {
+  for (envoy_map_size_t i = 0; i < headers.length; i++) {
     // Note this is just an initial implementation, and we will pass a more optimized structure in
     // the future.
 

--- a/library/common/jni/jni_utility.cc
+++ b/library/common/jni/jni_utility.cc
@@ -94,23 +94,23 @@ envoy_data* buffer_to_native_data_ptr(JNIEnv* env, jobject j_data) {
     return nullptr;
   }
 
-  envoy_data* native_data = static_cast<envoy_data*>(safe_malloc(sizeof(envoy_data_map_entry)));
+  envoy_data* native_data = static_cast<envoy_data*>(safe_malloc(sizeof(envoy_map_entry)));
   *native_data = buffer_to_native_data(env, j_data);
   return native_data;
 }
 
 envoy_headers to_native_headers(JNIEnv* env, jobjectArray headers) {
   // Note that headers is a flattened array of key/value pairs.
-  // Therefore, the length of the native header array is n envoy_data or n/2 envoy_data_map_entry.
-  envoy_data_map_size_t length = env->GetArrayLength(headers);
+  // Therefore, the length of the native header array is n envoy_data or n/2 envoy_map_entry.
+  envoy_map_size_t length = env->GetArrayLength(headers);
   if (length == 0) {
     return envoy_noheaders;
   }
 
-  envoy_data_map_entry* header_array =
-      static_cast<envoy_data_map_entry*>(safe_malloc(sizeof(envoy_data_map_entry) * length / 2));
+  envoy_map_entry* header_array =
+      static_cast<envoy_map_entry*>(safe_malloc(sizeof(envoy_map_entry) * length / 2));
 
-  for (envoy_data_map_size_t i = 0; i < length; i += 2) {
+  for (envoy_map_size_t i = 0; i < length; i += 2) {
     // Copy native byte array for header key
     jbyteArray j_key = static_cast<jbyteArray>(env->GetObjectArrayElement(headers, i));
     size_t key_length = env->GetArrayLength(j_key);
@@ -148,8 +148,7 @@ envoy_headers* to_native_headers_ptr(JNIEnv* env, jobjectArray headers) {
     return nullptr;
   }
 
-  envoy_headers* native_headers =
-      static_cast<envoy_headers*>(safe_malloc(sizeof(envoy_data_map_entry)));
+  envoy_headers* native_headers = static_cast<envoy_headers*>(safe_malloc(sizeof(envoy_map_entry)));
   *native_headers = to_native_headers(env, headers);
   return native_headers;
 }

--- a/library/common/jni/jni_utility.cc
+++ b/library/common/jni/jni_utility.cc
@@ -94,23 +94,23 @@ envoy_data* buffer_to_native_data_ptr(JNIEnv* env, jobject j_data) {
     return nullptr;
   }
 
-  envoy_data* native_data = static_cast<envoy_data*>(safe_malloc(sizeof(envoy_header)));
+  envoy_data* native_data = static_cast<envoy_data*>(safe_malloc(sizeof(envoy_data_map_entry)));
   *native_data = buffer_to_native_data(env, j_data);
   return native_data;
 }
 
 envoy_headers to_native_headers(JNIEnv* env, jobjectArray headers) {
   // Note that headers is a flattened array of key/value pairs.
-  // Therefore, the length of the native header array is n envoy_data or n/2 envoy_header.
-  envoy_header_size_t length = env->GetArrayLength(headers);
+  // Therefore, the length of the native header array is n envoy_data or n/2 envoy_data_map_entry.
+  envoy_data_map_size_t length = env->GetArrayLength(headers);
   if (length == 0) {
     return envoy_noheaders;
   }
 
-  envoy_header* header_array =
-      static_cast<envoy_header*>(safe_malloc(sizeof(envoy_header) * length / 2));
+  envoy_data_map_entry* header_array =
+      static_cast<envoy_data_map_entry*>(safe_malloc(sizeof(envoy_data_map_entry) * length / 2));
 
-  for (envoy_header_size_t i = 0; i < length; i += 2) {
+  for (envoy_data_map_size_t i = 0; i < length; i += 2) {
     // Copy native byte array for header key
     jbyteArray j_key = static_cast<jbyteArray>(env->GetObjectArrayElement(headers, i));
     size_t key_length = env->GetArrayLength(j_key);
@@ -148,7 +148,8 @@ envoy_headers* to_native_headers_ptr(JNIEnv* env, jobjectArray headers) {
     return nullptr;
   }
 
-  envoy_headers* native_headers = static_cast<envoy_headers*>(safe_malloc(sizeof(envoy_header)));
+  envoy_headers* native_headers =
+      static_cast<envoy_headers*>(safe_malloc(sizeof(envoy_data_map_entry)));
   *native_headers = to_native_headers(env, headers);
   return native_headers;
 }

--- a/library/common/types/c_types.cc
+++ b/library/common/types/c_types.cc
@@ -26,27 +26,31 @@ void* safe_calloc(size_t count, size_t size) {
 
 void envoy_noop_release(void* context) { (void)context; }
 
-void release_envoy_headers(envoy_headers headers) {
-  for (envoy_header_size_t i = 0; i < headers.length; i++) {
-    envoy_header header = headers.headers[i];
-    header.key.release(header.key.context);
-    header.value.release(header.value.context);
+void release_envoy_data_map(envoy_data_map map) {
+  for (envoy_data_map_size_t i = 0; i < map.length; i++) {
+    envoy_data_map_entry entry = map.entries[i];
+    entry.key.release(entry.key.context);
+    entry.value.release(entry.value.context);
   }
-  free(headers.headers);
+  free(map.entries);
 }
 
-envoy_headers copy_envoy_headers(envoy_headers src) {
-  envoy_header* dst_header_array =
-      static_cast<envoy_header*>(safe_malloc(sizeof(envoy_header) * src.length));
-  for (envoy_header_size_t i = 0; i < src.length; i++) {
-    envoy_header new_header = {
-        copy_envoy_data(src.headers[i].key.length, src.headers[i].key.bytes),
-        copy_envoy_data(src.headers[i].value.length, src.headers[i].value.bytes)};
-    dst_header_array[i] = new_header;
+void release_envoy_headers(envoy_headers headers) { release_envoy_data_map(headers); }
+
+envoy_data_map copy_envoy_data_map(envoy_data_map src) {
+  envoy_data_map_entry* dst_entries =
+      static_cast<envoy_data_map_entry*>(safe_malloc(sizeof(envoy_data_map_entry) * src.length));
+  for (envoy_data_map_size_t i = 0; i < src.length; i++) {
+    envoy_data_map_entry new_entry = {
+        copy_envoy_data(src.entries[i].key.length, src.entries[i].key.bytes),
+        copy_envoy_data(src.entries[i].value.length, src.entries[i].value.bytes)};
+    dst_entries[i] = new_entry;
   }
-  envoy_headers dst = {src.length, dst_header_array};
+  envoy_data_map dst = {src.length, dst_entries};
   return dst;
 }
+
+envoy_headers copy_envoy_headers(envoy_headers src) { return copy_envoy_data_map(src); }
 
 envoy_data copy_envoy_data(size_t length, const uint8_t* src_bytes) {
   uint8_t* dst_bytes = static_cast<uint8_t*>(safe_malloc(sizeof(uint8_t) * length));

--- a/library/common/types/c_types.cc
+++ b/library/common/types/c_types.cc
@@ -26,9 +26,9 @@ void* safe_calloc(size_t count, size_t size) {
 
 void envoy_noop_release(void* context) { (void)context; }
 
-void release_envoy_data_map(envoy_data_map map) {
-  for (envoy_data_map_size_t i = 0; i < map.length; i++) {
-    envoy_data_map_entry entry = map.entries[i];
+void release_envoy_data_map(envoy_map map) {
+  for (envoy_map_size_t i = 0; i < map.length; i++) {
+    envoy_map_entry entry = map.entries[i];
     entry.key.release(entry.key.context);
     entry.value.release(entry.value.context);
   }
@@ -37,16 +37,16 @@ void release_envoy_data_map(envoy_data_map map) {
 
 void release_envoy_headers(envoy_headers headers) { release_envoy_data_map(headers); }
 
-envoy_data_map copy_envoy_data_map(envoy_data_map src) {
-  envoy_data_map_entry* dst_entries =
-      static_cast<envoy_data_map_entry*>(safe_malloc(sizeof(envoy_data_map_entry) * src.length));
-  for (envoy_data_map_size_t i = 0; i < src.length; i++) {
-    envoy_data_map_entry new_entry = {
+envoy_map copy_envoy_data_map(envoy_map src) {
+  envoy_map_entry* dst_entries =
+      static_cast<envoy_map_entry*>(safe_malloc(sizeof(envoy_map_entry) * src.length));
+  for (envoy_map_size_t i = 0; i < src.length; i++) {
+    envoy_map_entry new_entry = {
         copy_envoy_data(src.entries[i].key.length, src.entries[i].key.bytes),
         copy_envoy_data(src.entries[i].value.length, src.entries[i].value.bytes)};
     dst_entries[i] = new_entry;
   }
-  envoy_data_map dst = {src.length, dst_entries};
+  envoy_map dst = {src.length, dst_entries};
   return dst;
 }
 

--- a/library/common/types/c_types.h
+++ b/library/common/types/c_types.h
@@ -92,25 +92,25 @@ typedef struct {
 typedef struct {
   envoy_data key;
   envoy_data value;
-} envoy_data_map_entry;
+} envoy_map_entry;
 
 /**
  * Consistent type for dealing with encodable/processable header counts.
  */
-typedef int envoy_data_map_size_t;
+typedef int envoy_map_size_t;
 
 /**
- * Holds a map as an array of envoy_data_map_entry structs.
+ * Holds a map as an array of envoy_map_entry structs.
  */
 typedef struct {
   // Number of entries in the array.
-  envoy_data_map_size_t length;
+  envoy_map_size_t length;
   // Array of map entries.
-  envoy_data_map_entry* entries;
-} envoy_data_map;
+  envoy_map_entry* entries;
+} envoy_map;
 
 // Multiple header values for the same header key are supported via a comma-delimited string.
-typedef envoy_data_map envoy_headers;
+typedef envoy_map envoy_headers;
 
 #ifdef __cplusplus
 extern "C" { // utility functions

--- a/library/common/types/c_types.h
+++ b/library/common/types/c_types.h
@@ -87,28 +87,30 @@ typedef struct {
 } envoy_data;
 
 /**
- * Holds a single key/value header.
+ * Holds a single key/value pair.
  */
 typedef struct {
   envoy_data key;
-  // Multiple header values for the same header key are supported via a comma-delimited string.
   envoy_data value;
-} envoy_header;
+} envoy_data_map_entry;
 
 /**
  * Consistent type for dealing with encodable/processable header counts.
  */
-typedef int envoy_header_size_t;
+typedef int envoy_data_map_size_t;
 
 /**
- * Holds an HTTP header map as an array of envoy_header structs.
+ * Holds a map as an array of envoy_data_map_entry structs.
  */
 typedef struct {
-  // Number of header elements in the array.
-  envoy_header_size_t length;
-  // Array of headers.
-  envoy_header* headers;
-} envoy_headers;
+  // Number of entries in the array.
+  envoy_data_map_size_t length;
+  // Array of map entries.
+  envoy_data_map_entry* entries;
+} envoy_data_map;
+
+// Multiple header values for the same header key are supported via a comma-delimited string.
+typedef envoy_data_map envoy_headers;
 
 #ifdef __cplusplus
 extern "C" { // utility functions

--- a/library/objective-c/EnvoyBridgeUtility.h
+++ b/library/objective-c/EnvoyBridgeUtility.h
@@ -36,18 +36,17 @@ static inline envoy_headers toNativeHeaders(EnvoyHeaders *headers) {
     return envoy_noheaders;
   }
 
-  envoy_data_map_size_t length = 0;
+  envoy_map_size_t length = 0;
   for (NSString *headerKey in headers) {
     length += [headers[headerKey] count];
   }
-  envoy_data_map_entry *header_array =
-      (envoy_data_map_entry *)safe_malloc(sizeof(envoy_data_map_entry) * length);
-  envoy_data_map_size_t header_index = 0;
+  envoy_map_entry *header_array = (envoy_map_entry *)safe_malloc(sizeof(envoy_map_entry) * length);
+  envoy_map_size_t header_index = 0;
   for (id headerKey in headers) {
     NSArray *headerList = headers[headerKey];
     for (NSString *headerValue in headerList) {
-      envoy_data_map_entry new_header = {toManagedNativeString(headerKey),
-                                         toManagedNativeString(headerValue)};
+      envoy_map_entry new_header = {toManagedNativeString(headerKey),
+                                    toManagedNativeString(headerValue)};
       header_array[header_index++] = new_header;
     }
   }
@@ -76,8 +75,8 @@ static inline NSData *to_ios_data(envoy_data data) {
 
 static inline EnvoyHeaders *to_ios_headers(envoy_headers headers) {
   NSMutableDictionary *headerDict = [NSMutableDictionary new];
-  for (envoy_data_map_size_t i = 0; i < headers.length; i++) {
-    envoy_data_map_entry header = headers.entries[i];
+  for (envoy_map_size_t i = 0; i < headers.length; i++) {
+    envoy_map_entry header = headers.entries[i];
     NSString *headerKey = [[NSString alloc] initWithBytes:header.key.bytes
                                                    length:header.key.length
                                                  encoding:NSUTF8StringEncoding];

--- a/library/objective-c/EnvoyBridgeUtility.h
+++ b/library/objective-c/EnvoyBridgeUtility.h
@@ -36,17 +36,18 @@ static inline envoy_headers toNativeHeaders(EnvoyHeaders *headers) {
     return envoy_noheaders;
   }
 
-  envoy_header_size_t length = 0;
+  envoy_data_map_size_t length = 0;
   for (NSString *headerKey in headers) {
     length += [headers[headerKey] count];
   }
-  envoy_header *header_array = (envoy_header *)safe_malloc(sizeof(envoy_header) * length);
-  envoy_header_size_t header_index = 0;
+  envoy_data_map_entry *header_array =
+      (envoy_data_map_entry *)safe_malloc(sizeof(envoy_data_map_entry) * length);
+  envoy_data_map_size_t header_index = 0;
   for (id headerKey in headers) {
     NSArray *headerList = headers[headerKey];
     for (NSString *headerValue in headerList) {
-      envoy_header new_header = {toManagedNativeString(headerKey),
-                                 toManagedNativeString(headerValue)};
+      envoy_data_map_entry new_header = {toManagedNativeString(headerKey),
+                                         toManagedNativeString(headerValue)};
       header_array[header_index++] = new_header;
     }
   }
@@ -75,8 +76,8 @@ static inline NSData *to_ios_data(envoy_data data) {
 
 static inline EnvoyHeaders *to_ios_headers(envoy_headers headers) {
   NSMutableDictionary *headerDict = [NSMutableDictionary new];
-  for (envoy_header_size_t i = 0; i < headers.length; i++) {
-    envoy_header header = headers.headers[i];
+  for (envoy_data_map_size_t i = 0; i < headers.length; i++) {
+    envoy_data_map_entry header = headers.entries[i];
     NSString *headerKey = [[NSString alloc] initWithBytes:header.key.bytes
                                                    length:header.key.length
                                                  encoding:NSUTF8StringEncoding];

--- a/test/common/extensions/filters/http/platform_bridge/platform_bridge_filter_test.cc
+++ b/test/common/extensions/filters/http/platform_bridge/platform_bridge_filter_test.cc
@@ -27,8 +27,8 @@ envoy_data make_envoy_data(const std::string& s) {
 }
 
 envoy_headers make_envoy_headers(std::vector<std::pair<std::string, std::string>> pairs) {
-  envoy_data_map_entry* headers =
-      static_cast<envoy_data_map_entry*>(safe_malloc(sizeof(envoy_data_map_entry) * pairs.size()));
+  envoy_map_entry* headers =
+      static_cast<envoy_map_entry*>(safe_malloc(sizeof(envoy_map_entry) * pairs.size()));
   envoy_headers new_headers;
   new_headers.length = 0;
   new_headers.entries = headers;

--- a/test/common/extensions/filters/http/platform_bridge/platform_bridge_filter_test.cc
+++ b/test/common/extensions/filters/http/platform_bridge/platform_bridge_filter_test.cc
@@ -27,17 +27,17 @@ envoy_data make_envoy_data(const std::string& s) {
 }
 
 envoy_headers make_envoy_headers(std::vector<std::pair<std::string, std::string>> pairs) {
-  envoy_header* headers =
-      static_cast<envoy_header*>(safe_malloc(sizeof(envoy_header) * pairs.size()));
+  envoy_data_map_entry* headers =
+      static_cast<envoy_data_map_entry*>(safe_malloc(sizeof(envoy_data_map_entry) * pairs.size()));
   envoy_headers new_headers;
   new_headers.length = 0;
-  new_headers.headers = headers;
+  new_headers.entries = headers;
 
   for (const auto& pair : pairs) {
     envoy_data key = make_envoy_data(pair.first);
     envoy_data value = make_envoy_data(pair.second);
 
-    new_headers.headers[new_headers.length] = {key, value};
+    new_headers.entries[new_headers.length] = {key, value};
     new_headers.length++;
   }
 
@@ -165,8 +165,8 @@ TEST_F(PlatformBridgeFilterTest, BasicContinueOnRequestHeaders) {
                                           const void* context) -> envoy_filter_headers_status {
     filter_invocations* invocations = static_cast<filter_invocations*>(const_cast<void*>(context));
     EXPECT_EQ(c_headers.length, 1);
-    EXPECT_EQ(to_string(c_headers.headers[0].key), ":authority");
-    EXPECT_EQ(to_string(c_headers.headers[0].value), "test.code");
+    EXPECT_EQ(to_string(c_headers.entries[0].key), ":authority");
+    EXPECT_EQ(to_string(c_headers.entries[0].value), "test.code");
     EXPECT_TRUE(end_stream);
     invocations->on_request_headers_calls++;
     return {kEnvoyFilterHeadersStatusContinue, c_headers};
@@ -199,8 +199,8 @@ TEST_F(PlatformBridgeFilterTest, StopOnRequestHeadersThenResumeOnData) {
                                           const void* context) -> envoy_filter_headers_status {
     filter_invocations* invocations = static_cast<filter_invocations*>(const_cast<void*>(context));
     EXPECT_EQ(c_headers.length, 1);
-    EXPECT_EQ(to_string(c_headers.headers[0].key), ":authority");
-    EXPECT_EQ(to_string(c_headers.headers[0].value), "test.code");
+    EXPECT_EQ(to_string(c_headers.entries[0].key), ":authority");
+    EXPECT_EQ(to_string(c_headers.entries[0].value), "test.code");
     EXPECT_FALSE(end_stream);
     invocations->on_request_headers_calls++;
     release_envoy_headers(c_headers);
@@ -256,8 +256,8 @@ TEST_F(PlatformBridgeFilterTest, StopOnRequestHeadersThenResumeOnResumeDecoding)
                                           const void* context) -> envoy_filter_headers_status {
     filter_invocations* invocations = static_cast<filter_invocations*>(const_cast<void*>(context));
     EXPECT_EQ(c_headers.length, 1);
-    EXPECT_EQ(to_string(c_headers.headers[0].key), ":authority");
-    EXPECT_EQ(to_string(c_headers.headers[0].value), "test.code");
+    EXPECT_EQ(to_string(c_headers.entries[0].key), ":authority");
+    EXPECT_EQ(to_string(c_headers.entries[0].value), "test.code");
     EXPECT_FALSE(end_stream);
     invocations->on_request_headers_calls++;
     release_envoy_headers(c_headers);
@@ -268,8 +268,8 @@ TEST_F(PlatformBridgeFilterTest, StopOnRequestHeadersThenResumeOnResumeDecoding)
                                          const void* context) -> envoy_filter_resume_status {
     filter_invocations* invocations = static_cast<filter_invocations*>(const_cast<void*>(context));
     EXPECT_EQ(pending_headers->length, 1);
-    EXPECT_EQ(to_string(pending_headers->headers[0].key), ":authority");
-    EXPECT_EQ(to_string(pending_headers->headers[0].value), "test.code");
+    EXPECT_EQ(to_string(pending_headers->entries[0].key), ":authority");
+    EXPECT_EQ(to_string(pending_headers->entries[0].value), "test.code");
     EXPECT_EQ(pending_data, nullptr);
     EXPECT_EQ(pending_trailers, nullptr);
     EXPECT_FALSE(end_stream);
@@ -322,8 +322,8 @@ TEST_F(PlatformBridgeFilterTest, AsyncResumeDecodingIsNoopAfterPreviousResume) {
                                           const void* context) -> envoy_filter_headers_status {
     filter_invocations* invocations = static_cast<filter_invocations*>(const_cast<void*>(context));
     EXPECT_EQ(c_headers.length, 1);
-    EXPECT_EQ(to_string(c_headers.headers[0].key), ":authority");
-    EXPECT_EQ(to_string(c_headers.headers[0].value), "test.code");
+    EXPECT_EQ(to_string(c_headers.entries[0].key), ":authority");
+    EXPECT_EQ(to_string(c_headers.entries[0].value), "test.code");
     EXPECT_FALSE(end_stream);
     invocations->on_request_headers_calls++;
     release_envoy_headers(c_headers);
@@ -549,8 +549,8 @@ TEST_F(PlatformBridgeFilterTest, StopOnRequestHeadersThenBufferThenResumeOnData)
                                           const void* context) -> envoy_filter_headers_status {
     filter_invocations* invocations = static_cast<filter_invocations*>(const_cast<void*>(context));
     EXPECT_EQ(c_headers.length, 1);
-    EXPECT_EQ(to_string(c_headers.headers[0].key), ":authority");
-    EXPECT_EQ(to_string(c_headers.headers[0].value), "test.code");
+    EXPECT_EQ(to_string(c_headers.entries[0].key), ":authority");
+    EXPECT_EQ(to_string(c_headers.entries[0].value), "test.code");
     EXPECT_FALSE(end_stream);
     invocations->on_request_headers_calls++;
     release_envoy_headers(c_headers);
@@ -687,8 +687,8 @@ TEST_F(PlatformBridgeFilterTest, BasicContinueOnRequestTrailers) {
                                            const void* context) -> envoy_filter_trailers_status {
     filter_invocations* invocations = static_cast<filter_invocations*>(const_cast<void*>(context));
     EXPECT_EQ(c_trailers.length, 1);
-    EXPECT_EQ(to_string(c_trailers.headers[0].key), "x-test-trailer");
-    EXPECT_EQ(to_string(c_trailers.headers[0].value), "test trailer");
+    EXPECT_EQ(to_string(c_trailers.entries[0].key), "x-test-trailer");
+    EXPECT_EQ(to_string(c_trailers.entries[0].value), "test trailer");
     invocations->on_request_trailers_calls++;
     return {kEnvoyFilterTrailersStatusContinue, c_trailers, nullptr, nullptr};
   };
@@ -720,8 +720,8 @@ TEST_F(PlatformBridgeFilterTest, StopOnRequestHeadersThenBufferThenResumeOnTrail
                                           const void* context) -> envoy_filter_headers_status {
     filter_invocations* invocations = static_cast<filter_invocations*>(const_cast<void*>(context));
     EXPECT_EQ(c_headers.length, 1);
-    EXPECT_EQ(to_string(c_headers.headers[0].key), ":authority");
-    EXPECT_EQ(to_string(c_headers.headers[0].value), "test.code");
+    EXPECT_EQ(to_string(c_headers.entries[0].key), ":authority");
+    EXPECT_EQ(to_string(c_headers.entries[0].value), "test.code");
     EXPECT_FALSE(end_stream);
     invocations->on_request_headers_calls++;
     release_envoy_headers(c_headers);
@@ -741,8 +741,8 @@ TEST_F(PlatformBridgeFilterTest, StopOnRequestHeadersThenBufferThenResumeOnTrail
                                            const void* context) -> envoy_filter_trailers_status {
     filter_invocations* invocations = static_cast<filter_invocations*>(const_cast<void*>(context));
     EXPECT_EQ(c_trailers.length, 1);
-    EXPECT_EQ(to_string(c_trailers.headers[0].key), "x-test-trailer");
-    EXPECT_EQ(to_string(c_trailers.headers[0].value), "test trailer");
+    EXPECT_EQ(to_string(c_trailers.entries[0].key), "x-test-trailer");
+    EXPECT_EQ(to_string(c_trailers.entries[0].value), "test trailer");
 
     Buffer::OwnedImpl final_buffer = Buffer::OwnedImpl("C");
     envoy_data* modified_data = static_cast<envoy_data*>(safe_malloc(sizeof(envoy_data)));
@@ -821,8 +821,8 @@ TEST_F(PlatformBridgeFilterTest, StopOnRequestHeadersThenBufferThenResumeOnResum
                                           const void* context) -> envoy_filter_headers_status {
     filter_invocations* invocations = static_cast<filter_invocations*>(const_cast<void*>(context));
     EXPECT_EQ(c_headers.length, 1);
-    EXPECT_EQ(to_string(c_headers.headers[0].key), ":authority");
-    EXPECT_EQ(to_string(c_headers.headers[0].value), "test.code");
+    EXPECT_EQ(to_string(c_headers.entries[0].key), ":authority");
+    EXPECT_EQ(to_string(c_headers.entries[0].value), "test.code");
     EXPECT_FALSE(end_stream);
     invocations->on_request_headers_calls++;
     release_envoy_headers(c_headers);
@@ -842,8 +842,8 @@ TEST_F(PlatformBridgeFilterTest, StopOnRequestHeadersThenBufferThenResumeOnResum
                                            const void* context) -> envoy_filter_trailers_status {
     filter_invocations* invocations = static_cast<filter_invocations*>(const_cast<void*>(context));
     EXPECT_EQ(c_trailers.length, 1);
-    EXPECT_EQ(to_string(c_trailers.headers[0].key), "x-test-trailer");
-    EXPECT_EQ(to_string(c_trailers.headers[0].value), "test trailer");
+    EXPECT_EQ(to_string(c_trailers.entries[0].key), "x-test-trailer");
+    EXPECT_EQ(to_string(c_trailers.entries[0].value), "test trailer");
     release_envoy_headers(c_trailers);
     invocations->on_request_trailers_calls++;
     return {kEnvoyFilterTrailersStatusStopIteration, envoy_noheaders, nullptr, nullptr};
@@ -853,12 +853,12 @@ TEST_F(PlatformBridgeFilterTest, StopOnRequestHeadersThenBufferThenResumeOnResum
                                          const void* context) -> envoy_filter_resume_status {
     filter_invocations* invocations = static_cast<filter_invocations*>(const_cast<void*>(context));
     EXPECT_EQ(pending_headers->length, 1);
-    EXPECT_EQ(to_string(pending_headers->headers[0].key), ":authority");
-    EXPECT_EQ(to_string(pending_headers->headers[0].value), "test.code");
+    EXPECT_EQ(to_string(pending_headers->entries[0].key), ":authority");
+    EXPECT_EQ(to_string(pending_headers->entries[0].value), "test.code");
     EXPECT_EQ(to_string(*pending_data), "AB");
     EXPECT_EQ(pending_trailers->length, 1);
-    EXPECT_EQ(to_string(pending_trailers->headers[0].key), "x-test-trailer");
-    EXPECT_EQ(to_string(pending_trailers->headers[0].value), "test trailer");
+    EXPECT_EQ(to_string(pending_trailers->entries[0].key), "x-test-trailer");
+    EXPECT_EQ(to_string(pending_trailers->entries[0].value), "test trailer");
     EXPECT_TRUE(end_stream);
 
     envoy_headers* modified_headers =
@@ -962,8 +962,8 @@ TEST_F(PlatformBridgeFilterTest, BasicContinueOnResponseHeaders) {
                                            const void* context) -> envoy_filter_headers_status {
     filter_invocations* invocations = static_cast<filter_invocations*>(const_cast<void*>(context));
     EXPECT_EQ(c_headers.length, 1);
-    EXPECT_EQ(to_string(c_headers.headers[0].key), ":status");
-    EXPECT_EQ(to_string(c_headers.headers[0].value), "test.code");
+    EXPECT_EQ(to_string(c_headers.entries[0].key), ":status");
+    EXPECT_EQ(to_string(c_headers.entries[0].value), "test.code");
     EXPECT_TRUE(end_stream);
     invocations->on_response_headers_calls++;
     return {kEnvoyFilterHeadersStatusContinue, c_headers};
@@ -996,8 +996,8 @@ TEST_F(PlatformBridgeFilterTest, StopOnResponseHeadersThenResumeOnData) {
                                            const void* context) -> envoy_filter_headers_status {
     filter_invocations* invocations = static_cast<filter_invocations*>(const_cast<void*>(context));
     EXPECT_EQ(c_headers.length, 1);
-    EXPECT_EQ(to_string(c_headers.headers[0].key), ":status");
-    EXPECT_EQ(to_string(c_headers.headers[0].value), "test.code");
+    EXPECT_EQ(to_string(c_headers.entries[0].key), ":status");
+    EXPECT_EQ(to_string(c_headers.entries[0].value), "test.code");
     EXPECT_FALSE(end_stream);
     invocations->on_response_headers_calls++;
     release_envoy_headers(c_headers);
@@ -1053,8 +1053,8 @@ TEST_F(PlatformBridgeFilterTest, StopOnResponseHeadersThenResumeOnResumeEncoding
                                            const void* context) -> envoy_filter_headers_status {
     filter_invocations* invocations = static_cast<filter_invocations*>(const_cast<void*>(context));
     EXPECT_EQ(c_headers.length, 1);
-    EXPECT_EQ(to_string(c_headers.headers[0].key), ":status");
-    EXPECT_EQ(to_string(c_headers.headers[0].value), "test.code");
+    EXPECT_EQ(to_string(c_headers.entries[0].key), ":status");
+    EXPECT_EQ(to_string(c_headers.entries[0].value), "test.code");
     EXPECT_FALSE(end_stream);
     invocations->on_response_headers_calls++;
     release_envoy_headers(c_headers);
@@ -1065,8 +1065,8 @@ TEST_F(PlatformBridgeFilterTest, StopOnResponseHeadersThenResumeOnResumeEncoding
                                           const void* context) -> envoy_filter_resume_status {
     filter_invocations* invocations = static_cast<filter_invocations*>(const_cast<void*>(context));
     EXPECT_EQ(pending_headers->length, 1);
-    EXPECT_EQ(to_string(pending_headers->headers[0].key), ":status");
-    EXPECT_EQ(to_string(pending_headers->headers[0].value), "test.code");
+    EXPECT_EQ(to_string(pending_headers->entries[0].key), ":status");
+    EXPECT_EQ(to_string(pending_headers->entries[0].value), "test.code");
     EXPECT_EQ(pending_data, nullptr);
     EXPECT_EQ(pending_trailers, nullptr);
     EXPECT_FALSE(end_stream);
@@ -1119,8 +1119,8 @@ TEST_F(PlatformBridgeFilterTest, AsyncResumeEncodingIsNoopAfterPreviousResume) {
                                            const void* context) -> envoy_filter_headers_status {
     filter_invocations* invocations = static_cast<filter_invocations*>(const_cast<void*>(context));
     EXPECT_EQ(c_headers.length, 1);
-    EXPECT_EQ(to_string(c_headers.headers[0].key), ":status");
-    EXPECT_EQ(to_string(c_headers.headers[0].value), "test.code");
+    EXPECT_EQ(to_string(c_headers.entries[0].key), ":status");
+    EXPECT_EQ(to_string(c_headers.entries[0].value), "test.code");
     EXPECT_FALSE(end_stream);
     invocations->on_response_headers_calls++;
     release_envoy_headers(c_headers);
@@ -1346,8 +1346,8 @@ TEST_F(PlatformBridgeFilterTest, StopOnResponseHeadersThenBufferThenResumeOnData
                                            const void* context) -> envoy_filter_headers_status {
     filter_invocations* invocations = static_cast<filter_invocations*>(const_cast<void*>(context));
     EXPECT_EQ(c_headers.length, 1);
-    EXPECT_EQ(to_string(c_headers.headers[0].key), ":status");
-    EXPECT_EQ(to_string(c_headers.headers[0].value), "test.code");
+    EXPECT_EQ(to_string(c_headers.entries[0].key), ":status");
+    EXPECT_EQ(to_string(c_headers.entries[0].value), "test.code");
     EXPECT_FALSE(end_stream);
     invocations->on_response_headers_calls++;
     release_envoy_headers(c_headers);
@@ -1483,8 +1483,8 @@ TEST_F(PlatformBridgeFilterTest, BasicContinueOnResponseTrailers) {
                                             const void* context) -> envoy_filter_trailers_status {
     filter_invocations* invocations = static_cast<filter_invocations*>(const_cast<void*>(context));
     EXPECT_EQ(c_trailers.length, 1);
-    EXPECT_EQ(to_string(c_trailers.headers[0].key), "x-test-trailer");
-    EXPECT_EQ(to_string(c_trailers.headers[0].value), "test trailer");
+    EXPECT_EQ(to_string(c_trailers.entries[0].key), "x-test-trailer");
+    EXPECT_EQ(to_string(c_trailers.entries[0].value), "test trailer");
     invocations->on_response_trailers_calls++;
     return {kEnvoyFilterTrailersStatusContinue, c_trailers, nullptr, nullptr};
   };
@@ -1516,8 +1516,8 @@ TEST_F(PlatformBridgeFilterTest, StopOnResponseHeadersThenBufferThenResumeOnTrai
                                            const void* context) -> envoy_filter_headers_status {
     filter_invocations* invocations = static_cast<filter_invocations*>(const_cast<void*>(context));
     EXPECT_EQ(c_headers.length, 1);
-    EXPECT_EQ(to_string(c_headers.headers[0].key), ":status");
-    EXPECT_EQ(to_string(c_headers.headers[0].value), "test.code");
+    EXPECT_EQ(to_string(c_headers.entries[0].key), ":status");
+    EXPECT_EQ(to_string(c_headers.entries[0].value), "test.code");
     EXPECT_FALSE(end_stream);
     invocations->on_response_headers_calls++;
     release_envoy_headers(c_headers);
@@ -1537,8 +1537,8 @@ TEST_F(PlatformBridgeFilterTest, StopOnResponseHeadersThenBufferThenResumeOnTrai
                                             const void* context) -> envoy_filter_trailers_status {
     filter_invocations* invocations = static_cast<filter_invocations*>(const_cast<void*>(context));
     EXPECT_EQ(c_trailers.length, 1);
-    EXPECT_EQ(to_string(c_trailers.headers[0].key), "x-test-trailer");
-    EXPECT_EQ(to_string(c_trailers.headers[0].value), "test trailer");
+    EXPECT_EQ(to_string(c_trailers.entries[0].key), "x-test-trailer");
+    EXPECT_EQ(to_string(c_trailers.entries[0].value), "test trailer");
 
     Buffer::OwnedImpl final_buffer = Buffer::OwnedImpl("C");
     envoy_data* modified_data = static_cast<envoy_data*>(safe_malloc(sizeof(envoy_data)));
@@ -1617,8 +1617,8 @@ TEST_F(PlatformBridgeFilterTest, StopOnResponseHeadersThenBufferThenResumeOnResu
                                            const void* context) -> envoy_filter_headers_status {
     filter_invocations* invocations = static_cast<filter_invocations*>(const_cast<void*>(context));
     EXPECT_EQ(c_headers.length, 1);
-    EXPECT_EQ(to_string(c_headers.headers[0].key), ":status");
-    EXPECT_EQ(to_string(c_headers.headers[0].value), "test.code");
+    EXPECT_EQ(to_string(c_headers.entries[0].key), ":status");
+    EXPECT_EQ(to_string(c_headers.entries[0].value), "test.code");
     EXPECT_FALSE(end_stream);
     invocations->on_response_headers_calls++;
     release_envoy_headers(c_headers);
@@ -1638,8 +1638,8 @@ TEST_F(PlatformBridgeFilterTest, StopOnResponseHeadersThenBufferThenResumeOnResu
                                             const void* context) -> envoy_filter_trailers_status {
     filter_invocations* invocations = static_cast<filter_invocations*>(const_cast<void*>(context));
     EXPECT_EQ(c_trailers.length, 1);
-    EXPECT_EQ(to_string(c_trailers.headers[0].key), "x-test-trailer");
-    EXPECT_EQ(to_string(c_trailers.headers[0].value), "test trailer");
+    EXPECT_EQ(to_string(c_trailers.entries[0].key), "x-test-trailer");
+    EXPECT_EQ(to_string(c_trailers.entries[0].value), "test trailer");
     release_envoy_headers(c_trailers);
     invocations->on_response_trailers_calls++;
     return {kEnvoyFilterTrailersStatusStopIteration, envoy_noheaders, nullptr, nullptr};
@@ -1649,12 +1649,12 @@ TEST_F(PlatformBridgeFilterTest, StopOnResponseHeadersThenBufferThenResumeOnResu
                                           const void* context) -> envoy_filter_resume_status {
     filter_invocations* invocations = static_cast<filter_invocations*>(const_cast<void*>(context));
     EXPECT_EQ(pending_headers->length, 1);
-    EXPECT_EQ(to_string(pending_headers->headers[0].key), ":status");
-    EXPECT_EQ(to_string(pending_headers->headers[0].value), "test.code");
+    EXPECT_EQ(to_string(pending_headers->entries[0].key), ":status");
+    EXPECT_EQ(to_string(pending_headers->entries[0].value), "test.code");
     EXPECT_EQ(to_string(*pending_data), "AB");
     EXPECT_EQ(pending_trailers->length, 1);
-    EXPECT_EQ(to_string(pending_trailers->headers[0].key), "x-test-trailer");
-    EXPECT_EQ(to_string(pending_trailers->headers[0].value), "test trailer");
+    EXPECT_EQ(to_string(pending_trailers->entries[0].key), "x-test-trailer");
+    EXPECT_EQ(to_string(pending_trailers->entries[0].value), "test trailer");
     EXPECT_TRUE(end_stream);
 
     envoy_headers* modified_headers =

--- a/test/common/http/dispatcher_test.cc
+++ b/test/common/http/dispatcher_test.cc
@@ -32,9 +32,9 @@ namespace Http {
 // Based on Http::Utility::toRequestHeaders() but only used for these tests.
 ResponseHeaderMapPtr toResponseHeaders(envoy_headers headers) {
   ResponseHeaderMapPtr transformed_headers = ResponseHeaderMapImpl::create();
-  for (envoy_header_size_t i = 0; i < headers.length; i++) {
-    transformed_headers->addCopy(LowerCaseString(Utility::convertToString(headers.headers[i].key)),
-                                 Utility::convertToString(headers.headers[i].value));
+  for (envoy_data_map_size_t i = 0; i < headers.length; i++) {
+    transformed_headers->addCopy(LowerCaseString(Utility::convertToString(headers.entries[i].key)),
+                                 Utility::convertToString(headers.entries[i].value));
   }
   // The C envoy_headers struct can be released now because the headers have been copied.
   release_envoy_headers(headers);

--- a/test/common/http/dispatcher_test.cc
+++ b/test/common/http/dispatcher_test.cc
@@ -32,7 +32,7 @@ namespace Http {
 // Based on Http::Utility::toRequestHeaders() but only used for these tests.
 ResponseHeaderMapPtr toResponseHeaders(envoy_headers headers) {
   ResponseHeaderMapPtr transformed_headers = ResponseHeaderMapImpl::create();
-  for (envoy_data_map_size_t i = 0; i < headers.length; i++) {
+  for (envoy_map_size_t i = 0; i < headers.length; i++) {
     transformed_headers->addCopy(LowerCaseString(Utility::convertToString(headers.entries[i].key)),
                                  Utility::convertToString(headers.entries[i].value));
   }

--- a/test/common/http/header_utility_test.cc
+++ b/test/common/http/header_utility_test.cc
@@ -17,7 +17,7 @@ envoy_data envoyTestString(std::string& s, uint32_t* sentinel) {
 }
 
 TEST(RequestHeaderDataConstructorTest, FromCToCppEmpty) {
-  envoy_header* header_array = new envoy_header[0];
+  envoy_data_map_entry* header_array = new envoy_data_map_entry[0];
   envoy_headers empty_headers = {0, header_array};
 
   RequestHeaderMapPtr cpp_headers = Utility::toRequestHeaders(empty_headers);
@@ -26,7 +26,7 @@ TEST(RequestHeaderDataConstructorTest, FromCToCppEmpty) {
 }
 
 TEST(RequestTrailerDataConstructorTest, FromCToCppEmpty) {
-  envoy_header* header_array = new envoy_header[0];
+  envoy_data_map_entry* header_array = new envoy_data_map_entry[0];
   envoy_headers empty_trailers = {0, header_array};
 
   RequestTrailerMapPtr cpp_trailers = Utility::toRequestTrailers(empty_trailers);
@@ -39,7 +39,7 @@ TEST(RequestHeaderDataConstructorTest, FromCToCpp) {
   std::vector<std::pair<std::string, std::string>> headers = {
       {":method", "GET"}, {":scheme", "https"}, {":authority", "api.lyft.com"}, {":path", "/ping"}};
 
-  envoy_header* header_array = new envoy_header[headers.size()];
+  envoy_data_map_entry* header_array = new envoy_data_map_entry[headers.size()];
 
   uint32_t* sentinel = new uint32_t;
   *sentinel = 0;
@@ -50,7 +50,7 @@ TEST(RequestHeaderDataConstructorTest, FromCToCpp) {
     };
   }
 
-  envoy_headers c_headers = {static_cast<envoy_header_size_t>(headers.size()), header_array};
+  envoy_headers c_headers = {static_cast<envoy_data_map_size_t>(headers.size()), header_array};
   // This copy is used for assertions given that envoy_headers are released when toRequestHeaders
   // is called.
   envoy_headers c_headers_copy = copy_envoy_headers(c_headers);
@@ -62,9 +62,9 @@ TEST(RequestHeaderDataConstructorTest, FromCToCpp) {
 
   ASSERT_EQ(cpp_headers->size(), c_headers_copy.length);
 
-  for (envoy_header_size_t i = 0; i < c_headers_copy.length; i++) {
-    auto expected_key = LowerCaseString(Utility::convertToString(c_headers_copy.headers[i].key));
-    auto expected_value = Utility::convertToString(c_headers_copy.headers[i].value);
+  for (envoy_data_map_size_t i = 0; i < c_headers_copy.length; i++) {
+    auto expected_key = LowerCaseString(Utility::convertToString(c_headers_copy.entries[i].key));
+    auto expected_value = Utility::convertToString(c_headers_copy.entries[i].value);
 
     // Key is present.
     EXPECT_FALSE(cpp_headers->get(expected_key).empty());
@@ -80,7 +80,7 @@ TEST(RequestTrailerDataConstructorTest, FromCToCpp) {
   std::vector<std::pair<std::string, std::string>> trailers = {
       {"processing-duration-ms", "25"}, {"response-compression-ratio", "0.61"}};
 
-  envoy_header* header_array = new envoy_header[trailers.size()];
+  envoy_data_map_entry* header_array = new envoy_data_map_entry[trailers.size()];
 
   uint32_t* sentinel = new uint32_t;
   *sentinel = 0;
@@ -91,7 +91,7 @@ TEST(RequestTrailerDataConstructorTest, FromCToCpp) {
     };
   }
 
-  envoy_headers c_trailers = {static_cast<envoy_header_size_t>(trailers.size()), header_array};
+  envoy_headers c_trailers = {static_cast<envoy_data_map_size_t>(trailers.size()), header_array};
   // This copy is used for assertions given that envoy_trailers are released when toRequestTrailers
   // is called.
   envoy_headers c_trailers_copy = copy_envoy_headers(c_trailers);
@@ -103,9 +103,9 @@ TEST(RequestTrailerDataConstructorTest, FromCToCpp) {
 
   ASSERT_EQ(cpp_trailers->size(), c_trailers_copy.length);
 
-  for (envoy_header_size_t i = 0; i < c_trailers_copy.length; i++) {
-    auto expected_key = LowerCaseString(Utility::convertToString(c_trailers_copy.headers[i].key));
-    auto expected_value = Utility::convertToString(c_trailers_copy.headers[i].value);
+  for (envoy_data_map_size_t i = 0; i < c_trailers_copy.length; i++) {
+    auto expected_key = LowerCaseString(Utility::convertToString(c_trailers_copy.entries[i].key));
+    auto expected_value = Utility::convertToString(c_trailers_copy.entries[i].value);
 
     // Key is present.
     EXPECT_FALSE(cpp_trailers->get(expected_key).empty());
@@ -132,11 +132,11 @@ TEST(HeaderDataConstructorTest, FromCppToC) {
 
   envoy_headers c_headers = Utility::toBridgeHeaders(*cpp_headers);
 
-  ASSERT_EQ(c_headers.length, static_cast<envoy_header_size_t>(cpp_headers->size()));
+  ASSERT_EQ(c_headers.length, static_cast<envoy_data_map_size_t>(cpp_headers->size()));
 
-  for (envoy_header_size_t i = 0; i < c_headers.length; i++) {
-    auto actual_key = LowerCaseString(Utility::convertToString(c_headers.headers[i].key));
-    auto actual_value = Utility::convertToString(c_headers.headers[i].value);
+  for (envoy_data_map_size_t i = 0; i < c_headers.length; i++) {
+    auto actual_key = LowerCaseString(Utility::convertToString(c_headers.entries[i].key));
+    auto actual_value = Utility::convertToString(c_headers.entries[i].value);
 
     // Key is present.
     EXPECT_FALSE(cpp_headers->get(actual_key).empty());

--- a/test/common/http/header_utility_test.cc
+++ b/test/common/http/header_utility_test.cc
@@ -17,7 +17,7 @@ envoy_data envoyTestString(std::string& s, uint32_t* sentinel) {
 }
 
 TEST(RequestHeaderDataConstructorTest, FromCToCppEmpty) {
-  envoy_data_map_entry* header_array = new envoy_data_map_entry[0];
+  envoy_map_entry* header_array = new envoy_map_entry[0];
   envoy_headers empty_headers = {0, header_array};
 
   RequestHeaderMapPtr cpp_headers = Utility::toRequestHeaders(empty_headers);
@@ -26,7 +26,7 @@ TEST(RequestHeaderDataConstructorTest, FromCToCppEmpty) {
 }
 
 TEST(RequestTrailerDataConstructorTest, FromCToCppEmpty) {
-  envoy_data_map_entry* header_array = new envoy_data_map_entry[0];
+  envoy_map_entry* header_array = new envoy_map_entry[0];
   envoy_headers empty_trailers = {0, header_array};
 
   RequestTrailerMapPtr cpp_trailers = Utility::toRequestTrailers(empty_trailers);
@@ -39,7 +39,7 @@ TEST(RequestHeaderDataConstructorTest, FromCToCpp) {
   std::vector<std::pair<std::string, std::string>> headers = {
       {":method", "GET"}, {":scheme", "https"}, {":authority", "api.lyft.com"}, {":path", "/ping"}};
 
-  envoy_data_map_entry* header_array = new envoy_data_map_entry[headers.size()];
+  envoy_map_entry* header_array = new envoy_map_entry[headers.size()];
 
   uint32_t* sentinel = new uint32_t;
   *sentinel = 0;
@@ -50,7 +50,7 @@ TEST(RequestHeaderDataConstructorTest, FromCToCpp) {
     };
   }
 
-  envoy_headers c_headers = {static_cast<envoy_data_map_size_t>(headers.size()), header_array};
+  envoy_headers c_headers = {static_cast<envoy_map_size_t>(headers.size()), header_array};
   // This copy is used for assertions given that envoy_headers are released when toRequestHeaders
   // is called.
   envoy_headers c_headers_copy = copy_envoy_headers(c_headers);
@@ -62,7 +62,7 @@ TEST(RequestHeaderDataConstructorTest, FromCToCpp) {
 
   ASSERT_EQ(cpp_headers->size(), c_headers_copy.length);
 
-  for (envoy_data_map_size_t i = 0; i < c_headers_copy.length; i++) {
+  for (envoy_map_size_t i = 0; i < c_headers_copy.length; i++) {
     auto expected_key = LowerCaseString(Utility::convertToString(c_headers_copy.entries[i].key));
     auto expected_value = Utility::convertToString(c_headers_copy.entries[i].value);
 
@@ -80,7 +80,7 @@ TEST(RequestTrailerDataConstructorTest, FromCToCpp) {
   std::vector<std::pair<std::string, std::string>> trailers = {
       {"processing-duration-ms", "25"}, {"response-compression-ratio", "0.61"}};
 
-  envoy_data_map_entry* header_array = new envoy_data_map_entry[trailers.size()];
+  envoy_map_entry* header_array = new envoy_map_entry[trailers.size()];
 
   uint32_t* sentinel = new uint32_t;
   *sentinel = 0;
@@ -91,7 +91,7 @@ TEST(RequestTrailerDataConstructorTest, FromCToCpp) {
     };
   }
 
-  envoy_headers c_trailers = {static_cast<envoy_data_map_size_t>(trailers.size()), header_array};
+  envoy_headers c_trailers = {static_cast<envoy_map_size_t>(trailers.size()), header_array};
   // This copy is used for assertions given that envoy_trailers are released when toRequestTrailers
   // is called.
   envoy_headers c_trailers_copy = copy_envoy_headers(c_trailers);
@@ -103,7 +103,7 @@ TEST(RequestTrailerDataConstructorTest, FromCToCpp) {
 
   ASSERT_EQ(cpp_trailers->size(), c_trailers_copy.length);
 
-  for (envoy_data_map_size_t i = 0; i < c_trailers_copy.length; i++) {
+  for (envoy_map_size_t i = 0; i < c_trailers_copy.length; i++) {
     auto expected_key = LowerCaseString(Utility::convertToString(c_trailers_copy.entries[i].key));
     auto expected_value = Utility::convertToString(c_trailers_copy.entries[i].value);
 
@@ -132,9 +132,9 @@ TEST(HeaderDataConstructorTest, FromCppToC) {
 
   envoy_headers c_headers = Utility::toBridgeHeaders(*cpp_headers);
 
-  ASSERT_EQ(c_headers.length, static_cast<envoy_data_map_size_t>(cpp_headers->size()));
+  ASSERT_EQ(c_headers.length, static_cast<envoy_map_size_t>(cpp_headers->size()));
 
-  for (envoy_data_map_size_t i = 0; i < c_headers.length; i++) {
+  for (envoy_map_size_t i = 0; i < c_headers.length; i++) {
     auto actual_key = LowerCaseString(Utility::convertToString(c_headers.entries[i].key));
     auto actual_value = Utility::convertToString(c_headers.entries[i].value);
 

--- a/test/common/integration/dispatcher_integration_test.cc
+++ b/test/common/integration/dispatcher_integration_test.cc
@@ -20,7 +20,7 @@ namespace {
 // Based on Http::Utility::toRequestHeaders() but only used for these tests.
 Http::ResponseHeaderMapPtr toResponseHeaders(envoy_headers headers) {
   Http::ResponseHeaderMapPtr transformed_headers = Http::ResponseHeaderMapImpl::create();
-  for (envoy_data_map_size_t i = 0; i < headers.length; i++) {
+  for (envoy_map_size_t i = 0; i < headers.length; i++) {
     transformed_headers->addCopy(
         Http::LowerCaseString(Http::Utility::convertToString(headers.entries[i].key)),
         Http::Utility::convertToString(headers.entries[i].value));

--- a/test/common/integration/dispatcher_integration_test.cc
+++ b/test/common/integration/dispatcher_integration_test.cc
@@ -20,10 +20,10 @@ namespace {
 // Based on Http::Utility::toRequestHeaders() but only used for these tests.
 Http::ResponseHeaderMapPtr toResponseHeaders(envoy_headers headers) {
   Http::ResponseHeaderMapPtr transformed_headers = Http::ResponseHeaderMapImpl::create();
-  for (envoy_header_size_t i = 0; i < headers.length; i++) {
+  for (envoy_data_map_size_t i = 0; i < headers.length; i++) {
     transformed_headers->addCopy(
-        Http::LowerCaseString(Http::Utility::convertToString(headers.headers[i].key)),
-        Http::Utility::convertToString(headers.headers[i].value));
+        Http::LowerCaseString(Http::Utility::convertToString(headers.entries[i].key)),
+        Http::Utility::convertToString(headers.entries[i].value));
   }
   // The C envoy_headers struct can be released now because the headers have been copied.
   release_envoy_headers(headers);

--- a/test/common/main_interface_test.cc
+++ b/test/common/main_interface_test.cc
@@ -34,7 +34,7 @@ const std::string LEVEL_DEBUG = "debug";
 // Based on Http::Utility::toRequestHeaders() but only used for these tests.
 Http::ResponseHeaderMapPtr toResponseHeaders(envoy_headers headers) {
   Http::ResponseHeaderMapPtr transformed_headers = Http::ResponseHeaderMapImpl::create();
-  for (envoy_data_map_size_t i = 0; i < headers.length; i++) {
+  for (envoy_map_size_t i = 0; i < headers.length; i++) {
     transformed_headers->addCopy(
         Http::LowerCaseString(Http::Utility::convertToString(headers.entries[i].key)),
         Http::Utility::convertToString(headers.entries[i].value));

--- a/test/common/main_interface_test.cc
+++ b/test/common/main_interface_test.cc
@@ -34,10 +34,10 @@ const std::string LEVEL_DEBUG = "debug";
 // Based on Http::Utility::toRequestHeaders() but only used for these tests.
 Http::ResponseHeaderMapPtr toResponseHeaders(envoy_headers headers) {
   Http::ResponseHeaderMapPtr transformed_headers = Http::ResponseHeaderMapImpl::create();
-  for (envoy_header_size_t i = 0; i < headers.length; i++) {
+  for (envoy_data_map_size_t i = 0; i < headers.length; i++) {
     transformed_headers->addCopy(
-        Http::LowerCaseString(Http::Utility::convertToString(headers.headers[i].key)),
-        Http::Utility::convertToString(headers.headers[i].value));
+        Http::LowerCaseString(Http::Utility::convertToString(headers.entries[i].key)),
+        Http::Utility::convertToString(headers.entries[i].value));
   }
   // The C envoy_headers struct can be released now because the headers have been copied.
   release_envoy_headers(headers);


### PR DESCRIPTION
Description: introduce `envoy_data_map_entry` and `envoy_data_map` to be reused. the first and existing use case is `envoy_headers`. this pr updated utility methods to match the newly introduced data structure(s).

Risk Level: medium
Testing: unit, ci
Co-authored-by:Jose Nino <jnino@lyft.com>
Signed-off-by: Jingwei Hao <jingwei.hao@gmail.com>
