### PR TITLE
core: set up cleartext http request path

### DIFF
--- a/library/common/config_template.cc
+++ b/library/common/config_template.cc
@@ -147,6 +147,42 @@ static_resources:
     transport_socket: *base_transport_socket
     upstream_connection_options: *upstream_opts
     circuit_breakers: *circuit_breakers_settings
+  - name: base_clear
+    connect_timeout: {{ connect_timeout_seconds }}s
+    lb_policy: CLUSTER_PROVIDED
+    cluster_type:
+      name: envoy.clusters.dynamic_forward_proxy
+      typed_config:
+        "@type": type.googleapis.com/envoy.extensions.clusters.dynamic_forward_proxy.v3.ClusterConfig
+        dns_cache_config: *dns_cache_config
+    transport_socket:
+      name: envoy.transport_sockets.raw_buffer
+    upstream_connection_options: *upstream_opts
+    circuit_breakers: *circuit_breakers_settings
+  - name: base_wlan_clear
+    connect_timeout: {{ connect_timeout_seconds }}s
+    lb_policy: CLUSTER_PROVIDED
+    cluster_type:
+      name: envoy.clusters.dynamic_forward_proxy
+      typed_config:
+        "@type": type.googleapis.com/envoy.extensions.clusters.dynamic_forward_proxy.v3.ClusterConfig
+        dns_cache_config: *dns_cache_config
+    transport_socket:
+      name: envoy.transport_sockets.raw_buffer
+    upstream_connection_options: *upstream_opts
+    circuit_breakers: *circuit_breakers_settings
+  - name: base_wwan_clear
+    connect_timeout: {{ connect_timeout_seconds }}s
+    lb_policy: CLUSTER_PROVIDED
+    cluster_type:
+      name: envoy.clusters.dynamic_forward_proxy
+      typed_config:
+        "@type": type.googleapis.com/envoy.extensions.clusters.dynamic_forward_proxy.v3.ClusterConfig
+        dns_cache_config: *dns_cache_config
+    transport_socket:
+      name: envoy.transport_sockets.raw_buffer
+    upstream_connection_options: *upstream_opts
+    circuit_breakers: *circuit_breakers_settings
   - name: base_h2
     http2_protocol_options: {}
     connect_timeout: {{ connect_timeout_seconds }}s

--- a/library/common/http/client.cc
+++ b/library/common/http/client.cc
@@ -345,19 +345,19 @@ const LowerCaseString ClusterHeader{"x-envoy-mobile-cluster"};
 const LowerCaseString H2UpstreamHeader{"x-envoy-mobile-upstream-protocol"};
 
 const char* BaseClusters[] = {
-  "base",
-  "base_wlan",
-  "base_wwan",
+    "base",
+    "base_wlan",
+    "base_wwan",
 };
 const char* H2Clusters[] = {
-  "base_h2",
-  "base_wlan_h2",
-  "base_wwan_h2",
+    "base_h2",
+    "base_wlan_h2",
+    "base_wwan_h2",
 };
 const char* ClearTextClusters[] = {
-  "base_clear",
-  "base_wlan_clear",
-  "base_wwan_clear",
+    "base_clear",
+    "base_wlan_clear",
+    "base_wwan_clear",
 };
 
 } // namespace

--- a/library/common/http/client.cc
+++ b/library/common/http/client.cc
@@ -342,46 +342,51 @@ void Client::removeStream(envoy_stream_t stream_handle) {
 
 namespace {
 const LowerCaseString ClusterHeader{"x-envoy-mobile-cluster"};
-const std::string BaseCluster = "base";
-const std::string BaseWlanCluster = "base_wlan";
-const std::string BaseWwanCluster = "base_wwan";
 const LowerCaseString H2UpstreamHeader{"x-envoy-mobile-upstream-protocol"};
-const std::string H2Suffix = "_h2";
-const std::string BaseClusterH2 = BaseCluster + H2Suffix;
-const std::string BaseWlanClusterH2 = BaseWlanCluster + H2Suffix;
-const std::string BaseWwanClusterH2 = BaseWwanCluster + H2Suffix;
+
+const char* BaseClusters[] = {
+  "base",
+  "base_wlan",
+  "base_wwan",
+};
+const char* H2Clusters[] = {
+  "base_h2",
+  "base_wlan_h2",
+  "base_wwan_h2",
+};
+const char* ClearTextClusters[] = {
+  "base_clear",
+  "base_wlan_clear",
+  "base_wwan_clear",
+};
+
 } // namespace
 
-void Client::setDestinationCluster(HeaderMap& headers) {
+void Client::setDestinationCluster(Http::RequestHeaderMap& headers) {
+  // Determine upstream cluster:
+  // - Use TLS by default.
+  // - Use http/2 if requested explicitly via x-envoy-mobile-upstream-protocol.
+  // - Force http/1.1 if request scheme is http (cleartext).
+  std::string cluster;
+  auto h2_header = headers.get(H2UpstreamHeader);
 
-  // Determine upstream protocol. Use http2 if selected for explicitly, otherwise (any other value,
-  // absence of value) select http1.
-  // TODO(junr03): once http3 is available this would probably benefit from some sort of struct that
-  // maps to appropriate cluster names. However, with only two options (http1/2) this suffices.
-  bool use_h2_cluster{};
-  auto get_result = headers.get(H2UpstreamHeader);
-  if (!get_result.empty()) {
-    ASSERT(get_result.size() == 1);
-    const auto value = get_result[0]->value().getStringView();
+  if (headers.getSchemeValue() == Headers::get().SchemeValues.Http) {
+    cluster = ClearTextClusters[preferred_network_.load()];
+  } else if (!h2_header.empty()) {
+    ASSERT(h2_header.size() == 1);
+    const auto value = h2_header[0]->value().getStringView();
     if (value == "http2") {
-      use_h2_cluster = true;
+      cluster = H2Clusters[preferred_network_.load()];
     } else {
-      ASSERT(value == "http1", fmt::format("using unsupported protocol version {}", value));
+      RELEASE_ASSERT(value == "http1", fmt::format("using unsupported protocol version {}", value));
+      cluster = BaseClusters[preferred_network_.load()];
     }
     headers.remove(H2UpstreamHeader);
+  } else {
+    cluster = BaseClusters[preferred_network_.load()];
   }
 
-  switch (preferred_network_.load()) {
-  case ENVOY_NET_WLAN:
-    headers.addReference(ClusterHeader, use_h2_cluster ? BaseWlanClusterH2 : BaseWlanCluster);
-    break;
-  case ENVOY_NET_WWAN:
-    headers.addReference(ClusterHeader, use_h2_cluster ? BaseWwanClusterH2 : BaseWwanCluster);
-    break;
-  case ENVOY_NET_GENERIC:
-  default:
-    headers.addReference(ClusterHeader, use_h2_cluster ? BaseClusterH2 : BaseCluster);
-  }
+  headers.addReference(ClusterHeader, cluster);
 }
 
 } // namespace Http

--- a/library/common/http/client.h
+++ b/library/common/http/client.h
@@ -214,7 +214,7 @@ private:
 
   DirectStreamSharedPtr getStream(envoy_stream_t stream_handle);
   void removeStream(envoy_stream_t stream_handle);
-  void setDestinationCluster(HeaderMap& headers);
+  void setDestinationCluster(RequestHeaderMap& headers);
 
   ApiListener& api_listener_;
   Event::ProvisionalDispatcher& dispatcher_;

--- a/library/common/types/c_types.h
+++ b/library/common/types/c_types.h
@@ -57,7 +57,11 @@ typedef enum {
  * ENVOY_NET_WLAN includes WiFi and other local area wireless networks.
  * ENVOY_NET_WWAN includes all mobile phone networks.
  */
-typedef enum { ENVOY_NET_GENERIC, ENVOY_NET_WLAN, ENVOY_NET_WWAN } envoy_network_t;
+typedef enum {
+  ENVOY_NET_GENERIC = 0,
+  ENVOY_NET_WLAN = 1,
+  ENVOY_NET_WWAN = 2,
+} envoy_network_t;
 
 #ifdef __cplusplus
 extern "C" { // release function

--- a/test/common/http/client_test.cc
+++ b/test/common/http/client_test.cc
@@ -102,31 +102,33 @@ TEST_F(ClientTest, SetDestinationCluster) {
   // accept it. However, given we are just trying to test preferred network headers and using mocks
   // this is fine.
 
-  TestRequestHeaderMapImpl headers;
-  HttpTestUtility::addDefaultHeaders(headers);
-  envoy_headers c_headers = Utility::toBridgeHeaders(headers);
+  TestRequestHeaderMapImpl headers1;
+  HttpTestUtility::addDefaultHeaders(headers1);
+  headers1.setScheme("https");
+  envoy_headers c_headers1 = Utility::toBridgeHeaders(headers1);
 
   preferred_network_.store(ENVOY_NET_GENERIC);
 
-  TestRequestHeaderMapImpl expected_headers{
-      {":scheme", "http"},
+  TestRequestHeaderMapImpl expected_headers1{
+      {":scheme", "https"},
       {":method", "GET"},
       {":authority", "host"},
       {":path", "/"},
       {"x-envoy-mobile-cluster", "base"},
       {"x-forwarded-proto", "https"},
   };
-  EXPECT_CALL(request_decoder_, decodeHeaders_(HeaderMapEqual(&expected_headers), false));
-  http_client_.sendHeaders(stream, c_headers, false);
+  EXPECT_CALL(request_decoder_, decodeHeaders_(HeaderMapEqual(&expected_headers1), false));
+  http_client_.sendHeaders(stream, c_headers1, false);
 
   TestRequestHeaderMapImpl headers2;
   HttpTestUtility::addDefaultHeaders(headers2);
+  headers2.setScheme("https");
   envoy_headers c_headers2 = Utility::toBridgeHeaders(headers2);
 
   preferred_network_.store(ENVOY_NET_WLAN);
 
   TestRequestHeaderMapImpl expected_headers2{
-      {":scheme", "http"},
+      {":scheme", "https"},
       {":method", "GET"},
       {":authority", "host"},
       {":path", "/"},
@@ -138,12 +140,13 @@ TEST_F(ClientTest, SetDestinationCluster) {
 
   TestRequestHeaderMapImpl headers3;
   HttpTestUtility::addDefaultHeaders(headers3);
+  headers3.setScheme("https");
   envoy_headers c_headers3 = Utility::toBridgeHeaders(headers3);
 
   preferred_network_.store(ENVOY_NET_WWAN);
 
   TestRequestHeaderMapImpl expected_headers3{
-      {":scheme", "http"},
+      {":scheme", "https"},
       {":method", "GET"},
       {":authority", "host"},
       {":path", "/"},
@@ -200,31 +203,33 @@ TEST_F(ClientTest, SetDestinationClusterUpstreamProtocol) {
   // accept it. However, given we are just trying to test preferred network headers and using mocks
   // this is fine.
 
-  TestRequestHeaderMapImpl headers{{"x-envoy-mobile-upstream-protocol", "http2"}};
-  HttpTestUtility::addDefaultHeaders(headers);
-  envoy_headers c_headers = Utility::toBridgeHeaders(headers);
+  TestRequestHeaderMapImpl headers1{{"x-envoy-mobile-upstream-protocol", "http2"}};
+  HttpTestUtility::addDefaultHeaders(headers1);
+  headers1.setScheme("https");
+  envoy_headers c_headers1 = Utility::toBridgeHeaders(headers1);
 
   preferred_network_.store(ENVOY_NET_GENERIC);
 
-  TestResponseHeaderMapImpl expected_headers{
-      {":scheme", "http"},
+  TestResponseHeaderMapImpl expected_headers1{
+      {":scheme", "https"},
       {":method", "GET"},
       {":authority", "host"},
       {":path", "/"},
       {"x-envoy-mobile-cluster", "base_h2"},
       {"x-forwarded-proto", "https"},
   };
-  EXPECT_CALL(request_decoder_, decodeHeaders_(HeaderMapEqual(&expected_headers), false));
-  http_client_.sendHeaders(stream, c_headers, false);
+  EXPECT_CALL(request_decoder_, decodeHeaders_(HeaderMapEqual(&expected_headers1), false));
+  http_client_.sendHeaders(stream, c_headers1, false);
 
   TestRequestHeaderMapImpl headers2{{"x-envoy-mobile-upstream-protocol", "http2"}};
   HttpTestUtility::addDefaultHeaders(headers2);
+  headers2.setScheme("https");
   envoy_headers c_headers2 = Utility::toBridgeHeaders(headers2);
 
   preferred_network_.store(ENVOY_NET_WLAN);
 
   TestResponseHeaderMapImpl expected_headers2{
-      {":scheme", "http"},
+      {":scheme", "https"},
       {":method", "GET"},
       {":authority", "host"},
       {":path", "/"},
@@ -236,12 +241,13 @@ TEST_F(ClientTest, SetDestinationClusterUpstreamProtocol) {
 
   TestRequestHeaderMapImpl headers3{{"x-envoy-mobile-upstream-protocol", "http2"}};
   HttpTestUtility::addDefaultHeaders(headers3);
+  headers3.setScheme("https");
   envoy_headers c_headers3 = Utility::toBridgeHeaders(headers3);
 
   preferred_network_.store(ENVOY_NET_WWAN);
 
   TestResponseHeaderMapImpl expected_headers3{
-      {":scheme", "http"},
+      {":scheme", "https"},
       {":method", "GET"},
       {":authority", "host"},
       {":path", "/"},
@@ -254,12 +260,13 @@ TEST_F(ClientTest, SetDestinationClusterUpstreamProtocol) {
   // Setting http1.
   TestRequestHeaderMapImpl headers4{{"x-envoy-mobile-upstream-protocol", "http1"}};
   HttpTestUtility::addDefaultHeaders(headers4);
+  headers4.setScheme("https");
   envoy_headers c_headers4 = Utility::toBridgeHeaders(headers4);
 
   preferred_network_.store(ENVOY_NET_WWAN);
 
   TestResponseHeaderMapImpl expected_headers4{
-      {":scheme", "http"},
+      {":scheme", "https"},
       {":method", "GET"},
       {":authority", "host"},
       {":path", "/"},


### PR DESCRIPTION
Description: Adds built-in support for cleartext HTTP requests, without requiring custom config. TLS will be negotiated or not based off the request scheme. If cleartext is chosen, h2 protocol options will be ignored, and h1 will be used regardless.
Risk Level: Lowish
Testing: Local, Unit, CI

Signed-off-by: Mike Schore <mike.schore@gmail.com>
