### PR TITLE
jni: pipe through terminating engine functionality

### DIFF
--- a/library/common/jni/jni_interface.cc
+++ b/library/common/jni/jni_interface.cc
@@ -24,8 +24,7 @@ JNIEXPORT jint JNICALL JNI_OnLoad(JavaVM* vm, void* reserved) {
 
 // JniLibrary
 
-extern "C" JNIEXPORT jlong JNICALL
-Java_io_envoyproxy_envoymobile_engine_JniLibrary_initEngine(
+extern "C" JNIEXPORT jlong JNICALL Java_io_envoyproxy_envoymobile_engine_JniLibrary_initEngine(
     JNIEnv* env,
     jclass // class
 ) {
@@ -57,8 +56,7 @@ static void jvm_on_exit(void*) {
   jvm_detach_thread();
 }
 
-extern "C" JNIEXPORT jint JNICALL
-Java_io_envoyproxy_envoymobile_engine_JniLibrary_runEngine(
+extern "C" JNIEXPORT jint JNICALL Java_io_envoyproxy_envoymobile_engine_JniLibrary_runEngine(
     JNIEnv* env, jclass, jlong engine, jstring config, jstring jvm_log_level, jobject context) {
   jobject retained_context = env->NewGlobalRef(context); // Required to keep context in memory
   envoy_engine_callbacks native_callbacks = {jvm_on_engine_running, jvm_on_exit, retained_context};
@@ -66,8 +64,7 @@ Java_io_envoyproxy_envoymobile_engine_JniLibrary_runEngine(
                     env->GetStringUTFChars(jvm_log_level, nullptr));
 }
 
-extern "C" JNIEXPORT void JNICALL
-Java_io_envoyproxy_envoymobile_engine_JniLibrary_terminateEngine(
+extern "C" JNIEXPORT void JNICALL Java_io_envoyproxy_envoymobile_engine_JniLibrary_terminateEngine(
     JNIEnv* env, jclass, jlong engine_handle) {
   terminate_engine(static_cast<envoy_engine_t>(engine_handle));
 }
@@ -96,8 +93,7 @@ Java_io_envoyproxy_envoymobile_engine_JniLibrary_nativeFilterTemplateString(JNIE
   return result;
 }
 
-extern "C" JNIEXPORT jint JNICALL
-Java_io_envoyproxy_envoymobile_engine_JniLibrary_recordCounterInc(
+extern "C" JNIEXPORT jint JNICALL Java_io_envoyproxy_envoymobile_engine_JniLibrary_recordCounterInc(
     JNIEnv* env,
     jclass, // class
     jlong engine, jstring elements, jint count) {
@@ -106,8 +102,7 @@ Java_io_envoyproxy_envoymobile_engine_JniLibrary_recordCounterInc(
                             count);
 }
 
-extern "C" JNIEXPORT jint JNICALL
-Java_io_envoyproxy_envoymobile_engine_JniLibrary_recordGaugeSet(
+extern "C" JNIEXPORT jint JNICALL Java_io_envoyproxy_envoymobile_engine_JniLibrary_recordGaugeSet(
     JNIEnv* env,
     jclass, // class
     jlong engine, jstring elements, jint value) {
@@ -115,8 +110,7 @@ Java_io_envoyproxy_envoymobile_engine_JniLibrary_recordGaugeSet(
                           value);
 }
 
-extern "C" JNIEXPORT jint JNICALL
-Java_io_envoyproxy_envoymobile_engine_JniLibrary_recordGaugeAdd(
+extern "C" JNIEXPORT jint JNICALL Java_io_envoyproxy_envoymobile_engine_JniLibrary_recordGaugeAdd(
     JNIEnv* env,
     jclass, // class
     jlong engine, jstring elements, jint amount) {
@@ -124,8 +118,7 @@ Java_io_envoyproxy_envoymobile_engine_JniLibrary_recordGaugeAdd(
                           amount);
 }
 
-extern "C" JNIEXPORT jint JNICALL
-Java_io_envoyproxy_envoymobile_engine_JniLibrary_recordGaugeSub(
+extern "C" JNIEXPORT jint JNICALL Java_io_envoyproxy_envoymobile_engine_JniLibrary_recordGaugeSub(
     JNIEnv* env,
     jclass, // class
     jlong engine, jstring elements, jint amount) {
@@ -653,15 +646,13 @@ static envoy_data jvm_get_string(const void* context) {
 
 // EnvoyHTTPStream
 
-extern "C" JNIEXPORT jlong JNICALL
-Java_io_envoyproxy_envoymobile_engine_JniLibrary_initStream(
+extern "C" JNIEXPORT jlong JNICALL Java_io_envoyproxy_envoymobile_engine_JniLibrary_initStream(
     JNIEnv* env, jclass, jlong engine_handle) {
 
   return init_stream(static_cast<envoy_engine_t>(engine_handle));
 }
 
-extern "C" JNIEXPORT jint JNICALL
-Java_io_envoyproxy_envoymobile_engine_JniLibrary_startStream(
+extern "C" JNIEXPORT jint JNICALL Java_io_envoyproxy_envoymobile_engine_JniLibrary_startStream(
     JNIEnv* env, jclass, jlong stream_handle, jobject j_context) {
 
   jclass jcls_JvmCallbackContext = env->GetObjectClass(j_context);
@@ -760,8 +751,7 @@ Java_io_envoyproxy_envoymobile_engine_JniLibrary_sendData__JLjava_nio_ByteBuffer
 
 // Note: J_3BZ is the mangled signature of the java method.
 // https://docs.oracle.com/javase/7/docs/technotes/guides/jni/spec/design.html
-extern "C" JNIEXPORT jint JNICALL
-_io_envoyproxy_envoymobile_engine_JniLibrary_sendData__J_3BZ(
+extern "C" JNIEXPORT jint JNICALL _io_envoyproxy_envoymobile_engine_JniLibrary_sendData__J_3BZ(
     JNIEnv* env, jclass, jlong stream_handle, jbyteArray data, jboolean end_stream) {
   if (end_stream) {
     jni_log("[Envoy]", "jvm_send_data_end_stream");
@@ -772,24 +762,21 @@ _io_envoyproxy_envoymobile_engine_JniLibrary_sendData__J_3BZ(
                    end_stream);
 }
 
-extern "C" JNIEXPORT jint JNICALL
-Java_io_envoyproxy_envoymobile_engine_JniLibrary_sendHeaders(
+extern "C" JNIEXPORT jint JNICALL Java_io_envoyproxy_envoymobile_engine_JniLibrary_sendHeaders(
     JNIEnv* env, jclass, jlong stream_handle, jobjectArray headers, jboolean end_stream) {
 
   return send_headers(static_cast<envoy_stream_t>(stream_handle), to_native_headers(env, headers),
                       end_stream);
 }
 
-extern "C" JNIEXPORT jint JNICALL
-Java_io_envoyproxy_envoymobile_engine_JniLibrary_sendTrailers(
+extern "C" JNIEXPORT jint JNICALL Java_io_envoyproxy_envoymobile_engine_JniLibrary_sendTrailers(
     JNIEnv* env, jclass, jlong stream_handle, jobjectArray trailers) {
   jni_log("[Envoy]", "jvm_send_trailers");
   return send_trailers(static_cast<envoy_stream_t>(stream_handle),
                        to_native_headers(env, trailers));
 }
 
-extern "C" JNIEXPORT jint JNICALL
-Java_io_envoyproxy_envoymobile_engine_JniLibrary_resetStream(
+extern "C" JNIEXPORT jint JNICALL Java_io_envoyproxy_envoymobile_engine_JniLibrary_resetStream(
     JNIEnv* env, jclass, jlong stream_handle) {
 
   return reset_stream(static_cast<envoy_stream_t>(stream_handle));

--- a/library/common/jni/jni_interface.cc
+++ b/library/common/jni/jni_interface.cc
@@ -24,7 +24,8 @@ JNIEXPORT jint JNICALL JNI_OnLoad(JavaVM* vm, void* reserved) {
 
 // JniLibrary
 
-extern "C" JNIEXPORT jlong JNICALL Java_io_envoyproxy_envoymobile_engine_JniLibrary_initEngine(
+extern "C" JNIEXPORT jlong JNICALL
+Java_io_envoyproxy_envoymobile_engine_JniLibrary_initEngine(
     JNIEnv* env,
     jclass // class
 ) {
@@ -56,12 +57,19 @@ static void jvm_on_exit(void*) {
   jvm_detach_thread();
 }
 
-extern "C" JNIEXPORT jint JNICALL Java_io_envoyproxy_envoymobile_engine_JniLibrary_runEngine(
+extern "C" JNIEXPORT jint JNICALL
+Java_io_envoyproxy_envoymobile_engine_JniLibrary_runEngine(
     JNIEnv* env, jclass, jlong engine, jstring config, jstring jvm_log_level, jobject context) {
   jobject retained_context = env->NewGlobalRef(context); // Required to keep context in memory
   envoy_engine_callbacks native_callbacks = {jvm_on_engine_running, jvm_on_exit, retained_context};
   return run_engine(engine, native_callbacks, env->GetStringUTFChars(config, nullptr),
                     env->GetStringUTFChars(jvm_log_level, nullptr));
+}
+
+extern "C" JNIEXPORT void JNICALL
+Java_io_envoyproxy_envoymobile_engine_JniLibrary_terminateEngine(
+    JNIEnv* env, jclass, jlong engine_handle) {
+  terminate_engine(static_cast<envoy_engine_t>(engine_handle));
 }
 
 extern "C" JNIEXPORT jstring JNICALL
@@ -88,7 +96,8 @@ Java_io_envoyproxy_envoymobile_engine_JniLibrary_nativeFilterTemplateString(JNIE
   return result;
 }
 
-extern "C" JNIEXPORT jint JNICALL Java_io_envoyproxy_envoymobile_engine_JniLibrary_recordCounterInc(
+extern "C" JNIEXPORT jint JNICALL
+Java_io_envoyproxy_envoymobile_engine_JniLibrary_recordCounterInc(
     JNIEnv* env,
     jclass, // class
     jlong engine, jstring elements, jint count) {
@@ -97,7 +106,8 @@ extern "C" JNIEXPORT jint JNICALL Java_io_envoyproxy_envoymobile_engine_JniLibra
                             count);
 }
 
-extern "C" JNIEXPORT jint JNICALL Java_io_envoyproxy_envoymobile_engine_JniLibrary_recordGaugeSet(
+extern "C" JNIEXPORT jint JNICALL
+Java_io_envoyproxy_envoymobile_engine_JniLibrary_recordGaugeSet(
     JNIEnv* env,
     jclass, // class
     jlong engine, jstring elements, jint value) {
@@ -105,7 +115,8 @@ extern "C" JNIEXPORT jint JNICALL Java_io_envoyproxy_envoymobile_engine_JniLibra
                           value);
 }
 
-extern "C" JNIEXPORT jint JNICALL Java_io_envoyproxy_envoymobile_engine_JniLibrary_recordGaugeAdd(
+extern "C" JNIEXPORT jint JNICALL
+Java_io_envoyproxy_envoymobile_engine_JniLibrary_recordGaugeAdd(
     JNIEnv* env,
     jclass, // class
     jlong engine, jstring elements, jint amount) {
@@ -113,7 +124,8 @@ extern "C" JNIEXPORT jint JNICALL Java_io_envoyproxy_envoymobile_engine_JniLibra
                           amount);
 }
 
-extern "C" JNIEXPORT jint JNICALL Java_io_envoyproxy_envoymobile_engine_JniLibrary_recordGaugeSub(
+extern "C" JNIEXPORT jint JNICALL
+Java_io_envoyproxy_envoymobile_engine_JniLibrary_recordGaugeSub(
     JNIEnv* env,
     jclass, // class
     jlong engine, jstring elements, jint amount) {
@@ -641,13 +653,15 @@ static envoy_data jvm_get_string(const void* context) {
 
 // EnvoyHTTPStream
 
-extern "C" JNIEXPORT jlong JNICALL Java_io_envoyproxy_envoymobile_engine_JniLibrary_initStream(
+extern "C" JNIEXPORT jlong JNICALL
+Java_io_envoyproxy_envoymobile_engine_JniLibrary_initStream(
     JNIEnv* env, jclass, jlong engine_handle) {
 
   return init_stream(static_cast<envoy_engine_t>(engine_handle));
 }
 
-extern "C" JNIEXPORT jint JNICALL Java_io_envoyproxy_envoymobile_engine_JniLibrary_startStream(
+extern "C" JNIEXPORT jint JNICALL
+Java_io_envoyproxy_envoymobile_engine_JniLibrary_startStream(
     JNIEnv* env, jclass, jlong stream_handle, jobject j_context) {
 
   jclass jcls_JvmCallbackContext = env->GetObjectClass(j_context);
@@ -746,7 +760,8 @@ Java_io_envoyproxy_envoymobile_engine_JniLibrary_sendData__JLjava_nio_ByteBuffer
 
 // Note: J_3BZ is the mangled signature of the java method.
 // https://docs.oracle.com/javase/7/docs/technotes/guides/jni/spec/design.html
-extern "C" JNIEXPORT jint JNICALL Java_io_envoyproxy_envoymobile_engine_JniLibrary_sendData__J_3BZ(
+extern "C" JNIEXPORT jint JNICALL
+_io_envoyproxy_envoymobile_engine_JniLibrary_sendData__J_3BZ(
     JNIEnv* env, jclass, jlong stream_handle, jbyteArray data, jboolean end_stream) {
   if (end_stream) {
     jni_log("[Envoy]", "jvm_send_data_end_stream");
@@ -757,21 +772,24 @@ extern "C" JNIEXPORT jint JNICALL Java_io_envoyproxy_envoymobile_engine_JniLibra
                    end_stream);
 }
 
-extern "C" JNIEXPORT jint JNICALL Java_io_envoyproxy_envoymobile_engine_JniLibrary_sendHeaders(
+extern "C" JNIEXPORT jint JNICALL
+Java_io_envoyproxy_envoymobile_engine_JniLibrary_sendHeaders(
     JNIEnv* env, jclass, jlong stream_handle, jobjectArray headers, jboolean end_stream) {
 
   return send_headers(static_cast<envoy_stream_t>(stream_handle), to_native_headers(env, headers),
                       end_stream);
 }
 
-extern "C" JNIEXPORT jint JNICALL Java_io_envoyproxy_envoymobile_engine_JniLibrary_sendTrailers(
+extern "C" JNIEXPORT jint JNICALL
+Java_io_envoyproxy_envoymobile_engine_JniLibrary_sendTrailers(
     JNIEnv* env, jclass, jlong stream_handle, jobjectArray trailers) {
   jni_log("[Envoy]", "jvm_send_trailers");
   return send_trailers(static_cast<envoy_stream_t>(stream_handle),
                        to_native_headers(env, trailers));
 }
 
-extern "C" JNIEXPORT jint JNICALL Java_io_envoyproxy_envoymobile_engine_JniLibrary_resetStream(
+extern "C" JNIEXPORT jint JNICALL
+Java_io_envoyproxy_envoymobile_engine_JniLibrary_resetStream(
     JNIEnv* env, jclass, jlong stream_handle) {
 
   return reset_stream(static_cast<envoy_stream_t>(stream_handle));

--- a/library/common/jni/jni_interface.cc
+++ b/library/common/jni/jni_interface.cc
@@ -751,7 +751,7 @@ Java_io_envoyproxy_envoymobile_engine_JniLibrary_sendData__JLjava_nio_ByteBuffer
 
 // Note: J_3BZ is the mangled signature of the java method.
 // https://docs.oracle.com/javase/7/docs/technotes/guides/jni/spec/design.html
-extern "C" JNIEXPORT jint JNICALL _io_envoyproxy_envoymobile_engine_JniLibrary_sendData__J_3BZ(
+extern "C" JNIEXPORT jint JNICALL Java_io_envoyproxy_envoymobile_engine_JniLibrary_sendData__J_3BZ(
     JNIEnv* env, jclass, jlong stream_handle, jbyteArray data, jboolean end_stream) {
   if (end_stream) {
     jni_log("[Envoy]", "jvm_send_data_end_stream");

--- a/library/java/io/envoyproxy/envoymobile/engine/AndroidEngineImpl.java
+++ b/library/java/io/envoyproxy/envoymobile/engine/AndroidEngineImpl.java
@@ -23,6 +23,11 @@ public class AndroidEngineImpl implements EnvoyEngine {
   }
 
   @Override
+  public void terminate() {
+    envoyEngine.terminate();
+  }
+
+  @Override
   public int runWithConfig(String configurationYAML, String logLevel,
                            EnvoyOnEngineRunning onEngineRunning) {
     // re-enable lifecycle-based stat flushing when https://github.com/lyft/envoy-mobile/issues/748

--- a/library/java/io/envoyproxy/envoymobile/engine/EnvoyEngine.java
+++ b/library/java/io/envoyproxy/envoymobile/engine/EnvoyEngine.java
@@ -15,7 +15,7 @@ public interface EnvoyEngine {
   EnvoyHTTPStream startStream(EnvoyHTTPCallbacks callbacks);
 
   /**
-   * Terminates the current engine.
+   * Terminates the running engine.
    */
   void terminate();
 

--- a/library/java/io/envoyproxy/envoymobile/engine/EnvoyEngine.java
+++ b/library/java/io/envoyproxy/envoymobile/engine/EnvoyEngine.java
@@ -15,6 +15,11 @@ public interface EnvoyEngine {
   EnvoyHTTPStream startStream(EnvoyHTTPCallbacks callbacks);
 
   /**
+   * Terminates the current engine.
+   */
+  void terminate();
+
+  /**
    * Run the Envoy engine with the provided yaml string and log level.
    *
    * @param configurationYAML The configuration yaml with which to start Envoy.

--- a/library/java/io/envoyproxy/envoymobile/engine/EnvoyEngineImpl.java
+++ b/library/java/io/envoyproxy/envoymobile/engine/EnvoyEngineImpl.java
@@ -35,6 +35,11 @@ public class EnvoyEngineImpl implements EnvoyEngine {
     return stream;
   }
 
+  @Override
+  public void terminate() {
+    JniLibrary.terminateEngine(engineHandle);
+  }
+
   /**
    * Run the Envoy engine with the provided yaml string and log level.
    *

--- a/library/java/io/envoyproxy/envoymobile/engine/JniLibrary.java
+++ b/library/java/io/envoyproxy/envoymobile/engine/JniLibrary.java
@@ -140,9 +140,9 @@ class JniLibrary {
                                         EnvoyOnEngineRunning onEngineRunning);
 
   /**
-   * Terminate or shutdown the Envoy Engine.
+   * Terminate the engine.
    *
-   * @param engine the engine to shutdown.
+   * @param engine handle for the engine to terminate.
    */
   protected static native void terminateEngine(long engine);
 

--- a/library/java/io/envoyproxy/envoymobile/engine/JniLibrary.java
+++ b/library/java/io/envoyproxy/envoymobile/engine/JniLibrary.java
@@ -1,11 +1,8 @@
 package io.envoyproxy.envoymobile.engine;
 
-import io.envoyproxy.envoymobile.engine.types.EnvoyHTTPCallbacks;
 import io.envoyproxy.envoymobile.engine.types.EnvoyOnEngineRunning;
 
 import java.nio.ByteBuffer;
-import java.util.List;
-import java.util.Map;
 
 class JniLibrary {
 
@@ -141,6 +138,13 @@ class JniLibrary {
    */
   protected static native int runEngine(long engine, String config, String logLevel,
                                         EnvoyOnEngineRunning onEngineRunning);
+
+  /**
+   * Terminate or shutdown the Envoy Engine.
+   *
+   * @param engine the engine to shutdown.
+   */
+  protected static native void terminateEngine(long engine);
 
   // Other native methods
 

--- a/library/kotlin/io/envoyproxy/envoymobile/mocks/MockEnvoyEngine.kt
+++ b/library/kotlin/io/envoyproxy/envoymobile/mocks/MockEnvoyEngine.kt
@@ -17,6 +17,8 @@ internal class MockEnvoyEngine : EnvoyEngine {
 
   override fun startStream(callbacks: EnvoyHTTPCallbacks?): EnvoyHTTPStream = MockEnvoyHTTPStream(callbacks!!)
 
+  override fun terminate() = Unit
+
   override fun recordCounterInc(elements: String, count: Int): Int = 0
 
   override fun recordGaugeSet(elements: String, value: Int): Int = 0


### PR DESCRIPTION
Adding termination functionality to the android and java interfaces. This is functionality is not really necessary for Android applications. 

This functionality is needed for running unit tests where controlling the start and shutdown of Envoy is required to avoid abrupt shutdown crashes.

Signed-off-by: Alan Chiu <achiu@lyft.com>

For an explanation of how to fill out the fields, please see the relevant section
in [PULL_REQUESTS.md](https://github.com/envoyproxy/envoy/blob/master/PULL_REQUESTS.md)

Description:  jni: pipe through terminating engine functionality
Risk Level: low
Testing: future unit tests
Docs Changes: n/a
Release Notes: n/a
[Optional Fixes #Issue]
[Optional Deprecated:]
