### PR TITLE
ci: add fast pass to obj-c/swift CI for immaterial branches

### DIFF
--- a/.github/workflows/ios_tests.yml
+++ b/.github/workflows/ios_tests.yml
@@ -18,7 +18,7 @@ jobs:
       - id: check_context
         name: 'Check whether to run'
         run: |
-          if git rev-parse --abbrev-ref HEAD | grep -q ^main$ || git diff --name-only origin/main | grep -qe common/ -e objective-c/ -e swift/ ; then
+          if git rev-parse --abbrev-ref HEAD | grep -q ^main$ || git diff --name-only origin/main | grep -qe common/ -e objective-c/ -e swift/ -e bazel/ -e ^\.bazelrc$ -e ^envoy$ -e ^WORKSPACE$ ; then
             echo "Tests will run."
             echo "::set-output name=run_tests::true"
           else

--- a/.github/workflows/ios_tests.yml
+++ b/.github/workflows/ios_tests.yml
@@ -24,7 +24,8 @@ jobs:
           else
             echo "Skipping tests."
             echo "::set-output name=run_tests::false"
-          fi      - name: 'Install dependencies'
+          fi
+      - name: 'Install dependencies'
         run: ./ci/mac_ci_setup.sh
       - name: 'Run swift library tests'
         if: steps.check_context.outputs.run_tests == 'true'

--- a/.github/workflows/ios_tests.yml
+++ b/.github/workflows/ios_tests.yml
@@ -15,7 +15,17 @@ jobs:
       - uses: actions/checkout@v1
         with:
           submodules: true
-      - name: 'Install dependencies'
+      - id: check_context
+        name: 'Check whether to run'
+        run: |
+          if git rev-parse --abbrev-ref HEAD | grep -q ^main$ || git diff --name-only origin/main | grep -qe common/ -e objective-c/ -e swift/ ; then
+            echo "Tests will run."
+            echo "::set-output name=run_tests::true"
+          else
+            echo "Skipping tests."
+            echo "::set-output name=run_tests::false"
+          fi      - name: 'Install dependencies'
         run: ./ci/mac_ci_setup.sh
       - name: 'Run swift library tests'
+        if: steps.check_context.outputs.run_tests == 'true'
         run: bazelisk test --test_output=all --config=ios --build_tests_only //test/swift/...


### PR DESCRIPTION
Description: Short-circuits Android/JVM CI runs when a branch contains no changes to any of:
- //library/common/...
- //library/java/...
- //library/kotlin/...
- //test/common/...
- //test/java/...
- //test/kotlin/...
- .bazelrc WORKSPACE bazel/* envoy/*

Tests will always run on main.
Risk Level: Low
Testing: CI

Signed-off-by: Mike Schore <mike.schore@gmail.com>