### PR TITLE
Add "HTTP Redirect" support to Cronvoy

### DIFF
--- a/library/java/org/cronvoy/CronvoyUrlRequest.java
+++ b/library/java/org/cronvoy/CronvoyUrlRequest.java
@@ -389,8 +389,7 @@ final class CronvoyUrlRequest extends UrlRequestBase {
         new ArrayList<>(urlChain), responseCode,
         "HTTP " + responseHeaders.getHttpStatus(), // UrlConnection.getResponseMessage(),
         Collections.unmodifiableList(headerList), false, selectedTransport, "", 0);
-    // TODO(carloseltuerto) make this "if" a possibility with Envoy-Mobile
-    if (responseCode >= 300 && responseCode < 400) {
+    if (responseCode >= 300 && responseCode < 400 && lastCallback) {
       List<String> locationFields = urlResponseInfo.getAllHeaders().get("location");
       if (locationFields != null) {
         fireRedirectReceived(locationFields.get(0));


### PR DESCRIPTION
Cronet requirements to support "HTTP redirect" seem fairly simple: always wait for the caller to confirm redirection acceptance. If the caller rejects the redirection, then the caller does not need to do anything else - the UrlRequest must be in a state where everything has been "closed" already.

There is one API subtlety: in the event that an HTTP Redirect response contains a body, that body must be ignored. Implementation wise, this implies that `setOnResponseData` callbacks must become a no-op.

Description: Add "HTTP Redirect" support, implemented within Cronvoy shim.
Risk Level: N/A
Testing: N/A
Docs Changes: N/A
Release Notes: N/A
Signed-off-by: Charles Le Borgne cleborgne@google.com