### PR TITLE
data: consolidate utility functions

### DIFF
--- a/library/cc/BUILD
+++ b/library/cc/BUILD
@@ -60,6 +60,6 @@ envoy_cc_library(
     visibility = ["//visibility:public"],
     deps = [
         "//library/common:envoy_main_interface_lib",
-        "//library/common/buffer:utility_lib",
+        "//library/common/data:utility_lib",
     ],
 )

--- a/library/cc/BUILD
+++ b/library/cc/BUILD
@@ -60,5 +60,6 @@ envoy_cc_library(
     visibility = ["//visibility:public"],
     deps = [
         "//library/common:envoy_main_interface_lib",
+        "//library/common/buffer:utility_lib",
     ],
 )

--- a/library/cc/bridge_utility.cc
+++ b/library/cc/bridge_utility.cc
@@ -7,8 +7,6 @@
 namespace Envoy {
 namespace Platform {
 
-// TODO(crockeo): we always copy memory across boundaries; consider allowing for moves and/or
-// shared ownership w/ reference counting via envoy-mobile's release callbacks
 envoy_headers raw_header_map_as_envoy_headers(const RawHeaderMap& headers) {
   size_t header_count = 0;
   for (const auto& pair : headers) {

--- a/library/cc/bridge_utility.cc
+++ b/library/cc/bridge_utility.cc
@@ -2,7 +2,7 @@
 
 #include <sstream>
 
-#include "library/common/buffer/utility.h"
+#include "library/common/data/utility.h"
 
 namespace Envoy {
 namespace Platform {
@@ -21,8 +21,8 @@ envoy_headers raw_header_map_as_envoy_headers(const RawHeaderMap& headers) {
     const auto& key = pair.first;
     for (const auto& value : pair.second) {
       envoy_map_entry& header = headers_list[i++];
-      header.key = Buffer::Utility::copyToBridgeData(key);
-      header.value = Buffer::Utility::copyToBridgeData(value);
+      header.key = Data::Utility::copyToBridgeData(key);
+      header.value = Data::Utility::copyToBridgeData(value);
     }
   }
 
@@ -36,8 +36,8 @@ envoy_headers raw_header_map_as_envoy_headers(const RawHeaderMap& headers) {
 RawHeaderMap envoy_headers_as_raw_headers(envoy_headers raw_headers) {
   RawHeaderMap headers;
   for (auto i = 0; i < raw_headers.length; i++) {
-    auto key = Buffer::Utility::copyToString(raw_headers.entries[i].key);
-    auto value = Buffer::Utility::copyToString(raw_headers.entries[i].value);
+    auto key = Data::Utility::copyToString(raw_headers.entries[i].key);
+    auto value = Data::Utility::copyToString(raw_headers.entries[i].value);
 
     if (!headers.contains(key)) {
       headers.emplace(key, std::vector<std::string>());

--- a/library/cc/bridge_utility.cc
+++ b/library/cc/bridge_utility.cc
@@ -2,31 +2,13 @@
 
 #include <sstream>
 
+#include "library/common/buffer/utility.h"
+
 namespace Envoy {
 namespace Platform {
 
 // TODO(crockeo): we always copy memory across boundaries; consider allowing for moves and/or
 // shared ownership w/ reference counting via envoy-mobile's release callbacks
-
-envoy_data string_as_envoy_data(const std::string& str) {
-  uint8_t* bytes = static_cast<uint8_t*>(safe_malloc(str.size()));
-  memcpy(bytes, &str[0], str.size());
-  return envoy_data{
-      .length = str.size(),
-      .bytes = bytes,
-      .release = free,
-      .context = bytes,
-  };
-}
-
-std::string envoy_data_as_string(envoy_data data) {
-  std::string str;
-  str.resize(data.length);
-  memcpy(&str[0], data.bytes, data.length);
-  data.release(data.context);
-  return str;
-}
-
 envoy_headers raw_header_map_as_envoy_headers(const RawHeaderMap& headers) {
   size_t header_count = 0;
   for (const auto& pair : headers) {
@@ -41,8 +23,8 @@ envoy_headers raw_header_map_as_envoy_headers(const RawHeaderMap& headers) {
     const auto& key = pair.first;
     for (const auto& value : pair.second) {
       envoy_map_entry& header = headers_list[i++];
-      header.key = string_as_envoy_data(key);
-      header.value = string_as_envoy_data(value);
+      header.key = Buffer::Utility::copyToBridgeData(key);
+      header.value = Buffer::Utility::copyToBridgeData(value);
     }
   }
 
@@ -56,8 +38,8 @@ envoy_headers raw_header_map_as_envoy_headers(const RawHeaderMap& headers) {
 RawHeaderMap envoy_headers_as_raw_headers(envoy_headers raw_headers) {
   RawHeaderMap headers;
   for (auto i = 0; i < raw_headers.length; i++) {
-    auto key = envoy_data_as_string(raw_headers.entries[i].key);
-    auto value = envoy_data_as_string(raw_headers.entries[i].value);
+    auto key = Buffer::Utility::copyToString(raw_headers.entries[i].key);
+    auto value = Buffer::Utility::copyToString(raw_headers.entries[i].value);
 
     if (!headers.contains(key)) {
       headers.emplace(key, std::vector<std::string>());

--- a/library/common/BUILD
+++ b/library/common/BUILD
@@ -26,7 +26,7 @@ envoy_cc_library(
     repository = "@envoy",
     deps = [
         ":envoy_mobile_main_common_lib",
-        "//library/common/buffer:utility_lib",
+        "//library/common/data:utility_lib",
         "//library/common/http:dispatcher_lib",
         "//library/common/http:header_utility_lib",
         "//library/common/types:c_types_lib",

--- a/library/common/buffer/BUILD
+++ b/library/common/buffer/BUILD
@@ -24,5 +24,6 @@ envoy_cc_library(
         "//library/common/types:c_types_lib",
         "@envoy//include/envoy/buffer:buffer_interface",
         "@envoy//source/common/buffer:buffer_lib",
+        "@envoy//source/common/common:empty_string",
     ],
 )

--- a/library/common/buffer/utility.cc
+++ b/library/common/buffer/utility.cc
@@ -35,7 +35,7 @@ envoy_data copyToBridgeData(absl::string_view str) {
 envoy_data copyToBridgeData(const Buffer::Instance& data) {
   uint8_t* buffer = static_cast<uint8_t*>(safe_malloc(sizeof(uint8_t) * data.length()));
   data.copyOut(0, data.length(), buffer);
-  return {data.length(), buffer, free, buffer};
+  return {static_cast<size_t>(data.length()), buffer, free, buffer};
 }
 
 std::string copyToString(envoy_data data) {

--- a/library/common/buffer/utility.h
+++ b/library/common/buffer/utility.h
@@ -38,7 +38,7 @@ envoy_data copyToBridgeData(const Buffer::Instance&);
 
 /**
  * Copy envoy_data into an std::string.
- * @param data the envoy_data to copy.
+ * @param data, the envoy_data to copy.
  * @return std::string the string constructed from data.
  */
 std::string copyToString(envoy_data data);

--- a/library/common/buffer/utility.h
+++ b/library/common/buffer/utility.h
@@ -36,6 +36,13 @@ envoy_data copyToBridgeData(absl::string_view);
  */
 envoy_data copyToBridgeData(const Buffer::Instance&);
 
+/**
+ * Copy envoy_data into an std::string.
+ * @param data the envoy_data to copy.
+ * @return std::string the string constructed from data.
+ */
+std::string copyToString(envoy_data data);
+
 } // namespace Utility
 } // namespace Buffer
 } // namespace Envoy

--- a/library/common/data/BUILD
+++ b/library/common/data/BUILD
@@ -5,11 +5,15 @@ licenses(["notice"])  # Apache 2
 envoy_package()
 
 envoy_cc_library(
-    name = "bridge_fragment_lib",
-    hdrs = ["bridge_fragment.h"],
+    name = "utility_lib",
+    srcs = ["utility.cc"],
+    hdrs = ["utility.h"],
     repository = "@envoy",
     deps = [
+        "//library/common/buffer:bridge_fragment_lib",
         "//library/common/types:c_types_lib",
         "@envoy//include/envoy/buffer:buffer_interface",
+        "@envoy//source/common/buffer:buffer_lib",
+        "@envoy//source/common/common:empty_string",
     ],
 )

--- a/library/common/data/utility.cc
+++ b/library/common/data/utility.cc
@@ -1,4 +1,4 @@
-#include "library/common/buffer/utility.h"
+#include "library/common/data/utility.h"
 
 #include <stdlib.h>
 
@@ -8,14 +8,14 @@
 #include "library/common/buffer/bridge_fragment.h"
 
 namespace Envoy {
-namespace Buffer {
+namespace Data {
 namespace Utility {
 
 Buffer::InstancePtr toInternalData(envoy_data data) {
   // This fragment only needs to live until done is called.
   // Therefore, it is sufficient to allocate on the heap, and delete in the done method.
   Buffer::BridgeFragment* fragment = Buffer::BridgeFragment::createBridgeFragment(data);
-  InstancePtr buf = std::make_unique<Buffer::OwnedImpl>();
+  Buffer::InstancePtr buf = std::make_unique<Buffer::OwnedImpl>();
   buf->addBufferFragment(*fragment);
   return buf;
 }
@@ -46,5 +46,5 @@ std::string copyToString(envoy_data data) {
 }
 
 } // namespace Utility
-} // namespace Buffer
+} // namespace Data
 } // namespace Envoy

--- a/library/common/data/utility.h
+++ b/library/common/data/utility.h
@@ -5,7 +5,7 @@
 #include "library/common/types/c_types.h"
 
 namespace Envoy {
-namespace Buffer {
+namespace Data {
 namespace Utility {
 
 /**
@@ -44,5 +44,5 @@ envoy_data copyToBridgeData(const Buffer::Instance&);
 std::string copyToString(envoy_data data);
 
 } // namespace Utility
-} // namespace Buffer
+} // namespace Data
 } // namespace Envoy

--- a/library/common/extensions/filters/http/platform_bridge/BUILD
+++ b/library/common/extensions/filters/http/platform_bridge/BUILD
@@ -30,7 +30,7 @@ envoy_cc_extension(
     deps = [
         ":filter_cc_proto",
         "//library/common/api:external_api_lib",
-        "//library/common/buffer:utility_lib",
+        "//library/common/data:utility_lib",
         "//library/common/http:header_utility_lib",
         "//library/common/http:internal_headers_lib",
         "//library/common/types:c_types_lib",

--- a/library/common/extensions/filters/http/platform_bridge/filter.cc
+++ b/library/common/extensions/filters/http/platform_bridge/filter.cc
@@ -23,8 +23,8 @@ namespace {
 void replaceHeaders(Http::HeaderMap& headers, envoy_headers c_headers) {
   headers.clear();
   for (envoy_map_size_t i = 0; i < c_headers.length; i++) {
-    headers.addCopy(Http::LowerCaseString(Http::Utility::convertToString(c_headers.entries[i].key)),
-                    Http::Utility::convertToString(c_headers.entries[i].value));
+    headers.addCopy(Http::LowerCaseString(Buffer::Utility::copyToString(c_headers.entries[i].key)),
+                    Buffer::Utility::copyToString(c_headers.entries[i].value));
   }
   // The C envoy_headers struct can be released now because the headers have been copied.
   release_envoy_headers(c_headers);

--- a/library/common/extensions/filters/http/platform_bridge/filter.cc
+++ b/library/common/extensions/filters/http/platform_bridge/filter.cc
@@ -8,7 +8,7 @@
 
 #include "library/common/api/external.h"
 #include "library/common/buffer/bridge_fragment.h"
-#include "library/common/buffer/utility.h"
+#include "library/common/data/utility.h"
 #include "library/common/extensions/filters/http/platform_bridge/c_type_definitions.h"
 #include "library/common/http/header_utility.h"
 #include "library/common/http/headers.h"
@@ -23,8 +23,8 @@ namespace {
 void replaceHeaders(Http::HeaderMap& headers, envoy_headers c_headers) {
   headers.clear();
   for (envoy_map_size_t i = 0; i < c_headers.length; i++) {
-    headers.addCopy(Http::LowerCaseString(Buffer::Utility::copyToString(c_headers.entries[i].key)),
-                    Buffer::Utility::copyToString(c_headers.entries[i].value));
+    headers.addCopy(Http::LowerCaseString(Data::Utility::copyToString(c_headers.entries[i].key)),
+                    Data::Utility::copyToString(c_headers.entries[i].value));
   }
   // The C envoy_headers struct can be released now because the headers have been copied.
   release_envoy_headers(c_headers);
@@ -201,9 +201,9 @@ Http::FilterDataStatus PlatformBridgeFilter::FilterBase::onData(Buffer::Instance
 
   if (prebuffer_data) {
     internal_buffer->move(data);
-    in_data = Buffer::Utility::copyToBridgeData(*internal_buffer);
+    in_data = Data::Utility::copyToBridgeData(*internal_buffer);
   } else {
-    in_data = Buffer::Utility::copyToBridgeData(data);
+    in_data = Data::Utility::copyToBridgeData(data);
   }
 
   ENVOY_LOG(trace, "PlatformBridgeFilter({})->on_*_data", parent_.filter_name_);
@@ -360,7 +360,7 @@ Http::FilterHeadersStatus PlatformBridgeFilter::encodeHeaders(Http::ResponseHead
     const auto error_message_header = headers.get(Http::InternalHeaders::get().ErrorMessage);
     if (!error_message_header.empty()) {
       error_message =
-          Buffer::Utility::copyToBridgeData(error_message_header[0]->value().getStringView());
+          Data::Utility::copyToBridgeData(error_message_header[0]->value().getStringView());
     }
 
     int32_t attempt_count;
@@ -474,7 +474,7 @@ void PlatformBridgeFilter::FilterBase::onResume() {
     pending_headers = &bridged_headers;
   }
   if (internal_buffer) {
-    bridged_data = Buffer::Utility::copyToBridgeData(*internal_buffer);
+    bridged_data = Data::Utility::copyToBridgeData(*internal_buffer);
     pending_data = &bridged_data;
   }
   if (pending_trailers_) {

--- a/library/common/http/BUILD
+++ b/library/common/http/BUILD
@@ -43,6 +43,7 @@ envoy_cc_library(
     hdrs = ["header_utility.h"],
     repository = "@envoy",
     deps = [
+        "//library/common/buffer:utility_lib",
         "//library/common/types:c_types_lib",
         "@envoy//include/envoy/buffer:buffer_interface",
         "@envoy//include/envoy/http:header_map_interface",

--- a/library/common/http/BUILD
+++ b/library/common/http/BUILD
@@ -12,7 +12,7 @@ envoy_cc_library(
     repository = "@envoy",
     deps = [
         "//library/common/buffer:bridge_fragment_lib",
-        "//library/common/buffer:utility_lib",
+        "//library/common/data:utility_lib",
         "//library/common/extensions/filters/http/local_error:local_error_filter_lib",
         "//library/common/http:header_utility_lib",
         "//library/common/network:synthetic_address_lib",
@@ -43,7 +43,7 @@ envoy_cc_library(
     hdrs = ["header_utility.h"],
     repository = "@envoy",
     deps = [
-        "//library/common/buffer:utility_lib",
+        "//library/common/data:utility_lib",
         "//library/common/types:c_types_lib",
         "@envoy//include/envoy/buffer:buffer_interface",
         "@envoy//include/envoy/http:header_map_interface",

--- a/library/common/http/dispatcher.cc
+++ b/library/common/http/dispatcher.cc
@@ -7,7 +7,7 @@
 #include "common/http/utility.h"
 
 #include "library/common/buffer/bridge_fragment.h"
-#include "library/common/buffer/utility.h"
+#include "library/common/data/utility.h"
 #include "library/common/http/header_utility.h"
 #include "library/common/http/headers.h"
 #include "library/common/network/synthetic_address_impl.h"
@@ -54,7 +54,7 @@ void Dispatcher::DirectStreamCallbacks::encodeHeaders(const ResponseHeaderMap& h
     const auto error_message_header = headers.get(InternalHeaders::get().ErrorMessage);
     if (!error_message_header.empty()) {
       error_message_ =
-          Buffer::Utility::copyToBridgeData(error_message_header[0]->value().getStringView());
+          Data::Utility::copyToBridgeData(error_message_header[0]->value().getStringView());
     }
 
     uint32_t attempt_count;
@@ -106,7 +106,7 @@ void Dispatcher::DirectStreamCallbacks::encodeData(Buffer::Instance& data, bool 
   ENVOY_LOG(debug,
             "[S{}] dispatching to platform response data for stream (length={} end_stream={})",
             direct_stream_.stream_handle_, data.length(), end_stream);
-  bridge_callbacks_.on_data(Buffer::Utility::toBridgeData(data), end_stream,
+  bridge_callbacks_.on_data(Data::Utility::toBridgeData(data), end_stream,
                             bridge_callbacks_.context);
   if (end_stream) {
     onComplete();
@@ -295,7 +295,7 @@ envoy_status_t Dispatcher::sendData(envoy_stream_t stream, envoy_data data, bool
     if (direct_stream) {
       // The buffer is moved internally, in a synchronous fashion, so we don't need the lifetime
       // of the InstancePtr to outlive this function call.
-      Buffer::InstancePtr buf = Buffer::Utility::toInternalData(data);
+      Buffer::InstancePtr buf = Data::Utility::toInternalData(data);
 
       ENVOY_LOG(debug, "[S{}] request data for stream (length={} end_stream={})\n", stream,
                 data.length, end_stream);

--- a/library/common/http/header_utility.cc
+++ b/library/common/http/header_utility.cc
@@ -1,20 +1,18 @@
 #include "library/common/http/header_utility.h"
 
+#include "library/common/buffer/utility.h"
+
 #include "common/http/header_map_impl.h"
 
 namespace Envoy {
 namespace Http {
 namespace Utility {
 
-std::string convertToString(envoy_data s) {
-  return std::string(reinterpret_cast<char*>(const_cast<uint8_t*>(s.bytes)), s.length);
-}
-
 RequestHeaderMapPtr toRequestHeaders(envoy_headers headers) {
   RequestHeaderMapPtr transformed_headers = RequestHeaderMapImpl::create();
   for (envoy_map_size_t i = 0; i < headers.length; i++) {
-    transformed_headers->addCopy(LowerCaseString(convertToString(headers.entries[i].key)),
-                                 convertToString(headers.entries[i].value));
+    transformed_headers->addCopy(LowerCaseString(Buffer::Utility::copyToString(headers.entries[i].key)),
+                                 Buffer::Utility::copyToString(headers.entries[i].value));
   }
   // The C envoy_headers struct can be released now because the headers have been copied.
   release_envoy_headers(headers);
@@ -24,8 +22,8 @@ RequestHeaderMapPtr toRequestHeaders(envoy_headers headers) {
 RequestTrailerMapPtr toRequestTrailers(envoy_headers trailers) {
   RequestTrailerMapPtr transformed_trailers = RequestTrailerMapImpl::create();
   for (envoy_map_size_t i = 0; i < trailers.length; i++) {
-    transformed_trailers->addCopy(LowerCaseString(convertToString(trailers.entries[i].key)),
-                                  convertToString(trailers.entries[i].value));
+    transformed_trailers->addCopy(LowerCaseString(Buffer::Utility::copyToString(trailers.entries[i].key)),
+                                  Buffer::Utility::copyToString(trailers.entries[i].value));
   }
   // The C envoy_headers struct can be released now because the headers have been copied.
   release_envoy_headers(trailers);

--- a/library/common/http/header_utility.cc
+++ b/library/common/http/header_utility.cc
@@ -2,7 +2,7 @@
 
 #include "common/http/header_map_impl.h"
 
-#include "library/common/buffer/utility.h"
+#include "library/common/data/utility.h"
 
 namespace Envoy {
 namespace Http {
@@ -12,8 +12,8 @@ RequestHeaderMapPtr toRequestHeaders(envoy_headers headers) {
   RequestHeaderMapPtr transformed_headers = RequestHeaderMapImpl::create();
   for (envoy_map_size_t i = 0; i < headers.length; i++) {
     transformed_headers->addCopy(
-        LowerCaseString(Buffer::Utility::copyToString(headers.entries[i].key)),
-        Buffer::Utility::copyToString(headers.entries[i].value));
+        LowerCaseString(Data::Utility::copyToString(headers.entries[i].key)),
+        Data::Utility::copyToString(headers.entries[i].value));
   }
   // The C envoy_headers struct can be released now because the headers have been copied.
   release_envoy_headers(headers);
@@ -24,8 +24,8 @@ RequestTrailerMapPtr toRequestTrailers(envoy_headers trailers) {
   RequestTrailerMapPtr transformed_trailers = RequestTrailerMapImpl::create();
   for (envoy_map_size_t i = 0; i < trailers.length; i++) {
     transformed_trailers->addCopy(
-        LowerCaseString(Buffer::Utility::copyToString(trailers.entries[i].key)),
-        Buffer::Utility::copyToString(trailers.entries[i].value));
+        LowerCaseString(Data::Utility::copyToString(trailers.entries[i].key)),
+        Data::Utility::copyToString(trailers.entries[i].value));
   }
   // The C envoy_headers struct can be released now because the headers have been copied.
   release_envoy_headers(trailers);
@@ -40,8 +40,8 @@ envoy_headers toBridgeHeaders(const HeaderMap& header_map) {
   transformed_headers.entries = headers;
 
   header_map.iterate([&transformed_headers](const HeaderEntry& header) -> HeaderMap::Iterate {
-    envoy_data key = Buffer::Utility::copyToBridgeData(header.key().getStringView());
-    envoy_data value = Buffer::Utility::copyToBridgeData(header.value().getStringView());
+    envoy_data key = Data::Utility::copyToBridgeData(header.key().getStringView());
+    envoy_data value = Data::Utility::copyToBridgeData(header.value().getStringView());
 
     transformed_headers.entries[transformed_headers.length] = {key, value};
     transformed_headers.length++;

--- a/library/common/http/header_utility.cc
+++ b/library/common/http/header_utility.cc
@@ -1,8 +1,8 @@
 #include "library/common/http/header_utility.h"
 
-#include "library/common/buffer/utility.h"
-
 #include "common/http/header_map_impl.h"
+
+#include "library/common/buffer/utility.h"
 
 namespace Envoy {
 namespace Http {
@@ -11,8 +11,9 @@ namespace Utility {
 RequestHeaderMapPtr toRequestHeaders(envoy_headers headers) {
   RequestHeaderMapPtr transformed_headers = RequestHeaderMapImpl::create();
   for (envoy_map_size_t i = 0; i < headers.length; i++) {
-    transformed_headers->addCopy(LowerCaseString(Buffer::Utility::copyToString(headers.entries[i].key)),
-                                 Buffer::Utility::copyToString(headers.entries[i].value));
+    transformed_headers->addCopy(
+        LowerCaseString(Buffer::Utility::copyToString(headers.entries[i].key)),
+        Buffer::Utility::copyToString(headers.entries[i].value));
   }
   // The C envoy_headers struct can be released now because the headers have been copied.
   release_envoy_headers(headers);
@@ -22,8 +23,9 @@ RequestHeaderMapPtr toRequestHeaders(envoy_headers headers) {
 RequestTrailerMapPtr toRequestTrailers(envoy_headers trailers) {
   RequestTrailerMapPtr transformed_trailers = RequestTrailerMapImpl::create();
   for (envoy_map_size_t i = 0; i < trailers.length; i++) {
-    transformed_trailers->addCopy(LowerCaseString(Buffer::Utility::copyToString(trailers.entries[i].key)),
-                                  Buffer::Utility::copyToString(trailers.entries[i].value));
+    transformed_trailers->addCopy(
+        LowerCaseString(Buffer::Utility::copyToString(trailers.entries[i].key)),
+        Buffer::Utility::copyToString(trailers.entries[i].value));
   }
   // The C envoy_headers struct can be released now because the headers have been copied.
   release_envoy_headers(trailers);
@@ -38,13 +40,8 @@ envoy_headers toBridgeHeaders(const HeaderMap& header_map) {
   transformed_headers.entries = headers;
 
   header_map.iterate([&transformed_headers](const HeaderEntry& header) -> HeaderMap::Iterate {
-    const absl::string_view header_key = header.key().getStringView();
-    const absl::string_view header_value = header.value().getStringView();
-
-    envoy_data key =
-        copy_envoy_data(header_key.size(), reinterpret_cast<const uint8_t*>(header_key.data()));
-    envoy_data value =
-        copy_envoy_data(header_value.size(), reinterpret_cast<const uint8_t*>(header_value.data()));
+    envoy_data key = Buffer::Utility::copyToBridgeData(header.key().getStringView());
+    envoy_data value = Buffer::Utility::copyToBridgeData(header.value().getStringView());
 
     transformed_headers.entries[transformed_headers.length] = {key, value};
     transformed_headers.length++;

--- a/library/common/http/header_utility.h
+++ b/library/common/http/header_utility.h
@@ -10,13 +10,6 @@ namespace Http {
 namespace Utility {
 
 /**
- * Copy envoy_data into an std::string.
- * @param s the envoy_data to copy.
- * @return std::string the string constructed from s.
- */
-std::string convertToString(envoy_data s);
-
-/**
  * Transform envoy_headers to RequestHeaderMap.
  * This function copies the content.
  * @param headers, the envoy_headers to transform.

--- a/library/common/jni/jni_utility.cc
+++ b/library/common/jni/jni_utility.cc
@@ -55,7 +55,7 @@ envoy_data array_to_native_data(JNIEnv* env, jbyteArray j_data) {
   size_t data_length = env->GetArrayLength(j_data);
   uint8_t* native_bytes = static_cast<uint8_t*>(safe_malloc(data_length));
   void* critical_data = env->GetPrimitiveArrayCritical(j_data, 0);
-  memcpy(native_bytes, critical_data, data_length);
+  memcpy(native_bytes, critical_data, data_length); // NOLINT(safe-memcpy)
   env->ReleasePrimitiveArrayCritical(j_data, critical_data, 0);
   return {data_length, native_bytes, free, native_bytes};
 }
@@ -64,7 +64,7 @@ jbyteArray native_data_to_array(JNIEnv* env, envoy_data data) {
   jbyteArray j_data = env->NewByteArray(data.length);
   void* critical_data = env->GetPrimitiveArrayCritical(j_data, nullptr);
   RELEASE_ASSERT(critical_data != nullptr, "unable to allocate memory in jni_utility");
-  memcpy(critical_data, data.bytes, data.length);
+  memcpy(critical_data, data.bytes, data.length); // NOLINT(safe-memcpy)
   // Here '0' (for which there is no named constant) indicates we want to commit the changes back
   // to the JVM and free the c array, where applicable.
   // TODO: potential perf improvement. Check if copied via isCopy, and optimize memory handling.

--- a/library/common/types/c_types.cc
+++ b/library/common/types/c_types.cc
@@ -54,7 +54,7 @@ envoy_headers copy_envoy_headers(envoy_headers src) { return copy_envoy_data_map
 
 envoy_data copy_envoy_data(size_t length, const uint8_t* src_bytes) {
   uint8_t* dst_bytes = static_cast<uint8_t*>(safe_malloc(sizeof(uint8_t) * length));
-  memcpy(dst_bytes, src_bytes, length);
+  memcpy(dst_bytes, src_bytes, length); // NOLINT(safe-memcpy)
   // Note: since this function is copying the bytes over to freshly allocated memory, free is an
   // appropriate release function and dst_bytes is an appropriate context.
   envoy_data dst = {length, dst_bytes, free, dst_bytes};

--- a/library/common/types/c_types.cc
+++ b/library/common/types/c_types.cc
@@ -41,9 +41,8 @@ envoy_map copy_envoy_data_map(envoy_map src) {
   envoy_map_entry* dst_entries =
       static_cast<envoy_map_entry*>(safe_malloc(sizeof(envoy_map_entry) * src.length));
   for (envoy_map_size_t i = 0; i < src.length; i++) {
-    envoy_map_entry new_entry = {
-        copy_envoy_data(src.entries[i].key.length, src.entries[i].key.bytes),
-        copy_envoy_data(src.entries[i].value.length, src.entries[i].value.bytes)};
+    envoy_map_entry new_entry = {copy_envoy_data(src.entries[i].key),
+                                 copy_envoy_data(src.entries[i].value)};
     dst_entries[i] = new_entry;
   }
   envoy_map dst = {src.length, dst_entries};
@@ -52,13 +51,12 @@ envoy_map copy_envoy_data_map(envoy_map src) {
 
 envoy_headers copy_envoy_headers(envoy_headers src) { return copy_envoy_data_map(src); }
 
-envoy_data copy_envoy_data(size_t length, const uint8_t* src_bytes) {
-  uint8_t* dst_bytes = static_cast<uint8_t*>(safe_malloc(sizeof(uint8_t) * length));
-  memcpy(dst_bytes, src_bytes, length); // NOLINT(safe-memcpy)
+envoy_data copy_envoy_data(envoy_data src) {
+  uint8_t* dst_bytes = static_cast<uint8_t*>(safe_malloc(sizeof(uint8_t) * src.length));
+  memcpy(dst_bytes, src.bytes, src.length); // NOLINT(safe-memcpy)
   // Note: since this function is copying the bytes over to freshly allocated memory, free is an
   // appropriate release function and dst_bytes is an appropriate context.
-  envoy_data dst = {length, dst_bytes, free, dst_bytes};
-  return dst;
+  return {src.length, dst_bytes, free, dst_bytes};
 }
 
 const envoy_data envoy_nodata = {0, NULL, envoy_noop_release, NULL};

--- a/library/common/types/c_types.h
+++ b/library/common/types/c_types.h
@@ -146,11 +146,10 @@ envoy_headers copy_envoy_headers(envoy_headers src);
 
 /**
  * Helper function to copy envoy_data.
- * @param length, the length of the data to copy.
- * @param src_bytes, the byte array to copy from.
+ * @param src, the envoy_data to copy from.
  * @return envoy_data, the envoy_data copied from the src.
  */
-envoy_data copy_envoy_data(size_t length, const uint8_t* src_bytes);
+envoy_data copy_envoy_data(envoy_data src);
 
 #ifdef __cplusplus
 } // utility functions

--- a/library/objective-c/EnvoyBridgeUtility.h
+++ b/library/objective-c/EnvoyBridgeUtility.h
@@ -8,7 +8,7 @@ static inline envoy_data toNativeData(NSData *data) {
   }
 
   uint8_t *native_bytes = (uint8_t *)safe_malloc(sizeof(uint8_t) * data.length);
-  memcpy(native_bytes, data.bytes, data.length);
+  memcpy(native_bytes, data.bytes, data.length); // NOLINT(safe-memcpy)
   envoy_data ret = {data.length, native_bytes, free, native_bytes};
   return ret;
 }
@@ -26,7 +26,7 @@ static inline envoy_data *toNativeDataPtr(NSData *data) {
 static inline envoy_data toManagedNativeString(NSString *s) {
   size_t length = s.length;
   uint8_t *native_string = (uint8_t *)safe_malloc(sizeof(uint8_t) * length);
-  memcpy(native_string, s.UTF8String, length);
+  memcpy(native_string, s.UTF8String, length); // NOLINT(safe-memcpy)
   envoy_data ret = {length, native_string, free, native_string};
   return ret;
 }

--- a/test/common/BUILD
+++ b/test/common/BUILD
@@ -30,7 +30,7 @@ envoy_cc_test(
     repository = "@envoy",
     deps = [
         "//library/common:envoy_main_interface_lib_no_stamp",
-        "//library/common/buffer:utility_lib",
+        "//library/common/data:utility_lib",
         "//library/common/http:header_utility_lib",
         "//library/common/types:c_types_lib",
         "@envoy//test/common/http:common_lib",

--- a/test/common/buffer/BUILD
+++ b/test/common/buffer/BUILD
@@ -21,7 +21,6 @@ envoy_cc_test(
     repository = "@envoy",
     deps = [
         "//library/common/buffer:utility_lib",
-        "//library/common/http:header_utility_lib",
         "//library/common/types:c_types_lib",
         "@envoy//source/common/buffer:buffer_lib",
     ],

--- a/test/common/buffer/utility_test.cc
+++ b/test/common/buffer/utility_test.cc
@@ -2,7 +2,6 @@
 
 #include "gtest/gtest.h"
 #include "library/common/buffer/utility.h"
-#include "library/common/http/header_utility.h"
 #include "library/common/types/c_types.h"
 
 namespace Envoy {
@@ -43,7 +42,7 @@ TEST(DataConstructorTest, FromCppToC) {
   envoy_data c_data = Utility::toBridgeData(cpp_data);
 
   ASSERT_EQ(c_data.length, s.size());
-  ASSERT_EQ(Http::Utility::convertToString(c_data), s);
+  ASSERT_EQ(Utility::copyToString(c_data), s);
   c_data.release(c_data.context);
 }
 
@@ -54,7 +53,7 @@ TEST(DataConstructorTest, CopyFromCppToC) {
   envoy_data c_data = Utility::copyToBridgeData(cpp_data);
 
   ASSERT_EQ(c_data.length, s.size());
-  ASSERT_EQ(Http::Utility::convertToString(c_data), s);
+  ASSERT_EQ(Utility::copyToString(c_data), s);
   c_data.release(c_data.context);
 }
 
@@ -64,7 +63,7 @@ TEST(DataConstructorTest, CopyStringFromCppToC) {
   envoy_data c_data = Utility::copyToBridgeData(s);
 
   ASSERT_EQ(c_data.length, s.size());
-  ASSERT_EQ(Http::Utility::convertToString(c_data), s);
+  ASSERT_EQ(Utility::copyToString(c_data), s);
   c_data.release(c_data.context);
 }
 

--- a/test/common/data/BUILD
+++ b/test/common/data/BUILD
@@ -5,11 +5,11 @@ licenses(["notice"])  # Apache 2
 envoy_package()
 
 envoy_cc_test(
-    name = "bridge_fragment_test",
-    srcs = ["bridge_fragment_test.cc"],
+    name = "utility_test",
+    srcs = ["utility_test.cc"],
     repository = "@envoy",
     deps = [
-        "//library/common/buffer:bridge_fragment_lib",
+        "//library/common/data:utility_lib",
         "//library/common/types:c_types_lib",
         "@envoy//source/common/buffer:buffer_lib",
     ],

--- a/test/common/data/utility_test.cc
+++ b/test/common/data/utility_test.cc
@@ -1,16 +1,16 @@
 #include "common/buffer/buffer_impl.h"
 
 #include "gtest/gtest.h"
-#include "library/common/buffer/utility.h"
+#include "library/common/data/utility.h"
 #include "library/common/types/c_types.h"
 
 namespace Envoy {
-namespace Buffer {
+namespace Data {
 
 TEST(DataConstructorTest, FromCToCppEmpty) {
   envoy_data empty_data = {0, nullptr, free, nullptr};
 
-  InstancePtr cpp_data = Utility::toInternalData(empty_data);
+  Buffer::InstancePtr cpp_data = Utility::toInternalData(empty_data);
 
   ASSERT_EQ(cpp_data->length(), 0);
 }
@@ -20,14 +20,14 @@ TEST(DataConstructorTest, FromCToCpp) {
   envoy_data c_data = {s.size(), reinterpret_cast<const uint8_t*>(s.c_str()), free, nullptr};
   ;
 
-  InstancePtr cpp_data = Utility::toInternalData(c_data);
+  Buffer::InstancePtr cpp_data = Utility::toInternalData(c_data);
 
   ASSERT_EQ(cpp_data->length(), c_data.length);
   ASSERT_EQ(cpp_data->toString(), s);
 }
 
 TEST(DataConstructorTest, FromCppToCEmpty) {
-  OwnedImpl empty_data;
+  Buffer::OwnedImpl empty_data;
 
   envoy_data c_data = Utility::toBridgeData(empty_data);
 
@@ -37,7 +37,7 @@ TEST(DataConstructorTest, FromCppToCEmpty) {
 
 TEST(DataConstructorTest, FromCppToC) {
   std::string s = "test string";
-  OwnedImpl cpp_data = OwnedImpl(absl::string_view(s));
+  Buffer::OwnedImpl cpp_data = Buffer::OwnedImpl(absl::string_view(s));
 
   envoy_data c_data = Utility::toBridgeData(cpp_data);
 
@@ -48,7 +48,7 @@ TEST(DataConstructorTest, FromCppToC) {
 
 TEST(DataConstructorTest, CopyFromCppToC) {
   std::string s = "test string";
-  OwnedImpl cpp_data = OwnedImpl(absl::string_view(s));
+  Buffer::OwnedImpl cpp_data = Buffer::OwnedImpl(absl::string_view(s));
 
   envoy_data c_data = Utility::copyToBridgeData(cpp_data);
 
@@ -67,5 +67,5 @@ TEST(DataConstructorTest, CopyStringFromCppToC) {
   c_data.release(c_data.context);
 }
 
-} // namespace Buffer
+} // namespace Data
 } // namespace Envoy

--- a/test/common/extensions/filters/http/platform_bridge/platform_bridge_filter_integration_test.cc
+++ b/test/common/extensions/filters/http/platform_bridge/platform_bridge_filter_integration_test.cc
@@ -9,11 +9,6 @@
 
 namespace Envoy {
 
-// TODO: consolidate all instances of this function to one utility class.
-std::string to_string(envoy_data data) {
-  return std::string(reinterpret_cast<const char*>(data.bytes), data.length);
-}
-
 class PlatformBridgeIntegrationTest : public testing::TestWithParam<Network::Address::IpVersion>,
                                       public HttpIntegrationTest {
 public:

--- a/test/common/extensions/filters/http/platform_bridge/platform_bridge_filter_test.cc
+++ b/test/common/extensions/filters/http/platform_bridge/platform_bridge_filter_test.cc
@@ -4,7 +4,7 @@
 
 #include "gtest/gtest.h"
 #include "library/common/api/external.h"
-#include "library/common/buffer/utility.h"
+#include "library/common/data/utility.h"
 #include "library/common/extensions/filters/http/platform_bridge/filter.h"
 #include "library/common/extensions/filters/http/platform_bridge/filter.pb.h"
 
@@ -26,8 +26,8 @@ envoy_headers make_envoy_headers(std::vector<std::pair<std::string, std::string>
   new_headers.entries = headers;
 
   for (const auto& pair : pairs) {
-    envoy_data key = Buffer::Utility::copyToBridgeData(pair.first);
-    envoy_data value = Buffer::Utility::copyToBridgeData(pair.second);
+    envoy_data key = Data::Utility::copyToBridgeData(pair.first);
+    envoy_data value = Data::Utility::copyToBridgeData(pair.second);
 
     new_headers.entries[new_headers.length] = {key, value};
     new_headers.length++;
@@ -157,8 +157,8 @@ TEST_F(PlatformBridgeFilterTest, BasicContinueOnRequestHeaders) {
                                           const void* context) -> envoy_filter_headers_status {
     filter_invocations* invocations = static_cast<filter_invocations*>(const_cast<void*>(context));
     EXPECT_EQ(c_headers.length, 1);
-    EXPECT_EQ(Buffer::Utility::copyToString(c_headers.entries[0].key), ":authority");
-    EXPECT_EQ(Buffer::Utility::copyToString(c_headers.entries[0].value), "test.code");
+    EXPECT_EQ(Data::Utility::copyToString(c_headers.entries[0].key), ":authority");
+    EXPECT_EQ(Data::Utility::copyToString(c_headers.entries[0].value), "test.code");
     EXPECT_TRUE(end_stream);
     invocations->on_request_headers_calls++;
     return {kEnvoyFilterHeadersStatusContinue, c_headers};
@@ -191,8 +191,8 @@ TEST_F(PlatformBridgeFilterTest, StopOnRequestHeadersThenResumeOnData) {
                                           const void* context) -> envoy_filter_headers_status {
     filter_invocations* invocations = static_cast<filter_invocations*>(const_cast<void*>(context));
     EXPECT_EQ(c_headers.length, 1);
-    EXPECT_EQ(Buffer::Utility::copyToString(c_headers.entries[0].key), ":authority");
-    EXPECT_EQ(Buffer::Utility::copyToString(c_headers.entries[0].value), "test.code");
+    EXPECT_EQ(Data::Utility::copyToString(c_headers.entries[0].key), ":authority");
+    EXPECT_EQ(Data::Utility::copyToString(c_headers.entries[0].value), "test.code");
     EXPECT_FALSE(end_stream);
     invocations->on_request_headers_calls++;
     release_envoy_headers(c_headers);
@@ -201,7 +201,7 @@ TEST_F(PlatformBridgeFilterTest, StopOnRequestHeadersThenResumeOnData) {
   platform_filter.on_request_data = [](envoy_data c_data, bool end_stream,
                                        const void* context) -> envoy_filter_data_status {
     filter_invocations* invocations = static_cast<filter_invocations*>(const_cast<void*>(context));
-    EXPECT_EQ(Buffer::Utility::copyToString(c_data), "request body");
+    EXPECT_EQ(Data::Utility::copyToString(c_data), "request body");
     EXPECT_TRUE(end_stream);
     invocations->on_request_data_calls++;
     envoy_headers* modified_headers =
@@ -248,8 +248,8 @@ TEST_F(PlatformBridgeFilterTest, StopOnRequestHeadersThenResumeOnResumeDecoding)
                                           const void* context) -> envoy_filter_headers_status {
     filter_invocations* invocations = static_cast<filter_invocations*>(const_cast<void*>(context));
     EXPECT_EQ(c_headers.length, 1);
-    EXPECT_EQ(Buffer::Utility::copyToString(c_headers.entries[0].key), ":authority");
-    EXPECT_EQ(Buffer::Utility::copyToString(c_headers.entries[0].value), "test.code");
+    EXPECT_EQ(Data::Utility::copyToString(c_headers.entries[0].key), ":authority");
+    EXPECT_EQ(Data::Utility::copyToString(c_headers.entries[0].value), "test.code");
     EXPECT_FALSE(end_stream);
     invocations->on_request_headers_calls++;
     release_envoy_headers(c_headers);
@@ -260,8 +260,8 @@ TEST_F(PlatformBridgeFilterTest, StopOnRequestHeadersThenResumeOnResumeDecoding)
                                          const void* context) -> envoy_filter_resume_status {
     filter_invocations* invocations = static_cast<filter_invocations*>(const_cast<void*>(context));
     EXPECT_EQ(pending_headers->length, 1);
-    EXPECT_EQ(Buffer::Utility::copyToString(pending_headers->entries[0].key), ":authority");
-    EXPECT_EQ(Buffer::Utility::copyToString(pending_headers->entries[0].value), "test.code");
+    EXPECT_EQ(Data::Utility::copyToString(pending_headers->entries[0].key), ":authority");
+    EXPECT_EQ(Data::Utility::copyToString(pending_headers->entries[0].value), "test.code");
     EXPECT_EQ(pending_data, nullptr);
     EXPECT_EQ(pending_trailers, nullptr);
     EXPECT_FALSE(end_stream);
@@ -314,8 +314,8 @@ TEST_F(PlatformBridgeFilterTest, AsyncResumeDecodingIsNoopAfterPreviousResume) {
                                           const void* context) -> envoy_filter_headers_status {
     filter_invocations* invocations = static_cast<filter_invocations*>(const_cast<void*>(context));
     EXPECT_EQ(c_headers.length, 1);
-    EXPECT_EQ(Buffer::Utility::copyToString(c_headers.entries[0].key), ":authority");
-    EXPECT_EQ(Buffer::Utility::copyToString(c_headers.entries[0].value), "test.code");
+    EXPECT_EQ(Data::Utility::copyToString(c_headers.entries[0].key), ":authority");
+    EXPECT_EQ(Data::Utility::copyToString(c_headers.entries[0].value), "test.code");
     EXPECT_FALSE(end_stream);
     invocations->on_request_headers_calls++;
     release_envoy_headers(c_headers);
@@ -324,7 +324,7 @@ TEST_F(PlatformBridgeFilterTest, AsyncResumeDecodingIsNoopAfterPreviousResume) {
   platform_filter.on_request_data = [](envoy_data c_data, bool end_stream,
                                        const void* context) -> envoy_filter_data_status {
     filter_invocations* invocations = static_cast<filter_invocations*>(const_cast<void*>(context));
-    EXPECT_EQ(Buffer::Utility::copyToString(c_data), "request body");
+    EXPECT_EQ(Data::Utility::copyToString(c_data), "request body");
     EXPECT_TRUE(end_stream);
     invocations->on_request_data_calls++;
     envoy_headers* modified_headers =
@@ -382,7 +382,7 @@ TEST_F(PlatformBridgeFilterTest, BasicContinueOnRequestData) {
   platform_filter.on_request_data = [](envoy_data c_data, bool end_stream,
                                        const void* context) -> envoy_filter_data_status {
     filter_invocations* invocations = static_cast<filter_invocations*>(const_cast<void*>(context));
-    EXPECT_EQ(Buffer::Utility::copyToString(c_data), "request body");
+    EXPECT_EQ(Data::Utility::copyToString(c_data), "request body");
     EXPECT_TRUE(end_stream);
     invocations->on_request_data_calls++;
     return {kEnvoyFilterDataStatusContinue, c_data, nullptr};
@@ -415,7 +415,7 @@ TEST_F(PlatformBridgeFilterTest, StopAndBufferOnRequestData) {
                                        const void* context) -> envoy_filter_data_status {
     filter_invocations* invocations = static_cast<filter_invocations*>(const_cast<void*>(context));
     std::string expected_data[3] = {"A", "AB", "ABC"};
-    EXPECT_EQ(Buffer::Utility::copyToString(c_data),
+    EXPECT_EQ(Data::Utility::copyToString(c_data),
               expected_data[invocations->on_request_data_calls++]);
     EXPECT_FALSE(end_stream);
     c_data.release(c_data.context);
@@ -474,17 +474,17 @@ TEST_F(PlatformBridgeFilterTest, StopAndBufferThenResumeOnRequestData) {
     envoy_filter_data_status return_status;
 
     if (invocations->on_request_data_calls == 0) {
-      EXPECT_EQ(Buffer::Utility::copyToString(c_data), "A");
+      EXPECT_EQ(Data::Utility::copyToString(c_data), "A");
       EXPECT_FALSE(end_stream);
 
       return_status.status = kEnvoyFilterDataStatusStopIterationAndBuffer;
       return_status.data = envoy_nodata;
       return_status.pending_headers = nullptr;
     } else {
-      EXPECT_EQ(Buffer::Utility::copyToString(c_data), "AB");
+      EXPECT_EQ(Data::Utility::copyToString(c_data), "AB");
       EXPECT_FALSE(end_stream);
       Buffer::OwnedImpl final_buffer = Buffer::OwnedImpl("C");
-      envoy_data final_data = Buffer::Utility::toBridgeData(final_buffer);
+      envoy_data final_data = Data::Utility::toBridgeData(final_buffer);
 
       return_status.status = kEnvoyFilterDataStatusResumeIteration;
       return_status.data = final_data;
@@ -542,8 +542,8 @@ TEST_F(PlatformBridgeFilterTest, StopOnRequestHeadersThenBufferThenResumeOnData)
                                           const void* context) -> envoy_filter_headers_status {
     filter_invocations* invocations = static_cast<filter_invocations*>(const_cast<void*>(context));
     EXPECT_EQ(c_headers.length, 1);
-    EXPECT_EQ(Buffer::Utility::copyToString(c_headers.entries[0].key), ":authority");
-    EXPECT_EQ(Buffer::Utility::copyToString(c_headers.entries[0].value), "test.code");
+    EXPECT_EQ(Data::Utility::copyToString(c_headers.entries[0].key), ":authority");
+    EXPECT_EQ(Data::Utility::copyToString(c_headers.entries[0].value), "test.code");
     EXPECT_FALSE(end_stream);
     invocations->on_request_headers_calls++;
     release_envoy_headers(c_headers);
@@ -555,17 +555,17 @@ TEST_F(PlatformBridgeFilterTest, StopOnRequestHeadersThenBufferThenResumeOnData)
     envoy_filter_data_status return_status;
 
     if (invocations->on_request_data_calls == 0) {
-      EXPECT_EQ(Buffer::Utility::copyToString(c_data), "A");
+      EXPECT_EQ(Data::Utility::copyToString(c_data), "A");
       EXPECT_FALSE(end_stream);
 
       return_status.status = kEnvoyFilterDataStatusStopIterationAndBuffer;
       return_status.data = envoy_nodata;
       return_status.pending_headers = nullptr;
     } else {
-      EXPECT_EQ(Buffer::Utility::copyToString(c_data), "AB");
+      EXPECT_EQ(Data::Utility::copyToString(c_data), "AB");
       EXPECT_TRUE(end_stream);
       Buffer::OwnedImpl final_buffer = Buffer::OwnedImpl("C");
-      envoy_data final_data = Buffer::Utility::toBridgeData(final_buffer);
+      envoy_data final_data = Data::Utility::toBridgeData(final_buffer);
       envoy_headers* modified_headers =
           static_cast<envoy_headers*>(safe_malloc(sizeof(envoy_headers)));
       *modified_headers =
@@ -639,7 +639,7 @@ TEST_F(PlatformBridgeFilterTest, StopNoBufferOnRequestData) {
                                        const void* context) -> envoy_filter_data_status {
     filter_invocations* invocations = static_cast<filter_invocations*>(const_cast<void*>(context));
     std::string expected_data[3] = {"A", "B", "C"};
-    EXPECT_EQ(Buffer::Utility::copyToString(c_data),
+    EXPECT_EQ(Data::Utility::copyToString(c_data),
               expected_data[invocations->on_request_data_calls++]);
     EXPECT_FALSE(end_stream);
     c_data.release(c_data.context);
@@ -681,8 +681,8 @@ TEST_F(PlatformBridgeFilterTest, BasicContinueOnRequestTrailers) {
                                            const void* context) -> envoy_filter_trailers_status {
     filter_invocations* invocations = static_cast<filter_invocations*>(const_cast<void*>(context));
     EXPECT_EQ(c_trailers.length, 1);
-    EXPECT_EQ(Buffer::Utility::copyToString(c_trailers.entries[0].key), "x-test-trailer");
-    EXPECT_EQ(Buffer::Utility::copyToString(c_trailers.entries[0].value), "test trailer");
+    EXPECT_EQ(Data::Utility::copyToString(c_trailers.entries[0].key), "x-test-trailer");
+    EXPECT_EQ(Data::Utility::copyToString(c_trailers.entries[0].value), "test trailer");
     invocations->on_request_trailers_calls++;
     return {kEnvoyFilterTrailersStatusContinue, c_trailers, nullptr, nullptr};
   };
@@ -714,8 +714,8 @@ TEST_F(PlatformBridgeFilterTest, StopOnRequestHeadersThenBufferThenResumeOnTrail
                                           const void* context) -> envoy_filter_headers_status {
     filter_invocations* invocations = static_cast<filter_invocations*>(const_cast<void*>(context));
     EXPECT_EQ(c_headers.length, 1);
-    EXPECT_EQ(Buffer::Utility::copyToString(c_headers.entries[0].key), ":authority");
-    EXPECT_EQ(Buffer::Utility::copyToString(c_headers.entries[0].value), "test.code");
+    EXPECT_EQ(Data::Utility::copyToString(c_headers.entries[0].key), ":authority");
+    EXPECT_EQ(Data::Utility::copyToString(c_headers.entries[0].value), "test.code");
     EXPECT_FALSE(end_stream);
     invocations->on_request_headers_calls++;
     release_envoy_headers(c_headers);
@@ -725,7 +725,7 @@ TEST_F(PlatformBridgeFilterTest, StopOnRequestHeadersThenBufferThenResumeOnTrail
                                        const void* context) -> envoy_filter_data_status {
     filter_invocations* invocations = static_cast<filter_invocations*>(const_cast<void*>(context));
     std::string expected_data[2] = {"A", "AB"};
-    EXPECT_EQ(Buffer::Utility::copyToString(c_data),
+    EXPECT_EQ(Data::Utility::copyToString(c_data),
               expected_data[invocations->on_request_data_calls]);
     EXPECT_FALSE(end_stream);
     c_data.release(c_data.context);
@@ -736,12 +736,12 @@ TEST_F(PlatformBridgeFilterTest, StopOnRequestHeadersThenBufferThenResumeOnTrail
                                            const void* context) -> envoy_filter_trailers_status {
     filter_invocations* invocations = static_cast<filter_invocations*>(const_cast<void*>(context));
     EXPECT_EQ(c_trailers.length, 1);
-    EXPECT_EQ(Buffer::Utility::copyToString(c_trailers.entries[0].key), "x-test-trailer");
-    EXPECT_EQ(Buffer::Utility::copyToString(c_trailers.entries[0].value), "test trailer");
+    EXPECT_EQ(Data::Utility::copyToString(c_trailers.entries[0].key), "x-test-trailer");
+    EXPECT_EQ(Data::Utility::copyToString(c_trailers.entries[0].value), "test trailer");
 
     Buffer::OwnedImpl final_buffer = Buffer::OwnedImpl("C");
     envoy_data* modified_data = static_cast<envoy_data*>(safe_malloc(sizeof(envoy_data)));
-    *modified_data = Buffer::Utility::toBridgeData(final_buffer);
+    *modified_data = Data::Utility::toBridgeData(final_buffer);
     envoy_headers* modified_headers =
         static_cast<envoy_headers*>(safe_malloc(sizeof(envoy_headers)));
     *modified_headers = make_envoy_headers({{":authority", "test.code"}, {"content-length", "1"}});
@@ -816,8 +816,8 @@ TEST_F(PlatformBridgeFilterTest, StopOnRequestHeadersThenBufferThenResumeOnResum
                                           const void* context) -> envoy_filter_headers_status {
     filter_invocations* invocations = static_cast<filter_invocations*>(const_cast<void*>(context));
     EXPECT_EQ(c_headers.length, 1);
-    EXPECT_EQ(Buffer::Utility::copyToString(c_headers.entries[0].key), ":authority");
-    EXPECT_EQ(Buffer::Utility::copyToString(c_headers.entries[0].value), "test.code");
+    EXPECT_EQ(Data::Utility::copyToString(c_headers.entries[0].key), ":authority");
+    EXPECT_EQ(Data::Utility::copyToString(c_headers.entries[0].value), "test.code");
     EXPECT_FALSE(end_stream);
     invocations->on_request_headers_calls++;
     release_envoy_headers(c_headers);
@@ -827,7 +827,7 @@ TEST_F(PlatformBridgeFilterTest, StopOnRequestHeadersThenBufferThenResumeOnResum
                                        const void* context) -> envoy_filter_data_status {
     filter_invocations* invocations = static_cast<filter_invocations*>(const_cast<void*>(context));
     std::string expected_data[2] = {"A", "AB"};
-    EXPECT_EQ(Buffer::Utility::copyToString(c_data),
+    EXPECT_EQ(Data::Utility::copyToString(c_data),
               expected_data[invocations->on_request_data_calls]);
     EXPECT_FALSE(end_stream);
     c_data.release(c_data.context);
@@ -838,8 +838,8 @@ TEST_F(PlatformBridgeFilterTest, StopOnRequestHeadersThenBufferThenResumeOnResum
                                            const void* context) -> envoy_filter_trailers_status {
     filter_invocations* invocations = static_cast<filter_invocations*>(const_cast<void*>(context));
     EXPECT_EQ(c_trailers.length, 1);
-    EXPECT_EQ(Buffer::Utility::copyToString(c_trailers.entries[0].key), "x-test-trailer");
-    EXPECT_EQ(Buffer::Utility::copyToString(c_trailers.entries[0].value), "test trailer");
+    EXPECT_EQ(Data::Utility::copyToString(c_trailers.entries[0].key), "x-test-trailer");
+    EXPECT_EQ(Data::Utility::copyToString(c_trailers.entries[0].value), "test trailer");
     release_envoy_headers(c_trailers);
     invocations->on_request_trailers_calls++;
     return {kEnvoyFilterTrailersStatusStopIteration, envoy_noheaders, nullptr, nullptr};
@@ -849,12 +849,12 @@ TEST_F(PlatformBridgeFilterTest, StopOnRequestHeadersThenBufferThenResumeOnResum
                                          const void* context) -> envoy_filter_resume_status {
     filter_invocations* invocations = static_cast<filter_invocations*>(const_cast<void*>(context));
     EXPECT_EQ(pending_headers->length, 1);
-    EXPECT_EQ(Buffer::Utility::copyToString(pending_headers->entries[0].key), ":authority");
-    EXPECT_EQ(Buffer::Utility::copyToString(pending_headers->entries[0].value), "test.code");
-    EXPECT_EQ(Buffer::Utility::copyToString(*pending_data), "AB");
+    EXPECT_EQ(Data::Utility::copyToString(pending_headers->entries[0].key), ":authority");
+    EXPECT_EQ(Data::Utility::copyToString(pending_headers->entries[0].value), "test.code");
+    EXPECT_EQ(Data::Utility::copyToString(*pending_data), "AB");
     EXPECT_EQ(pending_trailers->length, 1);
-    EXPECT_EQ(Buffer::Utility::copyToString(pending_trailers->entries[0].key), "x-test-trailer");
-    EXPECT_EQ(Buffer::Utility::copyToString(pending_trailers->entries[0].value), "test trailer");
+    EXPECT_EQ(Data::Utility::copyToString(pending_trailers->entries[0].key), "x-test-trailer");
+    EXPECT_EQ(Data::Utility::copyToString(pending_trailers->entries[0].value), "test trailer");
     EXPECT_TRUE(end_stream);
 
     envoy_headers* modified_headers =
@@ -864,7 +864,7 @@ TEST_F(PlatformBridgeFilterTest, StopOnRequestHeadersThenBufferThenResumeOnResum
     release_envoy_headers(*pending_headers);
     Buffer::OwnedImpl final_buffer = Buffer::OwnedImpl("C");
     envoy_data* modified_data = static_cast<envoy_data*>(safe_malloc(sizeof(envoy_data)));
-    *modified_data = Buffer::Utility::toBridgeData(final_buffer);
+    *modified_data = Data::Utility::toBridgeData(final_buffer);
     pending_data->release(pending_data->context);
     envoy_headers* modified_trailers =
         static_cast<envoy_headers*>(safe_malloc(sizeof(envoy_headers)));
@@ -958,8 +958,8 @@ TEST_F(PlatformBridgeFilterTest, BasicContinueOnResponseHeaders) {
                                            const void* context) -> envoy_filter_headers_status {
     filter_invocations* invocations = static_cast<filter_invocations*>(const_cast<void*>(context));
     EXPECT_EQ(c_headers.length, 1);
-    EXPECT_EQ(Buffer::Utility::copyToString(c_headers.entries[0].key), ":status");
-    EXPECT_EQ(Buffer::Utility::copyToString(c_headers.entries[0].value), "test.code");
+    EXPECT_EQ(Data::Utility::copyToString(c_headers.entries[0].key), ":status");
+    EXPECT_EQ(Data::Utility::copyToString(c_headers.entries[0].value), "test.code");
     EXPECT_TRUE(end_stream);
     invocations->on_response_headers_calls++;
     return {kEnvoyFilterHeadersStatusContinue, c_headers};
@@ -992,8 +992,8 @@ TEST_F(PlatformBridgeFilterTest, StopOnResponseHeadersThenResumeOnData) {
                                            const void* context) -> envoy_filter_headers_status {
     filter_invocations* invocations = static_cast<filter_invocations*>(const_cast<void*>(context));
     EXPECT_EQ(c_headers.length, 1);
-    EXPECT_EQ(Buffer::Utility::copyToString(c_headers.entries[0].key), ":status");
-    EXPECT_EQ(Buffer::Utility::copyToString(c_headers.entries[0].value), "test.code");
+    EXPECT_EQ(Data::Utility::copyToString(c_headers.entries[0].key), ":status");
+    EXPECT_EQ(Data::Utility::copyToString(c_headers.entries[0].value), "test.code");
     EXPECT_FALSE(end_stream);
     invocations->on_response_headers_calls++;
     release_envoy_headers(c_headers);
@@ -1002,7 +1002,7 @@ TEST_F(PlatformBridgeFilterTest, StopOnResponseHeadersThenResumeOnData) {
   platform_filter.on_response_data = [](envoy_data c_data, bool end_stream,
                                         const void* context) -> envoy_filter_data_status {
     filter_invocations* invocations = static_cast<filter_invocations*>(const_cast<void*>(context));
-    EXPECT_EQ(Buffer::Utility::copyToString(c_data), "response body");
+    EXPECT_EQ(Data::Utility::copyToString(c_data), "response body");
     EXPECT_TRUE(end_stream);
     invocations->on_response_data_calls++;
     envoy_headers* modified_headers =
@@ -1049,8 +1049,8 @@ TEST_F(PlatformBridgeFilterTest, StopOnResponseHeadersThenResumeOnResumeEncoding
                                            const void* context) -> envoy_filter_headers_status {
     filter_invocations* invocations = static_cast<filter_invocations*>(const_cast<void*>(context));
     EXPECT_EQ(c_headers.length, 1);
-    EXPECT_EQ(Buffer::Utility::copyToString(c_headers.entries[0].key), ":status");
-    EXPECT_EQ(Buffer::Utility::copyToString(c_headers.entries[0].value), "test.code");
+    EXPECT_EQ(Data::Utility::copyToString(c_headers.entries[0].key), ":status");
+    EXPECT_EQ(Data::Utility::copyToString(c_headers.entries[0].value), "test.code");
     EXPECT_FALSE(end_stream);
     invocations->on_response_headers_calls++;
     release_envoy_headers(c_headers);
@@ -1061,8 +1061,8 @@ TEST_F(PlatformBridgeFilterTest, StopOnResponseHeadersThenResumeOnResumeEncoding
                                           const void* context) -> envoy_filter_resume_status {
     filter_invocations* invocations = static_cast<filter_invocations*>(const_cast<void*>(context));
     EXPECT_EQ(pending_headers->length, 1);
-    EXPECT_EQ(Buffer::Utility::copyToString(pending_headers->entries[0].key), ":status");
-    EXPECT_EQ(Buffer::Utility::copyToString(pending_headers->entries[0].value), "test.code");
+    EXPECT_EQ(Data::Utility::copyToString(pending_headers->entries[0].key), ":status");
+    EXPECT_EQ(Data::Utility::copyToString(pending_headers->entries[0].value), "test.code");
     EXPECT_EQ(pending_data, nullptr);
     EXPECT_EQ(pending_trailers, nullptr);
     EXPECT_FALSE(end_stream);
@@ -1115,8 +1115,8 @@ TEST_F(PlatformBridgeFilterTest, AsyncResumeEncodingIsNoopAfterPreviousResume) {
                                            const void* context) -> envoy_filter_headers_status {
     filter_invocations* invocations = static_cast<filter_invocations*>(const_cast<void*>(context));
     EXPECT_EQ(c_headers.length, 1);
-    EXPECT_EQ(Buffer::Utility::copyToString(c_headers.entries[0].key), ":status");
-    EXPECT_EQ(Buffer::Utility::copyToString(c_headers.entries[0].value), "test.code");
+    EXPECT_EQ(Data::Utility::copyToString(c_headers.entries[0].key), ":status");
+    EXPECT_EQ(Data::Utility::copyToString(c_headers.entries[0].value), "test.code");
     EXPECT_FALSE(end_stream);
     invocations->on_response_headers_calls++;
     release_envoy_headers(c_headers);
@@ -1125,7 +1125,7 @@ TEST_F(PlatformBridgeFilterTest, AsyncResumeEncodingIsNoopAfterPreviousResume) {
   platform_filter.on_response_data = [](envoy_data c_data, bool end_stream,
                                         const void* context) -> envoy_filter_data_status {
     filter_invocations* invocations = static_cast<filter_invocations*>(const_cast<void*>(context));
-    EXPECT_EQ(Buffer::Utility::copyToString(c_data), "response body");
+    EXPECT_EQ(Data::Utility::copyToString(c_data), "response body");
     EXPECT_TRUE(end_stream);
     invocations->on_response_data_calls++;
     envoy_headers* modified_headers =
@@ -1183,7 +1183,7 @@ TEST_F(PlatformBridgeFilterTest, BasicContinueOnResponseData) {
   platform_filter.on_response_data = [](envoy_data c_data, bool end_stream,
                                         const void* context) -> envoy_filter_data_status {
     filter_invocations* invocations = static_cast<filter_invocations*>(const_cast<void*>(context));
-    EXPECT_EQ(Buffer::Utility::copyToString(c_data), "response body");
+    EXPECT_EQ(Data::Utility::copyToString(c_data), "response body");
     EXPECT_TRUE(end_stream);
     invocations->on_response_data_calls++;
     return {kEnvoyFilterDataStatusContinue, c_data, nullptr};
@@ -1216,7 +1216,7 @@ TEST_F(PlatformBridgeFilterTest, StopAndBufferOnResponseData) {
                                         const void* context) -> envoy_filter_data_status {
     filter_invocations* invocations = static_cast<filter_invocations*>(const_cast<void*>(context));
     std::string expected_data[3] = {"A", "AB", "ABC"};
-    EXPECT_EQ(Buffer::Utility::copyToString(c_data),
+    EXPECT_EQ(Data::Utility::copyToString(c_data),
               expected_data[invocations->on_response_data_calls++]);
     EXPECT_FALSE(end_stream);
     c_data.release(c_data.context);
@@ -1275,17 +1275,17 @@ TEST_F(PlatformBridgeFilterTest, StopAndBufferThenResumeOnResponseData) {
     envoy_filter_data_status return_status;
 
     if (invocations->on_response_data_calls == 0) {
-      EXPECT_EQ(Buffer::Utility::copyToString(c_data), "A");
+      EXPECT_EQ(Data::Utility::copyToString(c_data), "A");
       EXPECT_FALSE(end_stream);
 
       return_status.status = kEnvoyFilterDataStatusStopIterationAndBuffer;
       return_status.data = envoy_nodata;
       return_status.pending_headers = nullptr;
     } else {
-      EXPECT_EQ(Buffer::Utility::copyToString(c_data), "AB");
+      EXPECT_EQ(Data::Utility::copyToString(c_data), "AB");
       EXPECT_FALSE(end_stream);
       Buffer::OwnedImpl final_buffer = Buffer::OwnedImpl("C");
-      envoy_data final_data = Buffer::Utility::toBridgeData(final_buffer);
+      envoy_data final_data = Data::Utility::toBridgeData(final_buffer);
 
       return_status.status = kEnvoyFilterDataStatusResumeIteration;
       return_status.data = final_data;
@@ -1343,8 +1343,8 @@ TEST_F(PlatformBridgeFilterTest, StopOnResponseHeadersThenBufferThenResumeOnData
                                            const void* context) -> envoy_filter_headers_status {
     filter_invocations* invocations = static_cast<filter_invocations*>(const_cast<void*>(context));
     EXPECT_EQ(c_headers.length, 1);
-    EXPECT_EQ(Buffer::Utility::copyToString(c_headers.entries[0].key), ":status");
-    EXPECT_EQ(Buffer::Utility::copyToString(c_headers.entries[0].value), "test.code");
+    EXPECT_EQ(Data::Utility::copyToString(c_headers.entries[0].key), ":status");
+    EXPECT_EQ(Data::Utility::copyToString(c_headers.entries[0].value), "test.code");
     EXPECT_FALSE(end_stream);
     invocations->on_response_headers_calls++;
     release_envoy_headers(c_headers);
@@ -1356,17 +1356,17 @@ TEST_F(PlatformBridgeFilterTest, StopOnResponseHeadersThenBufferThenResumeOnData
     envoy_filter_data_status return_status;
 
     if (invocations->on_response_data_calls == 0) {
-      EXPECT_EQ(Buffer::Utility::copyToString(c_data), "A");
+      EXPECT_EQ(Data::Utility::copyToString(c_data), "A");
       EXPECT_FALSE(end_stream);
 
       return_status.status = kEnvoyFilterDataStatusStopIterationAndBuffer;
       return_status.data = envoy_nodata;
       return_status.pending_headers = nullptr;
     } else {
-      EXPECT_EQ(Buffer::Utility::copyToString(c_data), "AB");
+      EXPECT_EQ(Data::Utility::copyToString(c_data), "AB");
       EXPECT_TRUE(end_stream);
       Buffer::OwnedImpl final_buffer = Buffer::OwnedImpl("C");
-      envoy_data final_data = Buffer::Utility::toBridgeData(final_buffer);
+      envoy_data final_data = Data::Utility::toBridgeData(final_buffer);
       envoy_headers* modified_headers =
           static_cast<envoy_headers*>(safe_malloc(sizeof(envoy_headers)));
       *modified_headers = make_envoy_headers({{":status", "test.code"}, {"content-length", "1"}});
@@ -1439,7 +1439,7 @@ TEST_F(PlatformBridgeFilterTest, StopNoBufferOnResponseData) {
                                         const void* context) -> envoy_filter_data_status {
     filter_invocations* invocations = static_cast<filter_invocations*>(const_cast<void*>(context));
     std::string expected_data[3] = {"A", "B", "C"};
-    EXPECT_EQ(Buffer::Utility::copyToString(c_data),
+    EXPECT_EQ(Data::Utility::copyToString(c_data),
               expected_data[invocations->on_response_data_calls++]);
     EXPECT_FALSE(end_stream);
     c_data.release(c_data.context);
@@ -1481,8 +1481,8 @@ TEST_F(PlatformBridgeFilterTest, BasicContinueOnResponseTrailers) {
                                             const void* context) -> envoy_filter_trailers_status {
     filter_invocations* invocations = static_cast<filter_invocations*>(const_cast<void*>(context));
     EXPECT_EQ(c_trailers.length, 1);
-    EXPECT_EQ(Buffer::Utility::copyToString(c_trailers.entries[0].key), "x-test-trailer");
-    EXPECT_EQ(Buffer::Utility::copyToString(c_trailers.entries[0].value), "test trailer");
+    EXPECT_EQ(Data::Utility::copyToString(c_trailers.entries[0].key), "x-test-trailer");
+    EXPECT_EQ(Data::Utility::copyToString(c_trailers.entries[0].value), "test trailer");
     invocations->on_response_trailers_calls++;
     return {kEnvoyFilterTrailersStatusContinue, c_trailers, nullptr, nullptr};
   };
@@ -1514,8 +1514,8 @@ TEST_F(PlatformBridgeFilterTest, StopOnResponseHeadersThenBufferThenResumeOnTrai
                                            const void* context) -> envoy_filter_headers_status {
     filter_invocations* invocations = static_cast<filter_invocations*>(const_cast<void*>(context));
     EXPECT_EQ(c_headers.length, 1);
-    EXPECT_EQ(Buffer::Utility::copyToString(c_headers.entries[0].key), ":status");
-    EXPECT_EQ(Buffer::Utility::copyToString(c_headers.entries[0].value), "test.code");
+    EXPECT_EQ(Data::Utility::copyToString(c_headers.entries[0].key), ":status");
+    EXPECT_EQ(Data::Utility::copyToString(c_headers.entries[0].value), "test.code");
     EXPECT_FALSE(end_stream);
     invocations->on_response_headers_calls++;
     release_envoy_headers(c_headers);
@@ -1525,7 +1525,7 @@ TEST_F(PlatformBridgeFilterTest, StopOnResponseHeadersThenBufferThenResumeOnTrai
                                         const void* context) -> envoy_filter_data_status {
     filter_invocations* invocations = static_cast<filter_invocations*>(const_cast<void*>(context));
     std::string expected_data[2] = {"A", "AB"};
-    EXPECT_EQ(Buffer::Utility::copyToString(c_data),
+    EXPECT_EQ(Data::Utility::copyToString(c_data),
               expected_data[invocations->on_response_data_calls]);
     EXPECT_FALSE(end_stream);
     c_data.release(c_data.context);
@@ -1536,12 +1536,12 @@ TEST_F(PlatformBridgeFilterTest, StopOnResponseHeadersThenBufferThenResumeOnTrai
                                             const void* context) -> envoy_filter_trailers_status {
     filter_invocations* invocations = static_cast<filter_invocations*>(const_cast<void*>(context));
     EXPECT_EQ(c_trailers.length, 1);
-    EXPECT_EQ(Buffer::Utility::copyToString(c_trailers.entries[0].key), "x-test-trailer");
-    EXPECT_EQ(Buffer::Utility::copyToString(c_trailers.entries[0].value), "test trailer");
+    EXPECT_EQ(Data::Utility::copyToString(c_trailers.entries[0].key), "x-test-trailer");
+    EXPECT_EQ(Data::Utility::copyToString(c_trailers.entries[0].value), "test trailer");
 
     Buffer::OwnedImpl final_buffer = Buffer::OwnedImpl("C");
     envoy_data* modified_data = static_cast<envoy_data*>(safe_malloc(sizeof(envoy_data)));
-    *modified_data = Buffer::Utility::toBridgeData(final_buffer);
+    *modified_data = Data::Utility::toBridgeData(final_buffer);
     envoy_headers* modified_headers =
         static_cast<envoy_headers*>(safe_malloc(sizeof(envoy_headers)));
     *modified_headers = make_envoy_headers({{":status", "test.code"}, {"content-length", "1"}});
@@ -1616,8 +1616,8 @@ TEST_F(PlatformBridgeFilterTest, StopOnResponseHeadersThenBufferThenResumeOnResu
                                            const void* context) -> envoy_filter_headers_status {
     filter_invocations* invocations = static_cast<filter_invocations*>(const_cast<void*>(context));
     EXPECT_EQ(c_headers.length, 1);
-    EXPECT_EQ(Buffer::Utility::copyToString(c_headers.entries[0].key), ":status");
-    EXPECT_EQ(Buffer::Utility::copyToString(c_headers.entries[0].value), "test.code");
+    EXPECT_EQ(Data::Utility::copyToString(c_headers.entries[0].key), ":status");
+    EXPECT_EQ(Data::Utility::copyToString(c_headers.entries[0].value), "test.code");
     EXPECT_FALSE(end_stream);
     invocations->on_response_headers_calls++;
     release_envoy_headers(c_headers);
@@ -1627,7 +1627,7 @@ TEST_F(PlatformBridgeFilterTest, StopOnResponseHeadersThenBufferThenResumeOnResu
                                         const void* context) -> envoy_filter_data_status {
     filter_invocations* invocations = static_cast<filter_invocations*>(const_cast<void*>(context));
     std::string expected_data[2] = {"A", "AB"};
-    EXPECT_EQ(Buffer::Utility::copyToString(c_data),
+    EXPECT_EQ(Data::Utility::copyToString(c_data),
               expected_data[invocations->on_response_data_calls]);
     EXPECT_FALSE(end_stream);
     c_data.release(c_data.context);
@@ -1638,8 +1638,8 @@ TEST_F(PlatformBridgeFilterTest, StopOnResponseHeadersThenBufferThenResumeOnResu
                                             const void* context) -> envoy_filter_trailers_status {
     filter_invocations* invocations = static_cast<filter_invocations*>(const_cast<void*>(context));
     EXPECT_EQ(c_trailers.length, 1);
-    EXPECT_EQ(Buffer::Utility::copyToString(c_trailers.entries[0].key), "x-test-trailer");
-    EXPECT_EQ(Buffer::Utility::copyToString(c_trailers.entries[0].value), "test trailer");
+    EXPECT_EQ(Data::Utility::copyToString(c_trailers.entries[0].key), "x-test-trailer");
+    EXPECT_EQ(Data::Utility::copyToString(c_trailers.entries[0].value), "test trailer");
     release_envoy_headers(c_trailers);
     invocations->on_response_trailers_calls++;
     return {kEnvoyFilterTrailersStatusStopIteration, envoy_noheaders, nullptr, nullptr};
@@ -1649,12 +1649,12 @@ TEST_F(PlatformBridgeFilterTest, StopOnResponseHeadersThenBufferThenResumeOnResu
                                           const void* context) -> envoy_filter_resume_status {
     filter_invocations* invocations = static_cast<filter_invocations*>(const_cast<void*>(context));
     EXPECT_EQ(pending_headers->length, 1);
-    EXPECT_EQ(Buffer::Utility::copyToString(pending_headers->entries[0].key), ":status");
-    EXPECT_EQ(Buffer::Utility::copyToString(pending_headers->entries[0].value), "test.code");
-    EXPECT_EQ(Buffer::Utility::copyToString(*pending_data), "AB");
+    EXPECT_EQ(Data::Utility::copyToString(pending_headers->entries[0].key), ":status");
+    EXPECT_EQ(Data::Utility::copyToString(pending_headers->entries[0].value), "test.code");
+    EXPECT_EQ(Data::Utility::copyToString(*pending_data), "AB");
     EXPECT_EQ(pending_trailers->length, 1);
-    EXPECT_EQ(Buffer::Utility::copyToString(pending_trailers->entries[0].key), "x-test-trailer");
-    EXPECT_EQ(Buffer::Utility::copyToString(pending_trailers->entries[0].value), "test trailer");
+    EXPECT_EQ(Data::Utility::copyToString(pending_trailers->entries[0].key), "x-test-trailer");
+    EXPECT_EQ(Data::Utility::copyToString(pending_trailers->entries[0].value), "test trailer");
     EXPECT_TRUE(end_stream);
 
     envoy_headers* modified_headers =
@@ -1664,7 +1664,7 @@ TEST_F(PlatformBridgeFilterTest, StopOnResponseHeadersThenBufferThenResumeOnResu
     release_envoy_headers(*pending_headers);
     Buffer::OwnedImpl final_buffer = Buffer::OwnedImpl("C");
     envoy_data* modified_data = static_cast<envoy_data*>(safe_malloc(sizeof(envoy_data)));
-    *modified_data = Buffer::Utility::toBridgeData(final_buffer);
+    *modified_data = Data::Utility::toBridgeData(final_buffer);
     pending_data->release(pending_data->context);
     envoy_headers* modified_trailers =
         static_cast<envoy_headers*>(safe_malloc(sizeof(envoy_headers)));

--- a/test/common/extensions/filters/http/platform_bridge/platform_bridge_filter_test.cc
+++ b/test/common/extensions/filters/http/platform_bridge/platform_bridge_filter_test.cc
@@ -18,14 +18,6 @@ namespace HttpFilters {
 namespace PlatformBridge {
 namespace {
 
-std::string to_string(envoy_data data) {
-  return std::string(reinterpret_cast<const char*>(data.bytes), data.length);
-}
-
-envoy_data make_envoy_data(const std::string& s) {
-  return copy_envoy_data(s.size(), reinterpret_cast<const uint8_t*>(s.c_str()));
-}
-
 envoy_headers make_envoy_headers(std::vector<std::pair<std::string, std::string>> pairs) {
   envoy_map_entry* headers =
       static_cast<envoy_map_entry*>(safe_malloc(sizeof(envoy_map_entry) * pairs.size()));
@@ -34,8 +26,8 @@ envoy_headers make_envoy_headers(std::vector<std::pair<std::string, std::string>
   new_headers.entries = headers;
 
   for (const auto& pair : pairs) {
-    envoy_data key = make_envoy_data(pair.first);
-    envoy_data value = make_envoy_data(pair.second);
+    envoy_data key = Buffer::Utility::copyToBridgeData(pair.first);
+    envoy_data value = Buffer::Utility::copyToBridgeData(pair.second);
 
     new_headers.entries[new_headers.length] = {key, value};
     new_headers.length++;
@@ -165,8 +157,8 @@ TEST_F(PlatformBridgeFilterTest, BasicContinueOnRequestHeaders) {
                                           const void* context) -> envoy_filter_headers_status {
     filter_invocations* invocations = static_cast<filter_invocations*>(const_cast<void*>(context));
     EXPECT_EQ(c_headers.length, 1);
-    EXPECT_EQ(to_string(c_headers.entries[0].key), ":authority");
-    EXPECT_EQ(to_string(c_headers.entries[0].value), "test.code");
+    EXPECT_EQ(Buffer::Utility::copyToString(c_headers.entries[0].key), ":authority");
+    EXPECT_EQ(Buffer::Utility::copyToString(c_headers.entries[0].value), "test.code");
     EXPECT_TRUE(end_stream);
     invocations->on_request_headers_calls++;
     return {kEnvoyFilterHeadersStatusContinue, c_headers};
@@ -199,8 +191,8 @@ TEST_F(PlatformBridgeFilterTest, StopOnRequestHeadersThenResumeOnData) {
                                           const void* context) -> envoy_filter_headers_status {
     filter_invocations* invocations = static_cast<filter_invocations*>(const_cast<void*>(context));
     EXPECT_EQ(c_headers.length, 1);
-    EXPECT_EQ(to_string(c_headers.entries[0].key), ":authority");
-    EXPECT_EQ(to_string(c_headers.entries[0].value), "test.code");
+    EXPECT_EQ(Buffer::Utility::copyToString(c_headers.entries[0].key), ":authority");
+    EXPECT_EQ(Buffer::Utility::copyToString(c_headers.entries[0].value), "test.code");
     EXPECT_FALSE(end_stream);
     invocations->on_request_headers_calls++;
     release_envoy_headers(c_headers);
@@ -209,7 +201,7 @@ TEST_F(PlatformBridgeFilterTest, StopOnRequestHeadersThenResumeOnData) {
   platform_filter.on_request_data = [](envoy_data c_data, bool end_stream,
                                        const void* context) -> envoy_filter_data_status {
     filter_invocations* invocations = static_cast<filter_invocations*>(const_cast<void*>(context));
-    EXPECT_EQ(to_string(c_data), "request body");
+    EXPECT_EQ(Buffer::Utility::copyToString(c_data), "request body");
     EXPECT_TRUE(end_stream);
     invocations->on_request_data_calls++;
     envoy_headers* modified_headers =
@@ -256,8 +248,8 @@ TEST_F(PlatformBridgeFilterTest, StopOnRequestHeadersThenResumeOnResumeDecoding)
                                           const void* context) -> envoy_filter_headers_status {
     filter_invocations* invocations = static_cast<filter_invocations*>(const_cast<void*>(context));
     EXPECT_EQ(c_headers.length, 1);
-    EXPECT_EQ(to_string(c_headers.entries[0].key), ":authority");
-    EXPECT_EQ(to_string(c_headers.entries[0].value), "test.code");
+    EXPECT_EQ(Buffer::Utility::copyToString(c_headers.entries[0].key), ":authority");
+    EXPECT_EQ(Buffer::Utility::copyToString(c_headers.entries[0].value), "test.code");
     EXPECT_FALSE(end_stream);
     invocations->on_request_headers_calls++;
     release_envoy_headers(c_headers);
@@ -268,8 +260,8 @@ TEST_F(PlatformBridgeFilterTest, StopOnRequestHeadersThenResumeOnResumeDecoding)
                                          const void* context) -> envoy_filter_resume_status {
     filter_invocations* invocations = static_cast<filter_invocations*>(const_cast<void*>(context));
     EXPECT_EQ(pending_headers->length, 1);
-    EXPECT_EQ(to_string(pending_headers->entries[0].key), ":authority");
-    EXPECT_EQ(to_string(pending_headers->entries[0].value), "test.code");
+    EXPECT_EQ(Buffer::Utility::copyToString(pending_headers->entries[0].key), ":authority");
+    EXPECT_EQ(Buffer::Utility::copyToString(pending_headers->entries[0].value), "test.code");
     EXPECT_EQ(pending_data, nullptr);
     EXPECT_EQ(pending_trailers, nullptr);
     EXPECT_FALSE(end_stream);
@@ -322,8 +314,8 @@ TEST_F(PlatformBridgeFilterTest, AsyncResumeDecodingIsNoopAfterPreviousResume) {
                                           const void* context) -> envoy_filter_headers_status {
     filter_invocations* invocations = static_cast<filter_invocations*>(const_cast<void*>(context));
     EXPECT_EQ(c_headers.length, 1);
-    EXPECT_EQ(to_string(c_headers.entries[0].key), ":authority");
-    EXPECT_EQ(to_string(c_headers.entries[0].value), "test.code");
+    EXPECT_EQ(Buffer::Utility::copyToString(c_headers.entries[0].key), ":authority");
+    EXPECT_EQ(Buffer::Utility::copyToString(c_headers.entries[0].value), "test.code");
     EXPECT_FALSE(end_stream);
     invocations->on_request_headers_calls++;
     release_envoy_headers(c_headers);
@@ -332,7 +324,7 @@ TEST_F(PlatformBridgeFilterTest, AsyncResumeDecodingIsNoopAfterPreviousResume) {
   platform_filter.on_request_data = [](envoy_data c_data, bool end_stream,
                                        const void* context) -> envoy_filter_data_status {
     filter_invocations* invocations = static_cast<filter_invocations*>(const_cast<void*>(context));
-    EXPECT_EQ(to_string(c_data), "request body");
+    EXPECT_EQ(Buffer::Utility::copyToString(c_data), "request body");
     EXPECT_TRUE(end_stream);
     invocations->on_request_data_calls++;
     envoy_headers* modified_headers =
@@ -390,7 +382,7 @@ TEST_F(PlatformBridgeFilterTest, BasicContinueOnRequestData) {
   platform_filter.on_request_data = [](envoy_data c_data, bool end_stream,
                                        const void* context) -> envoy_filter_data_status {
     filter_invocations* invocations = static_cast<filter_invocations*>(const_cast<void*>(context));
-    EXPECT_EQ(to_string(c_data), "request body");
+    EXPECT_EQ(Buffer::Utility::copyToString(c_data), "request body");
     EXPECT_TRUE(end_stream);
     invocations->on_request_data_calls++;
     return {kEnvoyFilterDataStatusContinue, c_data, nullptr};
@@ -423,7 +415,8 @@ TEST_F(PlatformBridgeFilterTest, StopAndBufferOnRequestData) {
                                        const void* context) -> envoy_filter_data_status {
     filter_invocations* invocations = static_cast<filter_invocations*>(const_cast<void*>(context));
     std::string expected_data[3] = {"A", "AB", "ABC"};
-    EXPECT_EQ(to_string(c_data), expected_data[invocations->on_request_data_calls++]);
+    EXPECT_EQ(Buffer::Utility::copyToString(c_data),
+              expected_data[invocations->on_request_data_calls++]);
     EXPECT_FALSE(end_stream);
     c_data.release(c_data.context);
     return {kEnvoyFilterDataStatusStopIterationAndBuffer, envoy_nodata, nullptr};
@@ -481,14 +474,14 @@ TEST_F(PlatformBridgeFilterTest, StopAndBufferThenResumeOnRequestData) {
     envoy_filter_data_status return_status;
 
     if (invocations->on_request_data_calls == 0) {
-      EXPECT_EQ(to_string(c_data), "A");
+      EXPECT_EQ(Buffer::Utility::copyToString(c_data), "A");
       EXPECT_FALSE(end_stream);
 
       return_status.status = kEnvoyFilterDataStatusStopIterationAndBuffer;
       return_status.data = envoy_nodata;
       return_status.pending_headers = nullptr;
     } else {
-      EXPECT_EQ(to_string(c_data), "AB");
+      EXPECT_EQ(Buffer::Utility::copyToString(c_data), "AB");
       EXPECT_FALSE(end_stream);
       Buffer::OwnedImpl final_buffer = Buffer::OwnedImpl("C");
       envoy_data final_data = Buffer::Utility::toBridgeData(final_buffer);
@@ -549,8 +542,8 @@ TEST_F(PlatformBridgeFilterTest, StopOnRequestHeadersThenBufferThenResumeOnData)
                                           const void* context) -> envoy_filter_headers_status {
     filter_invocations* invocations = static_cast<filter_invocations*>(const_cast<void*>(context));
     EXPECT_EQ(c_headers.length, 1);
-    EXPECT_EQ(to_string(c_headers.entries[0].key), ":authority");
-    EXPECT_EQ(to_string(c_headers.entries[0].value), "test.code");
+    EXPECT_EQ(Buffer::Utility::copyToString(c_headers.entries[0].key), ":authority");
+    EXPECT_EQ(Buffer::Utility::copyToString(c_headers.entries[0].value), "test.code");
     EXPECT_FALSE(end_stream);
     invocations->on_request_headers_calls++;
     release_envoy_headers(c_headers);
@@ -562,14 +555,14 @@ TEST_F(PlatformBridgeFilterTest, StopOnRequestHeadersThenBufferThenResumeOnData)
     envoy_filter_data_status return_status;
 
     if (invocations->on_request_data_calls == 0) {
-      EXPECT_EQ(to_string(c_data), "A");
+      EXPECT_EQ(Buffer::Utility::copyToString(c_data), "A");
       EXPECT_FALSE(end_stream);
 
       return_status.status = kEnvoyFilterDataStatusStopIterationAndBuffer;
       return_status.data = envoy_nodata;
       return_status.pending_headers = nullptr;
     } else {
-      EXPECT_EQ(to_string(c_data), "AB");
+      EXPECT_EQ(Buffer::Utility::copyToString(c_data), "AB");
       EXPECT_TRUE(end_stream);
       Buffer::OwnedImpl final_buffer = Buffer::OwnedImpl("C");
       envoy_data final_data = Buffer::Utility::toBridgeData(final_buffer);
@@ -646,7 +639,8 @@ TEST_F(PlatformBridgeFilterTest, StopNoBufferOnRequestData) {
                                        const void* context) -> envoy_filter_data_status {
     filter_invocations* invocations = static_cast<filter_invocations*>(const_cast<void*>(context));
     std::string expected_data[3] = {"A", "B", "C"};
-    EXPECT_EQ(to_string(c_data), expected_data[invocations->on_request_data_calls++]);
+    EXPECT_EQ(Buffer::Utility::copyToString(c_data),
+              expected_data[invocations->on_request_data_calls++]);
     EXPECT_FALSE(end_stream);
     c_data.release(c_data.context);
     return {kEnvoyFilterDataStatusStopIterationNoBuffer, envoy_nodata, nullptr};
@@ -687,8 +681,8 @@ TEST_F(PlatformBridgeFilterTest, BasicContinueOnRequestTrailers) {
                                            const void* context) -> envoy_filter_trailers_status {
     filter_invocations* invocations = static_cast<filter_invocations*>(const_cast<void*>(context));
     EXPECT_EQ(c_trailers.length, 1);
-    EXPECT_EQ(to_string(c_trailers.entries[0].key), "x-test-trailer");
-    EXPECT_EQ(to_string(c_trailers.entries[0].value), "test trailer");
+    EXPECT_EQ(Buffer::Utility::copyToString(c_trailers.entries[0].key), "x-test-trailer");
+    EXPECT_EQ(Buffer::Utility::copyToString(c_trailers.entries[0].value), "test trailer");
     invocations->on_request_trailers_calls++;
     return {kEnvoyFilterTrailersStatusContinue, c_trailers, nullptr, nullptr};
   };
@@ -720,8 +714,8 @@ TEST_F(PlatformBridgeFilterTest, StopOnRequestHeadersThenBufferThenResumeOnTrail
                                           const void* context) -> envoy_filter_headers_status {
     filter_invocations* invocations = static_cast<filter_invocations*>(const_cast<void*>(context));
     EXPECT_EQ(c_headers.length, 1);
-    EXPECT_EQ(to_string(c_headers.entries[0].key), ":authority");
-    EXPECT_EQ(to_string(c_headers.entries[0].value), "test.code");
+    EXPECT_EQ(Buffer::Utility::copyToString(c_headers.entries[0].key), ":authority");
+    EXPECT_EQ(Buffer::Utility::copyToString(c_headers.entries[0].value), "test.code");
     EXPECT_FALSE(end_stream);
     invocations->on_request_headers_calls++;
     release_envoy_headers(c_headers);
@@ -731,7 +725,8 @@ TEST_F(PlatformBridgeFilterTest, StopOnRequestHeadersThenBufferThenResumeOnTrail
                                        const void* context) -> envoy_filter_data_status {
     filter_invocations* invocations = static_cast<filter_invocations*>(const_cast<void*>(context));
     std::string expected_data[2] = {"A", "AB"};
-    EXPECT_EQ(to_string(c_data), expected_data[invocations->on_request_data_calls]);
+    EXPECT_EQ(Buffer::Utility::copyToString(c_data),
+              expected_data[invocations->on_request_data_calls]);
     EXPECT_FALSE(end_stream);
     c_data.release(c_data.context);
     invocations->on_request_data_calls++;
@@ -741,8 +736,8 @@ TEST_F(PlatformBridgeFilterTest, StopOnRequestHeadersThenBufferThenResumeOnTrail
                                            const void* context) -> envoy_filter_trailers_status {
     filter_invocations* invocations = static_cast<filter_invocations*>(const_cast<void*>(context));
     EXPECT_EQ(c_trailers.length, 1);
-    EXPECT_EQ(to_string(c_trailers.entries[0].key), "x-test-trailer");
-    EXPECT_EQ(to_string(c_trailers.entries[0].value), "test trailer");
+    EXPECT_EQ(Buffer::Utility::copyToString(c_trailers.entries[0].key), "x-test-trailer");
+    EXPECT_EQ(Buffer::Utility::copyToString(c_trailers.entries[0].value), "test trailer");
 
     Buffer::OwnedImpl final_buffer = Buffer::OwnedImpl("C");
     envoy_data* modified_data = static_cast<envoy_data*>(safe_malloc(sizeof(envoy_data)));
@@ -821,8 +816,8 @@ TEST_F(PlatformBridgeFilterTest, StopOnRequestHeadersThenBufferThenResumeOnResum
                                           const void* context) -> envoy_filter_headers_status {
     filter_invocations* invocations = static_cast<filter_invocations*>(const_cast<void*>(context));
     EXPECT_EQ(c_headers.length, 1);
-    EXPECT_EQ(to_string(c_headers.entries[0].key), ":authority");
-    EXPECT_EQ(to_string(c_headers.entries[0].value), "test.code");
+    EXPECT_EQ(Buffer::Utility::copyToString(c_headers.entries[0].key), ":authority");
+    EXPECT_EQ(Buffer::Utility::copyToString(c_headers.entries[0].value), "test.code");
     EXPECT_FALSE(end_stream);
     invocations->on_request_headers_calls++;
     release_envoy_headers(c_headers);
@@ -832,7 +827,8 @@ TEST_F(PlatformBridgeFilterTest, StopOnRequestHeadersThenBufferThenResumeOnResum
                                        const void* context) -> envoy_filter_data_status {
     filter_invocations* invocations = static_cast<filter_invocations*>(const_cast<void*>(context));
     std::string expected_data[2] = {"A", "AB"};
-    EXPECT_EQ(to_string(c_data), expected_data[invocations->on_request_data_calls]);
+    EXPECT_EQ(Buffer::Utility::copyToString(c_data),
+              expected_data[invocations->on_request_data_calls]);
     EXPECT_FALSE(end_stream);
     c_data.release(c_data.context);
     invocations->on_request_data_calls++;
@@ -842,8 +838,8 @@ TEST_F(PlatformBridgeFilterTest, StopOnRequestHeadersThenBufferThenResumeOnResum
                                            const void* context) -> envoy_filter_trailers_status {
     filter_invocations* invocations = static_cast<filter_invocations*>(const_cast<void*>(context));
     EXPECT_EQ(c_trailers.length, 1);
-    EXPECT_EQ(to_string(c_trailers.entries[0].key), "x-test-trailer");
-    EXPECT_EQ(to_string(c_trailers.entries[0].value), "test trailer");
+    EXPECT_EQ(Buffer::Utility::copyToString(c_trailers.entries[0].key), "x-test-trailer");
+    EXPECT_EQ(Buffer::Utility::copyToString(c_trailers.entries[0].value), "test trailer");
     release_envoy_headers(c_trailers);
     invocations->on_request_trailers_calls++;
     return {kEnvoyFilterTrailersStatusStopIteration, envoy_noheaders, nullptr, nullptr};
@@ -853,12 +849,12 @@ TEST_F(PlatformBridgeFilterTest, StopOnRequestHeadersThenBufferThenResumeOnResum
                                          const void* context) -> envoy_filter_resume_status {
     filter_invocations* invocations = static_cast<filter_invocations*>(const_cast<void*>(context));
     EXPECT_EQ(pending_headers->length, 1);
-    EXPECT_EQ(to_string(pending_headers->entries[0].key), ":authority");
-    EXPECT_EQ(to_string(pending_headers->entries[0].value), "test.code");
-    EXPECT_EQ(to_string(*pending_data), "AB");
+    EXPECT_EQ(Buffer::Utility::copyToString(pending_headers->entries[0].key), ":authority");
+    EXPECT_EQ(Buffer::Utility::copyToString(pending_headers->entries[0].value), "test.code");
+    EXPECT_EQ(Buffer::Utility::copyToString(*pending_data), "AB");
     EXPECT_EQ(pending_trailers->length, 1);
-    EXPECT_EQ(to_string(pending_trailers->entries[0].key), "x-test-trailer");
-    EXPECT_EQ(to_string(pending_trailers->entries[0].value), "test trailer");
+    EXPECT_EQ(Buffer::Utility::copyToString(pending_trailers->entries[0].key), "x-test-trailer");
+    EXPECT_EQ(Buffer::Utility::copyToString(pending_trailers->entries[0].value), "test trailer");
     EXPECT_TRUE(end_stream);
 
     envoy_headers* modified_headers =
@@ -962,8 +958,8 @@ TEST_F(PlatformBridgeFilterTest, BasicContinueOnResponseHeaders) {
                                            const void* context) -> envoy_filter_headers_status {
     filter_invocations* invocations = static_cast<filter_invocations*>(const_cast<void*>(context));
     EXPECT_EQ(c_headers.length, 1);
-    EXPECT_EQ(to_string(c_headers.entries[0].key), ":status");
-    EXPECT_EQ(to_string(c_headers.entries[0].value), "test.code");
+    EXPECT_EQ(Buffer::Utility::copyToString(c_headers.entries[0].key), ":status");
+    EXPECT_EQ(Buffer::Utility::copyToString(c_headers.entries[0].value), "test.code");
     EXPECT_TRUE(end_stream);
     invocations->on_response_headers_calls++;
     return {kEnvoyFilterHeadersStatusContinue, c_headers};
@@ -996,8 +992,8 @@ TEST_F(PlatformBridgeFilterTest, StopOnResponseHeadersThenResumeOnData) {
                                            const void* context) -> envoy_filter_headers_status {
     filter_invocations* invocations = static_cast<filter_invocations*>(const_cast<void*>(context));
     EXPECT_EQ(c_headers.length, 1);
-    EXPECT_EQ(to_string(c_headers.entries[0].key), ":status");
-    EXPECT_EQ(to_string(c_headers.entries[0].value), "test.code");
+    EXPECT_EQ(Buffer::Utility::copyToString(c_headers.entries[0].key), ":status");
+    EXPECT_EQ(Buffer::Utility::copyToString(c_headers.entries[0].value), "test.code");
     EXPECT_FALSE(end_stream);
     invocations->on_response_headers_calls++;
     release_envoy_headers(c_headers);
@@ -1006,7 +1002,7 @@ TEST_F(PlatformBridgeFilterTest, StopOnResponseHeadersThenResumeOnData) {
   platform_filter.on_response_data = [](envoy_data c_data, bool end_stream,
                                         const void* context) -> envoy_filter_data_status {
     filter_invocations* invocations = static_cast<filter_invocations*>(const_cast<void*>(context));
-    EXPECT_EQ(to_string(c_data), "response body");
+    EXPECT_EQ(Buffer::Utility::copyToString(c_data), "response body");
     EXPECT_TRUE(end_stream);
     invocations->on_response_data_calls++;
     envoy_headers* modified_headers =
@@ -1053,8 +1049,8 @@ TEST_F(PlatformBridgeFilterTest, StopOnResponseHeadersThenResumeOnResumeEncoding
                                            const void* context) -> envoy_filter_headers_status {
     filter_invocations* invocations = static_cast<filter_invocations*>(const_cast<void*>(context));
     EXPECT_EQ(c_headers.length, 1);
-    EXPECT_EQ(to_string(c_headers.entries[0].key), ":status");
-    EXPECT_EQ(to_string(c_headers.entries[0].value), "test.code");
+    EXPECT_EQ(Buffer::Utility::copyToString(c_headers.entries[0].key), ":status");
+    EXPECT_EQ(Buffer::Utility::copyToString(c_headers.entries[0].value), "test.code");
     EXPECT_FALSE(end_stream);
     invocations->on_response_headers_calls++;
     release_envoy_headers(c_headers);
@@ -1065,8 +1061,8 @@ TEST_F(PlatformBridgeFilterTest, StopOnResponseHeadersThenResumeOnResumeEncoding
                                           const void* context) -> envoy_filter_resume_status {
     filter_invocations* invocations = static_cast<filter_invocations*>(const_cast<void*>(context));
     EXPECT_EQ(pending_headers->length, 1);
-    EXPECT_EQ(to_string(pending_headers->entries[0].key), ":status");
-    EXPECT_EQ(to_string(pending_headers->entries[0].value), "test.code");
+    EXPECT_EQ(Buffer::Utility::copyToString(pending_headers->entries[0].key), ":status");
+    EXPECT_EQ(Buffer::Utility::copyToString(pending_headers->entries[0].value), "test.code");
     EXPECT_EQ(pending_data, nullptr);
     EXPECT_EQ(pending_trailers, nullptr);
     EXPECT_FALSE(end_stream);
@@ -1119,8 +1115,8 @@ TEST_F(PlatformBridgeFilterTest, AsyncResumeEncodingIsNoopAfterPreviousResume) {
                                            const void* context) -> envoy_filter_headers_status {
     filter_invocations* invocations = static_cast<filter_invocations*>(const_cast<void*>(context));
     EXPECT_EQ(c_headers.length, 1);
-    EXPECT_EQ(to_string(c_headers.entries[0].key), ":status");
-    EXPECT_EQ(to_string(c_headers.entries[0].value), "test.code");
+    EXPECT_EQ(Buffer::Utility::copyToString(c_headers.entries[0].key), ":status");
+    EXPECT_EQ(Buffer::Utility::copyToString(c_headers.entries[0].value), "test.code");
     EXPECT_FALSE(end_stream);
     invocations->on_response_headers_calls++;
     release_envoy_headers(c_headers);
@@ -1129,7 +1125,7 @@ TEST_F(PlatformBridgeFilterTest, AsyncResumeEncodingIsNoopAfterPreviousResume) {
   platform_filter.on_response_data = [](envoy_data c_data, bool end_stream,
                                         const void* context) -> envoy_filter_data_status {
     filter_invocations* invocations = static_cast<filter_invocations*>(const_cast<void*>(context));
-    EXPECT_EQ(to_string(c_data), "response body");
+    EXPECT_EQ(Buffer::Utility::copyToString(c_data), "response body");
     EXPECT_TRUE(end_stream);
     invocations->on_response_data_calls++;
     envoy_headers* modified_headers =
@@ -1187,7 +1183,7 @@ TEST_F(PlatformBridgeFilterTest, BasicContinueOnResponseData) {
   platform_filter.on_response_data = [](envoy_data c_data, bool end_stream,
                                         const void* context) -> envoy_filter_data_status {
     filter_invocations* invocations = static_cast<filter_invocations*>(const_cast<void*>(context));
-    EXPECT_EQ(to_string(c_data), "response body");
+    EXPECT_EQ(Buffer::Utility::copyToString(c_data), "response body");
     EXPECT_TRUE(end_stream);
     invocations->on_response_data_calls++;
     return {kEnvoyFilterDataStatusContinue, c_data, nullptr};
@@ -1220,7 +1216,8 @@ TEST_F(PlatformBridgeFilterTest, StopAndBufferOnResponseData) {
                                         const void* context) -> envoy_filter_data_status {
     filter_invocations* invocations = static_cast<filter_invocations*>(const_cast<void*>(context));
     std::string expected_data[3] = {"A", "AB", "ABC"};
-    EXPECT_EQ(to_string(c_data), expected_data[invocations->on_response_data_calls++]);
+    EXPECT_EQ(Buffer::Utility::copyToString(c_data),
+              expected_data[invocations->on_response_data_calls++]);
     EXPECT_FALSE(end_stream);
     c_data.release(c_data.context);
     return {kEnvoyFilterDataStatusStopIterationAndBuffer, envoy_nodata, nullptr};
@@ -1278,14 +1275,14 @@ TEST_F(PlatformBridgeFilterTest, StopAndBufferThenResumeOnResponseData) {
     envoy_filter_data_status return_status;
 
     if (invocations->on_response_data_calls == 0) {
-      EXPECT_EQ(to_string(c_data), "A");
+      EXPECT_EQ(Buffer::Utility::copyToString(c_data), "A");
       EXPECT_FALSE(end_stream);
 
       return_status.status = kEnvoyFilterDataStatusStopIterationAndBuffer;
       return_status.data = envoy_nodata;
       return_status.pending_headers = nullptr;
     } else {
-      EXPECT_EQ(to_string(c_data), "AB");
+      EXPECT_EQ(Buffer::Utility::copyToString(c_data), "AB");
       EXPECT_FALSE(end_stream);
       Buffer::OwnedImpl final_buffer = Buffer::OwnedImpl("C");
       envoy_data final_data = Buffer::Utility::toBridgeData(final_buffer);
@@ -1346,8 +1343,8 @@ TEST_F(PlatformBridgeFilterTest, StopOnResponseHeadersThenBufferThenResumeOnData
                                            const void* context) -> envoy_filter_headers_status {
     filter_invocations* invocations = static_cast<filter_invocations*>(const_cast<void*>(context));
     EXPECT_EQ(c_headers.length, 1);
-    EXPECT_EQ(to_string(c_headers.entries[0].key), ":status");
-    EXPECT_EQ(to_string(c_headers.entries[0].value), "test.code");
+    EXPECT_EQ(Buffer::Utility::copyToString(c_headers.entries[0].key), ":status");
+    EXPECT_EQ(Buffer::Utility::copyToString(c_headers.entries[0].value), "test.code");
     EXPECT_FALSE(end_stream);
     invocations->on_response_headers_calls++;
     release_envoy_headers(c_headers);
@@ -1359,14 +1356,14 @@ TEST_F(PlatformBridgeFilterTest, StopOnResponseHeadersThenBufferThenResumeOnData
     envoy_filter_data_status return_status;
 
     if (invocations->on_response_data_calls == 0) {
-      EXPECT_EQ(to_string(c_data), "A");
+      EXPECT_EQ(Buffer::Utility::copyToString(c_data), "A");
       EXPECT_FALSE(end_stream);
 
       return_status.status = kEnvoyFilterDataStatusStopIterationAndBuffer;
       return_status.data = envoy_nodata;
       return_status.pending_headers = nullptr;
     } else {
-      EXPECT_EQ(to_string(c_data), "AB");
+      EXPECT_EQ(Buffer::Utility::copyToString(c_data), "AB");
       EXPECT_TRUE(end_stream);
       Buffer::OwnedImpl final_buffer = Buffer::OwnedImpl("C");
       envoy_data final_data = Buffer::Utility::toBridgeData(final_buffer);
@@ -1442,7 +1439,8 @@ TEST_F(PlatformBridgeFilterTest, StopNoBufferOnResponseData) {
                                         const void* context) -> envoy_filter_data_status {
     filter_invocations* invocations = static_cast<filter_invocations*>(const_cast<void*>(context));
     std::string expected_data[3] = {"A", "B", "C"};
-    EXPECT_EQ(to_string(c_data), expected_data[invocations->on_response_data_calls++]);
+    EXPECT_EQ(Buffer::Utility::copyToString(c_data),
+              expected_data[invocations->on_response_data_calls++]);
     EXPECT_FALSE(end_stream);
     c_data.release(c_data.context);
     return {kEnvoyFilterDataStatusStopIterationNoBuffer, envoy_nodata, nullptr};
@@ -1483,8 +1481,8 @@ TEST_F(PlatformBridgeFilterTest, BasicContinueOnResponseTrailers) {
                                             const void* context) -> envoy_filter_trailers_status {
     filter_invocations* invocations = static_cast<filter_invocations*>(const_cast<void*>(context));
     EXPECT_EQ(c_trailers.length, 1);
-    EXPECT_EQ(to_string(c_trailers.entries[0].key), "x-test-trailer");
-    EXPECT_EQ(to_string(c_trailers.entries[0].value), "test trailer");
+    EXPECT_EQ(Buffer::Utility::copyToString(c_trailers.entries[0].key), "x-test-trailer");
+    EXPECT_EQ(Buffer::Utility::copyToString(c_trailers.entries[0].value), "test trailer");
     invocations->on_response_trailers_calls++;
     return {kEnvoyFilterTrailersStatusContinue, c_trailers, nullptr, nullptr};
   };
@@ -1516,8 +1514,8 @@ TEST_F(PlatformBridgeFilterTest, StopOnResponseHeadersThenBufferThenResumeOnTrai
                                            const void* context) -> envoy_filter_headers_status {
     filter_invocations* invocations = static_cast<filter_invocations*>(const_cast<void*>(context));
     EXPECT_EQ(c_headers.length, 1);
-    EXPECT_EQ(to_string(c_headers.entries[0].key), ":status");
-    EXPECT_EQ(to_string(c_headers.entries[0].value), "test.code");
+    EXPECT_EQ(Buffer::Utility::copyToString(c_headers.entries[0].key), ":status");
+    EXPECT_EQ(Buffer::Utility::copyToString(c_headers.entries[0].value), "test.code");
     EXPECT_FALSE(end_stream);
     invocations->on_response_headers_calls++;
     release_envoy_headers(c_headers);
@@ -1527,7 +1525,8 @@ TEST_F(PlatformBridgeFilterTest, StopOnResponseHeadersThenBufferThenResumeOnTrai
                                         const void* context) -> envoy_filter_data_status {
     filter_invocations* invocations = static_cast<filter_invocations*>(const_cast<void*>(context));
     std::string expected_data[2] = {"A", "AB"};
-    EXPECT_EQ(to_string(c_data), expected_data[invocations->on_response_data_calls]);
+    EXPECT_EQ(Buffer::Utility::copyToString(c_data),
+              expected_data[invocations->on_response_data_calls]);
     EXPECT_FALSE(end_stream);
     c_data.release(c_data.context);
     invocations->on_response_data_calls++;
@@ -1537,8 +1536,8 @@ TEST_F(PlatformBridgeFilterTest, StopOnResponseHeadersThenBufferThenResumeOnTrai
                                             const void* context) -> envoy_filter_trailers_status {
     filter_invocations* invocations = static_cast<filter_invocations*>(const_cast<void*>(context));
     EXPECT_EQ(c_trailers.length, 1);
-    EXPECT_EQ(to_string(c_trailers.entries[0].key), "x-test-trailer");
-    EXPECT_EQ(to_string(c_trailers.entries[0].value), "test trailer");
+    EXPECT_EQ(Buffer::Utility::copyToString(c_trailers.entries[0].key), "x-test-trailer");
+    EXPECT_EQ(Buffer::Utility::copyToString(c_trailers.entries[0].value), "test trailer");
 
     Buffer::OwnedImpl final_buffer = Buffer::OwnedImpl("C");
     envoy_data* modified_data = static_cast<envoy_data*>(safe_malloc(sizeof(envoy_data)));
@@ -1617,8 +1616,8 @@ TEST_F(PlatformBridgeFilterTest, StopOnResponseHeadersThenBufferThenResumeOnResu
                                            const void* context) -> envoy_filter_headers_status {
     filter_invocations* invocations = static_cast<filter_invocations*>(const_cast<void*>(context));
     EXPECT_EQ(c_headers.length, 1);
-    EXPECT_EQ(to_string(c_headers.entries[0].key), ":status");
-    EXPECT_EQ(to_string(c_headers.entries[0].value), "test.code");
+    EXPECT_EQ(Buffer::Utility::copyToString(c_headers.entries[0].key), ":status");
+    EXPECT_EQ(Buffer::Utility::copyToString(c_headers.entries[0].value), "test.code");
     EXPECT_FALSE(end_stream);
     invocations->on_response_headers_calls++;
     release_envoy_headers(c_headers);
@@ -1628,7 +1627,8 @@ TEST_F(PlatformBridgeFilterTest, StopOnResponseHeadersThenBufferThenResumeOnResu
                                         const void* context) -> envoy_filter_data_status {
     filter_invocations* invocations = static_cast<filter_invocations*>(const_cast<void*>(context));
     std::string expected_data[2] = {"A", "AB"};
-    EXPECT_EQ(to_string(c_data), expected_data[invocations->on_response_data_calls]);
+    EXPECT_EQ(Buffer::Utility::copyToString(c_data),
+              expected_data[invocations->on_response_data_calls]);
     EXPECT_FALSE(end_stream);
     c_data.release(c_data.context);
     invocations->on_response_data_calls++;
@@ -1638,8 +1638,8 @@ TEST_F(PlatformBridgeFilterTest, StopOnResponseHeadersThenBufferThenResumeOnResu
                                             const void* context) -> envoy_filter_trailers_status {
     filter_invocations* invocations = static_cast<filter_invocations*>(const_cast<void*>(context));
     EXPECT_EQ(c_trailers.length, 1);
-    EXPECT_EQ(to_string(c_trailers.entries[0].key), "x-test-trailer");
-    EXPECT_EQ(to_string(c_trailers.entries[0].value), "test trailer");
+    EXPECT_EQ(Buffer::Utility::copyToString(c_trailers.entries[0].key), "x-test-trailer");
+    EXPECT_EQ(Buffer::Utility::copyToString(c_trailers.entries[0].value), "test trailer");
     release_envoy_headers(c_trailers);
     invocations->on_response_trailers_calls++;
     return {kEnvoyFilterTrailersStatusStopIteration, envoy_noheaders, nullptr, nullptr};
@@ -1649,12 +1649,12 @@ TEST_F(PlatformBridgeFilterTest, StopOnResponseHeadersThenBufferThenResumeOnResu
                                           const void* context) -> envoy_filter_resume_status {
     filter_invocations* invocations = static_cast<filter_invocations*>(const_cast<void*>(context));
     EXPECT_EQ(pending_headers->length, 1);
-    EXPECT_EQ(to_string(pending_headers->entries[0].key), ":status");
-    EXPECT_EQ(to_string(pending_headers->entries[0].value), "test.code");
-    EXPECT_EQ(to_string(*pending_data), "AB");
+    EXPECT_EQ(Buffer::Utility::copyToString(pending_headers->entries[0].key), ":status");
+    EXPECT_EQ(Buffer::Utility::copyToString(pending_headers->entries[0].value), "test.code");
+    EXPECT_EQ(Buffer::Utility::copyToString(*pending_data), "AB");
     EXPECT_EQ(pending_trailers->length, 1);
-    EXPECT_EQ(to_string(pending_trailers->entries[0].key), "x-test-trailer");
-    EXPECT_EQ(to_string(pending_trailers->entries[0].value), "test trailer");
+    EXPECT_EQ(Buffer::Utility::copyToString(pending_trailers->entries[0].key), "x-test-trailer");
+    EXPECT_EQ(Buffer::Utility::copyToString(pending_trailers->entries[0].value), "test trailer");
     EXPECT_TRUE(end_stream);
 
     envoy_headers* modified_headers =

--- a/test/common/http/BUILD
+++ b/test/common/http/BUILD
@@ -28,7 +28,7 @@ envoy_cc_test(
     srcs = ["header_utility_test.cc"],
     repository = "@envoy",
     deps = [
-        "//library/common/buffer:utility_lib",
+        "//library/common/data:utility_lib",
         "//library/common/http:header_utility_lib",
         "//library/common/types:c_types_lib",
         "@envoy//source/common/buffer:buffer_lib",

--- a/test/common/http/dispatcher_test.cc
+++ b/test/common/http/dispatcher_test.cc
@@ -33,8 +33,9 @@ namespace Http {
 ResponseHeaderMapPtr toResponseHeaders(envoy_headers headers) {
   ResponseHeaderMapPtr transformed_headers = ResponseHeaderMapImpl::create();
   for (envoy_map_size_t i = 0; i < headers.length; i++) {
-    transformed_headers->addCopy(LowerCaseString(Buffer::Utility::copyToString(headers.entries[i].key)),
-                                 Buffer::Utility::copyToString(headers.entries[i].value));
+    transformed_headers->addCopy(
+        LowerCaseString(Buffer::Utility::copyToString(headers.entries[i].key)),
+        Buffer::Utility::copyToString(headers.entries[i].value));
   }
   // The C envoy_headers struct can be released now because the headers have been copied.
   release_envoy_headers(headers);

--- a/test/common/http/dispatcher_test.cc
+++ b/test/common/http/dispatcher_test.cc
@@ -33,8 +33,8 @@ namespace Http {
 ResponseHeaderMapPtr toResponseHeaders(envoy_headers headers) {
   ResponseHeaderMapPtr transformed_headers = ResponseHeaderMapImpl::create();
   for (envoy_map_size_t i = 0; i < headers.length; i++) {
-    transformed_headers->addCopy(LowerCaseString(Utility::convertToString(headers.entries[i].key)),
-                                 Utility::convertToString(headers.entries[i].value));
+    transformed_headers->addCopy(LowerCaseString(Buffer::Utility::copyToString(headers.entries[i].key)),
+                                 Buffer::Utility::copyToString(headers.entries[i].value));
   }
   // The C envoy_headers struct can be released now because the headers have been copied.
   release_envoy_headers(headers);
@@ -443,7 +443,7 @@ TEST_F(DispatcherTest, BasicStreamData) {
   bridge_callbacks.context = &cc;
   bridge_callbacks.on_data = [](envoy_data c_data, bool end_stream, void* context) -> void* {
     EXPECT_TRUE(end_stream);
-    EXPECT_EQ(Http::Utility::convertToString(c_data), "response body");
+    EXPECT_EQ(Buffer::Utility::copyToString(c_data), "response body");
     callbacks_called* cc = static_cast<callbacks_called*>(context);
     cc->on_data_calls++;
     c_data.release(c_data.context);

--- a/test/common/http/dispatcher_test.cc
+++ b/test/common/http/dispatcher_test.cc
@@ -14,7 +14,7 @@
 
 #include "gmock/gmock.h"
 #include "gtest/gtest.h"
-#include "library/common/buffer/utility.h"
+#include "library/common/data/utility.h"
 #include "library/common/http/dispatcher.h"
 #include "library/common/http/header_utility.h"
 #include "library/common/types/c_types.h"
@@ -34,8 +34,8 @@ ResponseHeaderMapPtr toResponseHeaders(envoy_headers headers) {
   ResponseHeaderMapPtr transformed_headers = ResponseHeaderMapImpl::create();
   for (envoy_map_size_t i = 0; i < headers.length; i++) {
     transformed_headers->addCopy(
-        LowerCaseString(Buffer::Utility::copyToString(headers.entries[i].key)),
-        Buffer::Utility::copyToString(headers.entries[i].value));
+        LowerCaseString(Data::Utility::copyToString(headers.entries[i].key)),
+        Data::Utility::copyToString(headers.entries[i].value));
   }
   // The C envoy_headers struct can be released now because the headers have been copied.
   release_envoy_headers(headers);
@@ -444,7 +444,7 @@ TEST_F(DispatcherTest, BasicStreamData) {
   bridge_callbacks.context = &cc;
   bridge_callbacks.on_data = [](envoy_data c_data, bool end_stream, void* context) -> void* {
     EXPECT_TRUE(end_stream);
-    EXPECT_EQ(Buffer::Utility::copyToString(c_data), "response body");
+    EXPECT_EQ(Data::Utility::copyToString(c_data), "response body");
     callbacks_called* cc = static_cast<callbacks_called*>(context);
     cc->on_data_calls++;
     c_data.release(c_data.context);
@@ -458,7 +458,7 @@ TEST_F(DispatcherTest, BasicStreamData) {
 
   // Build body data
   Buffer::OwnedImpl request_data = Buffer::OwnedImpl("request body");
-  envoy_data c_data = Buffer::Utility::toBridgeData(request_data);
+  envoy_data c_data = Data::Utility::toBridgeData(request_data);
 
   // Create a stream.
   Event::PostCb start_stream_post_cb;
@@ -591,11 +591,11 @@ TEST_F(DispatcherTest, MultipleDataStream) {
 
   // Build first body data
   Buffer::OwnedImpl request_data = Buffer::OwnedImpl("request body");
-  envoy_data c_data = Buffer::Utility::toBridgeData(request_data);
+  envoy_data c_data = Data::Utility::toBridgeData(request_data);
 
   // Build second body data
   Buffer::OwnedImpl request_data2 = Buffer::OwnedImpl("request body2");
-  envoy_data c_data2 = Buffer::Utility::toBridgeData(request_data2);
+  envoy_data c_data2 = Data::Utility::toBridgeData(request_data2);
 
   // Create a stream.
   Event::PostCb start_stream_post_cb;

--- a/test/common/http/header_utility_test.cc
+++ b/test/common/http/header_utility_test.cc
@@ -1,7 +1,6 @@
 #include "common/http/header_map_impl.h"
 
 #include "gtest/gtest.h"
-
 #include "library/common/buffer/utility.h"
 #include "library/common/http/header_utility.h"
 #include "library/common/types/c_types.h"
@@ -65,7 +64,8 @@ TEST(RequestHeaderDataConstructorTest, FromCToCpp) {
   ASSERT_EQ(cpp_headers->size(), c_headers_copy.length);
 
   for (envoy_map_size_t i = 0; i < c_headers_copy.length; i++) {
-    auto expected_key = LowerCaseString(Buffer::Utility::copyToString(c_headers_copy.entries[i].key));
+    auto expected_key =
+        LowerCaseString(Buffer::Utility::copyToString(c_headers_copy.entries[i].key));
     auto expected_value = Buffer::Utility::copyToString(c_headers_copy.entries[i].value);
 
     // Key is present.
@@ -106,7 +106,8 @@ TEST(RequestTrailerDataConstructorTest, FromCToCpp) {
   ASSERT_EQ(cpp_trailers->size(), c_trailers_copy.length);
 
   for (envoy_map_size_t i = 0; i < c_trailers_copy.length; i++) {
-    auto expected_key = LowerCaseString(Buffer::Utility::copyToString(c_trailers_copy.entries[i].key));
+    auto expected_key =
+        LowerCaseString(Buffer::Utility::copyToString(c_trailers_copy.entries[i].key));
     auto expected_value = Buffer::Utility::copyToString(c_trailers_copy.entries[i].value);
 
     // Key is present.

--- a/test/common/http/header_utility_test.cc
+++ b/test/common/http/header_utility_test.cc
@@ -1,6 +1,8 @@
 #include "common/http/header_map_impl.h"
 
 #include "gtest/gtest.h"
+
+#include "library/common/buffer/utility.h"
 #include "library/common/http/header_utility.h"
 #include "library/common/types/c_types.h"
 
@@ -63,8 +65,8 @@ TEST(RequestHeaderDataConstructorTest, FromCToCpp) {
   ASSERT_EQ(cpp_headers->size(), c_headers_copy.length);
 
   for (envoy_map_size_t i = 0; i < c_headers_copy.length; i++) {
-    auto expected_key = LowerCaseString(Utility::convertToString(c_headers_copy.entries[i].key));
-    auto expected_value = Utility::convertToString(c_headers_copy.entries[i].value);
+    auto expected_key = LowerCaseString(Buffer::Utility::copyToString(c_headers_copy.entries[i].key));
+    auto expected_value = Buffer::Utility::copyToString(c_headers_copy.entries[i].value);
 
     // Key is present.
     EXPECT_FALSE(cpp_headers->get(expected_key).empty());
@@ -104,8 +106,8 @@ TEST(RequestTrailerDataConstructorTest, FromCToCpp) {
   ASSERT_EQ(cpp_trailers->size(), c_trailers_copy.length);
 
   for (envoy_map_size_t i = 0; i < c_trailers_copy.length; i++) {
-    auto expected_key = LowerCaseString(Utility::convertToString(c_trailers_copy.entries[i].key));
-    auto expected_value = Utility::convertToString(c_trailers_copy.entries[i].value);
+    auto expected_key = LowerCaseString(Buffer::Utility::copyToString(c_trailers_copy.entries[i].key));
+    auto expected_value = Buffer::Utility::copyToString(c_trailers_copy.entries[i].value);
 
     // Key is present.
     EXPECT_FALSE(cpp_trailers->get(expected_key).empty());
@@ -135,8 +137,8 @@ TEST(HeaderDataConstructorTest, FromCppToC) {
   ASSERT_EQ(c_headers.length, static_cast<envoy_map_size_t>(cpp_headers->size()));
 
   for (envoy_map_size_t i = 0; i < c_headers.length; i++) {
-    auto actual_key = LowerCaseString(Utility::convertToString(c_headers.entries[i].key));
-    auto actual_value = Utility::convertToString(c_headers.entries[i].value);
+    auto actual_key = LowerCaseString(Buffer::Utility::copyToString(c_headers.entries[i].key));
+    auto actual_value = Buffer::Utility::copyToString(c_headers.entries[i].value);
 
     // Key is present.
     EXPECT_FALSE(cpp_headers->get(actual_key).empty());

--- a/test/common/http/header_utility_test.cc
+++ b/test/common/http/header_utility_test.cc
@@ -1,7 +1,7 @@
 #include "common/http/header_map_impl.h"
 
 #include "gtest/gtest.h"
-#include "library/common/buffer/utility.h"
+#include "library/common/data/utility.h"
 #include "library/common/http/header_utility.h"
 #include "library/common/types/c_types.h"
 
@@ -64,9 +64,8 @@ TEST(RequestHeaderDataConstructorTest, FromCToCpp) {
   ASSERT_EQ(cpp_headers->size(), c_headers_copy.length);
 
   for (envoy_map_size_t i = 0; i < c_headers_copy.length; i++) {
-    auto expected_key =
-        LowerCaseString(Buffer::Utility::copyToString(c_headers_copy.entries[i].key));
-    auto expected_value = Buffer::Utility::copyToString(c_headers_copy.entries[i].value);
+    auto expected_key = LowerCaseString(Data::Utility::copyToString(c_headers_copy.entries[i].key));
+    auto expected_value = Data::Utility::copyToString(c_headers_copy.entries[i].value);
 
     // Key is present.
     EXPECT_FALSE(cpp_headers->get(expected_key).empty());
@@ -107,8 +106,8 @@ TEST(RequestTrailerDataConstructorTest, FromCToCpp) {
 
   for (envoy_map_size_t i = 0; i < c_trailers_copy.length; i++) {
     auto expected_key =
-        LowerCaseString(Buffer::Utility::copyToString(c_trailers_copy.entries[i].key));
-    auto expected_value = Buffer::Utility::copyToString(c_trailers_copy.entries[i].value);
+        LowerCaseString(Data::Utility::copyToString(c_trailers_copy.entries[i].key));
+    auto expected_value = Data::Utility::copyToString(c_trailers_copy.entries[i].value);
 
     // Key is present.
     EXPECT_FALSE(cpp_trailers->get(expected_key).empty());
@@ -138,8 +137,8 @@ TEST(HeaderDataConstructorTest, FromCppToC) {
   ASSERT_EQ(c_headers.length, static_cast<envoy_map_size_t>(cpp_headers->size()));
 
   for (envoy_map_size_t i = 0; i < c_headers.length; i++) {
-    auto actual_key = LowerCaseString(Buffer::Utility::copyToString(c_headers.entries[i].key));
-    auto actual_value = Buffer::Utility::copyToString(c_headers.entries[i].value);
+    auto actual_key = LowerCaseString(Data::Utility::copyToString(c_headers.entries[i].key));
+    auto actual_value = Data::Utility::copyToString(c_headers.entries[i].value);
 
     // Key is present.
     EXPECT_FALSE(cpp_headers->get(actual_key).empty());

--- a/test/common/integration/dispatcher_integration_test.cc
+++ b/test/common/integration/dispatcher_integration_test.cc
@@ -22,8 +22,8 @@ Http::ResponseHeaderMapPtr toResponseHeaders(envoy_headers headers) {
   Http::ResponseHeaderMapPtr transformed_headers = Http::ResponseHeaderMapImpl::create();
   for (envoy_map_size_t i = 0; i < headers.length; i++) {
     transformed_headers->addCopy(
-        Http::LowerCaseString(Http::Utility::convertToString(headers.entries[i].key)),
-        Http::Utility::convertToString(headers.entries[i].value));
+        Http::LowerCaseString(Buffer::Utility::copyToString(headers.entries[i].key)),
+        Buffer::Utility::copyToString(headers.entries[i].value));
   }
   // The C envoy_headers struct can be released now because the headers have been copied.
   release_envoy_headers(headers);
@@ -141,7 +141,7 @@ TEST_P(DispatcherIntegrationTest, Basic) {
   };
   bridge_callbacks.on_data = [](envoy_data c_data, bool end_stream, void* context) -> void* {
     if (end_stream) {
-      EXPECT_EQ(Http::Utility::convertToString(c_data), "");
+      EXPECT_EQ(Buffer::Utility::copyToString(c_data), "");
     } else {
       EXPECT_EQ(c_data.length, 10);
     }

--- a/test/common/integration/dispatcher_integration_test.cc
+++ b/test/common/integration/dispatcher_integration_test.cc
@@ -7,7 +7,7 @@
 
 #include "gmock/gmock.h"
 #include "gtest/gtest.h"
-#include "library/common/buffer/utility.h"
+#include "library/common/data/utility.h"
 #include "library/common/http/dispatcher.h"
 #include "library/common/http/header_utility.h"
 #include "library/common/types/c_types.h"
@@ -22,8 +22,8 @@ Http::ResponseHeaderMapPtr toResponseHeaders(envoy_headers headers) {
   Http::ResponseHeaderMapPtr transformed_headers = Http::ResponseHeaderMapImpl::create();
   for (envoy_map_size_t i = 0; i < headers.length; i++) {
     transformed_headers->addCopy(
-        Http::LowerCaseString(Buffer::Utility::copyToString(headers.entries[i].key)),
-        Buffer::Utility::copyToString(headers.entries[i].value));
+        Http::LowerCaseString(Data::Utility::copyToString(headers.entries[i].key)),
+        Data::Utility::copyToString(headers.entries[i].value));
   }
   // The C envoy_headers struct can be released now because the headers have been copied.
   release_envoy_headers(headers);
@@ -141,7 +141,7 @@ TEST_P(DispatcherIntegrationTest, Basic) {
   };
   bridge_callbacks.on_data = [](envoy_data c_data, bool end_stream, void* context) -> void* {
     if (end_stream) {
-      EXPECT_EQ(Buffer::Utility::copyToString(c_data), "");
+      EXPECT_EQ(Data::Utility::copyToString(c_data), "");
     } else {
       EXPECT_EQ(c_data.length, 10);
     }
@@ -166,7 +166,7 @@ TEST_P(DispatcherIntegrationTest, Basic) {
   envoy_headers c_headers = Http::Utility::toBridgeHeaders(headers);
 
   // Build body data
-  envoy_data c_data = Buffer::Utility::toBridgeData(request_data);
+  envoy_data c_data = Data::Utility::toBridgeData(request_data);
 
   // Build a set of request trailers.
   // TODO: update the autonomous upstream to assert on trailers, or to send trailers back.

--- a/test/common/main_interface_test.cc
+++ b/test/common/main_interface_test.cc
@@ -36,8 +36,8 @@ Http::ResponseHeaderMapPtr toResponseHeaders(envoy_headers headers) {
   Http::ResponseHeaderMapPtr transformed_headers = Http::ResponseHeaderMapImpl::create();
   for (envoy_map_size_t i = 0; i < headers.length; i++) {
     transformed_headers->addCopy(
-        Http::LowerCaseString(Http::Utility::convertToString(headers.entries[i].key)),
-        Http::Utility::convertToString(headers.entries[i].value));
+        Http::LowerCaseString(Buffer::Utility::copyToString(headers.entries[i].key)),
+        Buffer::Utility::copyToString(headers.entries[i].value));
   }
   // The C envoy_headers struct can be released now because the headers have been copied.
   release_envoy_headers(headers);

--- a/test/common/main_interface_test.cc
+++ b/test/common/main_interface_test.cc
@@ -2,7 +2,7 @@
 
 #include "absl/synchronization/notification.h"
 #include "gtest/gtest.h"
-#include "library/common/buffer/utility.h"
+#include "library/common/data/utility.h"
 #include "library/common/http/header_utility.h"
 #include "library/common/main_interface.h"
 
@@ -36,8 +36,8 @@ Http::ResponseHeaderMapPtr toResponseHeaders(envoy_headers headers) {
   Http::ResponseHeaderMapPtr transformed_headers = Http::ResponseHeaderMapImpl::create();
   for (envoy_map_size_t i = 0; i < headers.length; i++) {
     transformed_headers->addCopy(
-        Http::LowerCaseString(Buffer::Utility::copyToString(headers.entries[i].key)),
-        Buffer::Utility::copyToString(headers.entries[i].value));
+        Http::LowerCaseString(Data::Utility::copyToString(headers.entries[i].key)),
+        Data::Utility::copyToString(headers.entries[i].value));
   }
   // The C envoy_headers struct can be released now because the headers have been copied.
   release_envoy_headers(headers);
@@ -103,7 +103,7 @@ TEST(MainInterfaceTest, BasicStream) {
   envoy_headers c_headers = Http::Utility::toBridgeHeaders(headers);
 
   Buffer::OwnedImpl request_data = Buffer::OwnedImpl("request body");
-  envoy_data c_data = Buffer::Utility::toBridgeData(request_data);
+  envoy_data c_data = Data::Utility::toBridgeData(request_data);
 
   Http::TestRequestTrailerMapImpl trailers;
   envoy_headers c_trailers = Http::Utility::toBridgeHeaders(trailers);
@@ -214,7 +214,7 @@ TEST(MainInterfaceTest, UsingMainInterfaceWithoutARunningEngine) {
   envoy_headers c_headers = Http::Utility::toBridgeHeaders(headers);
 
   Buffer::OwnedImpl request_data = Buffer::OwnedImpl("request body");
-  envoy_data c_data = Buffer::Utility::toBridgeData(request_data);
+  envoy_data c_data = Data::Utility::toBridgeData(request_data);
 
   Http::TestRequestTrailerMapImpl trailers;
   envoy_headers c_trailers = Http::Utility::toBridgeHeaders(trailers);


### PR DESCRIPTION
Description: this PR consolidates all `envoy_data` related utility functions in order to a) keep code consistent b) more easily cover the functionality with fuzzing. It also moves from the `Buffer` namespace to the newly (and more aptly named) `Data` namespace -- credit to @jingwei99.
Risk Level: low - consolidating functionality.
Testing: existing tests pass giving confidence that no functionality has changed, only consolidation.

Signed-off-by: Jose Nino <jnino@lyft.com>