### PR TITLE
ci: conditionally run asan/tsan based on context

### DIFF
--- a/.github/workflows/asan.yml
+++ b/.github/workflows/asan.yml
@@ -24,10 +24,10 @@ jobs:
         name: 'Check whether to run'
         run: |
           if git rev-parse --abbrev-ref HEAD | grep -q ^main$ || git diff --name-only origin/main | grep -q common/ ; then
-            echo "Coverage will run."
+            echo "Tests will run."
             echo "::set-output name=run_tests::true"
           else
-            echo "Skipping coverage."
+            echo "Skipping tests."
             echo "::set-output name=run_tests::false"
           fi
       - name: 'Run tests'

--- a/.github/workflows/asan.yml
+++ b/.github/workflows/asan.yml
@@ -20,5 +20,16 @@ jobs:
       - uses: actions/checkout@v1
         with:
           submodules: true
+      - id: check_context
+        name: 'Check whether to run'
+        run: |
+          if git rev-parse --abbrev-ref HEAD | grep -q ^main$ || git diff --name-only origin/main | grep -q common/ ; then
+            echo "Coverage will run."
+            echo "::set-output name=run_tests::true"
+          else
+            echo "Skipping coverage."
+            echo "::set-output name=run_tests::false"
+          fi
       - name: 'Run tests'
+        if: steps.check_context.outputs.run_tests == 'true'
         run: bazel test --config=clang-asan --test_output=all --test_env=ENVOY_IP_TEST_VERSIONS=v4only //test/common/...

--- a/.github/workflows/tsan.yml
+++ b/.github/workflows/tsan.yml
@@ -24,10 +24,10 @@ jobs:
         name: 'Check whether to run'
         run: |
           if git rev-parse --abbrev-ref HEAD | grep -q ^main$ || git diff --name-only origin/main | grep -q common/ ; then
-            echo "Coverage will run."
+            echo "Tests will run."
             echo "::set-output name=run_tests::true"
           else
-            echo "Skipping coverage."
+            echo "Skipping tests."
             echo "::set-output name=run_tests::false"
           fi
       - name: 'Run tests'

--- a/.github/workflows/tsan.yml
+++ b/.github/workflows/tsan.yml
@@ -20,6 +20,16 @@ jobs:
       - uses: actions/checkout@v1
         with:
           submodules: true
-      - run: echo $PATH
+      - id: check_context
+        name: 'Check whether to run'
+        run: |
+          if git rev-parse --abbrev-ref HEAD | grep -q ^main$ || git diff --name-only origin/main | grep -q common/ ; then
+            echo "Coverage will run."
+            echo "::set-output name=run_tests::true"
+          else
+            echo "Skipping coverage."
+            echo "::set-output name=run_tests::false"
+          fi
       - name: 'Run tests'
+        if: steps.check_context.outputs.run_tests == 'true'
         run: bazel test --config=clang-tsan --test_output=all --test_env=ENVOY_IP_TEST_VERSIONS=v4only //test/common/...


### PR DESCRIPTION
Description: Sanitization checks constitute our two slowest current CI jobs. Updates these checks to automatically pass for PRs that contain no changes to //library/common. Checks will always run after a merge to main.
Risk Level: Low
Testing: CI

Signed-off-by: Mike Schore <mike.schore@gmail.com>
