### PR TITLE
jni: Fix JvmStringAccessorContext.getEnvoyString accessor in jni_interface

### DIFF
--- a/library/common/jni/jni_interface.cc
+++ b/library/common/jni/jni_interface.cc
@@ -620,7 +620,7 @@ static envoy_data jvm_get_string(const void* context) {
   JNIEnv* env = get_env();
   jobject j_context = static_cast<jobject>(const_cast<void*>(context));
   jclass jcls_JvmStringAccessorContext = env->GetObjectClass(j_context);
-  jmethodID jmid_getString = env->GetMethodID(jcls_JvmStringAccessorContext, "getString", "()[B");
+  jmethodID jmid_getString = env->GetMethodID(jcls_JvmStringAccessorContext, "getEnvoyString", "()[B");
   jbyteArray j_data = static_cast<jbyteArray>(env->CallObjectMethod(j_context, jmid_getString));
   envoy_data native_data = array_to_native_data(env, j_data);
 

--- a/library/common/jni/jni_interface.cc
+++ b/library/common/jni/jni_interface.cc
@@ -620,7 +620,8 @@ static envoy_data jvm_get_string(const void* context) {
   JNIEnv* env = get_env();
   jobject j_context = static_cast<jobject>(const_cast<void*>(context));
   jclass jcls_JvmStringAccessorContext = env->GetObjectClass(j_context);
-  jmethodID jmid_getString = env->GetMethodID(jcls_JvmStringAccessorContext, "getEnvoyString", "()[B");
+  jmethodID jmid_getString =
+      env->GetMethodID(jcls_JvmStringAccessorContext, "getEnvoyString", "()[B");
   jbyteArray j_data = static_cast<jbyteArray>(env->CallObjectMethod(j_context, jmid_getString));
   envoy_data native_data = array_to_native_data(env, j_data);
 

--- a/library/java/io/envoyproxy/envoymobile/engine/JvmStringAccessorContext.java
+++ b/library/java/io/envoyproxy/envoymobile/engine/JvmStringAccessorContext.java
@@ -8,7 +8,8 @@ class JvmStringAccessorContext {
   public JvmStringAccessorContext(EnvoyStringAccessor accessor) { this.accessor = accessor; }
 
   /**
-   * Invokes getEnvoyString callback.
+   * Invokes getEnvoyString callback. This method signature is used within the jni_interface.cc. Changing
+   * naming of this class or methods will likely require an audit across the jni usages and proguard rules.
    *
    * @return String, the string retrieved from the platform.
    */

--- a/library/java/io/envoyproxy/envoymobile/engine/JvmStringAccessorContext.java
+++ b/library/java/io/envoyproxy/envoymobile/engine/JvmStringAccessorContext.java
@@ -8,8 +8,9 @@ class JvmStringAccessorContext {
   public JvmStringAccessorContext(EnvoyStringAccessor accessor) { this.accessor = accessor; }
 
   /**
-   * Invokes getEnvoyString callback. This method signature is used within the jni_interface.cc. Changing
-   * naming of this class or methods will likely require an audit across the jni usages and proguard rules.
+   * Invokes getEnvoyString callback. This method signature is used within the jni_interface.cc.
+   * Changing naming of this class or methods will likely require an audit across the jni usages
+   * and proguard rules.
    *
    * @return String, the string retrieved from the platform.
    */


### PR DESCRIPTION
Missed rename when we were trying to unify Swift and Kotlin interfaces here: #1301
Signed-off-by: Alan Chiu <achiu@lyft.com>

For an explanation of how to fill out the fields, please see the relevant section
in [PULL_REQUESTS.md](https://github.com/envoyproxy/envoy/blob/master/PULL_REQUESTS.md)

Description: jni: Fix JvmStringAccessorContext.getEnvoyString accessor in jni_interface
Risk Level: low
Testing: local
Docs Changes: n/a
Release Notes: n/a
[Optional Fixes #Issue]
[Optional Deprecated:]
