### PR TITLE
engine: add configurable stream idle timeout

### DIFF
--- a/library/common/config_template.cc
+++ b/library/common/config_template.cc
@@ -85,6 +85,7 @@ static_resources:
       api_listener:
         "@type": type.googleapis.com/envoy.extensions.filters.network.http_connection_manager.v3.HttpConnectionManager
         stat_prefix: hcm
+        stream_idle_timeout: {{ stream_idle_timeout_seconds }}s
         route_config:
           name: api_router
           virtual_hosts:

--- a/library/java/io/envoyproxy/envoymobile/engine/EnvoyConfiguration.java
+++ b/library/java/io/envoyproxy/envoymobile/engine/EnvoyConfiguration.java
@@ -109,7 +109,7 @@ public class EnvoyConfiguration {
             .replace("{{ dns_failure_refresh_rate_seconds_max }}",
                      String.format("%s", dnsFailureRefreshSecondsMax))
             .replace("{{ stats_flush_interval_seconds }}", String.format("%s", statsFlushSeconds))
-            .replace("{{ stream_idle_timeout_seconds }",
+            .replace("{{ stream_idle_timeout_seconds }}",
                      String.format("%s", streamIdleTimeoutSeconds))
             .replace("{{ device_os }}", "Android")
             .replace("{{ app_version }}", appVersion)

--- a/library/java/io/envoyproxy/envoymobile/engine/EnvoyConfiguration.java
+++ b/library/java/io/envoyproxy/envoymobile/engine/EnvoyConfiguration.java
@@ -45,7 +45,7 @@ public class EnvoyConfiguration {
    */
   public EnvoyConfiguration(String statsDomain, int connectTimeoutSeconds, int dnsRefreshSeconds,
                             int dnsFailureRefreshSecondsBase, int dnsFailureRefreshSecondsMax,
-                            int statsFlushSeconds, int streamIdleTimeoutSeconds,  String appVersion,
+                            int statsFlushSeconds, int streamIdleTimeoutSeconds, String appVersion,
                             String appId, String virtualClusters,
                             List<EnvoyNativeFilterConfig> nativeFilterChain,
                             List<EnvoyHTTPFilterFactory> httpPlatformFilterFactories,
@@ -108,7 +108,7 @@ public class EnvoyConfiguration {
             .replace("{{ dns_failure_refresh_rate_seconds_max }}",
                      String.format("%s", dnsFailureRefreshSecondsMax))
             .replace("{{ stats_flush_interval_seconds }}", String.format("%s", statsFlushSeconds))
-            .replace("{{ stream_idle_timeout_seconds }", String.format("%s", streamIdleTimeoutSeconds ))
+            .replace("{{ stream_idle_timeout_seconds }", String.format("%s", streamIdleTimeoutSeconds))
             .replace("{{ device_os }}", "Android")
             .replace("{{ app_version }}", appVersion)
             .replace("{{ app_id }}", appId)

--- a/library/java/io/envoyproxy/envoymobile/engine/EnvoyConfiguration.java
+++ b/library/java/io/envoyproxy/envoymobile/engine/EnvoyConfiguration.java
@@ -108,7 +108,8 @@ public class EnvoyConfiguration {
             .replace("{{ dns_failure_refresh_rate_seconds_max }}",
                      String.format("%s", dnsFailureRefreshSecondsMax))
             .replace("{{ stats_flush_interval_seconds }}", String.format("%s", statsFlushSeconds))
-            .replace("{{ stream_idle_timeout_seconds }", String.format("%s", streamIdleTimeoutSeconds))
+            .replace("{{ stream_idle_timeout_seconds }",
+                     String.format("%s", streamIdleTimeoutSeconds))
             .replace("{{ device_os }}", "Android")
             .replace("{{ app_version }}", appVersion)
             .replace("{{ app_id }}", appId)

--- a/library/java/io/envoyproxy/envoymobile/engine/EnvoyConfiguration.java
+++ b/library/java/io/envoyproxy/envoymobile/engine/EnvoyConfiguration.java
@@ -17,6 +17,7 @@ public class EnvoyConfiguration {
   public final Integer dnsFailureRefreshSecondsMax;
   public final List<EnvoyHTTPFilterFactory> httpPlatformFilterFactories;
   public final Integer statsFlushSeconds;
+  public final Integer streamIdleTimeoutSeconds;
   public final String appVersion;
   public final String appId;
   public final String virtualClusters;

--- a/library/java/io/envoyproxy/envoymobile/engine/EnvoyConfiguration.java
+++ b/library/java/io/envoyproxy/envoymobile/engine/EnvoyConfiguration.java
@@ -35,6 +35,7 @@ public class EnvoyConfiguration {
    * @param dnsFailureRefreshSecondsBase base rate in seconds to refresh DNS on failure.
    * @param dnsFailureRefreshSecondsMax  max rate in seconds to refresh DNS on failure.
    * @param statsFlushSeconds            interval at which to flush Envoy stats.
+   * @param streamIdleTimeoutSeconds     idle timeout for HTTP streams.
    * @param appVersion                   the App Version of the App using this Envoy Client.
    * @param appId                        the App ID of the App using this Envoy Client.
    * @param virtualClusters              the JSON list of virtual cluster configs.
@@ -44,8 +45,9 @@ public class EnvoyConfiguration {
    */
   public EnvoyConfiguration(String statsDomain, int connectTimeoutSeconds, int dnsRefreshSeconds,
                             int dnsFailureRefreshSecondsBase, int dnsFailureRefreshSecondsMax,
-                            int statsFlushSeconds, String appVersion, String appId,
-                            String virtualClusters, List<EnvoyNativeFilterConfig> nativeFilterChain,
+                            int statsFlushSeconds, int streamIdleTimeoutSeconds,  String appVersion,
+                            String appId, String virtualClusters,
+                            List<EnvoyNativeFilterConfig> nativeFilterChain,
                             List<EnvoyHTTPFilterFactory> httpPlatformFilterFactories,
                             Map<String, EnvoyStringAccessor> stringAccessors) {
     this.statsDomain = statsDomain;
@@ -54,6 +56,7 @@ public class EnvoyConfiguration {
     this.dnsFailureRefreshSecondsBase = dnsFailureRefreshSecondsBase;
     this.dnsFailureRefreshSecondsMax = dnsFailureRefreshSecondsMax;
     this.statsFlushSeconds = statsFlushSeconds;
+    this.streamIdleTimeoutSeconds = streamIdleTimeoutSeconds;
     this.appVersion = appVersion;
     this.appId = appId;
     this.virtualClusters = virtualClusters;
@@ -105,6 +108,7 @@ public class EnvoyConfiguration {
             .replace("{{ dns_failure_refresh_rate_seconds_max }}",
                      String.format("%s", dnsFailureRefreshSecondsMax))
             .replace("{{ stats_flush_interval_seconds }}", String.format("%s", statsFlushSeconds))
+            .replace("{{ stream_idle_timeout_seconds }", String.format("%s", streamIdleTimeoutSeconds ))
             .replace("{{ device_os }}", "Android")
             .replace("{{ app_version }}", appVersion)
             .replace("{{ app_id }}", appId)

--- a/library/kotlin/io/envoyproxy/envoymobile/EngineBuilder.kt
+++ b/library/kotlin/io/envoyproxy/envoymobile/EngineBuilder.kt
@@ -241,8 +241,8 @@ open class EngineBuilder(
           EnvoyConfiguration(
             statsDomain, connectTimeoutSeconds,
             dnsRefreshSeconds, dnsFailureRefreshSecondsBase, dnsFailureRefreshSecondsMax,
-            statsFlushSeconds, streamIdleTimeoutSeconds, appVersion, appId, virtualClusters, nativeFilterChain,
-            platformFilterChain, stringAccessors
+            statsFlushSeconds, streamIdleTimeoutSeconds, appVersion, appId, virtualClusters,
+            nativeFilterChain, platformFilterChain, stringAccessors
           ),
           configuration.yaml,
           logLevel
@@ -254,8 +254,8 @@ open class EngineBuilder(
           EnvoyConfiguration(
             statsDomain, connectTimeoutSeconds,
             dnsRefreshSeconds, dnsFailureRefreshSecondsBase, dnsFailureRefreshSecondsMax,
-            statsFlushSeconds, streamIdleTimeoutSeconds, appVersion, appId, virtualClusters, nativeFilterChain,
-            platformFilterChain, stringAccessors
+            statsFlushSeconds, streamIdleTimeoutSeconds, appVersion, appId, virtualClusters,
+            nativeFilterChain, platformFilterChain, stringAccessors
           ),
           logLevel
         )

--- a/library/kotlin/io/envoyproxy/envoymobile/EngineBuilder.kt
+++ b/library/kotlin/io/envoyproxy/envoymobile/EngineBuilder.kt
@@ -29,6 +29,7 @@ open class EngineBuilder(
   private var dnsFailureRefreshSecondsBase = 2
   private var dnsFailureRefreshSecondsMax = 10
   private var statsFlushSeconds = 60
+  private var streamIdleTimeoutSeconds = 15
   private var appVersion = "unspecified"
   private var appId = "unspecified"
   private var virtualClusters = "[]"
@@ -108,6 +109,18 @@ open class EngineBuilder(
    */
   fun addStatsFlushSeconds(statsFlushSeconds: Int): EngineBuilder {
     this.statsFlushSeconds = statsFlushSeconds
+    return this
+  }
+
+  /**
+   * Add a custom idle timeout for HTTP streams. Defaults to 15 seconds.
+   *
+   * @param streamIdleTimeoutSeconds idle timeout for HTTP streams.
+   *
+   * @return this builder.
+   */
+  fun addStreamIdleTimeout(streamIdleTimeoutSeconds: Int): EngineBuilder {
+    this.streamIdleTimeoutSeconds = streamIdleTimeoutSeconds
     return this
   }
 
@@ -228,7 +241,7 @@ open class EngineBuilder(
           EnvoyConfiguration(
             statsDomain, connectTimeoutSeconds,
             dnsRefreshSeconds, dnsFailureRefreshSecondsBase, dnsFailureRefreshSecondsMax,
-            statsFlushSeconds, appVersion, appId, virtualClusters, nativeFilterChain,
+            statsFlushSeconds, streamIdleTimeoutSeconds, appVersion, appId, virtualClusters, nativeFilterChain,
             platformFilterChain, stringAccessors
           ),
           configuration.yaml,
@@ -241,7 +254,7 @@ open class EngineBuilder(
           EnvoyConfiguration(
             statsDomain, connectTimeoutSeconds,
             dnsRefreshSeconds, dnsFailureRefreshSecondsBase, dnsFailureRefreshSecondsMax,
-            statsFlushSeconds, appVersion, appId, virtualClusters, nativeFilterChain,
+            statsFlushSeconds, streamIdleTimeoutSeconds, appVersion, appId, virtualClusters, nativeFilterChain,
             platformFilterChain, stringAccessors
           ),
           logLevel

--- a/library/kotlin/io/envoyproxy/envoymobile/EngineBuilder.kt
+++ b/library/kotlin/io/envoyproxy/envoymobile/EngineBuilder.kt
@@ -119,7 +119,7 @@ open class EngineBuilder(
    *
    * @return this builder.
    */
-  fun addStreamIdleTimeout(streamIdleTimeoutSeconds: Int): EngineBuilder {
+  fun addStreamIdleTimeoutSeconds(streamIdleTimeoutSeconds: Int): EngineBuilder {
     this.streamIdleTimeoutSeconds = streamIdleTimeoutSeconds
     return this
   }

--- a/library/objective-c/EnvoyConfiguration.m
+++ b/library/objective-c/EnvoyConfiguration.m
@@ -96,7 +96,7 @@
         [NSString stringWithFormat:@"%lu", (unsigned long)self.dnsFailureRefreshSecondsMax],
     @"stats_flush_interval_seconds" :
         [NSString stringWithFormat:@"%lu", (unsigned long)self.statsFlushSeconds],
-   @"stream_idle_timeout_seconds" :
+    @"stream_idle_timeout_seconds" :
         [NSString stringWithFormat:@"%lu", (unsigned long)self.streamIdleTimeoutSeconds],
     @"device_os" : @"iOS",
     @"app_version" : self.appVersion,

--- a/library/objective-c/EnvoyConfiguration.m
+++ b/library/objective-c/EnvoyConfiguration.m
@@ -10,6 +10,7 @@
        dnsFailureRefreshSecondsBase:(UInt32)dnsFailureRefreshSecondsBase
         dnsFailureRefreshSecondsMax:(UInt32)dnsFailureRefreshSecondsMax
                   statsFlushSeconds:(UInt32)statsFlushSeconds
+           streamIdleTimeoutSeconds:(UInt32)streamIdleTimeoutSeconds
                          appVersion:(NSString *)appVersion
                               appId:(NSString *)appId
                     virtualClusters:(NSString *)virtualClusters
@@ -30,6 +31,7 @@
   self.dnsFailureRefreshSecondsBase = dnsFailureRefreshSecondsBase;
   self.dnsFailureRefreshSecondsMax = dnsFailureRefreshSecondsMax;
   self.statsFlushSeconds = statsFlushSeconds;
+  self.streamIdleTimeoutSeconds = streamIdleTimeoutSeconds;
   self.appVersion = appVersion;
   self.appId = appId;
   self.virtualClusters = virtualClusters;
@@ -94,6 +96,8 @@
         [NSString stringWithFormat:@"%lu", (unsigned long)self.dnsFailureRefreshSecondsMax],
     @"stats_flush_interval_seconds" :
         [NSString stringWithFormat:@"%lu", (unsigned long)self.statsFlushSeconds],
+   @"stream_idle_timeout_seconds" :
+        [NSString stringWithFormat:@"%lu", (unsigned long)self.streamIdleTimeoutSeconds],
     @"device_os" : @"iOS",
     @"app_version" : self.appVersion,
     @"app_id" : self.appId,

--- a/library/objective-c/EnvoyEngine.h
+++ b/library/objective-c/EnvoyEngine.h
@@ -259,6 +259,7 @@ extern const int kEnvoyFilterResumeStatusResumeIteration;
 @property (nonatomic, assign) UInt32 dnsFailureRefreshSecondsBase;
 @property (nonatomic, assign) UInt32 dnsFailureRefreshSecondsMax;
 @property (nonatomic, assign) UInt32 statsFlushSeconds;
+@property (nonatomic, assign) UInt32 streamIdleTimeoutSeconds;
 @property (nonatomic, strong) NSString *appVersion;
 @property (nonatomic, strong) NSString *appId;
 @property (nonatomic, strong) NSString *virtualClusters;
@@ -277,6 +278,7 @@ extern const int kEnvoyFilterResumeStatusResumeIteration;
        dnsFailureRefreshSecondsBase:(UInt32)dnsFailureRefreshSecondsBase
         dnsFailureRefreshSecondsMax:(UInt32)dnsFailureRefreshSecondsMax
                   statsFlushSeconds:(UInt32)statsFlushSeconds
+           streamIdleTimeoutSeconds:(UInt32)streamIdleTimeoutSeconds
                          appVersion:(NSString *)appVersion
                               appId:(NSString *)appId
                     virtualClusters:(NSString *)virtualClusters

--- a/library/swift/EngineBuilder.swift
+++ b/library/swift/EngineBuilder.swift
@@ -19,6 +19,7 @@ public class EngineBuilder: NSObject {
   private var dnsFailureRefreshSecondsBase: UInt32 = 2
   private var dnsFailureRefreshSecondsMax: UInt32 = 10
   private var statsFlushSeconds: UInt32 = 60
+  private var streamIdleTimeoutSeconds: UInt32 = 15
   private var appVersion: String = "unspecified"
   private var appId: String = "unspecified"
   private var virtualClusters: String = "[]"
@@ -111,6 +112,17 @@ public class EngineBuilder: NSObject {
   @discardableResult
   public func addStatsFlushSeconds(_ statsFlushSeconds: UInt32) -> Self {
     self.statsFlushSeconds = statsFlushSeconds
+    return self
+  }
+
+  /// Add a custom idle timeout for HTTP streams. Defaults to 15 seconds.
+  ///
+  /// - parameter streamIdleSeconds: Idle timeout for HTTP streams.
+  ///
+  /// - returns: This builder.
+  @discardableResult
+  public func addStreamIdleSeconds(_ streamIdleTimeoutSeconds: UInt32) -> Self {
+    self.streamIdleTimeoutSeconds = streamIdleTimeoutSeconds
     return self
   }
 
@@ -222,6 +234,7 @@ public class EngineBuilder: NSObject {
       dnsFailureRefreshSecondsBase: self.dnsFailureRefreshSecondsBase,
       dnsFailureRefreshSecondsMax: self.dnsFailureRefreshSecondsMax,
       statsFlushSeconds: self.statsFlushSeconds,
+      streamIdleTimeoutSeconds: self.streamIdleTimeoutSeconds,
       appVersion: self.appVersion,
       appId: self.appId,
       virtualClusters: self.virtualClusters,

--- a/library/swift/EngineBuilder.swift
+++ b/library/swift/EngineBuilder.swift
@@ -121,7 +121,7 @@ public class EngineBuilder: NSObject {
   ///
   /// - returns: This builder.
   @discardableResult
-  public func addStreamIdleSeconds(_ streamIdleTimeoutSeconds: UInt32) -> Self {
+  public func addStreamIdleTimeoutSeconds(_ streamIdleTimeoutSeconds: UInt32) -> Self {
     self.streamIdleTimeoutSeconds = streamIdleTimeoutSeconds
     return self
   }

--- a/test/java/io/envoyproxy/envoymobile/engine/EnvoyConfigurationTest.kt
+++ b/test/java/io/envoyproxy/envoymobile/engine/EnvoyConfigurationTest.kt
@@ -55,7 +55,7 @@ class EnvoyConfigurationTest {
   @Test
   fun `resolving with default configuration resolves with values`() {
     val envoyConfiguration = EnvoyConfiguration(
-      "stats.foo.com", 123, 234, 345, 456, 567, "v1.2.3", "com.mydomain.myapp", "[test]",
+      "stats.foo.com", 123, 234, 345, 456, 567, 678, "v1.2.3", "com.mydomain.myapp", "[test]",
       listOf<EnvoyNativeFilterConfig>(EnvoyNativeFilterConfig("filter_name", "test_config")),
       emptyList(), emptyMap()
     )
@@ -80,7 +80,7 @@ class EnvoyConfigurationTest {
   @Test
   fun `resolve templates with invalid templates will throw on build`() {
     val envoyConfiguration = EnvoyConfiguration(
-      "stats.foo.com", 123, 234, 345, 456, 567, "v1.2.3", "com.mydomain.myapp", "[test]",
+      "stats.foo.com", 123, 234, 345, 456, 567, 678, "v1.2.3", "com.mydomain.myapp", "[test]",
       emptyList(), emptyList(), emptyMap()
     )
 

--- a/test/kotlin/io/envoyproxy/envoymobile/EngineBuilderTest.kt
+++ b/test/kotlin/io/envoyproxy/envoymobile/EngineBuilderTest.kt
@@ -71,6 +71,16 @@ class EngineBuilderTest {
   }
 
   @Test
+  fun `specifying stream idle timeout overrides default`() {
+    engineBuilder = EngineBuilder(Standard())
+    engineBuilder.addEngineType { envoyEngine }
+    engineBuilder.addStreamIdleTimeoutSeconds(1234)
+
+    val engine = engineBuilder.build() as EngineImpl
+    assertThat(engine.envoyConfiguration!!.streamIdleTimeoutSeconds).isEqualTo(1234)
+  }
+
+  @Test
   fun `specifying app version overrides default`() {
     engineBuilder = EngineBuilder(Standard())
     engineBuilder.addEngineType { envoyEngine }

--- a/test/swift/EngineBuilderTests.swift
+++ b/test/swift/EngineBuilderTests.swift
@@ -15,6 +15,7 @@ mock_template:
     max_interval: {{ dns_failure_refresh_rate_seconds_max }}s
   platform_filter_chain: {{ platform_filter_chain }}
   stats_flush_interval: {{ stats_flush_interval_seconds }}s
+  stream_idle_timeout: {{ stream_idle_timeout_seconds }}s
   app_version: {{ app_version }}
   app_id: {{ app_id }}
   virtual_clusters: {{ virtual_clusters }}

--- a/test/swift/EngineBuilderTests.swift
+++ b/test/swift/EngineBuilderTests.swift
@@ -147,6 +147,20 @@ final class EngineBuilderTests: XCTestCase {
     self.waitForExpectations(timeout: 0.01)
   }
 
+  func testAddingStreamIdleTimeoutSecondsAddsToConfigurationWhenRunningEnvoy() {
+    let expectation = self.expectation(description: "Run called with expected data")
+    MockEnvoyEngine.onRunWithConfig = { config, _ in
+      XCTAssertEqual(42, config.streamIdleTimeoutSeconds)
+      expectation.fulfill()
+    }
+
+    _ = EngineBuilder()
+      .addEngineType(MockEnvoyEngine.self)
+      .addStreamIdleTimeoutSeconds(42)
+      .build()
+    self.waitForExpectations(timeout: 0.01)
+  }
+
   func testAddingAppVersionAddsToConfigurationWhenRunningEnvoy() {
     let expectation = self.expectation(description: "Run called with expected data")
     MockEnvoyEngine.onRunWithConfig = { config, _ in
@@ -225,6 +239,7 @@ final class EngineBuilderTests: XCTestCase {
       dnsFailureRefreshSecondsBase: 400,
       dnsFailureRefreshSecondsMax: 500,
       statsFlushSeconds: 600,
+      streamIdleTimeoutSeconds: 700,
       appVersion: "v1.2.3",
       appId: "com.envoymobile.ios",
       virtualClusters: "[test]",
@@ -246,6 +261,7 @@ final class EngineBuilderTests: XCTestCase {
     XCTAssertTrue(resolvedYAML.contains("max_interval: 500s"))
     XCTAssertTrue(resolvedYAML.contains("filter_name: TestFilter"))
     XCTAssertTrue(resolvedYAML.contains("stats_flush_interval: 600s"))
+    XCTAssertTrue(resolvedYAML.contains("stream_idle_timeout: 700s"))
     XCTAssertTrue(resolvedYAML.contains("device_os: iOS"))
     XCTAssertTrue(resolvedYAML.contains("app_version: v1.2.3"))
     XCTAssertTrue(resolvedYAML.contains("app_id: com.envoymobile.ios"))
@@ -262,6 +278,7 @@ final class EngineBuilderTests: XCTestCase {
       dnsFailureRefreshSecondsBase: 400,
       dnsFailureRefreshSecondsMax: 500,
       statsFlushSeconds: 600,
+      streamIdleTimeoutSeconds: 700,
       appVersion: "v1.2.3",
       appId: "com.envoymobile.ios",
       virtualClusters: "[test]",


### PR DESCRIPTION
Description: Exposes HTTP stream idle timeout as a configurable option via the Swift and Kotlin EngineBuilders.
Risk Level: Low
Testing: Local and CI

Signed-off-by: Mike Schore <mike.schore@gmail.com>