### PR TITLE
engine: set concurrency to 0

### DIFF
--- a/library/common/engine.cc
+++ b/library/common/engine.cc
@@ -34,9 +34,14 @@ envoy_status_t Engine::run(const std::string config, const std::string log_level
       const std::string log_flag = "-l";
       const std::string concurrency_option = "--concurrency";
       const std::string concurrency_arg = "0";
-      const char* envoy_argv[] = {name.c_str(),     config_flag.c_str(), config.c_str(),
-                                  concurrency_option.c_str(), concurrency_arg.c_str(),
-                                  log_flag.c_str(), log_level.c_str(),   nullptr};
+      const char* envoy_argv[] = {name.c_str(),
+                                  config_flag.c_str(),
+                                  config.c_str(),
+                                  concurrency_option.c_str(),
+                                  concurrency_arg.c_str(),
+                                  log_flag.c_str(),
+                                  log_level.c_str(),
+                                  nullptr};
 
       main_common_ = std::make_unique<MobileMainCommon>(5, envoy_argv);
       event_dispatcher_ = &main_common_->server()->dispatcher();

--- a/library/common/engine.cc
+++ b/library/common/engine.cc
@@ -32,7 +32,10 @@ envoy_status_t Engine::run(const std::string config, const std::string log_level
       const std::string name = "envoy";
       const std::string config_flag = "--config-yaml";
       const std::string log_flag = "-l";
+      const std::string concurrency_option = "--concurrency";
+      const std::string concurrency_arg = "0";
       const char* envoy_argv[] = {name.c_str(),     config_flag.c_str(), config.c_str(),
+                                  concurrency_option.c_str(), concurrency_arg.c_str(),
                                   log_flag.c_str(), log_level.c_str(),   nullptr};
 
       main_common_ = std::make_unique<MobileMainCommon>(5, envoy_argv);


### PR DESCRIPTION
Description: Until now, we've relied upon the implicit behavior that Envoy will start at most one worker without a connection-based listener. This explicitly sets concurrency to 0 to prevent multiple workers from starting.
Risk Level: Moderate
Testing: Local and CI

Signed-off-by: Mike Schore <mike.schore@gmail.com>
