### PR TITLE
testing: jni unit test wip

### DIFF
--- a/bazel/BUILD
+++ b/bazel/BUILD
@@ -5,6 +5,21 @@ licenses(["notice"])  # Apache 2
 
 envoy_package()
 
+alias(
+    name = "darwin",
+    actual = "@bazel_tools//src/conditions:darwin",
+)
+
+alias(
+    name = "darwin_x86_64",
+    actual = "@bazel_tools//src/conditions:darwin_x86_64",
+)
+
+alias(
+    name = "linux_x86_64",
+    actual = "@bazel_tools//src/conditions:linux_x86_64",
+)
+
 kt_jvm_library(
     name = "envoy_mobile_test_suite",
     srcs = [

--- a/bazel/kotlin_test.bzl
+++ b/bazel/kotlin_test.bzl
@@ -29,9 +29,11 @@ def _internal_kt_test(name, srcs, deps = [], data = [], jvm_flags = []):
 # A basic macro to make it easier to declare and run kotlin tests which depend on a JNI lib
 # This will create the native .so binary (for linux) and a .jnilib (for OS X) look up
 def envoy_mobile_jni_kt_test(name, srcs, lib = "", deps = []):
+    jnilib = "{}.jnilib".format(lib)
+    so_file = "{}.so".format(lib)
     # .so file
     native.cc_binary(
-        name = name + "_envoy_jni.so",
+        name = so_file,
         linkshared = 1,
         visibility = ["//visibility:public"],
         deps = [lib],
@@ -39,16 +41,16 @@ def envoy_mobile_jni_kt_test(name, srcs, lib = "", deps = []):
 
     # Generate .jnilib file for OS X look up
     native.genrule(
-        name = name + "_envoy_jni.jnilib",
+        name = jnilib,
         cmd = """
         cp $(location {src}) $@
-        """.format(src = name + "_envoy_jni.so"),
-        outs = ["libenvoy_jni.jnilib"],
-        srcs = [name + "_envoy_jni.so"],
+        """.format(src = so_file),
+        outs = ["lib"+jnilib],
+        srcs = [so_file],
         visibility = ["//visibility:public"],
     )
 
-    _internal_kt_test(name, srcs, deps, data = [name + "_envoy_jni.jnilib"], jvm_flags = ["-Djava.library.path=../.."])
+    _internal_kt_test(name, srcs, deps, data = [jnilib, so_file], jvm_flags = ["-Djava.library.path=../.."])
 
 # A basic macro to make it easier to declare and run kotlin tests
 #

--- a/bazel/kotlin_test.bzl
+++ b/bazel/kotlin_test.bzl
@@ -1,24 +1,6 @@
 load("@io_bazel_rules_kotlin//kotlin:kotlin.bzl", "kt_jvm_test")
 
-# A basic macro to make it easier to declare and run kotlin tests
-#
-# Ergonomic improvements include:
-# 1. Avoiding the need to declare the test_class which requires a fully qualified class name (example below)
-# 2. Avoiding the need to redeclare common unit testing dependencies like JUnit
-# 3. Ability to run more than one test file per target
-# 4. Ability to test internal envoy mobile entities
-#
-# Usage example:
-# load("@envoy_mobile//bazel:kotlin_test.bzl", "envoy_mobile_kt_test)
-#
-# envoy_mobile_kt_test(
-#     name = "example_kotlin_test",
-#     srcs = [
-#         "ExampleTest.kt",
-#     ],
-# )
-#
-def envoy_mobile_kt_test(name, srcs, deps = []):
+def _internal_kt_test(name, srcs, deps = [], data = [], jvm_flags = []):
     # This is to work around the issue where we have specific implementation functionality which
     # we want to avoid consumers to use but we want to unit test
     dep_srcs = []
@@ -40,4 +22,49 @@ def envoy_mobile_kt_test(name, srcs, deps = []):
             "@maven//:org_mockito_mockito_inline",
             "@maven//:org_mockito_mockito_core",
         ] + deps,
+        data = data,
+        jvm_flags = jvm_flags,
     )
+
+# A basic macro to make it easier to declare and run kotlin tests which depend on a JNI lib
+# This will create the native .so binary (for linux) and a .jnilib (for OS X) look up
+def envoy_mobile_jni_kt_test(name, srcs, lib = "", deps = []):
+    # .so file
+    native.cc_binary(
+        name = name + "_envoy_jni.so",
+        linkshared = 1,
+        visibility = ["//visibility:public"],
+        deps = [lib],
+    )
+
+    # Generate .jnilib file for OS X look up
+    native.genrule(
+        name = name + "_envoy_jni.jnilib",
+        cmd = """
+        cp $(location {src}) $@
+        """.format(src = name + "_envoy_jni.so"),
+        outs = ["libenvoy_jni.jnilib"],
+        srcs = [name + "_envoy_jni.so"],
+        visibility = ["//visibility:public"],
+    )
+
+    _internal_kt_test(name, srcs, deps, data = [name + "_envoy_jni.jnilib"], jvm_flags = ["-Djava.library.path=../.."])
+
+# A basic macro to make it easier to declare and run kotlin tests
+#
+# Ergonomic improvements include:
+# 1. Avoiding the need to declare the test_class which requires a fully qualified class name (example below)
+# 2. Avoiding the need to redeclare common unit testing dependencies like JUnit
+# 3. Ability to run more than one test file per target
+# 4. Ability to test internal envoy mobile entities
+# Usage example:
+# load("//bazel:kotlin_test.bzl", "envoy_mobile_kt_test)
+#
+# envoy_mobile_kt_test(
+#     name = "example_kotlin_test",
+#     srcs = [
+#         "ExampleTest.kt",
+#     ],
+# )
+def envoy_mobile_kt_test(name, srcs, deps = []):
+    _internal_kt_test(name, srcs, deps)

--- a/library/common/jni/BUILD
+++ b/library/common/jni/BUILD
@@ -41,3 +41,52 @@ cc_binary(
         "//library/common/api:c_types",
     ],
 )
+
+cc_library(
+    name = "envoy_android_jni_lib",
+    srcs = [
+        "jni_interface.cc",
+    ],
+    hdrs = ["jni_support.h"],
+    copts = ["-std=c++14"],
+    linkopts = [
+        "-lm",
+        "-llog",
+    ],
+    deps = [":envoy_main_interface_lib"],
+)
+
+cc_library(
+    name = "envoy_java_jni_lib",
+    srcs = [
+        "jni_interface.cc",
+        "jni_utility.cc",
+        "jni_version.cc",
+        "@local_jdk//:jni_header",
+    ]
+#    + select({
+#        "//bazel:darwin": ["@local_jdk//:jni_md_header-darwin"],
+#        "//bazel:darwin_x86_64": ["@local_jdk//:jni_md_header-darwin"],
+#        "//bazel:linux_x86_64": ["@local_jdk//:jni_md_header-linux"],
+#    })
+    ,
+    hdrs = [
+        "jni_support.h",
+        "jni_utility.h",
+        "jni_version.h",
+    ],
+    copts = ["-std=c++14"],
+    includes = [
+        "../../../external/local_jdk/include",
+        "../../../external/local_jdk/include/darwin",
+        "../../../external/local_jdk/include/linux",
+    ],
+    linkopts = [
+        "-lm",
+    ],
+    deps = [
+        "//library/common:envoy_main_interface_lib",
+        "//library/common/types:c_types_lib",
+        "@envoy//source/common/common:assert_lib",
+    ],
+)

--- a/library/common/jni/android_support.cc
+++ b/library/common/jni/android_support.cc
@@ -1,0 +1,10 @@
+#include <android/log.h>
+#include <jni.h>
+
+// NOLINT(namespace-envoy)
+
+void jni_log(const char* tag, const char* text) {
+  // FIXME: https://github.com/lyft/envoy-mobile/issues/120
+  // For now, this can be used for debugging purposes on Android
+  //  __android_log_write(ANDROID_LOG_ERROR, tag, text);
+}

--- a/library/common/jni/java_support.cc
+++ b/library/common/jni/java_support.cc
@@ -1,0 +1,12 @@
+#include <jni.h>
+
+// NOLINT(namespace-envoy)
+
+jint platform_setup(JavaVM*, jobject) { return 0; }
+
+void jni_log(const char* tag, const char* text) {
+  // FIXME: https://github.com/lyft/envoy-mobile/issues/120
+}
+void jni_log(const char* tag, const char* text, jobject* arg) {
+  // FIXME: https://github.com/lyft/envoy-mobile/issues/120
+}

--- a/library/common/jni/jni_interface.cc
+++ b/library/common/jni/jni_interface.cc
@@ -1,9 +1,8 @@
-#include <android/log.h>
-#include <ares.h>
 #include <jni.h>
 
 #include <string>
 
+#include "jni_support.h"
 #include "library/common/api/c_types.h"
 #include "library/common/extensions/filters/http/platform_bridge/c_types.h"
 #include "library/common/jni/jni_utility.h"
@@ -32,7 +31,7 @@ extern "C" JNIEXPORT jlong JNICALL Java_io_envoyproxy_envoymobile_engine_JniLibr
 }
 
 static void jvm_on_engine_running(void* context) {
-  __android_log_write(ANDROID_LOG_VERBOSE, "[Envoy]", "jvm_on_engine_running");
+  jni_log("[Envoy]", "jvm_on_engine_running");
 
   JNIEnv* env = get_env();
   jobject j_context = static_cast<jobject>(context);
@@ -48,7 +47,7 @@ static void jvm_on_engine_running(void* context) {
 }
 
 static void jvm_on_exit(void*) {
-  __android_log_write(ANDROID_LOG_INFO, "[Envoy]", "library is exiting");
+  jni_log("[Envoy]", "library is exiting");
   // Note that this is not dispatched because the thread that
   // needs to be detached is the engine thread.
   // This function is called from the context of the engine's
@@ -180,7 +179,7 @@ static void pass_headers(const char* method, envoy_headers headers, jobject j_co
 
 static void* jvm_on_headers(const char* method, envoy_headers headers, bool end_stream,
                             void* context) {
-  __android_log_write(ANDROID_LOG_VERBOSE, "[Envoy]", "jvm_on_headers");
+  jni_log("[Envoy]", "jvm_on_headers");
   JNIEnv* env = get_env();
   jobject j_context = static_cast<jobject>(context);
   pass_headers("passHeader", headers, j_context);
@@ -243,7 +242,7 @@ jvm_http_filter_on_response_headers(envoy_headers headers, bool end_stream, cons
 }
 
 static void* jvm_on_data(const char* method, envoy_data data, bool end_stream, void* context) {
-  __android_log_write(ANDROID_LOG_VERBOSE, "[Envoy]", "jvm_on_data");
+  jni_log("[Envoy]", "jvm_on_data");
   JNIEnv* env = get_env();
   jobject j_context = static_cast<jobject>(context);
 
@@ -325,13 +324,13 @@ static envoy_filter_data_status jvm_http_filter_on_response_data(envoy_data data
 }
 
 static void* jvm_on_metadata(envoy_headers metadata, void* context) {
-  __android_log_write(ANDROID_LOG_VERBOSE, "[Envoy]", "jvm_on_metadata");
-  __android_log_write(ANDROID_LOG_VERBOSE, "[Envoy]", std::to_string(metadata.length).c_str());
+  jni_log("[Envoy]", "jvm_on_metadata");
+  jni_log("[Envoy]", std::to_string(metadata.length).c_str());
   return NULL;
 }
 
 static void* jvm_on_trailers(const char* method, envoy_headers trailers, void* context) {
-  __android_log_write(ANDROID_LOG_VERBOSE, "[Envoy]", "jvm_on_trailers");
+  jni_log("[Envoy]", "jvm_on_trailers");
 
   JNIEnv* env = get_env();
   jobject j_context = static_cast<jobject>(context);
@@ -426,7 +425,7 @@ static envoy_filter_trailers_status jvm_http_filter_on_response_trailers(envoy_h
 static void jvm_http_filter_set_request_callbacks(envoy_http_filter_callbacks callbacks,
                                                   const void* context) {
 
-  __android_log_write(ANDROID_LOG_VERBOSE, "[Envoy]", "jvm_http_filter_set_request_callbacks");
+  jni_log("[Envoy]", "jvm_http_filter_set_request_callbacks");
 
   JNIEnv* env = get_env();
   jobject j_context = static_cast<jobject>(const_cast<void*>(context));
@@ -447,7 +446,7 @@ static void jvm_http_filter_set_request_callbacks(envoy_http_filter_callbacks ca
 static void jvm_http_filter_set_response_callbacks(envoy_http_filter_callbacks callbacks,
                                                    const void* context) {
 
-  __android_log_write(ANDROID_LOG_VERBOSE, "[Envoy]", "jvm_http_filter_set_response_callbacks");
+  jni_log("[Envoy]", "jvm_http_filter_set_response_callbacks");
 
   JNIEnv* env = get_env();
   jobject j_context = static_cast<jobject>(const_cast<void*>(context));
@@ -468,7 +467,7 @@ static void jvm_http_filter_set_response_callbacks(envoy_http_filter_callbacks c
 static envoy_filter_resume_status
 jvm_http_filter_on_resume(const char* method, envoy_headers* headers, envoy_data* data,
                           envoy_headers* trailers, bool end_stream, const void* context) {
-  __android_log_write(ANDROID_LOG_VERBOSE, "[Envoy]", "jvm_on_resume");
+  jni_log("[Envoy]", "jvm_on_resume");
 
   JNIEnv* env = get_env();
   jobject j_context = static_cast<jobject>(const_cast<void*>(context));
@@ -542,7 +541,7 @@ static void* jvm_on_complete(void* context) {
 }
 
 static void* call_jvm_on_error(envoy_error error, void* context) {
-  __android_log_write(ANDROID_LOG_VERBOSE, "[Envoy]", "jvm_on_error");
+  jni_log("[Envoy]", "jvm_on_error");
   JNIEnv* env = get_env();
   jobject j_context = static_cast<jobject>(context);
 
@@ -568,7 +567,7 @@ static void* jvm_on_error(envoy_error error, void* context) {
 }
 
 static void* call_jvm_on_cancel(void* context) {
-  __android_log_write(ANDROID_LOG_VERBOSE, "[Envoy]", "jvm_on_cancel");
+  jni_log("[Envoy]", "jvm_on_cancel");
 
   JNIEnv* env = get_env();
   jobject j_context = static_cast<jobject>(context);
@@ -599,21 +598,21 @@ static void jvm_http_filter_on_cancel(const void* context) {
 // JvmFilterFactoryContext
 
 static const void* jvm_http_filter_init(const void* context) {
-  __android_log_write(ANDROID_LOG_VERBOSE, "[Envoy]", "jvm_filter_init");
+  jni_log("[Envoy]", "jvm_filter_init");
 
   JNIEnv* env = get_env();
 
   envoy_http_filter* c_filter = static_cast<envoy_http_filter*>(const_cast<void*>(context));
   jobject j_context = static_cast<jobject>(const_cast<void*>(c_filter->static_context));
 
-  __android_log_print(ANDROID_LOG_VERBOSE, "[Envoy]", "j_context: %p", j_context);
+  jni_log("[Envoy]", "j_context: %p", j_context);
 
   jclass jcls_JvmFilterFactoryContext = env->GetObjectClass(j_context);
   jmethodID jmid_create = env->GetMethodID(jcls_JvmFilterFactoryContext, "create",
                                            "()Lio/envoyproxy/envoymobile/engine/JvmFilterContext;");
 
   jobject j_filter = env->CallObjectMethod(j_context, jmid_create);
-  __android_log_print(ANDROID_LOG_VERBOSE, "[Envoy]", "j_filter: %p", j_filter);
+  jni_log("[Envoy]", "j_filter: %p", j_filter);
   jobject retained_filter = env->NewGlobalRef(j_filter);
 
   env->DeleteLocalRef(jcls_JvmFilterFactoryContext);
@@ -680,11 +679,11 @@ Java_io_envoyproxy_envoymobile_engine_JniLibrary_registerFilterFactory(JNIEnv* e
 
   // TODO(goaway): Everything here leaks, but it's all be tied to the life of the engine.
   // This will need to be updated for https://github.com/lyft/envoy-mobile/issues/332
-  __android_log_write(ANDROID_LOG_VERBOSE, "[Envoy]", "registerFilterFactory");
-  __android_log_print(ANDROID_LOG_VERBOSE, "[Envoy]", "j_context: %p", j_context);
+  jni_log("[Envoy]", "registerFilterFactory");
+  jni_log("[Envoy]", "j_context: %p", j_context);
   jclass jcls_JvmFilterFactoryContext = env->GetObjectClass(j_context);
   jobject retained_context = env->NewGlobalRef(j_context);
-  __android_log_print(ANDROID_LOG_VERBOSE, "[Envoy]", "retained_context: %p", retained_context);
+  jni_log("[Envoy]", "retained_context: %p", retained_context);
   envoy_http_filter* api = (envoy_http_filter*)safe_malloc(sizeof(envoy_http_filter));
   api->init_filter = jvm_http_filter_init;
   api->on_request_headers = jvm_http_filter_on_request_headers;
@@ -711,7 +710,7 @@ Java_io_envoyproxy_envoymobile_engine_JniLibrary_registerFilterFactory(JNIEnv* e
 extern "C" JNIEXPORT void JNICALL
 Java_io_envoyproxy_envoymobile_engine_EnvoyHTTPFilterCallbacksImpl_callResumeIteration(
     JNIEnv* env, jclass, jlong callback_handle, jobject j_context) {
-  __android_log_write(ANDROID_LOG_VERBOSE, "[Envoy]", "callResumeIteration");
+  jni_log("[Envoy]", "callResumeIteration");
   // Context is only passed here to ensure it's not inadvertently gc'd during execution of this
   // function. To be extra safe, do an explicit retain with a GlobalRef.
   jobject retained_context = env->NewGlobalRef(j_context);
@@ -724,7 +723,7 @@ Java_io_envoyproxy_envoymobile_engine_EnvoyHTTPFilterCallbacksImpl_callResumeIte
 extern "C" JNIEXPORT void JNICALL
 Java_io_envoyproxy_envoymobile_engine_EnvoyHTTPFilterCallbacksImpl_callReleaseCallbacks(
     JNIEnv* env, jclass, jlong callback_handle) {
-  __android_log_write(ANDROID_LOG_VERBOSE, "[Envoy]", "callReleaseCallbacks");
+  jni_log("[Envoy]", "callReleaseCallbacks");
   envoy_http_filter_callbacks* callbacks =
       reinterpret_cast<envoy_http_filter_callbacks*>(callback_handle);
   callbacks->release_callbacks(callbacks->callback_context);
@@ -748,6 +747,9 @@ Java_io_envoyproxy_envoymobile_engine_JniLibrary_sendData__JLjava_nio_ByteBuffer
 // https://docs.oracle.com/javase/7/docs/technotes/guides/jni/spec/design.html
 extern "C" JNIEXPORT jint JNICALL Java_io_envoyproxy_envoymobile_engine_JniLibrary_sendData__J_3BZ(
     JNIEnv* env, jclass, jlong stream_handle, jbyteArray data, jboolean end_stream) {
+  if (end_stream) {
+    jni_log("[Envoy]", "jvm_send_data_end_stream");
+  }
 
   // TODO: check for null pointer in envoy_data.bytes - we could copy or raise an exception.
   return send_data(static_cast<envoy_stream_t>(stream_handle), array_to_native_data(env, data),
@@ -763,7 +765,7 @@ extern "C" JNIEXPORT jint JNICALL Java_io_envoyproxy_envoymobile_engine_JniLibra
 
 extern "C" JNIEXPORT jint JNICALL Java_io_envoyproxy_envoymobile_engine_JniLibrary_sendTrailers(
     JNIEnv* env, jclass, jlong stream_handle, jobjectArray trailers) {
-
+  jni_log("[Envoy]", "jvm_send_trailers");
   return send_trailers(static_cast<envoy_stream_t>(stream_handle),
                        to_native_headers(env, trailers));
 }

--- a/library/common/jni/jni_support.h
+++ b/library/common/jni/jni_support.h
@@ -1,0 +1,9 @@
+#include <jni.h>
+
+// NOLINT(namespace-envoy)
+
+// We initialize c-ares on Android and we no-op for Java
+jint platform_setup(JavaVM* jvm, jobject connectivity_manager);
+
+void jni_log(const char* tag, const char* text);
+void jni_log(const char* tag, const char* text, jobject arg);

--- a/library/common/jni/jni_utility.cc
+++ b/library/common/jni/jni_utility.cc
@@ -25,7 +25,7 @@ JNIEnv* get_env() {
   if (result == JNI_EDETACHED) {
     // Note: the only thread that should need to be attached is Envoy's engine std::thread.
     JavaVMAttachArgs args = {JNI_VERSION, "EnvoyMain", NULL};
-    result = static_jvm->AttachCurrentThread(&local_env, &args);
+    result = static_jvm->AttachCurrentThread(reinterpret_cast<void**>(&local_env), &args);
   }
   // TODO(goaway): add assertions and uncomment
   // ASSERT(result == JNI_OK);

--- a/test/kotlin/io/envoyproxy/envoymobile/integration/BUILD
+++ b/test/kotlin/io/envoyproxy/envoymobile/integration/BUILD
@@ -1,0 +1,14 @@
+load("@envoy_mobile//bazel:kotlin_test.bzl", "envoy_mobile_jni_kt_test")
+
+licenses(["notice"])  # Apache 2
+
+envoy_mobile_jni_kt_test(
+    name = "jni_test",
+    srcs = [
+        "FooTest.kt",
+    ],
+    lib = "//library/common/jni:envoy_java_jni_lib",
+    deps = [
+        "//library/kotlin/io/envoyproxy/envoymobile:envoy_interfaces_lib",
+    ],
+)

--- a/test/kotlin/io/envoyproxy/envoymobile/integration/BUILD
+++ b/test/kotlin/io/envoyproxy/envoymobile/integration/BUILD
@@ -1,14 +1,230 @@
+load("@bazel_skylib//lib:selects.bzl", "selects")
+load("@io_bazel_rules_kotlin//kotlin:kotlin.bzl", "kt_jvm_library")
 load("@envoy_mobile//bazel:kotlin_test.bzl", "envoy_mobile_jni_kt_test")
 
 licenses(["notice"])  # Apache 2
+
+cc_library(
+    name = "copy_jni_hdr_lib",
+    hdrs = [
+        ":copy_link_jni_header",
+        ":copy_link_jni_md_header",
+    ],
+    includes = ["."],
+)
+cc_library(
+    name = "main_lib",
+    srcs = ["Main.cc"],
+    deps = ["copy_jni_hdr_lib"],
+    alwayslink = True,
+)
+
+kt_jvm_library(
+    name = "main_java",
+    srcs = ["Main.kt"],
+)
 
 envoy_mobile_jni_kt_test(
     name = "jni_test",
     srcs = [
         "FooTest.kt",
     ],
-    lib = "//library/common/jni:envoy_java_jni_lib",
+    lib = "main_lib",
     deps = [
-        "//library/kotlin/io/envoyproxy/envoymobile:envoy_interfaces_lib",
+        ":main_java",
     ],
+)
+
+###############
+genrule(
+    name = "copy_link_jni_md_header",
+    srcs = select({
+        "darwin": ["@bazel_tools//tools/jdk:jni_md_header-darwin"],
+        "freebsd": ["@bazel_tools//tools/jdk:jni_md_header-freebsd"],
+        "openbsd": ["@bazel_tools//tools/jdk:jni_md_header-openbsd"],
+        "windows": ["@bazel_tools//tools/jdk:jni_md_header-windows"],
+        "//conditions:default": ["@bazel_tools//tools/jdk:jni_md_header-linux"],
+    }),
+    outs = ["jni_md.h"],
+    cmd = "cp -f $< $@",
+)
+
+genrule(
+    name = "copy_link_jni_header",
+    srcs = ["@bazel_tools//tools/jdk:jni_header"],
+    outs = ["jni.h"],
+    cmd = "cp -f $< $@",
+)
+
+
+config_setting(
+    name = "linux",
+    constraint_values = ["@platforms//os:linux"],
+    visibility = ["//visibility:public"],
+)
+
+config_setting(
+    name = "linux_aarch64",
+    constraint_values = [
+        "@platforms//os:linux",
+        "@platforms//cpu:aarch64",
+    ],
+    visibility = ["//visibility:public"],
+)
+
+config_setting(
+    name = "linux_arm",
+    constraint_values = [
+        "@platforms//os:linux",
+        "@platforms//cpu:arm",
+    ],
+    visibility = ["//visibility:public"],
+)
+
+config_setting(
+    name = "linux_ppc",
+    constraint_values = [
+        "@platforms//os:linux",
+        "@platforms//cpu:ppc",
+    ],
+    visibility = ["//visibility:public"],
+)
+
+config_setting(
+    name = "linux_ppc64le",
+    constraint_values = [
+        "@platforms//os:linux",
+        "@platforms//cpu:ppc",
+    ],
+    visibility = ["//visibility:public"],
+)
+
+config_setting(
+    name = "linux_s390x",
+    constraint_values = [
+        "@platforms//os:linux",
+        "@platforms//cpu:s390x",
+    ],
+    visibility = ["//visibility:public"],
+)
+
+config_setting(
+    name = "linux_mips64",
+    constraint_values = [
+        "@platforms//os:linux",
+        "@platforms//cpu:mips64",
+    ],
+    visibility = ["//visibility:public"],
+)
+
+config_setting(
+    name = "linux_riscv64",
+    constraint_values = [
+        "@platforms//os:linux",
+        "@platforms//cpu:riscv64",
+    ],
+    visibility = ["//visibility:public"],
+)
+
+config_setting(
+    name = "linux_x86_64",
+    constraint_values = [
+        "@platforms//os:linux",
+        "@platforms//cpu:x86_64",
+    ],
+    visibility = ["//visibility:public"],
+)
+
+config_setting(
+    name = "darwin",
+    constraint_values = ["@platforms//os:macos"],
+    visibility = ["//visibility:public"],
+)
+
+config_setting(
+    name = "darwin_x86_64",
+    constraint_values = [
+        "@platforms//os:macos",
+        "@platforms//cpu:x86_64",
+    ],
+    visibility = ["//visibility:public"],
+)
+
+config_setting(
+    name = "darwin_arm64_constraint",
+    constraint_values = [
+        "@platforms//os:macos",
+        "@platforms//cpu:arm64",
+    ],
+)
+
+config_setting(
+    name = "darwin_arm64_flag",
+    values = {"cpu": "darwin_arm64"},
+)
+
+# Workaround for an issue where the dummy cc toolchain isn't being picked up
+# when cross-compile from darwin_x86_64 to darwin_arm64 cpu.
+# TODO(https://github.com/bazelbuild/bazel/issues/12655): Remove the flag based
+# select when the issue is resolved.
+selects.config_setting_group(
+    name = "darwin_arm64",
+    match_any = [
+        ":darwin_arm64_constraint",
+        ":darwin_arm64_flag",
+    ],
+    visibility = ["//visibility:public"],
+)
+
+config_setting(
+    name = "darwin_arm64e",
+    constraint_values = [
+        "@platforms//os:macos",
+        "@platforms//cpu:arm64e",
+    ],
+    visibility = ["//visibility:public"],
+)
+
+config_setting(
+    name = "iphonesdk",
+    values = {"define": "IPHONE_SDK=1"},
+    visibility = ["//visibility:public"],
+)
+
+config_setting(
+    name = "freebsd",
+    constraint_values = ["@platforms//os:freebsd"],
+    visibility = ["//visibility:public"],
+)
+
+config_setting(
+    name = "openbsd",
+    constraint_values = ["@platforms//os:openbsd"],
+    visibility = ["//visibility:public"],
+)
+
+config_setting(
+    name = "windows",
+    constraint_values = ["@platforms//os:windows"],
+    visibility = ["//visibility:public"],
+)
+
+config_setting(
+    name = "arm",
+    constraint_values = ["@platforms//cpu:arm"],
+    visibility = ["//visibility:public"],
+)
+
+config_setting(
+    name = "remote",
+    values = {"define": "EXECUTOR=remote"},
+    visibility = ["//visibility:public"],
+)
+
+config_setting(
+    name = "debian_build",
+    values = {
+        "define": "distribution=debian",
+    },
+    visibility = ["//visibility:public"],
 )

--- a/test/kotlin/io/envoyproxy/envoymobile/integration/FooTest.kt
+++ b/test/kotlin/io/envoyproxy/envoymobile/integration/FooTest.kt
@@ -1,6 +1,6 @@
 package test.kotlin.io.envoyproxy.envoymobile.integration
 
-import io.envoyproxy.envoymobile.EngineBuilder
+import org.assertj.core.api.Assertions.assertThat
 import org.junit.Test
 
 class FooTest {
@@ -8,10 +8,10 @@ class FooTest {
   @Test
   fun tst() {
     println("~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~")
+    println(System.getProperty("user.dir"))
     println(System.getProperty("java.library.path"))
     println("~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~")
 
-    val engine = EngineBuilder().build()
-    engine.streamClient()
+    assertThat(Main().foo()).isEqualTo(42)
   }
 }

--- a/test/kotlin/io/envoyproxy/envoymobile/integration/FooTest.kt
+++ b/test/kotlin/io/envoyproxy/envoymobile/integration/FooTest.kt
@@ -1,0 +1,17 @@
+package test.kotlin.io.envoyproxy.envoymobile.integration
+
+import io.envoyproxy.envoymobile.EngineBuilder
+import org.junit.Test
+
+class FooTest {
+
+  @Test
+  fun tst() {
+    println("~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~")
+    println(System.getProperty("java.library.path"))
+    println("~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~")
+
+    val engine = EngineBuilder().build()
+    engine.streamClient()
+  }
+}

--- a/test/kotlin/io/envoyproxy/envoymobile/integration/Main.kt
+++ b/test/kotlin/io/envoyproxy/envoymobile/integration/Main.kt
@@ -1,0 +1,9 @@
+package test.kotlin.io.envoyproxy.envoymobile.integration
+
+class Main {
+  init {
+    System.loadLibrary("main_lib")
+  }
+
+  external fun foo(): Int
+}

--- a/test/kotlin/io/envoyproxy/envoymobile/integration/main.cc
+++ b/test/kotlin/io/envoyproxy/envoymobile/integration/main.cc
@@ -1,0 +1,6 @@
+#include <jni.h>
+#include <stdio.h>
+
+JNIEXPORT jint JNICALL Java_Main_foo(JNIEnv *, jobject) {
+   return 42;
+}


### PR DESCRIPTION
Signed-off-by: Alan Chiu <achiu@lyft.com>

For an explanation of how to fill out the fields, please see the relevant section
in [PULL_REQUESTS.md](https://github.com/envoyproxy/envoy/blob/master/PULL_REQUESTS.md)

Description:
Risk Level:
Testing:
Docs Changes:
Release Notes:
[Optional Fixes #Issue]
[Optional Deprecated:]

Ran with:
```
bazelisk test --test_output=all //test/kotlin/io/envoyproxy/envoymobile/integration:jni_test
```
Current error:
```
.~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
/private/var/tmp/_bazel_achiu/e95f0937739315919b86dd2afc724e3e/execroot/envoy_mobile/bazel-out/darwin-fastbuild/bin/test/kotlin/io/envoyproxy/envoymobile/integration/jni_test.runfiles/envoy_mobile
../..
~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
E
Time: 0.024
There was 1 failure:
1) tst(test.kotlin.io.envoyproxy.envoymobile.integration.FooTest)
java.lang.UnsatisfiedLinkError: test.kotlin.io.envoyproxy.envoymobile.integration.Main.foo()I
	at test.kotlin.io.envoyproxy.envoymobile.integration.Main.foo(Native Method)
	at test.kotlin.io.envoyproxy.envoymobile.integration.FooTest.tst(FooTest.kt:15)
	at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
	at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
	at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
	at java.lang.reflect.Method.invoke(Method.java:498)
	at org.junit.runners.model.FrameworkMethod$1.runReflectiveCall(FrameworkMethod.java:50)
	at org.junit.internal.runners.model.ReflectiveCallable.run(ReflectiveCallable.java:12)
	at org.junit.runners.model.FrameworkMethod.invokeExplosively(FrameworkMethod.java:47)
	at org.junit.internal.runners.statements.InvokeMethod.evaluate(InvokeMethod.java:17)
	at org.junit.runners.ParentRunner.runLeaf(ParentRunner.java:325)
	at org.junit.runners.BlockJUnit4ClassRunner.runChild(BlockJUnit4ClassRunner.java:78)
	at org.junit.runners.BlockJUnit4ClassRunner.runChild(BlockJUnit4ClassRunner.java:57)
	at org.junit.runners.ParentRunner$3.run(ParentRunner.java:290)
	at org.junit.runners.ParentRunner$1.schedule(ParentRunner.java:71)
	at org.junit.runners.ParentRunner.runChildren(ParentRunner.java:288)
	at org.junit.runners.ParentRunner.access$000(ParentRunner.java:58)
	at org.junit.runners.ParentRunner$2.evaluate(ParentRunner.java:268)
	at org.junit.runners.ParentRunner.run(ParentRunner.java:363)
	at junit.framework.JUnit4TestAdapter.run(JUnit4TestAdapter.java:38)
	at junit.framework.TestSuite.runTest(TestSuite.java:252)
	at junit.framework.TestSuite.run(TestSuite.java:247)
	at org.junit.internal.runners.JUnit38ClassRunner.run(JUnit38ClassRunner.java:86)
	at com.google.testing.junit.runner.internal.junit4.CancellableRequestFactory$CancellableRunner.run(CancellableRequestFactory.java:108)
	at org.junit.runner.JUnitCore.run(JUnitCore.java:137)
	at org.junit.runner.JUnitCore.run(JUnitCore.java:115)
	at com.google.testing.junit.runner.junit4.JUnit4Runner.run(JUnit4Runner.java:116)
	at com.google.testing.junit.runner.BazelTestRunner.runTestsInSuite(BazelTestRunner.java:159)
	at com.google.testing.junit.runner.BazelTestRunner.main(BazelTestRunner.java:85)

FAILURES!!!
Tests run: 1,  Failures: 1


BazelTestRunner exiting with a return value of 1
JVM shutdown hooks (if any) will run now.
The JVM will exit once they complete.

-- JVM shutdown starting at 2021-04-01 02:10:04 --
```
