### PR TITLE
Revert "android: fix permissions with network state access (#1376)"

### DIFF
--- a/bazel/android_artifacts.bzl
+++ b/bazel/android_artifacts.bzl
@@ -310,9 +310,5 @@ def _manifest(package_name):
     return """
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
     package="{}" >
-
-    <uses-sdk
-            android:minSdkVersion="21"
-            android:targetSdkVersion="29"/>
 </manifest>
 """.format(package_name)

--- a/bazel/envoy_mobile_dependencies.bzl
+++ b/bazel/envoy_mobile_dependencies.bzl
@@ -24,7 +24,6 @@ def kotlin_dependencies():
             # Kotlin
             "org.jetbrains.kotlin:kotlin-stdlib-jdk8:1.3.11",
             "androidx.recyclerview:recyclerview:1.1.0",
-            "androidx.core:core:1.3.2",
             # Test artifacts
             "org.assertj:assertj-core:3.12.0",
             "junit:junit:4.12",

--- a/library/java/io/envoyproxy/envoymobile/engine/AndroidEngineImpl.java
+++ b/library/java/io/envoyproxy/envoymobile/engine/AndroidEngineImpl.java
@@ -17,7 +17,7 @@ public class AndroidEngineImpl implements EnvoyEngine {
   public AndroidEngineImpl(Context context, EnvoyOnEngineRunning runningCallback) {
     this.envoyEngine = new EnvoyEngineImpl(runningCallback);
     AndroidJniLibrary.load(context);
-    AndroidNetworkMonitor.load(context, envoyEngine);
+    AndroidNetworkMonitor.load(context);
   }
 
   @Override

--- a/library/java/io/envoyproxy/envoymobile/engine/AndroidEngineManifest.xml
+++ b/library/java/io/envoyproxy/envoymobile/engine/AndroidEngineManifest.xml
@@ -2,7 +2,7 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
           package="io.envoyproxy.envoymobile.engine">
     <uses-sdk
-            android:minSdkVersion="21"
-            android:targetSdkVersion="29"/>
+            android:minSdkVersion="9"
+            android:targetSdkVersion="27" />
 
 </manifest>

--- a/library/java/io/envoyproxy/envoymobile/engine/AndroidNetworkMonitor.java
+++ b/library/java/io/envoyproxy/envoymobile/engine/AndroidNetworkMonitor.java
@@ -1,12 +1,10 @@
 package io.envoyproxy.envoymobile.engine;
 
-import android.Manifest;
 import android.annotation.TargetApi;
 import android.content.BroadcastReceiver;
 import android.content.Context;
 import android.content.Intent;
 import android.content.IntentFilter;
-import android.content.pm.PackageManager;
 import android.net.ConnectivityManager;
 import android.net.ConnectivityManager.NetworkCallback;
 import android.net.Network;
@@ -14,9 +12,6 @@ import android.net.NetworkCapabilities;
 import android.net.NetworkInfo;
 import android.net.NetworkRequest;
 import android.os.Build;
-import androidx.core.content.ContextCompat;
-
-import java.util.Collections;
 
 /**
  * This class makes use of some deprecated APIs, but it's only current purpose is to attempt to
@@ -25,8 +20,6 @@ import java.util.Collections;
  */
 @TargetApi(Build.VERSION_CODES.LOLLIPOP)
 public class AndroidNetworkMonitor extends BroadcastReceiver {
-  private static final String PERMISSION_DENIED_STATS_ELEMENT =
-      "android_permissions.network_state_denied";
   private static final int ENVOY_NET_GENERIC = 0;
   private static final int ENVOY_NET_WWAN = 1;
   private static final int ENVOY_NET_WLAN = 2;
@@ -37,7 +30,7 @@ public class AndroidNetworkMonitor extends BroadcastReceiver {
   private NetworkCallback networkCallback;
   private NetworkRequest networkRequest;
 
-  public static void load(Context context, EnvoyEngine envoyEngine) {
+  public static void load(Context context) {
     if (instance != null) {
       return;
     }
@@ -46,22 +39,11 @@ public class AndroidNetworkMonitor extends BroadcastReceiver {
       if (instance != null) {
         return;
       }
-      instance = new AndroidNetworkMonitor(context, envoyEngine);
+      instance = new AndroidNetworkMonitor(context);
     }
   }
 
-  private AndroidNetworkMonitor(Context context, EnvoyEngine envoyEngine) {
-    int permission =
-        ContextCompat.checkSelfPermission(context, Manifest.permission.ACCESS_NETWORK_STATE);
-    if (permission == PackageManager.PERMISSION_DENIED) {
-      try {
-        envoyEngine.recordCounterInc(PERMISSION_DENIED_STATS_ELEMENT, Collections.emptyMap(), 1);
-      } catch (Throwable t) {
-        // no-op if this errors out and return
-      }
-      return;
-    }
-
+  private AndroidNetworkMonitor(Context context) {
     connectivityManager =
         (ConnectivityManager)context.getSystemService(Context.CONNECTIVITY_SERVICE);
     networkRequest = new NetworkRequest.Builder()

--- a/library/java/io/envoyproxy/envoymobile/engine/BUILD
+++ b/library/java/io/envoyproxy/envoymobile/engine/BUILD
@@ -16,7 +16,6 @@ android_library(
     deps = [
         "//library/java/io/envoyproxy/envoymobile/engine:envoy_base_engine_lib",
         "//library/java/io/envoyproxy/envoymobile/engine/types:envoy_c_types_lib",
-        "@maven//:androidx_core_core",
     ],
 )
 

--- a/library/kotlin/io/envoyproxy/envoymobile/EnvoyManifest.xml
+++ b/library/kotlin/io/envoyproxy/envoymobile/EnvoyManifest.xml
@@ -2,7 +2,7 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
           package="io.envoyproxy.envoymobile">
     <uses-sdk
-            android:minSdkVersion="21"
-            android:targetSdkVersion="29"/>
+            android:minSdkVersion="9"
+            android:targetSdkVersion="27" />
 
 </manifest>


### PR DESCRIPTION
This reverts commit 774bde4b4f70772459480a7243354e1ed9ecb775.

This is required since we have run into a build edge case with this specific commit. Reverting this change for now to unblock envoy mobile updates for Lyft.

Signed-off-by: Alan Chiu <achiu@lyft.com>

For an explanation of how to fill out the fields, please see the relevant section
in [PULL_REQUESTS.md](https://github.com/envoyproxy/envoy/blob/master/PULL_REQUESTS.md)

Description: Revert "android: fix permissions with network state access (#1376)"
Risk Level: low
Testing: local
Docs Changes: n/a
Release Notes: n/a
[Optional Fixes #Issue]
[Optional Deprecated:]
