### PR TITLE
kotlin/swift: include version file in source

### DIFF
--- a/library/kotlin/io/envoyproxy/envoymobile/BUILD
+++ b/library/kotlin/io/envoyproxy/envoymobile/BUILD
@@ -64,6 +64,7 @@ envoy_mobile_kt_library(
         "StringAccessor.kt",
         "Trailers.kt",
         "UpstreamHttpProtocol.kt",
+        "Version.kt",
         "filters/*.kt",
         "grpc/*.kt",
         "mocks/*.kt",

--- a/library/kotlin/io/envoyproxy/envoymobile/Version.kt
+++ b/library/kotlin/io/envoyproxy/envoymobile/Version.kt
@@ -1,0 +1,4 @@
+package io.envoyproxy.envoymobile
+
+const val ENVOY_MOBILE_VERSION = "0.4.0.04282021"
+const val ENVOY_VERSION = "46b646cbfa87c274700174b142be4525c46bb0d0"

--- a/library/swift/BUILD
+++ b/library/swift/BUILD
@@ -35,6 +35,7 @@ swift_static_framework(
         "TestEngineBuilder.swift",
         "Trailers.swift",
         "UpstreamHttpProtocol.swift",
+        "Version.swift",
         "filters/*.swift",
         "grpc/*.swift",
         "mocks/*.swift",

--- a/library/swift/Version.swift
+++ b/library/swift/Version.swift
@@ -1,4 +1,4 @@
 import Foundation
 
-let envoy_mobile_version = "0.4.0.04282021"
-let envoy_version = "46b646cbfa87c274700174b142be4525c46bb0d0"
+public let envoy_mobile_version = "0.4.0.04282021"
+public let envoy_version = "46b646cbfa87c274700174b142be4525c46bb0d0"

--- a/library/swift/Version.swift
+++ b/library/swift/Version.swift
@@ -1,0 +1,4 @@
+import Foundation
+
+let envoy_mobile_version = "0.4.0.04282021"
+let envoy_version = "46b646cbfa87c274700174b142be4525c46bb0d0"

--- a/library/swift/Version.swift
+++ b/library/swift/Version.swift
@@ -1,4 +1,4 @@
 import Foundation
 
-public let envoy_mobile_version = "0.4.0.04282021"
-public let envoy_version = "46b646cbfa87c274700174b142be4525c46bb0d0"
+public let envoyMobileVersion = "0.4.0.04282021"
+public let envoyVersion = "46b646cbfa87c274700174b142be4525c46bb0d0"


### PR DESCRIPTION
Including the envoy mobile and envoy upstream sha in a source file. At Lyft, we're looking to tie envoy mobile versions with a particular release for bug reporting purposes.

Signed-off-by: Alan Chiu <achiu@lyft.com>

For an explanation of how to fill out the fields, please see the relevant section
in [PULL_REQUESTS.md](https://github.com/envoyproxy/envoy/blob/master/PULL_REQUESTS.md)

Description: kotlin/swift: include version file in source
Risk Level: low
Testing: n/a
Docs Changes: n/a
Release Notes: n/a
[Optional Fixes #Issue]
[Optional Deprecated:]
