### PR TITLE
Disable Java Tests on Mac - only keep Unix tests

### DIFF
--- a/.github/workflows/android_tests.yml
+++ b/.github/workflows/android_tests.yml
@@ -96,3 +96,4 @@ jobs:
     - run: |
         bazel test --test_output=all --build_tests_only //test/java/...
       name: 'Run Java library integration tests'
+

--- a/.github/workflows/android_tests.yml
+++ b/.github/workflows/android_tests.yml
@@ -8,6 +8,8 @@ on:
 
 jobs:
   kotlintestsmac:
+    # Only Kotlin tests are executed since with Mac:
+    # https://github.com/envoyproxy/envoy-mobile/issues/1447.
     name: kotlin_tests_mac
     runs-on: macOS-latest
     timeout-minutes: 90
@@ -39,41 +41,7 @@ jobs:
         if: steps.check_context.outputs.run_tests == 'true'
         run: |
           bazelisk test --test_output=all --build_tests_only //test/kotlin/...
-  javatestsmac:
-    name: java_tests_mac
-    runs-on: macOS-latest
-    timeout-minutes: 90
-    steps:
-      - uses: actions/checkout@v1
-        with:
-          submodules: true
-      - id: check_context
-        name: 'Check whether to run'
-        run: |
-          if git rev-parse --abbrev-ref HEAD | grep -q ^main$ || git diff --name-only origin/main | grep -qe common/ -e java/ -e kotlin/ -e bazel/ -e ^\.bazelrc$ -e ^envoy$ -e ^WORKSPACE$ ; then
-            echo "Tests will run."
-            echo "::set-output name=run_tests::true"
-          else
-            echo "Skipping tests."
-            echo "::set-output name=run_tests::false"
-          fi
-      - name: 'Java setup'
-        if: steps.check_context.outputs.run_tests == 'true'
-        uses: actions/setup-java@v1
-        with:
-          java-version: '8'
-          java-package: jdk
-          architecture: x64
-      - name: 'Install dependencies'
-        if: steps.check_context.outputs.run_tests == 'true'
-        run: ./ci/mac_ci_setup.sh
-      - name: 'Run Java library tests'
-        if: steps.check_context.outputs.run_tests == 'true'
-        run: |
-          bazelisk test --test_output=all --build_tests_only  //test/java/...
   kotlintestslinux:
-    # Only kotlin tests are executed since with linux:
-    # https://github.com/envoyproxy/envoy-mobile/issues/1418.
     name: kotlin_tests_linux
     runs-on: ubuntu-18.04
     timeout-minutes: 90
@@ -107,3 +75,24 @@ jobs:
         if: steps.check_context.outputs.run_tests == 'true'
         run: |
           bazel test --test_output=all --build_tests_only //test/kotlin/...
+  javatestslinux:
+    name: java_tests_linux
+    runs-on: ubuntu-18.04
+    timeout-minutes: 90
+    container:
+      image: envoyproxy/envoy-build-ubuntu:e33c93e6d79804bf95ff80426d10bdcc9096c785
+      env:
+        CC: /opt/llvm/bin/clang
+        CXX: /opt/llvm/bin/clang++
+    steps:
+    - uses: actions/checkout@v1
+      with:
+        submodules: true
+    - uses: actions/setup-java@v1
+      with:
+        java-version: '8'
+        java-package: jdk
+        architecture: x64
+    - run: |
+        bazel test --test_output=all --build_tests_only //test/java/...
+      name: 'Run Java library integration tests'


### PR DESCRIPTION
This PR is tentative:  only works if issue https://github.com/envoyproxy/envoy-mobile/issues/1418 gets resolution.

Description: Circumvent failure when running Java tests with Mac
Risk Level: N/A
Testing: N/A
Docs Changes: N/A
Release Notes: N/A
Signed-off-by: Charles Le Borgne <cleborgne@google.com>

