### PR TITLE
update envoy to f40e279

### DIFF
--- a/library/common/config_template.cc
+++ b/library/common/config_template.cc
@@ -237,7 +237,7 @@ stats_config:
             google_re2: {}
             regex: '^vhost.api.vcluster\.[\w]+?\.upstream_rq_(?:[12345]xx|retry.*|time|timeout|total)'
   use_all_default_tags:
-    true
+    false
 watchdog:
   megamiss_timeout: 60s
   miss_timeout: 60s

--- a/library/common/config_template.cc
+++ b/library/common/config_template.cc
@@ -204,6 +204,7 @@ stats_sinks:
       "@type": type.googleapis.com/envoy.config.metrics.v3.MetricsServiceConfig
       transport_api_version: V3
       report_counters_as_deltas: true
+      emit_tags_as_labels: true
       grpc_service:
         envoy_grpc:
           cluster_name: stats
@@ -235,6 +236,8 @@ stats_config:
         - safe_regex:
             google_re2: {}
             regex: '^vhost.api.vcluster\.[\w]+?\.upstream_rq_(?:[12345]xx|retry.*|time|timeout|total)'
+  use_all_default_tags:
+    true
 watchdog:
   megamiss_timeout: 60s
   miss_timeout: 60s

--- a/library/common/extensions/stat_sinks/metrics_service/config.cc
+++ b/library/common/extensions/stat_sinks/metrics_service/config.cc
@@ -33,7 +33,7 @@ Stats::SinkPtr EnvoyMobileMetricsServiceSinkFactory::createStatsSink(
       envoymobile::extensions::stat_sinks::metrics_service::EnvoyMobileStreamMetricsMessage,
       envoymobile::extensions::stat_sinks::metrics_service::EnvoyMobileStreamMetricsResponse>>(
       grpc_metrics_streamer,
-      PROTOBUF_GET_WRAPPED_OR_DEFAULT(sink_config, report_counters_as_deltas, false), 
+      PROTOBUF_GET_WRAPPED_OR_DEFAULT(sink_config, report_counters_as_deltas, false),
       sink_config.emit_tags_as_labels());
 }
 

--- a/library/common/extensions/stat_sinks/metrics_service/config.cc
+++ b/library/common/extensions/stat_sinks/metrics_service/config.cc
@@ -33,7 +33,8 @@ Stats::SinkPtr EnvoyMobileMetricsServiceSinkFactory::createStatsSink(
       envoymobile::extensions::stat_sinks::metrics_service::EnvoyMobileStreamMetricsMessage,
       envoymobile::extensions::stat_sinks::metrics_service::EnvoyMobileStreamMetricsResponse>>(
       grpc_metrics_streamer,
-      PROTOBUF_GET_WRAPPED_OR_DEFAULT(sink_config, report_counters_as_deltas, false));
+      PROTOBUF_GET_WRAPPED_OR_DEFAULT(sink_config, report_counters_as_deltas, false), 
+      sink_config.emit_tags_as_labels());
 }
 
 ProtobufTypes::MessagePtr EnvoyMobileMetricsServiceSinkFactory::createEmptyConfigProto() {

--- a/library/common/extensions/stat_sinks/metrics_service/config.proto
+++ b/library/common/extensions/stat_sinks/metrics_service/config.proto
@@ -16,4 +16,10 @@ message EnvoyMobileMetricsServiceConfig {
   // If true, counters are reported as the delta between flushing intervals. Otherwise, the current
   // counter value is reported. Defaults to false.
   google.protobuf.BoolValue report_counters_as_deltas = 2;
+
+  // Placeholder for now. The plan is to use it in the same way as in upstream envoy. 
+  // If true, metrics will have their tags emitted as labels on the metrics objects sent to the MetricsService,
+  // and the tag extracted name will be used instead of the full name, which may contain values used by the tag
+  // extractor or additional tags added during stats creation. 
+  bool emit_tags_as_labels = 4;
 }

--- a/library/common/extensions/stat_sinks/metrics_service/config.proto
+++ b/library/common/extensions/stat_sinks/metrics_service/config.proto
@@ -17,9 +17,9 @@ message EnvoyMobileMetricsServiceConfig {
   // counter value is reported. Defaults to false.
   google.protobuf.BoolValue report_counters_as_deltas = 2;
 
-  // Placeholder for now. The plan is to use it in the same way as in upstream envoy. 
-  // If true, metrics will have their tags emitted as labels on the metrics objects sent to the MetricsService,
-  // and the tag extracted name will be used instead of the full name, which may contain values used by the tag
-  // extractor or additional tags added during stats creation. 
+  // Placeholder for now. The plan is to use it in the same way as in upstream envoy.
+  // If true, metrics will have their tags emitted as labels on the metrics objects sent to the
+  // MetricsService, and the tag extracted name will be used instead of the full name, which may
+  // contain values used by the tag extractor or additional tags added during stats creation.
   bool emit_tags_as_labels = 4;
 }

--- a/test/common/extensions/filters/http/platform_bridge/platform_bridge_filter_integration_test.cc
+++ b/test/common/extensions/filters/http/platform_bridge/platform_bridge_filter_integration_test.cc
@@ -125,7 +125,7 @@ TEST_P(PlatformBridgeIntegrationTest, MultipleFilters) {
   upstream_request_->encodeData(100, true);
 
   // Wait for frames to arrive downstream.
-  response->waitForEndStream();
+  ASSERT_TRUE(response->waitForEndStream());
 
   EXPECT_TRUE(response->complete());
   EXPECT_EQ("200", response->headers().Status()->value().getStringView());


### PR DESCRIPTION
Description: the primary goal is to pull this pr https://github.com/envoyproxy/envoy/pull/16125, as it includes behavior of metrics_sink to send `tags` as `labels` of the `MetricFamily` field.
Risk Level: medium
Testing: local build/ci
Signed-off-by: Jingwei Hao <jingwei.hao@gmail.com>
