### PR TITLE
swift: add a couple missing discardable annotations to EngineBuilder

### DIFF
--- a/library/swift/EngineBuilder.swift
+++ b/library/swift/EngineBuilder.swift
@@ -47,6 +47,7 @@ public final class EngineBuilder: NSObject {
   /// - parameter statsDomain: the domain to use.
   ///
   /// - returns: This builder.
+  @discardableResult
   public func addStatsDomain(_ statsDomain: String) -> EngineBuilder {
     self.statsDomain = statsDomain
     return self
@@ -57,6 +58,7 @@ public final class EngineBuilder: NSObject {
   /// - parameter logLevel: The log level to use with Envoy.
   ///
   /// - returns: This builder.
+  @discardableResult
   public func addLogLevel(_ logLevel: LogLevel) -> EngineBuilder {
     self.logLevel = logLevel
     return self


### PR DESCRIPTION
Description: Hit a couple warnings while testing dispatcher; noticed these were missing.
Risk Level: Low
Testing: Local and CI

Signed-off-by: Mike Schore <mike.schore@gmail.com>