### PR TITLE
add stream_idle_timeout_seconds to cc lib

### DIFF
--- a/library/cc/engine_builder.cc
+++ b/library/cc/engine_builder.cc
@@ -111,6 +111,10 @@ EngineSharedPtr EngineBuilder::build() {
     }
   }
 
+  if (config_str.find("{{") != std::string::npos) {
+    throw std::runtime_error("could not resolve all template keys in config:\n" + config_str);
+  }
+
   envoy_logger null_logger{
       .log = nullptr,
       .release = envoy_noop_const_release,

--- a/library/cc/engine_builder.cc
+++ b/library/cc/engine_builder.cc
@@ -91,6 +91,7 @@ EngineSharedPtr EngineBuilder::build() {
       {"{{ stats_domain }}", this->stats_domain_},
       {"{{ stats_flush_interval_seconds }}", std::to_string(this->stats_flush_seconds_)},
       {"{{ virtual_clusters }}", this->virtual_clusters_},
+      {"{{ stream_idle_timeout_seconds }}", std::to_string(this->stream_idle_timeout_seconds_)},
       // TODO(crockeo): expose an API to these configuration options
       {"{{ fake_remote_listener }}", ""},
       {"{{ fake_cluster_matchers }}", ""},

--- a/library/cc/engine_builder.h
+++ b/library/cc/engine_builder.h
@@ -48,6 +48,7 @@ private:
   std::string app_version_ = "unspecified";
   std::string app_id_ = "unspecified";
   std::string virtual_clusters_ = "[]";
+  int stream_idle_timeout_seconds_ = 15;
 
   // TODO(crockeo): add after filter integration
   // private var platformFilterChain = mutableListOf<EnvoyHTTPFilterFactory>()


### PR DESCRIPTION
Description: Fixes a bug where C++ and Python couldn't start because `stream_idle_timeout_seconds` wasn't populated on the C++-lib `EngineBuilder`
Risk Level: Low
Testing: `bazel test //test/cc/...` and `bazel test //test/python/...`
Docs Changes: N/A
Release Notes: N/A
