### PR TITLE
python: remove dependency on gevent for e2e test

### DIFF
--- a/test/python/integration/test_send_headers.py
+++ b/test/python/integration/test_send_headers.py
@@ -1,34 +1,32 @@
+import threading
 import unittest
 
-from gevent.event import Event
-
 from library.python import envoy_engine
-from library.python.gevent_util import GeventEngineBuilder
 
 
 class TestSendHeaders(unittest.TestCase):
     def test_send_headers(self):
-        engine_running = Event()
+        engine_running = threading.Event()
         engine = (
-            GeventEngineBuilder()
+            envoy_engine.EngineBuilder()
             .add_log_level(envoy_engine.LogLevel.Error)
             .set_on_engine_running(lambda: engine_running.set())
             .build()
         )
         engine_running.wait()
 
-        status = None
-        data = b""
+        response_lock = threading.Lock()
+        response = {"status": None, "data": bytearray()}
 
         def _on_headers(response_headers: envoy_engine.ResponseHeaders, _: bool):
-            nonlocal status
-            status = response_headers.http_status()
+            with response_lock:
+                response["status"] = response_headers.http_status()
 
         def _on_data(response_data: bytes, _: bool):
-            nonlocal data
-            data += response_data
+            with response_lock:
+                response["data"].extend(response_data)
 
-        stream_complete = Event()
+        stream_complete = threading.Event()
         stream = (
             engine
             .stream_client()
@@ -39,8 +37,8 @@ class TestSendHeaders(unittest.TestCase):
             # .set_on_metadata(on_metadata)
             # .set_on_trailers(on_trailers)
             .set_on_complete(lambda: stream_complete.set())
-            .set_on_error(lambda error: stream_complete.set())
-            .set_on_cancel(lambda cancel: stream_complete.set())
+            .set_on_error(lambda _: stream_complete.set())
+            .set_on_cancel(lambda: stream_complete.set())
             .start()
         )
         stream.send_headers(
@@ -55,8 +53,8 @@ class TestSendHeaders(unittest.TestCase):
         )
         stream_complete.wait()
 
-        assert status == 200
-        assert data == b"{}"
+        assert response["status"] == 200
+        assert bytes(response["data"]) == b"{}"
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
**Description:** https://github.com/envoyproxy/envoy-mobile/pull/1314 attempts to make `//test/python/integration:test_send_headers` runnable in CI by defining a Python toolchain + installing pip dependencies as part of the Bazel build. Unfortunately I'm still on the steep part of the Bazel learning curve, aka I can't actually get anything working 🙂 

But then I realized: I don't actually need to install `gevent` to get this working, I just need to stop using `gevent`. This approach also has the advantage of cutting out an unnecessary dependency.

I will still be working on #1314, but unblocks getting coverage on the Python platform + is cleaner, imo.

Risk Level: Low
Testing: This is the test!
Docs Changes: N/A
Release Notes: N/A