### PR TITLE
stats utility: fix memory leak

### DIFF
--- a/library/common/http/header_utility.h
+++ b/library/common/http/header_utility.h
@@ -12,7 +12,8 @@ namespace Utility {
 /**
  * Transform envoy_headers to RequestHeaderMap.
  * This function copies the content.
- * @param headers, the envoy_headers to transform.
+ * @param headers, the envoy_headers to transform. headers is free'd. Use after function return is
+ * unsafe.
  * @return RequestHeaderMapPtr, the RequestHeaderMap 1:1 transformation of the headers param.
  */
 RequestHeaderMapPtr toRequestHeaders(envoy_headers headers);
@@ -20,7 +21,8 @@ RequestHeaderMapPtr toRequestHeaders(envoy_headers headers);
 /**
  * Transform envoy_headers to RequestHeaderMap.
  * This function copies the content.
- * @param trailers, the envoy_headers (trailers) to transform.
+ * @param trailers, the envoy_headers (trailers) to transform. headers is free'd. Use after function
+ * return is unsafe.
  * @return RequestTrailerMapPtr, the RequestTrailerMap 1:1 transformation of the headers param.
  */
 RequestTrailerMapPtr toRequestTrailers(envoy_headers trailers);

--- a/library/common/stats/utility.cc
+++ b/library/common/stats/utility.cc
@@ -17,6 +17,8 @@ Stats::StatNameTagVector transformToStatNameTagVector(envoy_stats_tags tags,
 
     transformed_tags.push_back({stat_name_set->add(key), stat_name_set->add(val)});
   }
+  // The C envoy_stats_tags struct can be released now because the tags have been copied.
+  release_envoy_stats_tags(tags);
   return transformed_tags;
 }
 } // namespace Utility

--- a/library/common/stats/utility.h
+++ b/library/common/stats/utility.h
@@ -12,7 +12,8 @@ namespace Utility {
 /**
  * Transforms from envoy_stats_tags to Stats::StatNameTagVector.
  *
- * @param envoy_stats_tags tags to be transformed.
+ * @param envoy_stats_tags tags to be transformed. tags is free'd. Use after function return is
+ * unsafe.
  * @param stat_name_set the Stats::StatNameSetPtr for the transformed Stats::StatNameTagVector to be
  * kept in.
  * @return Stats::StatNameTagVector within the given stat_name_set.

--- a/library/common/types/c_types.cc
+++ b/library/common/types/c_types.cc
@@ -37,6 +37,8 @@ void release_envoy_data_map(envoy_map map) {
 
 void release_envoy_headers(envoy_headers headers) { release_envoy_data_map(headers); }
 
+void release_envoy_stats_tags(envoy_stats_tags stats_tags) { release_envoy_data_map(stats_tags); }
+
 envoy_map copy_envoy_data_map(envoy_map src) {
   envoy_map_entry* dst_entries =
       static_cast<envoy_map_entry*>(safe_malloc(sizeof(envoy_map_entry) * src.length));

--- a/library/common/types/c_types.h
+++ b/library/common/types/c_types.h
@@ -140,6 +140,12 @@ void* safe_calloc(size_t count, size_t size);
 void release_envoy_headers(envoy_headers headers);
 
 /**
+ * Helper function to free/release memory associated with underlying stats_tags.
+ * @param headers, envoy_stats_tags to release.
+ */
+void release_envoy_stats_tags(envoy_stats_tags stats_tags);
+
+/**
  * Helper function to copy envoy_headers.
  * @param src, the envoy_headers to copy from.
  * @param envoy_headers, copied headers.


### PR DESCRIPTION
Description: https://github.com/envoyproxy/envoy-mobile/pull/1271 introduced envoy_stats_tags and transformation utility into C++. This PR updates the transformation utility to free the c struct after copy inline with existing utility functions.
Risk Level: low - fixes existing memory leak in tests and main_interface
Testing: ASAN ci run.

Signed-off-by: Jose Nino <jnino@lyft.com>