### PR TITLE
platform brdige: fix leak in platform bridge filter in core code and in iOS code

### DIFF
--- a/library/common/extensions/filters/http/platform_bridge/filter.cc
+++ b/library/common/extensions/filters/http/platform_bridge/filter.cc
@@ -361,7 +361,8 @@ Http::FilterHeadersStatus PlatformBridgeFilter::encodeHeaders(Http::ResponseHead
     if (!error_message_header.empty()) {
       error_message =
           Data::Utility::copyToBridgeData(error_message_header[0]->value().getStringView());
-      ENVOY_LOG(error, "Parsed error {} {}", error_message_header[0]->value().getStringView().length(), error_message.length);
+      ENVOY_LOG(error, "Parsed error {} {}",
+                error_message_header[0]->value().getStringView().length(), error_message.length);
     }
 
     int32_t attempt_count;

--- a/library/common/extensions/filters/http/platform_bridge/filter.cc
+++ b/library/common/extensions/filters/http/platform_bridge/filter.cc
@@ -361,8 +361,6 @@ Http::FilterHeadersStatus PlatformBridgeFilter::encodeHeaders(Http::ResponseHead
     if (!error_message_header.empty()) {
       error_message =
           Data::Utility::copyToBridgeData(error_message_header[0]->value().getStringView());
-      ENVOY_LOG(error, "Parsed error {} {}",
-                error_message_header[0]->value().getStringView().length(), error_message.length);
     }
 
     int32_t attempt_count;

--- a/library/common/extensions/filters/http/platform_bridge/filter.cc
+++ b/library/common/extensions/filters/http/platform_bridge/filter.cc
@@ -361,6 +361,7 @@ Http::FilterHeadersStatus PlatformBridgeFilter::encodeHeaders(Http::ResponseHead
     if (!error_message_header.empty()) {
       error_message =
           Data::Utility::copyToBridgeData(error_message_header[0]->value().getStringView());
+      ENVOY_LOG(error, "Parsed error {} {}", error_message_header[0]->value().getStringView().length(), error_message.length);
     }
 
     int32_t attempt_count;
@@ -373,7 +374,10 @@ Http::FilterHeadersStatus PlatformBridgeFilter::encodeHeaders(Http::ResponseHead
     if (platform_filter_.on_error) {
       platform_filter_.on_error({error_code, error_message, attempt_count},
                                 platform_filter_.instance_context);
+    } else {
+      error_message.release(error_message.context);
     }
+
     error_response_ = true;
     return Http::FilterHeadersStatus::Continue;
   }

--- a/library/objective-c/EnvoyEngineImpl.m
+++ b/library/objective-c/EnvoyEngineImpl.m
@@ -280,11 +280,14 @@ static void ios_http_filter_on_error(envoy_error error, const void *context) {
     return;
   }
 
-  NSString *errorMessage = [[NSString alloc] initWithBytes:error.message.bytes
-                                                    length:error.message.length
-                                                  encoding:NSUTF8StringEncoding];
-  error.message.release(error.message.context);
-  filter.onError(error.error_code, errorMessage, error.attempt_count);
+  @autoreleasepool {
+    NSString *errorMessage = [[NSString alloc] initWithBytes:error.message.bytes
+                                                      length:error.message.length
+                                                    encoding:NSUTF8StringEncoding];
+
+    error.message.release(error.message.context);
+    filter.onError(error.error_code, errorMessage, error.attempt_count);
+  }
 }
 
 static void ios_http_filter_release(const void *context) {


### PR DESCRIPTION
Description: fixes two leaks in the platform filter chain. One in the common code, and one specific to iOS
Risk Level: low
Testing: ran with Lyft's Driver app under xcode's memory profiler.

Signed-off-by: Jose Nino <jnino@lyft.com>