### PR TITLE
engine: ensure thread-safety in postinit setup

### DIFF
--- a/library/common/engine.cc
+++ b/library/common/engine.cc
@@ -78,6 +78,7 @@ envoy_status_t Engine::main(const std::string config, const std::string log_leve
 
     postinit_callback_handler_ = main_common->server()->lifecycleNotifier().registerCallback(
         Envoy::Server::ServerLifecycleNotifier::Stage::PostInit, [this]() -> void {
+          ASSERT(Thread::MainThread::isMainThread());
           client_scope_ = server_->serverFactoryContext().scope().createScope("pulse.");
           // StatNameSet is lock-free, the benefit of using it is being able to create StatsName
           // on-the-fly without risking contention on system with lots of threads.


### PR DESCRIPTION
Description: It's critical that postinit setup is thread-safe relative to the dispatcher, but we can't actually call Event::Dispatcher::isThreadSafe() because it blows up at this juncture. This safety check is leveraged elsewhere by Envoy to execution is happening on the main thread regardless of dispatch.
Risk Level: Low
Testing: Local and CI

Signed-off-by: Mike Schore <mike.schore@gmail.com>