### PR TITLE
ci: cache build artifact across runs

### DIFF
--- a/.github/workflows/android_build.yml
+++ b/.github/workflows/android_build.yml
@@ -21,6 +21,9 @@ jobs:
           key: aar-${{ github.sha }}
           path: dist/envoy.aar
         name: 'Check cache'
+      - run: echo "Found envoy.aar from previous run!"
+        if: steps.check-cache.outputs.cache-hit == 'true'
+        name: 'Build cache hit'
       - uses: actions/setup-java@v1
         if: steps.check-cache.outputs.cache-hit != 'true'
         with:
@@ -33,9 +36,6 @@ jobs:
       - run: bazelisk build --fat_apk_cpu=x86 //:android_dist_ci
         if: steps.check-cache.outputs.cache-hit != 'true'
         name: 'Build envoy.aar distributable'
-      - run: echo "Found envoy.aar from previous run!"
-        if: steps.check-cache.outputs.cache-hit == 'true'
-        name: 'Cache hit'
   javahelloworld:
     name: java_helloworld
     needs: androidbuild
@@ -60,7 +60,7 @@ jobs:
         name: 'Download aar'
       - run: exit 1
         if: steps.check-cache.outputs.cache-hit != 'true'
-        name: 'Failed to locate aar'
+        name: 'Short-circuit'
       #- run: ls -lh dist/
       - name: start simulator
         run: ./ci/mac_start_emulator.sh
@@ -98,7 +98,7 @@ jobs:
         name: 'Download aar'
       - run: exit 1
         if: steps.check-cache.outputs.cache-hit != 'true'
-        name: 'Failed to locate aar'
+        name: 'Short-circuit'
       #- run: ls -lh dist/
       - name: start simulator
         run: ./ci/mac_start_emulator.sh

--- a/.github/workflows/android_build.yml
+++ b/.github/workflows/android_build.yml
@@ -61,7 +61,6 @@ jobs:
       - run: exit 1
         if: steps.check-cache.outputs.cache-hit != 'true'
         name: 'Short-circuit'
-      #- run: ls -lh dist/
       - name: start simulator
         run: ./ci/mac_start_emulator.sh
       # Return to using:
@@ -99,7 +98,6 @@ jobs:
       - run: exit 1
         if: steps.check-cache.outputs.cache-hit != 'true'
         name: 'Short-circuit'
-      #- run: ls -lh dist/
       - name: start simulator
         run: ./ci/mac_start_emulator.sh
       # Return to using:

--- a/.github/workflows/android_build.yml
+++ b/.github/workflows/android_build.yml
@@ -15,19 +15,27 @@ jobs:
       - uses: actions/checkout@v1
         with:
           submodules: true
+      - uses: actions/cache@v2
+        id: check-cache
+        with:
+          key: aar-${{ github.sha }}
+          path: dist/envoy.aar
+        name: 'Check cache'
       - uses: actions/setup-java@v1
+        if: steps.check-cache.outputs.cache-hit != 'true'
         with:
           java-version: '8'
           java-package: jdk
           architecture: x64
       - run: ./ci/mac_ci_setup.sh
+        if: steps.check-cache.outputs.cache-hit != 'true'
         name: 'Install dependencies'
-      - name: 'Build envoy.aar distributable'
-        run: bazelisk build --fat_apk_cpu=x86 //:android_dist_ci
-      - uses: actions/upload-artifact@v2
-        with:
-          name: envoy.aar
-          path: dist/envoy.aar
+      - run: bazelisk build --fat_apk_cpu=x86 //:android_dist_ci
+        if: steps.check-cache.outputs.cache-hit != 'true'
+        name: 'Build envoy.aar distributable'
+      - run: echo "Found envoy.aar from previous run!"
+        if: steps.check-cache.outputs.cache-hit == 'true'
+        name: 'Cache hit'
   javahelloworld:
     name: java_helloworld
     needs: androidbuild
@@ -44,11 +52,16 @@ jobs:
           architecture: x64
       - run: ./ci/mac_ci_setup.sh
         name: 'Install dependencies'
-      - uses: actions/download-artifact@v2
+      - uses: actions/cache@v2
+        id: check-cache
         with:
-          name: envoy.aar
-          path: dist/
-      - run: ls -lh dist/
+          key: aar-${{ github.sha }}
+          path: dist/envoy.aar
+        name: 'Download aar'
+      - run: exit 1
+        if: steps.check-cache.outputs.cache-hit != 'true'
+        name: 'Failed to locate aar'
+      #- run: ls -lh dist/
       - name: start simulator
         run: ./ci/mac_start_emulator.sh
       # Return to using:
@@ -77,11 +90,16 @@ jobs:
           architecture: x64
       - run: ./ci/mac_ci_setup.sh
         name: 'Install dependencies'
-      - uses: actions/download-artifact@v2
+      - uses: actions/cache@v2
+        id: check-cache
         with:
-          name: envoy.aar
-          path: dist/
-      - run: ls -lh dist/
+          key: aar-${{ github.sha }}
+          path: dist/envoy.aar
+        name: 'Download aar'
+      - run: exit 1
+        if: steps.check-cache.outputs.cache-hit != 'true'
+        name: 'Failed to locate aar'
+      #- run: ls -lh dist/
       - name: start simulator
         run: ./ci/mac_start_emulator.sh
       # Return to using:


### PR DESCRIPTION
Description: Updates build job to use cached library artifact when run on the same SHA, allowing retries for connectivity failure or flakiness to run much faster.
Risk Level: Low
Testing: CI

Signed-off-by: Mike Schore <mike.schore@gmail.com>