### PR TITLE
python: add in a headers iterator

### DIFF
--- a/library/cc/headers.cc
+++ b/library/cc/headers.cc
@@ -3,6 +3,14 @@
 namespace Envoy {
 namespace Platform {
 
+Headers::const_iterator Headers::begin() const {
+  return Headers::const_iterator(this->all_headers().begin());
+}
+
+Headers::const_iterator Headers::end() const {
+  return Headers::const_iterator(this->all_headers().end());
+}
+
 const std::vector<std::string>& Headers::operator[](const std::string& key) const {
   return this->headers_.at(key);
 }

--- a/library/cc/headers.h
+++ b/library/cc/headers.h
@@ -12,7 +12,44 @@ using RawHeaderMap = absl::flat_hash_map<std::string, std::vector<std::string>>;
 
 class Headers {
 public:
+  class const_iterator {
+  public:
+    const_iterator(RawHeaderMap::const_iterator position) : position_(position){};
+
+    using iterator_category = RawHeaderMap::const_iterator::iterator_category;
+    using value_type = std::string;
+    using reference = const value_type&;
+    using pointer = const value_type*;
+    using difference_type = std::ptrdiff_t;
+
+    reference operator*() const { return position_->first; }
+    pointer operator->() { return &position_->first; }
+
+    const_iterator& operator++() {
+      this->position_++;
+      return *this;
+    }
+    const_iterator operator++(int) {
+      auto tmp = *this;
+      ++(*this);
+      return tmp;
+    }
+
+    friend bool operator==(const const_iterator& a, const const_iterator& b) {
+      return a.position_ == b.position_;
+    }
+    friend bool operator!=(const const_iterator& a, const const_iterator& b) {
+      return a.position_ != b.position_;
+    }
+
+  private:
+    RawHeaderMap::const_iterator position_;
+  };
+
   virtual ~Headers() {}
+
+  const_iterator begin() const;
+  const_iterator end() const;
 
   const std::vector<std::string>& operator[](const std::string& key) const;
   const RawHeaderMap& all_headers() const;

--- a/library/python/module_definition.cc
+++ b/library/python/module_definition.cc
@@ -80,6 +80,14 @@ PYBIND11_MODULE(envoy_engine, m) {
 
   py::class_<RequestHeaders, RequestHeadersSharedPtr>(m, "RequestHeaders")
       .def("__getitem__", &RequestHeaders::operator[])
+      .def("__len__",
+           [](RequestHeadersSharedPtr request_headers) {
+             return request_headers->all_headers().size();
+           })
+      .def("__iter__",
+           [](RequestHeadersSharedPtr request_headers) {
+             return py::make_iterator(request_headers->begin(), request_headers->end());
+           })
       .def("all_headers", &RequestHeaders::all_headers)
       .def("request_method", &RequestHeaders::request_method)
       .def("scheme", &RequestHeaders::scheme)
@@ -110,6 +118,14 @@ PYBIND11_MODULE(envoy_engine, m) {
 
   py::class_<RequestTrailers, RequestTrailersSharedPtr>(m, "RequestTrailers")
       .def("__getitem__", &RequestTrailers::operator[])
+      .def("__len__",
+           [](RequestTrailersSharedPtr request_trailers) {
+             return request_trailers->all_headers().size();
+           })
+      .def("__iter__",
+           [](RequestTrailersSharedPtr request_trailers) {
+             return py::make_iterator(request_trailers->begin(), request_trailers->end());
+           })
       .def("all_headers", &RequestTrailers::all_headers)
       .def("to_request_trailers_builder", &RequestTrailers::to_request_trailers_builder);
 
@@ -121,6 +137,14 @@ PYBIND11_MODULE(envoy_engine, m) {
 
   py::class_<ResponseHeaders, ResponseHeadersSharedPtr>(m, "ResponseHeaders")
       .def("__getitem__", &ResponseHeaders::operator[])
+      .def("__len__",
+           [](ResponseHeadersSharedPtr response_headers) {
+             return response_headers->all_headers().size();
+           })
+      .def("__iter__",
+           [](ResponseHeadersSharedPtr response_headers) {
+             return py::make_iterator(response_headers->begin(), response_headers->end());
+           })
       .def("all_headers", &ResponseHeaders::all_headers)
       .def("http_status", &ResponseHeaders::http_status)
       .def("to_response_headers_builder", &ResponseHeaders::to_response_headers_builder);
@@ -134,6 +158,14 @@ PYBIND11_MODULE(envoy_engine, m) {
 
   py::class_<ResponseTrailers, ResponseTrailersSharedPtr>(m, "ResponseTrailers")
       .def("__getitem__", &ResponseTrailers::operator[])
+      .def("__len__",
+           [](ResponseTrailersSharedPtr response_trailers) {
+             return response_trailers->all_headers().size();
+           })
+      .def("__iter__",
+           [](ResponseTrailersSharedPtr response_trailers) {
+             return py::make_iterator(response_trailers->begin(), response_trailers->end());
+           })
       .def("all_headers", &ResponseTrailers::all_headers)
       .def("to_response_trailers_builder", &ResponseTrailers::to_response_trailers_builder);
 


### PR DESCRIPTION
Description: Adds an iterator to the `Headers` classes to iterate through headers. Note that this violates C++ design by iterating through the header key, not the header key/value pair. I chose this design because `pybind11` was giving me invalid memory access errors while trying to iterate through pairs. That said, I'm happy to make the key/value -> key downgrade inside of a shim if preferred.

Risk Level: Low

Testing: N/A

Docs Changes: N/A

Release Notes: N/A