### PR TITLE
deps: update boring ssl

### DIFF
--- a/bazel/envoy_mobile_repositories.bzl
+++ b/bazel/envoy_mobile_repositories.bzl
@@ -60,9 +60,9 @@ def upstream_envoy_overrides():
     http_archive(
         name = "boringssl",
         patches = ["@envoy_mobile//bazel:boringssl.patch"],
-        sha256 = "36049e6cd09b353c83878cae0dd84e8b603ba1a40dcd74e44ebad101fc5c672d",
-        strip_prefix = "boringssl-37b57ed537987f1b4c60c60fa1aba20f3a0f6d26",
-        urls = ["https://github.com/google/boringssl/archive/37b57ed537987f1b4c60c60fa1aba20f3a0f6d26.tar.gz"],
+        sha256 = "d78f7b11b8665feea1b6def8e6f235ad8671db8de950f5429f1bf2b3503b3894",
+        strip_prefix = "boringssl-b049eae83d25977661556dcd913b35fbafb3a93a",
+        urls = ["https://github.com/google/boringssl/archive/b049eae83d25977661556dcd913b35fbafb3a93a.tar.gz"],
     )
 
 def swift_repos():


### PR DESCRIPTION
Updating boringssl to be the same version as upstream envoy

Signed-off-by: Alan Chiu <achiu@lyft.com>

For an explanation of how to fill out the fields, please see the relevant section
in [PULL_REQUESTS.md](https://github.com/envoyproxy/envoy/blob/master/PULL_REQUESTS.md)

Description: deps: update boring ssl
Risk Level: low
Testing: ci
Docs Changes: n/a
Release Notes: n/a
[Optional Fixes #Issue]
[Optional Deprecated:]
