### PR TITLE
engine: disable the default route timeout

### DIFF
--- a/library/common/config_template.cc
+++ b/library/common/config_template.cc
@@ -99,7 +99,7 @@ static_resources:
                     prefix: "/"
                   route:
                     cluster_header: x-envoy-mobile-cluster
-                    timeout: 0
+                    timeout: 0s
                     retry_policy:
                       retry_back_off:
                         base_interval: 0.25s

--- a/library/common/config_template.cc
+++ b/library/common/config_template.cc
@@ -99,6 +99,7 @@ static_resources:
                     prefix: "/"
                   route:
                     cluster_header: x-envoy-mobile-cluster
+                    timeout: 0
                     retry_policy:
                       retry_back_off:
                         base_interval: 0.25s


### PR DESCRIPTION
Description: This defaults to 15 seconds, including all retries. This disables the timeout entirely, in preference of more granular settings via a request's retry policy.
Risk Level: Low
Testing: CI, Pending

Signed-off-by: Mike Schore <mike.schore@gmail.com>
