### PR TITLE
ci: conditionally run coverage based on context

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -19,13 +19,13 @@ jobs:
         CXX: /opt/llvm/bin/clang++
         COVERAGE_THRESHOLD: 95
     steps:
-      - uses: actions/checkout@v1
+      - uses: actions/checkout@v2
         with:
           submodules: true
       - id: check_context
         name: 'Check whether to run'
         run: |
-          if git rev-parse --abbrev-ref HEAD | grep -q ^main$ || git diff --name-only main | grep -q common/ ; then
+          if git rev-parse --abbrev-ref HEAD | grep -q ^main$ || git diff --name-only origin/main | grep -q common/ ; then
             echo "Coverage will run."
             echo "::set-output name=run_coverage::true"
           else

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -25,7 +25,7 @@ jobs:
       - id: check_context
         name: 'Check whether to run'
         run: |
-          if git branch --show-current | grep -q ^main$ || git diff --name-only HEAD^ HEAD | grep -q common/ ; then
+          if git rev-parse --abbrev-ref HEAD | grep -q ^main$ || git diff --name-only HEAD^ HEAD | grep -q common/ ; then
             echo "::set-output name=run_coverage::true"
           else
             echo "::set-output name=run_coverage::false"

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -22,13 +22,25 @@ jobs:
       - uses: actions/checkout@v1
         with:
           submodules: true
+      - id: check_context
+        name: 'Check whether to run'
+        run: |
+          if [git branch --show-current | grep -q ^main$] || [git diff --name-only HEAD^ HEAD | grep -q common/]; then
+            echo "::set-output name=run_coverage::true"
+          else
+            echo "::set-output name=run_coverage::false"
+          fi
       - name: 'Run coverage'
+        if: steps.check_context.outputs.run_coverage == 'true'
         continue-on-error: true
         run: "PATH=/opt/llvm/bin:${PATH} ./envoy/test/run_envoy_bazel_coverage.sh //test/common/..."
-      - name: 'package coverage'
+      - name: 'Package coverage'
+        if: steps.check_context.outputs.run_coverage == 'true'
         run: |
           tar -czvf coverage.tar.gz generated/coverage
-      - uses: actions/upload-artifact@v2
+      - name: 'Upload report'
+        if: steps.check_context.outputs.run_coverage == 'true'
+        uses: actions/upload-artifact@v2
         with:
           name: coverage.tar.gz
           path: coverage.tar.gz

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -25,7 +25,7 @@ jobs:
       - id: check_context
         name: 'Check whether to run'
         run: |
-          if [ git branch --show-current | grep -q ^main$ ] || [ git diff --name-only HEAD^ HEAD | grep -q common/ ]; then
+          if git branch --show-current | grep -q ^main$ || git diff --name-only HEAD^ HEAD | grep -q common/ ; then
             echo "::set-output name=run_coverage::true"
           else
             echo "::set-output name=run_coverage::false"

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -19,7 +19,7 @@ jobs:
         CXX: /opt/llvm/bin/clang++
         COVERAGE_THRESHOLD: 95
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v1
         with:
           submodules: true
       - id: check_context

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -26,8 +26,10 @@ jobs:
         name: 'Check whether to run'
         run: |
           if git rev-parse --abbrev-ref HEAD | grep -q ^main$ || git diff --name-only HEAD^ HEAD | grep -q common/ ; then
+            echo "Coverage will run."
             echo "::set-output name=run_coverage::true"
           else
+            echo "Skipping coverage."
             echo "::set-output name=run_coverage::false"
           fi
       - name: 'Run coverage'

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -25,7 +25,7 @@ jobs:
       - id: check_context
         name: 'Check whether to run'
         run: |
-          if [git branch --show-current | grep -q ^main$] || [git diff --name-only HEAD^ HEAD | grep -q common/]; then
+          if [ git branch --show-current | grep -q ^main$ ] || [ git diff --name-only HEAD^ HEAD | grep -q common/ ]; then
             echo "::set-output name=run_coverage::true"
           else
             echo "::set-output name=run_coverage::false"

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -25,7 +25,7 @@ jobs:
       - id: check_context
         name: 'Check whether to run'
         run: |
-          if git rev-parse --abbrev-ref HEAD | grep -q ^main$ || git diff --name-only HEAD^ HEAD | grep -q common/ ; then
+          if git rev-parse --abbrev-ref HEAD | grep -q ^main$ || git diff --name-only main | grep -q common/ ; then
             echo "Coverage will run."
             echo "::set-output name=run_coverage::true"
           else


### PR DESCRIPTION
Description: Updates coverage check to automatically pass for PRs that contain no changes to //library/common. Coverage will always run after a merge to main.
Risk Level: Low
Testing: CI

Signed-off-by: Mike Schore <mike.schore@gmail.com>