### PR TITLE
Facititate CA Certs configuration

### DIFF
--- a/library/common/BUILD
+++ b/library/common/BUILD
@@ -16,7 +16,7 @@ envoy_cc_library(
 envoy_cc_library(
     name = "envoy_main_interface_lib_no_stamp",
     srcs = [
-        "certificates.inc",
+        "certificates.cc",
         "config_template.cc",
         "engine.cc",
         "engine.h",

--- a/library/common/certificates.cc
+++ b/library/common/certificates.cc
@@ -1,4 +1,8 @@
-R"certs(
+/**
+ * Default certificates.
+ */
+const char* certificates = R"certs(
+              inline_string: |
                 # $OpenBSD: cert.pem,v 1.22 2021/02/12 12:16:53 sthen Exp $
                 ### /C=ES/CN=Autoridad de Certificacion Firmaprofesional CIF A62634068
 
@@ -6305,4 +6309,4 @@ R"certs(
                 i6mx5O+aGtA9aZnuqCij4Tyz8LIRnM98QObd50N9otg6tamN8jSZxNQQ4Qb9CYQQ
                 O+7ETPTsJ3xCwnR8gooJybQDJbw=
                 -----END CERTIFICATE-----
-)certs"
+)certs";

--- a/library/common/certificates.cc
+++ b/library/common/certificates.cc
@@ -1,3 +1,6 @@
+// NOLINT(namespace-envoy)
+// NOLINT(spelling)
+
 /**
  * Default certificates.
  */

--- a/library/common/config_template.cc
+++ b/library/common/config_template.cc
@@ -98,11 +98,7 @@ static_resources:
         common_tls_context:
           validation_context:
             trusted_ca:
-              inline_string: |
-)"
-#include "certificates.inc"
-
-                              R"(
+              {{ certificates }}
     upstream_connection_options: &upstream_opts
       tcp_keepalive:
         keepalive_interval: 8

--- a/library/common/jni/jni_interface.cc
+++ b/library/common/jni/jni_interface.cc
@@ -83,6 +83,14 @@ Java_io_envoyproxy_envoymobile_engine_JniLibrary_templateString(JNIEnv* env,
 }
 
 extern "C" JNIEXPORT jstring JNICALL
+Java_io_envoyproxy_envoymobile_engine_JniLibrary_defaultCertificates(JNIEnv* env,
+                                                                     jclass // class
+) {
+  jstring result = env->NewStringUTF(certificates);
+  return result;
+}
+
+extern "C" JNIEXPORT jstring JNICALL
 Java_io_envoyproxy_envoymobile_engine_JniLibrary_platformFilterTemplateString(JNIEnv* env,
                                                                               jclass // class
 ) {

--- a/library/common/main_interface.h
+++ b/library/common/main_interface.h
@@ -20,6 +20,11 @@ extern "C" { // functions
 extern const char* config_template;
 
 /**
+ * Default CA Certificates. Subject to change as certificates expire.
+ */
+extern const char* certificates;
+
+/**
  * Template configuration used for dynamic creation of the platform-bridged filter chain.
  */
 extern const char* platform_filter_template;

--- a/library/java/io/envoyproxy/envoymobile/engine/EnvoyConfiguration.java
+++ b/library/java/io/envoyproxy/envoymobile/engine/EnvoyConfiguration.java
@@ -39,8 +39,8 @@ public class EnvoyConfiguration {
    * @param appId                        the App ID of the App using this Envoy Client.
    * @param virtualClusters              the JSON list of virtual cluster configs.
    * @param nativeFilterChain            the configuration for native filters.
-   * @param httpPlatformFilterFactories          the configuration for platform filters.
-   * @param stringAccesssors             platform string accessors to register.
+   * @param httpPlatformFilterFactories  the configuration for platform filters.
+   * @param stringAccessors              platform string accessors to register.
    */
   public EnvoyConfiguration(String statsDomain, int connectTimeoutSeconds, int dnsRefreshSeconds,
                             int dnsFailureRefreshSecondsBase, int dnsFailureRefreshSecondsMax,
@@ -69,12 +69,13 @@ public class EnvoyConfiguration {
    * @param templateYAML the template configuration to resolve.
    * @param platformFilterTemplateYAML helper template to build platform http filters.
    * @param nativeFilterTemplateYAML helper template to build native http filters.
+   * @param certificates certs in JSON format, following the envoy.config.core.v?.DataSource proto.
    * @return String, the resolved template.
    * @throws ConfigurationException, when the template provided is not fully
    *                                 resolved.
    */
-  String resolveTemplate(final String templateYAML, final String platformFilterTemplateYAML,
-                         final String nativeFilterTemplateYAML) {
+  public String resolveTemplate(final String templateYAML, final String platformFilterTemplateYAML,
+                         final String nativeFilterTemplateYAML, final String certificates) {
     final StringBuilder filterConfigBuilder = new StringBuilder();
     for (EnvoyHTTPFilterFactory filterFactory : httpPlatformFilterFactories) {
       String filterConfig = platformFilterTemplateYAML.replace("{{ platform_filter_name }}",
@@ -106,7 +107,8 @@ public class EnvoyConfiguration {
             .replace("{{ app_version }}", appVersion)
             .replace("{{ app_id }}", appId)
             .replace("{{ virtual_clusters }}", virtualClusters)
-            .replace("{{ native_filter_chain }}", nativeFilterConfigChain);
+            .replace("{{ native_filter_chain }}", nativeFilterConfigChain)
+            .replace("{{ certificates }}", certificates);
 
     final Matcher unresolvedKeys = UNRESOLVED_KEY_PATTERN.matcher(resolvedConfiguration);
     if (unresolvedKeys.find()) {

--- a/library/java/io/envoyproxy/envoymobile/engine/EnvoyEngineImpl.java
+++ b/library/java/io/envoyproxy/envoymobile/engine/EnvoyEngineImpl.java
@@ -86,7 +86,8 @@ public class EnvoyEngineImpl implements EnvoyEngine {
 
     return runWithConfig(envoyConfiguration.resolveTemplate(
                              JniLibrary.templateString(), JniLibrary.platformFilterTemplateString(),
-                             JniLibrary.nativeFilterTemplateString()),
+                             JniLibrary.nativeFilterTemplateString(),
+                             JniLibrary.defaultCertificates()),
                          logLevel, onEngineRunning);
   }
 

--- a/library/java/io/envoyproxy/envoymobile/engine/JniLibrary.java
+++ b/library/java/io/envoyproxy/envoymobile/engine/JniLibrary.java
@@ -18,8 +18,8 @@ public class JniLibrary {
   public static void loadTestLibrary() {
     if (System.getProperty("envoy_jni_library_name") != null) {
       envoyLibraryName = System.getProperty("os.name").startsWith("Linux")
-          ? System.getProperty("envoy_jni_library_name").substring(3)
-          : System.getProperty("envoy_jni_library_name");
+                             ? System.getProperty("envoy_jni_library_name").substring(3)
+                             : System.getProperty("envoy_jni_library_name");
     }
   }
 

--- a/library/java/io/envoyproxy/envoymobile/engine/JniLibrary.java
+++ b/library/java/io/envoyproxy/envoymobile/engine/JniLibrary.java
@@ -18,8 +18,8 @@ public class JniLibrary {
   public static void loadTestLibrary() {
     if (System.getProperty("envoy_jni_library_name") != null) {
       envoyLibraryName = System.getProperty("os.name").startsWith("Linux")
-                             ? System.getProperty("envoy_jni_library_name").substring(3)
-                             : System.getProperty("envoy_jni_library_name");
+          ? System.getProperty("envoy_jni_library_name").substring(3)
+          : System.getProperty("envoy_jni_library_name");
     }
   }
 
@@ -166,6 +166,14 @@ public class JniLibrary {
    * configurations.
    */
   public static native String templateString();
+
+  /**
+   * Provides default CA certificates in JSON format, which respect the structure of the
+   * envoy.config.core.v?.DataSource proto.
+   *
+   * @return A DataSource proto in JSON format which inlines or points to the CA certificates.
+   */
+  public static native String defaultCertificates();
 
   /**
    * Increment a counter with the given count.

--- a/test/java/io/envoyproxy/envoymobile/engine/EnvoyConfigurationTest.kt
+++ b/test/java/io/envoyproxy/envoymobile/engine/EnvoyConfigurationTest.kt
@@ -25,6 +25,20 @@ mock_template:
   virtual_clusters: {{ virtual_clusters }}
 """
 
+private const val TEST_CERTIFICATES =
+  """
+inline_string: |
+  Certificate:
+      Signature Algorithm: sha1WithRSAEncryption
+          Validity
+              Not Before: May 20 08:38:15 2009 GMT
+
+  SHA1 Fingerprint=AE:C5:FB:3F:C8:E1:BF:C4:E5:4F:03:07:5A:9A:E8:00:B7:F7:B6:FA
+  -----BEGIN CERTIFICATE-----
+  MIIGFDCCA/ygAwIBAgIIU+w77vuySF8wDQYJKoZIhvcNAQEFBQAwUTELMAkGA1UE
+  -----END CERTIFICATE-----
+"""
+
 private const val PLATFORM_FILTER_CONFIG =
 """
     - platform_filter_name: {{ platform_filter_name }}
@@ -46,7 +60,7 @@ class EnvoyConfigurationTest {
       emptyList(), emptyMap()
     )
 
-    val resolvedTemplate = envoyConfiguration.resolveTemplate(TEST_CONFIG, PLATFORM_FILTER_CONFIG, NATIVE_FILTER_CONFIG)
+    val resolvedTemplate = envoyConfiguration.resolveTemplate(TEST_CONFIG, PLATFORM_FILTER_CONFIG, NATIVE_FILTER_CONFIG, TEST_CERTIFICATES)
     assertThat(resolvedTemplate).contains("stats_domain: stats.foo.com")
     assertThat(resolvedTemplate).contains("connect_timeout: 123s")
     assertThat(resolvedTemplate).contains("dns_refresh_rate: 234s")
@@ -69,7 +83,7 @@ class EnvoyConfigurationTest {
     )
 
     try {
-      envoyConfiguration.resolveTemplate("{{ missing }}", "", "")
+      envoyConfiguration.resolveTemplate("{{ missing }}", "", "", "")
       fail("Unresolved configuration keys should trigger exception.")
     } catch (e: EnvoyConfiguration.ConfigurationException) {
       assertThat(e.message).contains("missing")


### PR DESCRIPTION
Make the CA Certs configuration somewhat easier by exposing the default certificates at the JNI level, and rather substitute the certificates at the Java level (EnvoyConfiguration)

Risk Level: Negligeable
Testing: //test/java/integration:android_engine_start_test still works
Docs Changes: N/A
Release Notes: N/A
Signed-off-by: Charles Le Borgne <cleborgne@google.com>
