### PR TITLE
ci: add fast pass to JVM/Android CI for immaterial branches

### DIFF
--- a/.github/workflows/android_tests.yml
+++ b/.github/workflows/android_tests.yml
@@ -15,16 +15,30 @@ jobs:
       - uses: actions/checkout@v1
         with:
           submodules: true
-      - uses: actions/setup-java@v1
+      - id: check_context
+        name: 'Check whether to run'
+        run: |
+          if git rev-parse --abbrev-ref HEAD | grep -q ^main$ || git diff --name-only origin/main | grep -qe common/ -e java/ -e kotlin/ ; then
+            echo "Tests will run."
+            echo "::set-output name=run_tests::true"
+          else
+            echo "Skipping tests."
+            echo "::set-output name=run_tests::false"
+          fi
+      - name: 'Java setup'
+        if: steps.check_context.outputs.run_tests == 'true'
+        uses: actions/setup-java@v1
         with:
           java-version: '8'
           java-package: jdk
           architecture: x64
-      - run: ./ci/mac_ci_setup.sh
-        name: 'Install dependencies'
-      - run: |
+      - name: 'Install dependencies'
+        if: steps.check_context.outputs.run_tests == 'true'
+        run: ./ci/mac_ci_setup.sh
+      - name: 'Run Kotlin library tests'
+        if: steps.check_context.outputs.run_tests == 'true'
+        run: |
           bazelisk test --test_output=all --build_tests_only //test/kotlin/...
-        name: 'Run Kotlin library tests'
   javatestsmac:
     name: java_tests_mac
     runs-on: macOS-latest
@@ -33,16 +47,30 @@ jobs:
       - uses: actions/checkout@v1
         with:
           submodules: true
-      - uses: actions/setup-java@v1
+      - id: check_context
+        name: 'Check whether to run'
+        run: |
+          if git rev-parse --abbrev-ref HEAD | grep -q ^main$ || git diff --name-only origin/main | grep -qe common/ -e java/ -e kotlin/ ; then
+            echo "Tests will run."
+            echo "::set-output name=run_tests::true"
+          else
+            echo "Skipping tests."
+            echo "::set-output name=run_tests::false"
+          fi
+      - name: 'Java setup'
+        if: steps.check_context.outputs.run_tests == 'true'
+        uses: actions/setup-java@v1
         with:
           java-version: '8'
           java-package: jdk
           architecture: x64
-      - run: ./ci/mac_ci_setup.sh
-        name: 'Install dependencies'
-      - run: |
+      - name: 'Install dependencies'
+        if: steps.check_context.outputs.run_tests == 'true'
+        run: ./ci/mac_ci_setup.sh
+      - name: 'Run Java library tests'
+        if: steps.check_context.outputs.run_tests == 'true'
+        run: |
           bazelisk test --test_output=all --build_tests_only  //test/java/...
-        name: 'Run Java library tests'
   kotlintestslinux:
     # Only kotlin tests are executed since with linux:
     # https://github.com/envoyproxy/envoy-mobile/issues/1418.
@@ -58,11 +86,24 @@ jobs:
       - uses: actions/checkout@v1
         with:
           submodules: true
-      - uses: actions/setup-java@v1
+      - id: check_context
+        name: 'Check whether to run'
+        run: |
+          if git rev-parse --abbrev-ref HEAD | grep -q ^main$ || git diff --name-only origin/main | grep -qe common/ -e java/ -e kotlin/ ; then
+            echo "Tests will run."
+            echo "::set-output name=run_tests::true"
+          else
+            echo "Skipping tests."
+            echo "::set-output name=run_tests::false"
+          fi
+      - name: 'Java setup'
+        if: steps.check_context.outputs.run_tests == 'true'
+        uses: actions/setup-java@v1
         with:
           java-version: '8'
           java-package: jdk
           architecture: x64
-      - run: |
+      - name: 'Run Kotlin library integration tests'
+        if: steps.check_context.outputs.run_tests == 'true'
+        run: |
           bazel test --test_output=all --build_tests_only //test/kotlin/...
-        name: 'Run Kotlin library integration tests'

--- a/.github/workflows/android_tests.yml
+++ b/.github/workflows/android_tests.yml
@@ -18,7 +18,7 @@ jobs:
       - id: check_context
         name: 'Check whether to run'
         run: |
-          if git rev-parse --abbrev-ref HEAD | grep -q ^main$ || git diff --name-only origin/main | grep -qe common/ -e java/ -e kotlin/ ; then
+          if git rev-parse --abbrev-ref HEAD | grep -q ^main$ || git diff --name-only origin/main | grep -qe common/ -e java/ -e kotlin/ -e bazel/ -e ^\.bazelrc$ -e ^envoy$ -e ^WORKSPACE$ ; then
             echo "Tests will run."
             echo "::set-output name=run_tests::true"
           else
@@ -50,7 +50,7 @@ jobs:
       - id: check_context
         name: 'Check whether to run'
         run: |
-          if git rev-parse --abbrev-ref HEAD | grep -q ^main$ || git diff --name-only origin/main | grep -qe common/ -e java/ -e kotlin/ ; then
+          if git rev-parse --abbrev-ref HEAD | grep -q ^main$ || git diff --name-only origin/main | grep -qe common/ -e java/ -e kotlin/ -e bazel/ -e ^\.bazelrc$ -e ^envoy$ -e ^WORKSPACE$ ; then
             echo "Tests will run."
             echo "::set-output name=run_tests::true"
           else
@@ -89,7 +89,7 @@ jobs:
       - id: check_context
         name: 'Check whether to run'
         run: |
-          if git rev-parse --abbrev-ref HEAD | grep -q ^main$ || git diff --name-only origin/main | grep -qe common/ -e java/ -e kotlin/ ; then
+          if git rev-parse --abbrev-ref HEAD | grep -q ^main$ || git diff --name-only origin/main | grep -qe common/ -e java/ -e kotlin/ -e bazel/ -e ^\.bazelrc$ -e ^envoy$ -e ^WORKSPACE$ ; then
             echo "Tests will run."
             echo "::set-output name=run_tests::true"
           else


### PR DESCRIPTION
Description: Short-circuits Android/JVM CI runs when a branch contains no changes to any of:
- //library/common/...
- //library/java/...
- //library/kotlin/...
- //test/common/...
- //test/java/...
- //test/kotlin/...
- .bazelrc WORKSPACE bazel/* envoy/*

Tests will always run on main.
Risk Level: Low
Testing: CI

Signed-off-by: Mike Schore <mike.schore@gmail.com>