### PR TITLE
build: suppress deprecated declaration warnings

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -25,7 +25,7 @@ build --define cxxopts=-std=c++17
 build --incompatible_objc_compile_info_migration
 # Unset per_object_debug_info. Causes failures on Android Linux release builds.
 build --features=-per_object_debug_info
-# Suppress deprecated call warnings due to extensive noise from protobuf
+# Suppress deprecated declaration warnings due to extensive transitive noise from protobuf.
 build --copt -Wno-deprecated-declarations
 build --@envoy//bazel:http3=False
 

--- a/.bazelrc
+++ b/.bazelrc
@@ -25,6 +25,8 @@ build --define cxxopts=-std=c++17
 build --incompatible_objc_compile_info_migration
 # Unset per_object_debug_info. Causes failures on Android Linux release builds.
 build --features=-per_object_debug_info
+# Suppress deprecated call warnings due to extensive noise from protobuf
+build --copt -Wno-deprecated-declarations
 build --@envoy//bazel:http3=False
 
 # Default flags for builds targeting iOS


### PR DESCRIPTION
Description: We get a ton of noise transitively from proto compilation due to this warning. This makes it much easier to parse build output.
Risk Level: Low
Testing: Local and CI

Signed-off-by: Mike Schore <mike.schore@gmail.com>