### PR TITLE
stats: fix leaky jni strings

### DIFF
--- a/library/common/jni/jni_interface.cc
+++ b/library/common/jni/jni_interface.cc
@@ -100,32 +100,40 @@ extern "C" JNIEXPORT jint JNICALL Java_io_envoyproxy_envoymobile_engine_JniLibra
     JNIEnv* env,
     jclass, // class
     jlong engine, jstring elements, jobjectArray tags, jint count) {
-  return record_counter_inc(engine, env->GetStringUTFChars(elements, nullptr),
-                            to_native_tags(env, tags), count);
+  const char* native_elements = env->GetStringUTFChars(elements, nullptr);
+  jint result = record_counter_inc(engine, native_elements, to_native_tags(env, tags), count);
+  env->ReleaseStringUTFChars(elements, native_elements);
+  return result;
 }
 
 extern "C" JNIEXPORT jint JNICALL Java_io_envoyproxy_envoymobile_engine_JniLibrary_recordGaugeSet(
     JNIEnv* env,
     jclass, // class
     jlong engine, jstring elements, jobjectArray tags, jint value) {
-  return record_gauge_set(engine, env->GetStringUTFChars(elements, nullptr),
-                          to_native_tags(env, tags), value);
+  const char* native_elements = env->GetStringUTFChars(elements, nullptr);
+  jint result = record_gauge_set(engine, native_elements, to_native_tags(env, tags), value);
+  env->ReleaseStringUTFChars(elements, native_elements);
+  return result;
 }
 
 extern "C" JNIEXPORT jint JNICALL Java_io_envoyproxy_envoymobile_engine_JniLibrary_recordGaugeAdd(
     JNIEnv* env,
     jclass, // class
     jlong engine, jstring elements, jobjectArray tags, jint amount) {
-  return record_gauge_add(engine, env->GetStringUTFChars(elements, nullptr),
-                          to_native_tags(env, tags), amount);
+  const char* native_elements = env->GetStringUTFChars(elements, nullptr);
+  jint result = record_gauge_add(engine, native_elements, to_native_tags(env, tags), amount);
+  env->ReleaseStringUTFChars(elements, native_elements);
+  return result;
 }
 
 extern "C" JNIEXPORT jint JNICALL Java_io_envoyproxy_envoymobile_engine_JniLibrary_recordGaugeSub(
     JNIEnv* env,
     jclass, // class
     jlong engine, jstring elements, jobjectArray tags, jint amount) {
-  return record_gauge_sub(engine, env->GetStringUTFChars(elements, nullptr),
-                          to_native_tags(env, tags), amount);
+  const char* native_elements = env->GetStringUTFChars(elements, nullptr);
+  jint result = record_gauge_sub(engine, native_elements, to_native_tags(env, tags), amount);
+  env->ReleaseStringUTFChars(elements, native_elements);
+  return result;
 }
 
 extern "C" JNIEXPORT jint JNICALL
@@ -135,8 +143,11 @@ Java_io_envoyproxy_envoymobile_engine_JniLibrary_recordHistogramDuration(JNIEnv*
                                                                          jstring elements,
                                                                          jobjectArray tags,
                                                                          jint durationMs) {
-  return record_histogram_value(engine, env->GetStringUTFChars(elements, nullptr),
-                                to_native_tags(env, tags), durationMs, MILLISECONDS);
+  const char* native_elements = env->GetStringUTFChars(elements, nullptr);
+  jint result = record_histogram_value(engine, native_elements, to_native_tags(env, tags),
+                                       durationMs, MILLISECONDS);
+  env->ReleaseStringUTFChars(elements, native_elements);
+  return result;
 }
 
 extern "C" JNIEXPORT jint JNICALL
@@ -146,8 +157,11 @@ Java_io_envoyproxy_envoymobile_engine_JniLibrary_recordHistogramValue(JNIEnv* en
                                                                       jstring elements,
                                                                       jobjectArray tags,
                                                                       jint value) {
-  return record_histogram_value(engine, env->GetStringUTFChars(elements, nullptr),
-                                to_native_tags(env, tags), value, UNSPECIFIED);
+  const char* native_elements = env->GetStringUTFChars(elements, nullptr);
+  jint result = record_histogram_value(engine, native_elements, to_native_tags(env, tags), value,
+                                       UNSPECIFIED);
+  env->ReleaseStringUTFChars(elements, native_elements);
+  return result;
 }
 
 // JvmCallbackContext


### PR DESCRIPTION
Description: Fixes a leak in our usage of strings produced by JNI translation. The introduction of the stats interface changes this from something that would only occur O(1) on engine creation, to something that will occur as frequently as stats are emitted.
Risk Level: Low
Testing: Local and CI

Signed-off-by: Mike Schore <mike.schore@gmail.com>