### PR TITLE
python: release GIL while calling terminate to avoid deadlock

### DIFF
--- a/library/python/module_definition.cc
+++ b/library/python/module_definition.cc
@@ -44,7 +44,7 @@ PYBIND11_MODULE(envoy_engine, m) {
   py::class_<Engine, EngineSharedPtr>(m, "Engine")
       .def("stream_client", &Engine::streamClient)
       .def("pulse_client", &Engine::pulseClient)
-      .def("terminate", &Engine::terminate);
+      .def("terminate", &Engine::terminate, py::call_guard<py::gil_scoped_release>());
 
   py::class_<EngineBuilder, EngineBuilderSharedPtr>(m, "EngineBuilder")
       .def(py::init<std::string>())


### PR DESCRIPTION
Description: Alternative to https://github.com/envoyproxy/envoy-mobile/pull/1379 for getting rid of the deadlocks. The deadlocks are caused by:

* Thread 1 calls `Engine::terminate` with GIL in hand, asks Thread 2, and then waits for it to die.
* Thread 2 (envoy main thread) begins teardown, which causes `EngineCallbacks::~EngineCallbacks` to run, which attempts to grab the GIL.
* Thread 1 is waiting for Thread 2 to die
* Thread 2 is waiting for Thread 1 to give up the GIL

Risk Level: Low

Testing: ...a little convoluted. These deadlocks occur at process teardown, so I've been installing the envoy-requests wheel and making a pair of files:

```python
# named test.py
import envoy_engine
import envoy_requests
from envoy_requests.common.engine import Engine

if __name__ == "__main__":
    Engine.log_level = envoy_engine.LogLevel.Debug
    envoy_requests.get("https://api.lyft.com/ping")
```

and

```bash
#!/usr/bin/env bash

while true; do
    python test.py
    sleep 0.5
done
```

and then running several of these until a deadlock occurs. You can also reproduce them by running several test jobs at the same time (`--runs_per_test`), but I found the above method to result in a deadlock sooner.

Docs Changes: N/A
Release Notes: N/A