### PR TITLE
build: update envoy and disable h3 (for now)

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -25,6 +25,7 @@ build --define cxxopts=-std=c++17
 build --incompatible_objc_compile_info_migration
 # Unset per_object_debug_info. Causes failures on Android Linux release builds.
 build --features=-per_object_debug_info
+build --@envoy//bazel:http3=False
 
 # Default flags for builds targeting iOS
 # Manual stamping is necessary in order to get versioning information in the iOS


### PR DESCRIPTION
Description: Adds new upstream flag for temporarily disabling HTTP/3.
Risk Level: Low
Testing: Local and CI

Signed-off-by: Mike Schore <mike.schore@gmail.com>