### PR TITLE
jni: ensure jvm_on_engine_running handles null

### DIFF
--- a/library/common/jni/jni_interface.cc
+++ b/library/common/jni/jni_interface.cc
@@ -32,8 +32,11 @@ extern "C" JNIEXPORT jlong JNICALL Java_io_envoyproxy_envoymobile_engine_JniLibr
 }
 
 static void jvm_on_engine_running(void* context) {
-  jni_log("[Envoy]", "jvm_on_engine_running");
+  if (context == nullptr) {
+    return;
+  }
 
+  jni_log("[Envoy]", "jvm_on_engine_running");
   JNIEnv* env = get_env();
   jobject j_context = static_cast<jobject>(context);
   jclass jcls_JvmonEngineRunningContext = env->GetObjectClass(j_context);


### PR DESCRIPTION
Signed-off-by: Alan Chiu <achiu@lyft.com>

For an explanation of how to fill out the fields, please see the relevant section
in [PULL_REQUESTS.md](https://github.com/envoyproxy/envoy/blob/master/PULL_REQUESTS.md)

Description: jni: ensure jvm_on_engine_running handles null
Risk Level: low
Testing: unit
Docs Changes: n/a
Release Notes: n/a
[Optional Fixes #Issue]
[Optional Deprecated:]
