### PR TITLE
config: increase some arbitrary limits to practical maximums

### DIFF
--- a/library/common/config_template.cc
+++ b/library/common/config_template.cc
@@ -172,20 +172,11 @@ static_resources:
     circuit_breakers: &circuit_breakers_settings
       thresholds:
         - priority: DEFAULT
-          # n.b: with mobile clients there are scenarios where all concurrent requests might be
-          # retries (e.g., when the phone goes offline). Therefore, Envoy Mobile allows for the same
-          # amount of concurrency for retries as the default value for concurrency for requests.
-          # This configuration uses the default for max concurrent requests (1024) because there is
-          # no reasonable scenario where a mobile client should have even close to that many concurrent
-          # requests.
-          #
-          # `max_retries` could be used but maintainers advised against it, as there are plans to
-          # deprecate that setting.
-          # https://github.com/lyft/envoy-mobile/pull/811#issuecomment-619169529.
+          # Don't impose limits on concurrent retries.
           retry_budget:
             budget_percent:
               value: 100
-            min_retry_concurrency: 1024
+            min_retry_concurrency: 0xffffffff # uint32 max
   - name: base_wlan
     connect_timeout: {{ connect_timeout_seconds }}s
     lb_policy: CLUSTER_PROVIDED
@@ -340,5 +331,5 @@ layered_runtime:
     - name: static_layer_0
       static_layer:
         overload:
-          global_downstream_max_connections: 50000
+          global_downstream_max_connections: 0xffffffff # uint32 max
 )";


### PR DESCRIPTION
Description: While it might be unusual to run up against these limits as currently configured, there's simply no reason to be opinionated about them at all in default config. Benchmarking, stress testing, and unanticipated use cases could still run up against them. This PR increases them to their practical maximum.
Risk Level: Low
Testing: CI

Signed-off-by: Mike Schore <mike.schore@gmail.com>