### PR TITLE
logging: add LambdaDelegate

### DIFF
--- a/library/common/BUILD
+++ b/library/common/BUILD
@@ -26,7 +26,7 @@ envoy_cc_library(
     repository = "@envoy",
     deps = [
         ":envoy_mobile_main_common_lib",
-        # "//library/common/common:lambda_logger_delegate_lib",
+        "//library/common/common:lambda_logger_delegate_lib",
         "//library/common/data:utility_lib",
         "//library/common/http:dispatcher_lib",
         "//library/common/http:header_utility_lib",

--- a/library/common/common/BUILD
+++ b/library/common/common/BUILD
@@ -1,0 +1,18 @@
+load("@envoy//bazel:envoy_build_system.bzl", "envoy_cc_library", "envoy_package")
+
+licenses(["notice"])  # Apache 2
+
+envoy_package()
+
+envoy_cc_library(
+    name = "lambda_logger_delegate_lib",
+    srcs = ["lambda_logger_delegate.cc"],
+    hdrs = ["lambda_logger_delegate.h"],
+    repository = "@envoy",
+    deps = [
+        "@envoy//source/common/common:lock_guard_lib",
+        "@envoy//source/common/common:macros",
+        "@envoy//source/common/common:minimal_logger_lib",
+        "@envoy//source/common/common:thread_lib",
+    ],
+)

--- a/library/common/common/BUILD
+++ b/library/common/common/BUILD
@@ -10,9 +10,7 @@ envoy_cc_library(
     hdrs = ["lambda_logger_delegate.h"],
     repository = "@envoy",
     deps = [
-        "@envoy//source/common/common:lock_guard_lib",
         "@envoy//source/common/common:macros",
         "@envoy//source/common/common:minimal_logger_lib",
-        "@envoy//source/common/common:thread_lib",
     ],
 )

--- a/library/common/common/BUILD
+++ b/library/common/common/BUILD
@@ -10,6 +10,8 @@ envoy_cc_library(
     hdrs = ["lambda_logger_delegate.h"],
     repository = "@envoy",
     deps = [
+        "//library/common/data:utility_lib",
+        "//library/common/types:c_types_lib",
         "@envoy//source/common/common:macros",
         "@envoy//source/common/common:minimal_logger_lib",
     ],

--- a/library/common/common/lambda_logger_delegate.cc
+++ b/library/common/common/lambda_logger_delegate.cc
@@ -2,8 +2,6 @@
 
 #include <iostream>
 
-#include "common/common/lock_guard.h"
-
 namespace Envoy {
 namespace Logger {
 
@@ -16,12 +14,10 @@ LambdaDelegate::LambdaDelegate(LogCb log_callback, FlushCb flush_callback,
 LambdaDelegate::~LambdaDelegate() { restoreDelegate(); }
 
 void LambdaDelegate::log(absl::string_view msg) {
-  Thread::LockGuard lock(mutex_);
   log_callback_(msg);
 }
 
 void LambdaDelegate::flush() {
-  Thread::LockGuard lock(mutex_);
   flush_callback_();
 }
 

--- a/library/common/common/lambda_logger_delegate.cc
+++ b/library/common/common/lambda_logger_delegate.cc
@@ -13,13 +13,9 @@ LambdaDelegate::LambdaDelegate(LogCb log_callback, FlushCb flush_callback,
 
 LambdaDelegate::~LambdaDelegate() { restoreDelegate(); }
 
-void LambdaDelegate::log(absl::string_view msg) {
-  log_callback_(msg);
-}
+void LambdaDelegate::log(absl::string_view msg) { log_callback_(msg); }
 
-void LambdaDelegate::flush() {
-  flush_callback_();
-}
+void LambdaDelegate::flush() { flush_callback_(); }
 
 } // namespace Logger
 } // namespace Envoy

--- a/library/common/common/lambda_logger_delegate.cc
+++ b/library/common/common/lambda_logger_delegate.cc
@@ -2,17 +2,21 @@
 
 #include <iostream>
 
+#include "library/common/data/utility.h"
+
 namespace Envoy {
 namespace Logger {
 
-LambdaDelegate::LambdaDelegate(LogCb log_callback, DelegatingLogSinkSharedPtr log_sink)
-    : SinkDelegate(log_sink), log_callback_(log_callback) {
+LambdaDelegate::LambdaDelegate(envoy_logger logger, DelegatingLogSinkSharedPtr log_sink)
+    : SinkDelegate(log_sink), logger_(logger) {
   setDelegate();
 }
 
 LambdaDelegate::~LambdaDelegate() { restoreDelegate(); }
 
-void LambdaDelegate::log(absl::string_view msg) { log_callback_(msg); }
+void LambdaDelegate::log(absl::string_view msg) {
+  logger_.log(Data::Utility::copyToBridgeData(msg), logger_.context);
+}
 
 } // namespace Logger
 } // namespace Envoy

--- a/library/common/common/lambda_logger_delegate.cc
+++ b/library/common/common/lambda_logger_delegate.cc
@@ -1,0 +1,29 @@
+#include "library/common/common/lambda_logger_delegate.h"
+
+#include <iostream>
+
+#include "common/common/lock_guard.h"
+
+namespace Envoy {
+namespace Logger {
+
+LambdaDelegate::LambdaDelegate(LogCb log_callback, FlushCb flush_callback,
+                               DelegatingLogSinkSharedPtr log_sink)
+    : SinkDelegate(log_sink), log_callback_(log_callback), flush_callback_(flush_callback) {
+  setDelegate();
+}
+
+LambdaDelegate::~LambdaDelegate() { restoreDelegate(); }
+
+void LambdaDelegate::log(absl::string_view msg) {
+  Thread::LockGuard lock(mutex_);
+  log_callback_(msg);
+}
+
+void LambdaDelegate::flush() {
+  Thread::LockGuard lock(mutex_);
+  flush_callback_();
+}
+
+} // namespace Logger
+} // namespace Envoy

--- a/library/common/common/lambda_logger_delegate.cc
+++ b/library/common/common/lambda_logger_delegate.cc
@@ -5,17 +5,14 @@
 namespace Envoy {
 namespace Logger {
 
-LambdaDelegate::LambdaDelegate(LogCb log_callback, FlushCb flush_callback,
-                               DelegatingLogSinkSharedPtr log_sink)
-    : SinkDelegate(log_sink), log_callback_(log_callback), flush_callback_(flush_callback) {
+LambdaDelegate::LambdaDelegate(LogCb log_callback, DelegatingLogSinkSharedPtr log_sink)
+    : SinkDelegate(log_sink), log_callback_(log_callback) {
   setDelegate();
 }
 
 LambdaDelegate::~LambdaDelegate() { restoreDelegate(); }
 
 void LambdaDelegate::log(absl::string_view msg) { log_callback_(msg); }
-
-void LambdaDelegate::flush() { flush_callback_(); }
 
 } // namespace Logger
 } // namespace Envoy

--- a/library/common/common/lambda_logger_delegate.h
+++ b/library/common/common/lambda_logger_delegate.h
@@ -3,7 +3,6 @@
 #include <string>
 
 #include "common/common/logger.h"
-#include "common/common/thread.h"
 
 #include "absl/strings/string_view.h"
 
@@ -23,9 +22,8 @@ public:
   void flush() override;
 
 private:
-  Thread::MutexBasicLockable mutex_;
-  LogCb log_callback_ ABSL_GUARDED_BY(mutex_);
-  FlushCb flush_callback_ ABSL_GUARDED_BY(mutex_);
+  LogCb log_callback_;
+  FlushCb flush_callback_;
 };
 
 using LambdaDelegatePtr = std::unique_ptr<LambdaDelegate>;

--- a/library/common/common/lambda_logger_delegate.h
+++ b/library/common/common/lambda_logger_delegate.h
@@ -12,18 +12,17 @@ namespace Logger {
 class LambdaDelegate : public SinkDelegate {
 public:
   using LogCb = std::function<void(absl::string_view)>;
-  using FlushCb = std::function<void()>;
 
-  LambdaDelegate(LogCb log_callback, FlushCb flush_callback, DelegatingLogSinkSharedPtr log_sink);
+  LambdaDelegate(LogCb log_callback, DelegatingLogSinkSharedPtr log_sink);
   ~LambdaDelegate() override;
 
   // SinkDelegate
   void log(absl::string_view msg) override;
-  void flush() override;
+  // Currently unexposed. May be desired in the future.
+  void flush() override{};
 
 private:
   LogCb log_callback_;
-  FlushCb flush_callback_;
 };
 
 using LambdaDelegatePtr = std::unique_ptr<LambdaDelegate>;

--- a/library/common/common/lambda_logger_delegate.h
+++ b/library/common/common/lambda_logger_delegate.h
@@ -1,0 +1,34 @@
+#pragma once
+
+#include <string>
+
+#include "common/common/logger.h"
+#include "common/common/thread.h"
+
+#include "absl/strings/string_view.h"
+
+namespace Envoy {
+namespace Logger {
+
+class LambdaDelegate : public SinkDelegate {
+public:
+  using LogCb = std::function<void(absl::string_view)>;
+  using FlushCb = std::function<void()>;
+
+  LambdaDelegate(LogCb log_callback, FlushCb flush_callback, DelegatingLogSinkSharedPtr log_sink);
+  ~LambdaDelegate() override;
+
+  // SinkDelegate
+  void log(absl::string_view msg) override;
+  void flush() override;
+
+private:
+  Thread::MutexBasicLockable mutex_;
+  LogCb log_callback_ ABSL_GUARDED_BY(mutex_);
+  FlushCb flush_callback_ ABSL_GUARDED_BY(mutex_);
+};
+
+using LambdaDelegatePtr = std::unique_ptr<LambdaDelegate>;
+
+} // namespace Logger
+} // namespace Envoy

--- a/library/common/common/lambda_logger_delegate.h
+++ b/library/common/common/lambda_logger_delegate.h
@@ -5,15 +5,14 @@
 #include "common/common/logger.h"
 
 #include "absl/strings/string_view.h"
+#include "library/common/types/c_types.h"
 
 namespace Envoy {
 namespace Logger {
 
 class LambdaDelegate : public SinkDelegate {
 public:
-  using LogCb = std::function<void(absl::string_view)>;
-
-  LambdaDelegate(LogCb log_callback, DelegatingLogSinkSharedPtr log_sink);
+  LambdaDelegate(envoy_logger logger, DelegatingLogSinkSharedPtr log_sink);
   ~LambdaDelegate() override;
 
   // SinkDelegate
@@ -22,7 +21,7 @@ public:
   void flush() override{};
 
 private:
-  LogCb log_callback_;
+  envoy_logger logger_;
 };
 
 using LambdaDelegatePtr = std::unique_ptr<LambdaDelegate>;

--- a/library/common/engine.h
+++ b/library/common/engine.h
@@ -6,8 +6,7 @@
 
 #include "absl/base/call_once.h"
 #include "extension_registry.h"
-
-// #include "library/common/common/lambda_logger_delegate.h"
+#include "library/common/common/lambda_logger_delegate.h"
 #include "library/common/envoy_mobile_main_common.h"
 #include "library/common/http/dispatcher.h"
 #include "library/common/types/c_types.h"
@@ -89,12 +88,12 @@ private:
   Stats::ScopePtr client_scope_;
   Stats::StatNameSetPtr stat_name_set_;
   envoy_engine_callbacks callbacks_;
-  // envoy_logger logger_;
+  envoy_logger logger_;
   Thread::MutexBasicLockable mutex_;
   Thread::CondVar cv_;
   std::unique_ptr<Http::Dispatcher> http_dispatcher_;
   std::unique_ptr<MobileMainCommon> main_common_ GUARDED_BY(mutex_);
-  // Logger::LambdaDelegatePtr lambda_logger_{};
+  Logger::LambdaDelegatePtr lambda_logger_{};
   Server::Instance* server_{};
   Server::ServerLifecycleNotifier::HandlePtr postinit_callback_handler_;
   Event::Dispatcher* event_dispatcher_;

--- a/test/common/common/BUILD
+++ b/test/common/common/BUILD
@@ -10,6 +10,7 @@ envoy_cc_test(
     repository = "@envoy",
     deps = [
         "//library/common/common:lambda_logger_delegate_lib",
+        "//library/common/data:utility_lib",
         "//library/common/types:c_types_lib",
     ],
 )

--- a/test/common/common/BUILD
+++ b/test/common/common/BUILD
@@ -1,0 +1,15 @@
+load("@envoy//bazel:envoy_build_system.bzl", "envoy_cc_test", "envoy_package")
+
+licenses(["notice"])  # Apache 2
+
+envoy_package()
+
+envoy_cc_test(
+    name = "lambda_logger_delegate_test",
+    srcs = ["lambda_logger_delegate_test.cc"],
+    repository = "@envoy",
+    deps = [
+        "//library/common/common:lambda_logger_delegate_lib",
+        "//library/common/types:c_types_lib",
+    ],
+)

--- a/test/common/common/lambda_logger_delegate_test.cc
+++ b/test/common/common/lambda_logger_delegate_test.cc
@@ -1,6 +1,7 @@
 #include "gmock/gmock.h"
 #include "gtest/gtest.h"
 #include "library/common/common/lambda_logger_delegate.h"
+#include "library/common/data/utility.h"
 
 using testing::_;
 using testing::HasSubstr;
@@ -12,8 +13,12 @@ TEST(LambdaDelegate, LogCb) {
   std::string expected_msg = "Hello LambdaDelegate";
   std::string actual_msg;
 
-  LambdaDelegate delegate = LambdaDelegate(
-      [&actual_msg](absl::string_view msg) -> void { actual_msg = msg; }, Registry::getSink());
+  LambdaDelegate delegate = LambdaDelegate({[](envoy_data data, void* context) -> void {
+                                              auto* actual_msg = static_cast<std::string*>(context);
+                                              *actual_msg = Data::Utility::copyToString(data);
+                                            },
+                                            &actual_msg},
+                                           Registry::getSink());
 
   ENVOY_LOG_MISC(error, expected_msg);
   EXPECT_THAT(actual_msg, HasSubstr(expected_msg));

--- a/test/common/common/lambda_logger_delegate_test.cc
+++ b/test/common/common/lambda_logger_delegate_test.cc
@@ -1,0 +1,38 @@
+#include "gmock/gmock.h"
+#include "gtest/gtest.h"
+#include "library/common/common/lambda_logger_delegate.h"
+
+using testing::_;
+using testing::HasSubstr;
+
+namespace Envoy {
+namespace Logger {
+
+TEST(LambdaDelegate, LogCb) {
+  uint i{0};
+  std::string expected_msg = "Hello LambdaDelegate";
+
+  LambdaDelegate delegate = LambdaDelegate(
+      [&i, &expected_msg](absl::string_view msg) -> void {
+        EXPECT_THAT(msg, HasSubstr(expected_msg));
+        i++;
+      },
+      []() -> void {}, Registry::getSink());
+
+  EXPECT_EQ(i, 0U);
+  ENVOY_LOG_MISC(error, expected_msg);
+  EXPECT_EQ(i, 1U);
+}
+
+TEST(LambdaDelegate, FlushCb) {
+  uint i{0};
+  LambdaDelegate delegate = LambdaDelegate([](absl::string_view) -> void {},
+                                           [&i]() -> void { i++; }, Registry::getSink());
+
+  EXPECT_EQ(i, 0U);
+  Registry::getSink()->flush();
+  EXPECT_EQ(i, 1U);
+}
+
+} // namespace Logger
+} // namespace Envoy

--- a/test/common/common/lambda_logger_delegate_test.cc
+++ b/test/common/common/lambda_logger_delegate_test.cc
@@ -9,19 +9,17 @@ namespace Envoy {
 namespace Logger {
 
 TEST(LambdaDelegate, LogCb) {
-  uint i{0};
   std::string expected_msg = "Hello LambdaDelegate";
+  std::string actual_msg;
 
   LambdaDelegate delegate = LambdaDelegate(
-      [&i, &expected_msg](absl::string_view msg) -> void {
-        EXPECT_THAT(msg, HasSubstr(expected_msg));
-        i++;
+      [&actual_msg](absl::string_view msg) -> void {
+        actual_msg = msg;
       },
       []() -> void {}, Registry::getSink());
 
-  EXPECT_EQ(i, 0U);
   ENVOY_LOG_MISC(error, expected_msg);
-  EXPECT_EQ(i, 1U);
+  EXPECT_THAT(actual_msg, HasSubstr(expected_msg));
 }
 
 TEST(LambdaDelegate, FlushCb) {

--- a/test/common/common/lambda_logger_delegate_test.cc
+++ b/test/common/common/lambda_logger_delegate_test.cc
@@ -12,11 +12,9 @@ TEST(LambdaDelegate, LogCb) {
   std::string expected_msg = "Hello LambdaDelegate";
   std::string actual_msg;
 
-  LambdaDelegate delegate = LambdaDelegate(
-      [&actual_msg](absl::string_view msg) -> void {
-        actual_msg = msg;
-      },
-      []() -> void {}, Registry::getSink());
+  LambdaDelegate delegate =
+      LambdaDelegate([&actual_msg](absl::string_view msg) -> void { actual_msg = msg; },
+                     []() -> void {}, Registry::getSink());
 
   ENVOY_LOG_MISC(error, expected_msg);
   EXPECT_THAT(actual_msg, HasSubstr(expected_msg));

--- a/test/common/common/lambda_logger_delegate_test.cc
+++ b/test/common/common/lambda_logger_delegate_test.cc
@@ -16,6 +16,7 @@ TEST(LambdaDelegate, LogCb) {
   LambdaDelegate delegate = LambdaDelegate({[](envoy_data data, void* context) -> void {
                                               auto* actual_msg = static_cast<std::string*>(context);
                                               *actual_msg = Data::Utility::copyToString(data);
+                                              data.release(data.context);
                                             },
                                             &actual_msg},
                                            Registry::getSink());

--- a/test/common/common/lambda_logger_delegate_test.cc
+++ b/test/common/common/lambda_logger_delegate_test.cc
@@ -12,22 +12,11 @@ TEST(LambdaDelegate, LogCb) {
   std::string expected_msg = "Hello LambdaDelegate";
   std::string actual_msg;
 
-  LambdaDelegate delegate =
-      LambdaDelegate([&actual_msg](absl::string_view msg) -> void { actual_msg = msg; },
-                     []() -> void {}, Registry::getSink());
+  LambdaDelegate delegate = LambdaDelegate(
+      [&actual_msg](absl::string_view msg) -> void { actual_msg = msg; }, Registry::getSink());
 
   ENVOY_LOG_MISC(error, expected_msg);
   EXPECT_THAT(actual_msg, HasSubstr(expected_msg));
-}
-
-TEST(LambdaDelegate, FlushCb) {
-  uint i{0};
-  LambdaDelegate delegate = LambdaDelegate([](absl::string_view) -> void {},
-                                           [&i]() -> void { i++; }, Registry::getSink());
-
-  EXPECT_EQ(i, 0U);
-  Registry::getSink()->flush();
-  EXPECT_EQ(i, 1U);
 }
 
 } // namespace Logger

--- a/test/common/main_interface_test.cc
+++ b/test/common/main_interface_test.cc
@@ -406,6 +406,7 @@ TEST(EngineTest, Logger) {
   envoy_logger logger{[](envoy_data data, void* context) -> void {
                         auto* actual_log = static_cast<std::string*>(context);
                         *actual_log = Data::Utility::copyToString(data);
+                        data.release(data.context);
                       },
                       &actual_log};
 

--- a/test/common/main_interface_test.cc
+++ b/test/common/main_interface_test.cc
@@ -1,10 +1,14 @@
 #include "test/common/http/common.h"
 
 #include "absl/synchronization/notification.h"
+#include "gmock/gmock.h"
 #include "gtest/gtest.h"
 #include "library/common/data/utility.h"
 #include "library/common/http/header_utility.h"
 #include "library/common/main_interface.h"
+
+using testing::_;
+using testing::HasSubstr;
 
 namespace Envoy {
 
@@ -380,6 +384,38 @@ TEST(EngineTest, RecordHistogramValue) {
 
   EXPECT_EQ(ENVOY_SUCCESS,
             record_histogram_value(0, "histogram", envoy_stats_notags, 99, MILLISECONDS));
+
+  terminate_engine(0);
+  ASSERT_TRUE(test_context.on_exit.WaitForNotificationWithTimeout(absl::Seconds(3)));
+}
+
+TEST(EngineTest, Logger) {
+  engine_test_context test_context{};
+  envoy_engine_callbacks engine_cbs{[](void* context) -> void {
+                                      auto* engine_running =
+                                          static_cast<engine_test_context*>(context);
+                                      engine_running->on_engine_running.Notify();
+                                    } /*on_engine_running*/,
+                                    [](void* context) -> void {
+                                      auto* exit = static_cast<engine_test_context*>(context);
+                                      exit->on_exit.Notify();
+                                    } /*on_exit*/,
+                                    &test_context /*context*/};
+
+  std::string actual_log;
+  envoy_logger logger{[](envoy_data data, void* context) -> void {
+                        auto* actual_log = static_cast<std::string*>(context);
+                        *actual_log = Data::Utility::copyToString(data);
+                      },
+                      &actual_log};
+
+  run_engine(0, engine_cbs, logger, MINIMAL_NOOP_CONFIG.c_str(), LEVEL_DEBUG.c_str());
+  ASSERT_TRUE(test_context.on_engine_running.WaitForNotificationWithTimeout(absl::Seconds(3)));
+
+  std::string expected_log = "logging!";
+  ENVOY_LOG_MISC(error, expected_log);
+
+  EXPECT_THAT(actual_log, HasSubstr(expected_log));
 
   terminate_engine(0);
   ASSERT_TRUE(test_context.on_exit.WaitForNotificationWithTimeout(absl::Seconds(3)));


### PR DESCRIPTION
Description: adds a new SinkDelegate called LambdaDelegate which uses user-provided callbacks to drive `log` functionality.
Risk Level: low
Testing: new unit tests and integration test in main_interface_test.

Signed-off-by: Jose Nino <jnino@lyft.com>
