### PR TITLE
swift: SendDataTest.swift clean up

### DIFF
--- a/test/swift/integration/SendDataTest.swift
+++ b/test/swift/integration/SendDataTest.swift
@@ -9,6 +9,7 @@ final class SendDataTests: XCTestCase {
     let apiListenerType = "type.googleapis.com/envoy.extensions.filters.network.http_connection_manager.v3.HttpConnectionManager"
     // swiftlint:disable:next line_length
     let assertionFilterType = "type.googleapis.com/envoymobile.extensions.filters.http.assertion.Assertion"
+    let requestStringMatch = "match_me"
     let config =
     """
     static_resources:
@@ -41,7 +42,7 @@ final class SendDataTests: XCTestCase {
                   match_config:
                     http_request_generic_body_match:
                       patterns:
-                        - string_match: match_me
+                        - string_match: \(requestStringMatch)
               - name: envoy.filters.http.buffer
                 typed_config:
                   "@type": type.googleapis.com/envoy.extensions.filters.http.buffer.v3.Buffer
@@ -61,7 +62,7 @@ final class SendDataTests: XCTestCase {
                                                authority: "example.com", path: "/test")
       .addUpstreamHttpProtocol(.http2)
       .build()
-    let body = try XCTUnwrap("match_me".data(using: .utf8))
+    let body = try XCTUnwrap(requestStringMatch.data(using: .utf8))
 
     client
       .newStreamPrototype()


### PR DESCRIPTION
The change is just to extract out the matching request body to a constant.

Signed-off-by: Alan Chiu <achiu@lyft.com>

For an explanation of how to fill out the fields, please see the relevant section
in [PULL_REQUESTS.md](https://github.com/envoyproxy/envoy/blob/master/PULL_REQUESTS.md)

Description: swift: SendDataTest.swift clean up
Risk Level: low
Testing: ci
Docs Changes: n/a
Release Notes: n/a
[Optional Fixes #Issue]
[Optional Deprecated:]
