### PR TITLE
string accessor: adding client test via c++ filter

### DIFF
--- a/envoy_build_config/BUILD
+++ b/envoy_build_config/BUILD
@@ -29,6 +29,7 @@ envoy_cc_library(
         "@envoy_mobile//library/common/extensions/filters/http/assertion:config",
         "@envoy_mobile//library/common/extensions/filters/http/local_error:config",
         "@envoy_mobile//library/common/extensions/filters/http/platform_bridge:config",
+        "@envoy_mobile//library/common/extensions/filters/http/test_accessor:config",
         "@envoy_mobile//library/common/extensions/stat_sinks/metrics_service:config",
     ],
 )

--- a/envoy_build_config/extension_registry.cc
+++ b/envoy_build_config/extension_registry.cc
@@ -18,6 +18,7 @@
 
 #include "library/common/extensions/filters/http/assertion/config.h"
 #include "library/common/extensions/filters/http/platform_bridge/config.h"
+#include "library/common/extensions/filters/http/test_accessor/config.h"
 
 namespace Envoy {
 
@@ -32,6 +33,7 @@ void ExtensionRegistry::registerFactories() {
   Envoy::Extensions::HttpFilters::LocalError::forceRegisterLocalErrorFilterFactory();
   Envoy::Extensions::HttpFilters::PlatformBridge::forceRegisterPlatformBridgeFilterFactory();
   Envoy::Extensions::HttpFilters::RouterFilter::forceRegisterRouterFilterConfig();
+  Envoy::Extensions::HttpFilters::TestAccessor::forceRegisterTestAccessorFilterFactory();
   Envoy::Extensions::NetworkFilters::HttpConnectionManager::
       forceRegisterHttpConnectionManagerFilterConfigFactory();
   Envoy::Extensions::StatSinks::MetricsService::forceRegisterMetricsServiceSinkFactory();

--- a/envoy_build_config/extension_registry.h
+++ b/envoy_build_config/extension_registry.h
@@ -18,6 +18,7 @@
 #include "library/common/extensions/filters/http/assertion/config.h"
 #include "library/common/extensions/filters/http/local_error/config.h"
 #include "library/common/extensions/filters/http/platform_bridge/config.h"
+#include "library/common/extensions/filters/http/test_accessor/config.h"
 
 namespace Envoy {
 class ExtensionRegistry {

--- a/envoy_build_config/extensions_build_config.bzl
+++ b/envoy_build_config/extensions_build_config.bzl
@@ -9,6 +9,7 @@ EXTENSIONS = {
     "envoy.filters.http.local_error":                 "@envoy_mobile//library/common/extensions/filters/http/local_error:config",
     "envoy.filters.http.platform_bridge":             "@envoy_mobile//library/common/extensions/filters/http/platform_bridge:config",
     "envoy.filters.http.router":                      "//source/extensions/filters/http/router:config",
+    "envoy.filters.http.test_accessor":               "@envoy_mobile//library/common/extensions/filters/http/test_accessor:config",
     "envoy.filters.network.http_connection_manager":  "//source/extensions/filters/network/http_connection_manager:config",
     "envoy.stat_sinks.metrics_service":               "//source/extensions/stat_sinks/metrics_service:config",
     "envoy.transport_sockets.raw_buffer":             "//source/extensions/transport_sockets/raw_buffer:config",

--- a/examples/kotlin/hello_world/MainActivity.kt
+++ b/examples/kotlin/hello_world/MainActivity.kt
@@ -14,6 +14,7 @@ import io.envoyproxy.envoymobile.Engine
 import io.envoyproxy.envoymobile.RequestHeadersBuilder
 import io.envoyproxy.envoymobile.RequestMethod
 import io.envoyproxy.envoymobile.UpstreamHttpProtocol
+import io.envoyproxy.envoymobile.LogLevel
 import io.envoyproxy.envoymobile.shared.Failure
 import io.envoyproxy.envoymobile.shared.ResponseRecyclerViewAdapter
 import io.envoyproxy.envoymobile.shared.Success
@@ -49,8 +50,10 @@ class MainActivity : Activity() {
       .addPlatformFilter { BufferDemoFilter() }
       .addPlatformFilter { AsyncDemoFilter() }
       .addStringAccessor("demo-accessor", { "PlatformString" })
+      .addNativeFilter("envoy.filters.http.test_accessor", "{\"@type\":\"type.googleapis.com/envoymobile.extensions.filters.http.test_accessor.TestAccessor\",\"accessor_name\":\"demo-accessor\",\"expected_string\":\"PlatformString\"}")
       .addNativeFilter("envoy.filters.http.buffer", "{\"@type\":\"type.googleapis.com/envoy.extensions.filters.http.buffer.v3.Buffer\",\"max_request_bytes\":5242880}")
       .setOnEngineRunning { Log.d("MainActivity", "Envoy async internal setup completed") }
+      .addLogLevel(LogLevel.DEBUG)
       .build()
 
     recyclerView = findViewById(R.id.recycler_view) as RecyclerView

--- a/library/common/extensions/filters/http/test_accessor/BUILD
+++ b/library/common/extensions/filters/http/test_accessor/BUILD
@@ -1,0 +1,48 @@
+load(
+    "@envoy//bazel:envoy_build_system.bzl",
+    "envoy_cc_extension",
+    "envoy_extension_package",
+    "envoy_proto_library",
+)
+
+licenses(["notice"])  # Apache 2
+
+envoy_extension_package()
+
+envoy_proto_library(
+    name = "filter",
+    srcs = ["filter.proto"],
+    deps = [
+        "@envoy_api//envoy/config/common/matcher/v3:pkg",
+    ],
+)
+
+envoy_cc_extension(
+    name = "test_accessor_filter_lib",
+    srcs = ["filter.cc"],
+    hdrs = ["filter.h"],
+    category = "envoy.filters.http",
+    repository = "@envoy",
+    security_posture = "robust_to_untrusted_downstream_and_upstream",
+    deps = [
+        "filter_cc_proto",
+        "//library/common/api:c_types",
+        "//library/common/api:external_api_lib",
+        "//library/common/data:utility_lib",
+        "@envoy//source/common/common:assert_lib",
+        "@envoy//source/extensions/filters/http/common:pass_through_filter_lib",
+    ],
+)
+
+envoy_cc_extension(
+    name = "config",
+    srcs = ["config.cc"],
+    hdrs = ["config.h"],
+    category = "envoy.filters.http",
+    repository = "@envoy",
+    security_posture = "robust_to_untrusted_downstream_and_upstream",
+    deps = [
+        ":test_accessor_filter_lib",
+        "@envoy//source/extensions/filters/http/common:factory_base_lib",
+    ],
+)

--- a/library/common/extensions/filters/http/test_accessor/config.cc
+++ b/library/common/extensions/filters/http/test_accessor/config.cc
@@ -1,0 +1,27 @@
+#include "library/common/extensions/filters/http/test_accessor/config.h"
+
+#include "library/common/extensions/filters/http/test_accessor/filter.h"
+
+namespace Envoy {
+namespace Extensions {
+namespace HttpFilters {
+namespace TestAccessor {
+
+Http::FilterFactoryCb TestAccessorFilterFactory::createFilterFactoryFromProtoTyped(
+    const envoymobile::extensions::filters::http::test_accessor::TestAccessor&,
+    const std::string&, Server::Configuration::FactoryContext&) {
+
+  return [](Http::FilterChainFactoryCallbacks& callbacks) -> void {
+    callbacks.addStreamFilter(std::make_shared<TestAccessorFilter>());
+  };
+}
+
+/**
+ * Static registration for the TestAccessor filter. @see NamedHttpFilterConfigFactory.
+ */
+REGISTER_FACTORY(TestAccessorFilterFactory, Server::Configuration::NamedHttpFilterConfigFactory);
+
+} // namespace TestAccessor
+} // namespace HttpFilters
+} // namespace Extensions
+} // namespace Envoy

--- a/library/common/extensions/filters/http/test_accessor/config.cc
+++ b/library/common/extensions/filters/http/test_accessor/config.cc
@@ -8,11 +8,12 @@ namespace HttpFilters {
 namespace TestAccessor {
 
 Http::FilterFactoryCb TestAccessorFilterFactory::createFilterFactoryFromProtoTyped(
-    const envoymobile::extensions::filters::http::test_accessor::TestAccessor&,
+    const envoymobile::extensions::filters::http::test_accessor::TestAccessor& proto_config,
     const std::string&, Server::Configuration::FactoryContext&) {
 
-  return [](Http::FilterChainFactoryCallbacks& callbacks) -> void {
-    callbacks.addStreamFilter(std::make_shared<TestAccessorFilter>());
+  auto config = std::make_shared<TestAccessorFilterConfig>(proto_config);
+  return [config](Http::FilterChainFactoryCallbacks& callbacks) -> void {
+    callbacks.addStreamFilter(std::make_shared<TestAccessorFilter>(config));
   };
 }
 

--- a/library/common/extensions/filters/http/test_accessor/config.h
+++ b/library/common/extensions/filters/http/test_accessor/config.h
@@ -1,0 +1,36 @@
+#pragma once
+
+#include <string>
+
+#include "extensions/filters/http/common/factory_base.h"
+
+#include "library/common/extensions/filters/http/test_accessor/filter.h"
+#include "library/common/extensions/filters/http/test_accessor/filter.pb.h"
+#include "library/common/extensions/filters/http/test_accessor/filter.pb.validate.h"
+
+namespace Envoy {
+namespace Extensions {
+namespace HttpFilters {
+namespace TestAccessor {
+
+/**
+ * Config registration for the TestAccessor filter. @see NamedHttpFilterConfigFactory.
+ */
+class TestAccessorFilterFactory
+    : public Common::FactoryBase<
+          envoymobile::extensions::filters::http::test_accessor::TestAccessor> {
+public:
+  TestAccessorFilterFactory() : FactoryBase("test_accessor") {}
+
+private:
+  Http::FilterFactoryCb createFilterFactoryFromProtoTyped(
+      const envoymobile::extensions::filters::http::test_accessor::TestAccessor& config,
+      const std::string& stats_prefix, Server::Configuration::FactoryContext& context) override;
+};
+
+DECLARE_FACTORY(TestAccessorFilterFactory);
+
+} // namespace TestAccessor
+} // namespace HttpFilters
+} // namespace Extensions
+} // namespace Envoy

--- a/library/common/extensions/filters/http/test_accessor/filter.cc
+++ b/library/common/extensions/filters/http/test_accessor/filter.cc
@@ -1,0 +1,31 @@
+#include "library/common/extensions/filters/http/test_accessor/filter.h"
+
+#include "envoy/server/filter_config.h"
+
+#include "common/common/assert.h"
+
+#include "library/common/data/utility.h"
+
+namespace Envoy {
+namespace Extensions {
+namespace HttpFilters {
+namespace TestAccessor {
+
+// TestAccessorFilterConfig::TestAccessorFilterConfig(
+//     const envoymobile::extensions::filters::http::test_accessor::TestAccessor& proto_config)
+//     : accessor_(static_cast<envoy_string_accessor*>(
+//           Api::External::retrieveApi(proto_config.accessor_name()))),
+//       expected_string_(proto_config.expected_string()) {}
+
+Http::FilterHeadersStatus TestAccessorFilter::decodeHeaders(Http::RequestHeaderMap&, bool) {
+  RELEASE_ASSERT("PlatformString" ==
+                     Data::Utility::copyToString(
+                         accessor_->get_string(accessor_->context)),
+                 "accessed string is not equal to expected string");
+  return Http::FilterHeadersStatus::Continue;
+}
+
+} // namespace TestAccessor
+} // namespace HttpFilters
+} // namespace Extensions
+} // namespace Envoy

--- a/library/common/extensions/filters/http/test_accessor/filter.cc
+++ b/library/common/extensions/filters/http/test_accessor/filter.cc
@@ -11,16 +11,16 @@ namespace Extensions {
 namespace HttpFilters {
 namespace TestAccessor {
 
-// TestAccessorFilterConfig::TestAccessorFilterConfig(
-//     const envoymobile::extensions::filters::http::test_accessor::TestAccessor& proto_config)
-//     : accessor_(static_cast<envoy_string_accessor*>(
-//           Api::External::retrieveApi(proto_config.accessor_name()))),
-//       expected_string_(proto_config.expected_string()) {}
+TestAccessorFilterConfig::TestAccessorFilterConfig(
+    const envoymobile::extensions::filters::http::test_accessor::TestAccessor& proto_config)
+    : accessor_(static_cast<envoy_string_accessor*>(
+          Api::External::retrieveApi(proto_config.accessor_name()))),
+      expected_string_(proto_config.expected_string()) {}
 
 Http::FilterHeadersStatus TestAccessorFilter::decodeHeaders(Http::RequestHeaderMap&, bool) {
-  RELEASE_ASSERT("PlatformString" ==
+  RELEASE_ASSERT(config_->expectedString() ==
                      Data::Utility::copyToString(
-                         accessor_->get_string(accessor_->context)),
+                         config_->accessor()->get_string(config_->accessor()->context)),
                  "accessed string is not equal to expected string");
   return Http::FilterHeadersStatus::Continue;
 }

--- a/library/common/extensions/filters/http/test_accessor/filter.h
+++ b/library/common/extensions/filters/http/test_accessor/filter.h
@@ -5,40 +5,39 @@
 #include "extensions/filters/http/common/pass_through_filter.h"
 
 #include "library/common/api/c_types.h"
-#include "library/common/extensions/filters/http/test_accessor/filter.pb.h"
 #include "library/common/api/external.h"
-
+#include "library/common/extensions/filters/http/test_accessor/filter.pb.h"
 
 namespace Envoy {
 namespace Extensions {
 namespace HttpFilters {
 namespace TestAccessor {
 
-// class TestAccessorFilterConfig {
-// public:
-//   TestAccessorFilterConfig(
-//       const envoymobile::extensions::filters::http::test_accessor::TestAccessor& proto_config);
+class TestAccessorFilterConfig {
+public:
+  TestAccessorFilterConfig(
+      const envoymobile::extensions::filters::http::test_accessor::TestAccessor& proto_config);
 
-//   const envoy_string_accessor* accessor() const { return accessor_; }
-//   const std::string& expectedString() const { return expected_string_; }
+  const envoy_string_accessor* accessor() const { return accessor_; }
+  const std::string& expectedString() const { return expected_string_; }
 
-// private:
-//   const envoy_string_accessor* accessor_;
-//   const std::string expected_string_;
-// };
+private:
+  const envoy_string_accessor* accessor_;
+  const std::string expected_string_;
+};
+
+using TestAccessorFilterConfigSharedPtr = std::shared_ptr<TestAccessorFilterConfig>;
 
 class TestAccessorFilter final : public Http::PassThroughFilter {
 public:
-  TestAccessorFilter(): accessor_(static_cast<envoy_string_accessor*>(
-          Api::External::retrieveApi("demo-accessor"))) {}
+  TestAccessorFilter(std::shared_ptr<TestAccessorFilterConfig> config) : config_(config) {}
 
   // StreamDecoderFilter
   Http::FilterHeadersStatus decodeHeaders(Http::RequestHeaderMap& headers,
                                           bool end_stream) override;
 
 private:
-  // const std::shared_ptr<TestAccessorFilterConfig> config_;
-  const envoy_string_accessor* accessor_;
+  const std::shared_ptr<TestAccessorFilterConfig> config_;
 };
 
 } // namespace TestAccessor

--- a/library/common/extensions/filters/http/test_accessor/filter.h
+++ b/library/common/extensions/filters/http/test_accessor/filter.h
@@ -1,0 +1,47 @@
+#pragma once
+
+#include "envoy/http/filter.h"
+
+#include "extensions/filters/http/common/pass_through_filter.h"
+
+#include "library/common/api/c_types.h"
+#include "library/common/extensions/filters/http/test_accessor/filter.pb.h"
+#include "library/common/api/external.h"
+
+
+namespace Envoy {
+namespace Extensions {
+namespace HttpFilters {
+namespace TestAccessor {
+
+// class TestAccessorFilterConfig {
+// public:
+//   TestAccessorFilterConfig(
+//       const envoymobile::extensions::filters::http::test_accessor::TestAccessor& proto_config);
+
+//   const envoy_string_accessor* accessor() const { return accessor_; }
+//   const std::string& expectedString() const { return expected_string_; }
+
+// private:
+//   const envoy_string_accessor* accessor_;
+//   const std::string expected_string_;
+// };
+
+class TestAccessorFilter final : public Http::PassThroughFilter {
+public:
+  TestAccessorFilter(): accessor_(static_cast<envoy_string_accessor*>(
+          Api::External::retrieveApi("demo-accessor"))) {}
+
+  // StreamDecoderFilter
+  Http::FilterHeadersStatus decodeHeaders(Http::RequestHeaderMap& headers,
+                                          bool end_stream) override;
+
+private:
+  // const std::shared_ptr<TestAccessorFilterConfig> config_;
+  const envoy_string_accessor* accessor_;
+};
+
+} // namespace TestAccessor
+} // namespace HttpFilters
+} // namespace Extensions
+} // namespace Envoy

--- a/library/common/extensions/filters/http/test_accessor/filter.proto
+++ b/library/common/extensions/filters/http/test_accessor/filter.proto
@@ -1,0 +1,10 @@
+syntax = "proto3";
+
+package envoymobile.extensions.filters.http.test_accessor;
+
+import "validate/validate.proto";
+
+message TestAccessor {
+  string accessor_name = 1 [(validate.rules).string.min_len = 1];
+  string expected_string = 2 [(validate.rules).string.min_len = 1];
+}


### PR DESCRIPTION
Description: adds execution of string accessor code path to the swift and kotlin example apps.
Risk Level: low 
Testing: adds new testing via c++ filter.

Fixes #1317 
