### PR TITLE
ci: always run coverage

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -5,9 +5,6 @@ on:
     branches:
       - main
   pull_request:
-    paths:
-      - 'library/common/**'
-      - 'test/common/**'
 
 jobs:
   coverage:


### PR DESCRIPTION
Description: This needs to run since CI requires it to pass; as a future optimization we can short-circuit if there's no changes to these directories.
Risk Level: Low
Testing: CI

Signed-off-by: Mike Schore <mike.schore@gmail.com>