### PR TITLE
ci: extend iOS artifact timeout

### DIFF
--- a/.github/workflows/artifacts.yml
+++ b/.github/workflows/artifacts.yml
@@ -99,7 +99,7 @@ jobs:
   main_ios_dist:
     name: main_ios_dist
     runs-on: macOS-latest
-    timeout-minutes: 120 
+    timeout-minutes: 120
     steps:
       - uses: actions/checkout@v1
         with:

--- a/.github/workflows/artifacts.yml
+++ b/.github/workflows/artifacts.yml
@@ -99,7 +99,7 @@ jobs:
   main_ios_dist:
     name: main_ios_dist
     runs-on: macOS-latest
-    timeout-minutes: 90
+    timeout-minutes: 120 
     steps:
       - uses: actions/checkout@v1
         with:


### PR DESCRIPTION
Description: Noticed this was timing out on main.
Risk Level: Low
Testing: CI

Signed-off-by: Mike Schore <mike.schore@gmail.com>