### PR TITLE
core: define some missing pointer types

### DIFF
--- a/library/common/engine.h
+++ b/library/common/engine.h
@@ -109,8 +109,8 @@ private:
   envoy_logger logger_;
   Thread::MutexBasicLockable mutex_;
   Thread::CondVar cv_;
-  std::unique_ptr<Http::Client> http_client_;
-  std::unique_ptr<Event::ProvisionalDispatcher> dispatcher_;
+  Http::ClientPtr http_client_;
+  Event::ProvisionalDispatcherPtr dispatcher_;
   Logger::LambdaDelegatePtr lambda_logger_{};
   Server::Instance* server_{};
   Server::ServerLifecycleNotifier::HandlePtr postinit_callback_handler_;

--- a/library/common/event/provisional_dispatcher.h
+++ b/library/common/event/provisional_dispatcher.h
@@ -62,5 +62,7 @@ private:
   Thread::ThreadSynchronizer synchronizer_;
 };
 
+using ProvisionalDispatcherPtr = std::unique_ptr<ProvisionalDispatcher>;
+
 } // namespace Event
 } // namespace Envoy

--- a/library/common/http/client.h
+++ b/library/common/http/client.h
@@ -226,5 +226,7 @@ private:
   Thread::ThreadSynchronizer synchronizer_;
 };
 
+using ClientPtr = std::unique_ptr<Client>;
+
 } // namespace Http
 } // namespace Envoy


### PR DESCRIPTION
Description: It's Envoy convention to define these types and use these in place of wrappers.
Risk Level: Low
Testing: CI

Signed-off-by: Mike Schore <mike.schore@gmail.com>