### PR TITLE
bazel: add missing input for swift generated header

### DIFF
--- a/bazel/swift_static_framework.bzl
+++ b/bazel/swift_static_framework.bzl
@@ -61,6 +61,7 @@ def _swift_static_framework_impl(ctx):
         ]
 
         if len(objc_headers) == 1:
+            input_modules_docs.append(objc_headers[0])
             zip_args.append(_zip_header_arg(module_name, objc_headers[0]))
         else:
             header_names = [header.basename for header in objc_headers]


### PR DESCRIPTION
Remote Build without the Bytes and/or Remote Execution doesn't work otherwise.

Signed-off-by: Brentley Jones <brentleyjones@lyft.com>

Risk Level: Low.
Testing: Unit tests.
Docs Changes: N/A.
Release Notes: N/A.
