### PR TITLE
kotlin: add grpc receive error test

### DIFF
--- a/library/kotlin/io/envoyproxy/envoymobile/grpc/GRPCStreamPrototype.kt
+++ b/library/kotlin/io/envoyproxy/envoymobile/grpc/GRPCStreamPrototype.kt
@@ -4,6 +4,7 @@ import java.io.ByteArrayOutputStream
 import java.nio.ByteBuffer
 import java.nio.ByteOrder
 import java.util.concurrent.Executor
+import java.util.concurrent.Executors
 
 /**
  * A type representing a gRPC stream that has not yet been started.
@@ -19,7 +20,7 @@ class GRPCStreamPrototype(
    * @param executor Executor on which to receive callback events.
    * @return The new gRPC stream.
    */
-  fun start(executor: Executor): GRPCStream {
+  fun start(executor: Executor = Executors.newSingleThreadExecutor()): GRPCStream {
     val stream = underlyingStream.start(executor)
     return GRPCStream(stream)
   }

--- a/test/kotlin/integration/BUILD
+++ b/test/kotlin/integration/BUILD
@@ -41,3 +41,17 @@ envoy_mobile_jni_kt_test(
         "//library/kotlin/io/envoyproxy/envoymobile:envoy_interfaces_lib",
     ],
 )
+
+envoy_mobile_jni_kt_test(
+    name = "grpc_receive_error_test",
+    srcs = [
+        "GRPCReceiveErrorTest.kt",
+    ],
+    native_deps = [
+        "//library/common/jni:libjava_jni_lib.so",
+        "//library/common/jni:java_jni_lib.jnilib",
+    ],
+    deps = [
+        "//library/kotlin/io/envoyproxy/envoymobile:envoy_interfaces_lib",
+    ],
+)

--- a/test/kotlin/integration/GRPCReceiveErrorTest.kt
+++ b/test/kotlin/integration/GRPCReceiveErrorTest.kt
@@ -12,11 +12,11 @@ import io.envoyproxy.envoymobile.ResponseFilter
 import io.envoyproxy.envoymobile.ResponseHeaders
 import io.envoyproxy.envoymobile.ResponseTrailers
 import io.envoyproxy.envoymobile.engine.JniLibrary
-import org.assertj.core.api.Assertions
-import org.junit.Test
 import java.nio.ByteBuffer
 import java.util.concurrent.CountDownLatch
 import java.util.concurrent.TimeUnit
+import org.assertj.core.api.Assertions
+import org.junit.Test
 
 private const val hcmType =
   "type.googleapis.com/envoy.extensions.filters.network.http_connection_manager.v3.HttpConnectionManager"

--- a/test/kotlin/integration/GRPCReceiveErrorTest.kt
+++ b/test/kotlin/integration/GRPCReceiveErrorTest.kt
@@ -1,0 +1,122 @@
+package test.kotlin.integration
+
+import io.envoyproxy.envoymobile.Custom
+import io.envoyproxy.envoymobile.EngineBuilder
+import io.envoyproxy.envoymobile.EnvoyError
+import io.envoyproxy.envoymobile.FilterDataStatus
+import io.envoyproxy.envoymobile.FilterHeadersStatus
+import io.envoyproxy.envoymobile.FilterTrailersStatus
+import io.envoyproxy.envoymobile.GRPCClient
+import io.envoyproxy.envoymobile.GRPCRequestHeadersBuilder
+import io.envoyproxy.envoymobile.ResponseFilter
+import io.envoyproxy.envoymobile.ResponseHeaders
+import io.envoyproxy.envoymobile.ResponseTrailers
+import io.envoyproxy.envoymobile.engine.JniLibrary
+import org.assertj.core.api.Assertions
+import org.junit.Test
+import java.nio.ByteBuffer
+import java.util.concurrent.CountDownLatch
+import java.util.concurrent.TimeUnit
+
+private const val hcmType =
+  "type.googleapis.com/envoy.extensions.filters.network.http_connection_manager.v3.HttpConnectionManager"
+private const val pbfType = "type.googleapis.com/envoymobile.extensions.filters.http.platform_bridge.PlatformBridge"
+private const val localErrorFilterType =
+  "type.googleapis.com/envoymobile.extensions.filters.http.local_error.LocalError"
+private const val filterName = "error_validation_filter"
+private const val config =
+  """
+    static_resources:
+      listeners:
+      - name: base_api_listener
+        address:
+          socket_address: { protocol: TCP, address: 0.0.0.0, port_value: 10000 }
+        api_listener:
+          api_listener:
+            "@type": $hcmType
+            stat_prefix: hcm
+            route_config:
+              name: api_router
+              virtual_hosts:
+              - name: api
+                domains: ["*"]
+                routes:
+                - match: { prefix: "/" }
+                  direct_response: { status: 503 }
+            http_filters:
+            - name: envoy.filters.http.platform_bridge
+              typed_config:
+                "@type": $pbfType
+                platform_filter_name: $filterName
+            - name: envoy.filters.http.local_error
+              typed_config:
+                "@type": $localErrorFilterType
+            - name: envoy.router
+              typed_config:
+                "@type": type.googleapis.com/envoy.extensions.filters.http.router.v3.Router
+    """
+
+class GRPCReceiveErrorTest {
+  init {
+    JniLibrary.loadTestLibrary()
+  }
+
+  private val filterExpectation = CountDownLatch(1)
+  private val runExpectation = CountDownLatch(1)
+
+  class ErrorValidationFilter(
+    private val latch: CountDownLatch
+  ) : ResponseFilter {
+    override fun onResponseHeaders(headers: ResponseHeaders, endStream: Boolean): FilterHeadersStatus<ResponseHeaders> {
+      return FilterHeadersStatus.Continue(headers)
+    }
+
+    override fun onResponseData(body: ByteBuffer, endStream: Boolean): FilterDataStatus<ResponseHeaders> {
+      return FilterDataStatus.Continue(body)
+    }
+
+    override fun onResponseTrailers(trailers: ResponseTrailers): FilterTrailersStatus<ResponseHeaders, ResponseTrailers> {
+      return FilterTrailersStatus.Continue(trailers)
+    }
+
+    override fun onError(error: EnvoyError) {}
+
+    override fun onCancel() {
+      latch.countDown()
+    }
+  }
+
+  @Test
+  fun `errors on stream call onError callback`() {
+    val requestHeader = GRPCRequestHeadersBuilder(
+      scheme = "https",
+      authority = "example.com",
+      path = "/pb.api.v1.Foo/GetBar"
+    ).build()
+
+    val engine = EngineBuilder(Custom(config))
+      .addPlatformFilter(
+        name = filterName,
+        factory = { ErrorValidationFilter(filterExpectation) }
+      )
+      .setOnEngineRunning {}
+      .build()
+
+    GRPCClient(engine.streamClient())
+      .newGRPCStreamPrototype()
+      .setOnResponseHeaders { headers, endStream -> }
+      .setOnResponseMessage { }
+      .setOnError {
+        runExpectation.countDown()
+      }
+      .start()
+      .sendHeaders(requestHeader, false)
+      .sendMessage(ByteBuffer.wrap(ByteArray(5)))
+
+    engine.terminate()
+    filterExpectation.await(10, TimeUnit.SECONDS)
+    runExpectation.await(10, TimeUnit.SECONDS)
+    Assertions.assertThat(filterExpectation.count).isEqualTo(0)
+    Assertions.assertThat(runExpectation.count).isEqualTo(0)
+  }
+}

--- a/test/swift/integration/GRPCReceiveErrorTest.swift
+++ b/test/swift/integration/GRPCReceiveErrorTest.swift
@@ -11,6 +11,7 @@ final class ReceiveErrorTests: XCTestCase {
     let pbfType = "type.googleapis.com/envoymobile.extensions.filters.http.platform_bridge.PlatformBridge"
     // swiftlint:disable:next line_length
     let localErrorFilterType = "type.googleapis.com/envoymobile.extensions.filters.http.local_error.LocalError"
+    let filterName = "error_validation_filter"
     let config =
     """
     static_resources:
@@ -34,7 +35,7 @@ final class ReceiveErrorTests: XCTestCase {
             - name: envoy.filters.http.platform_bridge
               typed_config:
                 "@type": \(pbfType)
-                platform_filter_name: error_validation_filter
+                platform_filter_name: \(filterName)
             - name: envoy.filters.http.local_error
               typed_config:
                 "@type": \(localErrorFilterType)
@@ -75,7 +76,7 @@ final class ReceiveErrorTests: XCTestCase {
     let httpStreamClient = EngineBuilder(yaml: config)
       .addLogLevel(.trace)
       .addPlatformFilter(
-        name: "error_validation_filter",
+        name: filterName,
         factory: { ErrorValidationFilter(expectation: filterExpectation) }
       )
       .build()
@@ -102,7 +103,7 @@ final class ReceiveErrorTests: XCTestCase {
          runExpectation.fulfill()
       }
       .start()
-      .sendHeaders(requestHeaders, endStream: true)
+      .sendHeaders(requestHeaders, endStream: false)
       .sendMessage(message)
 
     XCTAssertEqual(XCTWaiter.wait(for: [filterExpectation, runExpectation], timeout: 1), .completed)


### PR DESCRIPTION
Signed-off-by: Alan Chiu <achiu@lyft.com>

For an explanation of how to fill out the fields, please see the relevant section
in [PULL_REQUESTS.md](https://github.com/envoyproxy/envoy/blob/master/PULL_REQUESTS.md)

Description: kotlin: add grpc receive error test
Risk Level: low
Testing: unit
Docs Changes: n/a
Release Notes: n/a
[Optional Fixes #Issue]
[Optional Deprecated:]
