### PR TITLE
http client: select from a pair of clusters for each connection class

### DIFF
--- a/library/common/config_template.cc
+++ b/library/common/config_template.cc
@@ -179,7 +179,29 @@ static_resources:
             budget_percent:
               value: 100
             min_retry_concurrency: 0xffffffff # uint32 max
+  - name: base_alt
+    connect_timeout: {{ connect_timeout_seconds }}s
+    lb_policy: CLUSTER_PROVIDED
+    cluster_type:
+      name: envoy.clusters.dynamic_forward_proxy
+      typed_config:
+        "@type": type.googleapis.com/envoy.extensions.clusters.dynamic_forward_proxy.v3.ClusterConfig
+        dns_cache_config: *dns_cache_config
+    transport_socket: *base_transport_socket
+    upstream_connection_options: *upstream_opts
+    circuit_breakers: *circuit_breakers_settings
   - name: base_wlan
+    connect_timeout: {{ connect_timeout_seconds }}s
+    lb_policy: CLUSTER_PROVIDED
+    cluster_type:
+      name: envoy.clusters.dynamic_forward_proxy
+      typed_config:
+        "@type": type.googleapis.com/envoy.extensions.clusters.dynamic_forward_proxy.v3.ClusterConfig
+        dns_cache_config: *dns_cache_config
+    transport_socket: *base_transport_socket
+    upstream_connection_options: *upstream_opts
+    circuit_breakers: *circuit_breakers_settings
+  - name: base_wlan_alt
     connect_timeout: {{ connect_timeout_seconds }}s
     lb_policy: CLUSTER_PROVIDED
     cluster_type:
@@ -201,7 +223,30 @@ static_resources:
     transport_socket: *base_transport_socket
     upstream_connection_options: *upstream_opts
     circuit_breakers: *circuit_breakers_settings
+  - name: base_wwan_alt
+    connect_timeout: {{ connect_timeout_seconds }}s
+    lb_policy: CLUSTER_PROVIDED
+    cluster_type:
+      name: envoy.clusters.dynamic_forward_proxy
+      typed_config:
+        "@type": type.googleapis.com/envoy.extensions.clusters.dynamic_forward_proxy.v3.ClusterConfig
+        dns_cache_config: *dns_cache_config
+    transport_socket: *base_transport_socket
+    upstream_connection_options: *upstream_opts
+    circuit_breakers: *circuit_breakers_settings
   - name: base_clear
+    connect_timeout: {{ connect_timeout_seconds }}s
+    lb_policy: CLUSTER_PROVIDED
+    cluster_type:
+      name: envoy.clusters.dynamic_forward_proxy
+      typed_config:
+        "@type": type.googleapis.com/envoy.extensions.clusters.dynamic_forward_proxy.v3.ClusterConfig
+        dns_cache_config: *dns_cache_config
+    transport_socket:
+      name: envoy.transport_sockets.raw_buffer
+    upstream_connection_options: *upstream_opts
+    circuit_breakers: *circuit_breakers_settings
+  - name: base_clear_alt
     connect_timeout: {{ connect_timeout_seconds }}s
     lb_policy: CLUSTER_PROVIDED
     cluster_type:
@@ -225,7 +270,31 @@ static_resources:
       name: envoy.transport_sockets.raw_buffer
     upstream_connection_options: *upstream_opts
     circuit_breakers: *circuit_breakers_settings
+  - name: base_wlan_clear_alt
+    connect_timeout: {{ connect_timeout_seconds }}s
+    lb_policy: CLUSTER_PROVIDED
+    cluster_type:
+      name: envoy.clusters.dynamic_forward_proxy
+      typed_config:
+        "@type": type.googleapis.com/envoy.extensions.clusters.dynamic_forward_proxy.v3.ClusterConfig
+        dns_cache_config: *dns_cache_config
+    transport_socket:
+      name: envoy.transport_sockets.raw_buffer
+    upstream_connection_options: *upstream_opts
+    circuit_breakers: *circuit_breakers_settings
   - name: base_wwan_clear
+    connect_timeout: {{ connect_timeout_seconds }}s
+    lb_policy: CLUSTER_PROVIDED
+    cluster_type:
+      name: envoy.clusters.dynamic_forward_proxy
+      typed_config:
+        "@type": type.googleapis.com/envoy.extensions.clusters.dynamic_forward_proxy.v3.ClusterConfig
+        dns_cache_config: *dns_cache_config
+    transport_socket:
+      name: envoy.transport_sockets.raw_buffer
+    upstream_connection_options: *upstream_opts
+    circuit_breakers: *circuit_breakers_settings
+  - name: base_wwan_clear_alt
     connect_timeout: {{ connect_timeout_seconds }}s
     lb_policy: CLUSTER_PROVIDED
     cluster_type:
@@ -249,6 +318,18 @@ static_resources:
     transport_socket: *base_transport_socket
     upstream_connection_options: *upstream_opts
     circuit_breakers: *circuit_breakers_settings
+  - name: base_h2_alt
+    http2_protocol_options: {}
+    connect_timeout: {{ connect_timeout_seconds }}s
+    lb_policy: CLUSTER_PROVIDED
+    cluster_type:
+      name: envoy.clusters.dynamic_forward_proxy
+      typed_config:
+        "@type": type.googleapis.com/envoy.extensions.clusters.dynamic_forward_proxy.v3.ClusterConfig
+        dns_cache_config: *dns_cache_config
+    transport_socket: *base_transport_socket
+    upstream_connection_options: *upstream_opts
+    circuit_breakers: *circuit_breakers_settings
   - name: base_wlan_h2
     http2_protocol_options: {}
     connect_timeout: {{ connect_timeout_seconds }}s
@@ -261,7 +342,31 @@ static_resources:
     transport_socket: *base_transport_socket
     upstream_connection_options: *upstream_opts
     circuit_breakers: *circuit_breakers_settings
+  - name: base_wlan_h2_alt
+    http2_protocol_options: {}
+    connect_timeout: {{ connect_timeout_seconds }}s
+    lb_policy: CLUSTER_PROVIDED
+    cluster_type:
+      name: envoy.clusters.dynamic_forward_proxy
+      typed_config:
+        "@type": type.googleapis.com/envoy.extensions.clusters.dynamic_forward_proxy.v3.ClusterConfig
+        dns_cache_config: *dns_cache_config
+    transport_socket: *base_transport_socket
+    upstream_connection_options: *upstream_opts
+    circuit_breakers: *circuit_breakers_settings
   - name: base_wwan_h2
+    http2_protocol_options: {}
+    connect_timeout: {{ connect_timeout_seconds }}s
+    lb_policy: CLUSTER_PROVIDED
+    cluster_type:
+      name: envoy.clusters.dynamic_forward_proxy
+      typed_config:
+        "@type": type.googleapis.com/envoy.extensions.clusters.dynamic_forward_proxy.v3.ClusterConfig
+        dns_cache_config: *dns_cache_config
+    transport_socket: *base_transport_socket
+    upstream_connection_options: *upstream_opts
+    circuit_breakers: *circuit_breakers_settings
+  - name: base_wwan_h2_alt
     http2_protocol_options: {}
     connect_timeout: {{ connect_timeout_seconds }}s
     lb_policy: CLUSTER_PROVIDED

--- a/library/common/engine.cc
+++ b/library/common/engine.cc
@@ -86,10 +86,9 @@ envoy_status_t Engine::main(const std::string config, const std::string log_leve
           stat_name_set_ = client_scope_->symbolTable().makeSet("pulse");
           auto api_listener = server_->listenerManager().apiListener()->get().http();
           ASSERT(api_listener.has_value());
-          http_client_ = std::make_unique<Http::Client>(api_listener.value(), *dispatcher_,
-                                                        server_->serverFactoryContext().scope(),
-                                                        preferred_network_,
-                                                        server_->api().randomGenerator());
+          http_client_ = std::make_unique<Http::Client>(
+              api_listener.value(), *dispatcher_, server_->serverFactoryContext().scope(),
+              preferred_network_, server_->api().randomGenerator());
           dispatcher_->drain(server_->dispatcher());
           if (callbacks_.on_engine_running != nullptr) {
             callbacks_.on_engine_running(callbacks_.context);

--- a/library/common/engine.cc
+++ b/library/common/engine.cc
@@ -88,7 +88,8 @@ envoy_status_t Engine::main(const std::string config, const std::string log_leve
           ASSERT(api_listener.has_value());
           http_client_ = std::make_unique<Http::Client>(api_listener.value(), *dispatcher_,
                                                         server_->serverFactoryContext().scope(),
-                                                        preferred_network_);
+                                                        preferred_network_,
+                                                        server_->api().randomGenerator());
           dispatcher_->drain(server_->dispatcher());
           if (callbacks_.on_engine_running != nullptr) {
             callbacks_.on_engine_running(callbacks_.context);

--- a/library/common/http/BUILD
+++ b/library/common/http/BUILD
@@ -28,6 +28,7 @@ envoy_cc_library(
         "@envoy//source/common/buffer:buffer_lib",
         "@envoy//source/common/common:lock_guard_lib",
         "@envoy//source/common/common:minimal_logger_lib",
+        "@envoy//source/common/common:random_generator_lib",
         "@envoy//source/common/common:thread_lib",
         "@envoy//source/common/common:thread_synchronizer_lib",
         "@envoy//source/common/http:codec_helper_lib",

--- a/library/common/http/client.cc
+++ b/library/common/http/client.cc
@@ -360,44 +360,38 @@ const LowerCaseString H2UpstreamHeader{"x-envoy-mobile-upstream-protocol"};
 // Long-term we will be working to generally provide more responsive connection handling within
 // Envoy itself.
 
-const char* BaseClusters[][3] = {
-  {
-    "base",
-    "base_wlan",
-    "base_wwan",
-  },
-  {
-    "base_alt",
-    "base_wlan_alt",
-    "base_wwan_alt",
-  }
-};
+const char* BaseClusters[][3] = {{
+                                     "base",
+                                     "base_wlan",
+                                     "base_wwan",
+                                 },
+                                 {
+                                     "base_alt",
+                                     "base_wlan_alt",
+                                     "base_wwan_alt",
+                                 }};
 
-const char* H2Clusters[][3] = {
-  {
-    "base_h2",
-    "base_wlan_h2",
-    "base_wwan_h2",
-  },
-  {
-    "base_h2_alt",
-    "base_wlan_h2_alt",
-    "base_wwan_h2_alt",
-  }
-};
+const char* H2Clusters[][3] = {{
+                                   "base_h2",
+                                   "base_wlan_h2",
+                                   "base_wwan_h2",
+                               },
+                               {
+                                   "base_h2_alt",
+                                   "base_wlan_h2_alt",
+                                   "base_wwan_h2_alt",
+                               }};
 
-const char* ClearTextClusters[][3] = {
-  {
-    "base_clear",
-    "base_wlan_clear",
-    "base_wwan_clear",
-  },
-  {
-    "base_clear_alt",
-    "base_wlan_clear_alt",
-    "base_wwan_clear_alt",
-  }
-};
+const char* ClearTextClusters[][3] = {{
+                                          "base_clear",
+                                          "base_wlan_clear",
+                                          "base_wwan_clear",
+                                      },
+                                      {
+                                          "base_clear_alt",
+                                          "base_wlan_clear_alt",
+                                          "base_wwan_clear_alt",
+                                      }};
 
 } // namespace
 

--- a/library/common/http/client.cc
+++ b/library/common/http/client.cc
@@ -217,7 +217,7 @@ envoy_status_t Client::sendHeaders(envoy_stream_t stream, envoy_headers headers,
   // https://github.com/lyft/envoy-mobile/issues/301
   if (direct_stream) {
     RequestHeaderMapPtr internal_headers = Utility::toRequestHeaders(headers);
-    setDestinationCluster(*internal_headers, random_.bernoulli(UnitFloat(0.5f)));
+    setDestinationCluster(*internal_headers, random_.random() % 2);
     // Set the x-forwarded-proto header to https because Envoy Mobile only has clusters with TLS
     // enabled. This is done here because the ApiListener's synthetic connection would make the
     // Http::ConnectionManager set the scheme to http otherwise. In the future we might want to

--- a/library/common/http/client.cc
+++ b/library/common/http/client.cc
@@ -401,7 +401,6 @@ void Client::setDestinationCluster(Http::RequestHeaderMap& headers, bool alterna
   auto h2_header = headers.get(H2UpstreamHeader);
   auto network = preferred_network_.load();
   ASSERT(network >= 0 && network < 3, "preferred_network_ must be valid index into cluster array");
-  ASSERT(!alternate, "every time");
 
   if (headers.getSchemeValue() == Headers::get().SchemeValues.Http) {
     cluster = ClearTextClusters[alternate][network];

--- a/library/common/http/client.h
+++ b/library/common/http/client.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include "envoy/buffer/buffer.h"
+#include "envoy/common/random_generator.h"
 #include "envoy/event/deferred_deletable.h"
 #include "envoy/http/api_listener.h"
 #include "envoy/http/codec.h"
@@ -40,11 +41,12 @@ struct HttpClientStats {
 class Client : public Logger::Loggable<Logger::Id::http> {
 public:
   Client(ApiListener& api_listener, Event::ProvisionalDispatcher& dispatcher, Stats::Scope& scope,
-         std::atomic<envoy_network_t>& preferred_network)
+         std::atomic<envoy_network_t>& preferred_network, Random::RandomGenerator& random)
       : api_listener_(api_listener), dispatcher_(dispatcher),
         stats_(HttpClientStats{ALL_HTTP_CLIENT_STATS(POOL_COUNTER_PREFIX(scope, "http.client."))}),
         preferred_network_(preferred_network),
-        address_(std::make_shared<Network::Address::SyntheticAddressImpl>()) {}
+        address_(std::make_shared<Network::Address::SyntheticAddressImpl>()),
+        random_(random) {}
 
   /**
    * Attempts to open a new stream to the remote. Note that this function is asynchronous and
@@ -214,7 +216,7 @@ private:
 
   DirectStreamSharedPtr getStream(envoy_stream_t stream_handle);
   void removeStream(envoy_stream_t stream_handle);
-  void setDestinationCluster(RequestHeaderMap& headers);
+  void setDestinationCluster(RequestHeaderMap& headers, bool alternate);
 
   ApiListener& api_listener_;
   Event::ProvisionalDispatcher& dispatcher_;
@@ -223,6 +225,7 @@ private:
   std::atomic<envoy_network_t>& preferred_network_;
   // Shared synthetic address across DirectStreams.
   Network::Address::InstanceConstSharedPtr address_;
+  Random::RandomGenerator& random_;
   Thread::ThreadSynchronizer synchronizer_;
 };
 

--- a/library/common/http/client.h
+++ b/library/common/http/client.h
@@ -45,8 +45,7 @@ public:
       : api_listener_(api_listener), dispatcher_(dispatcher),
         stats_(HttpClientStats{ALL_HTTP_CLIENT_STATS(POOL_COUNTER_PREFIX(scope, "http.client."))}),
         preferred_network_(preferred_network),
-        address_(std::make_shared<Network::Address::SyntheticAddressImpl>()),
-        random_(random) {}
+        address_(std::make_shared<Network::Address::SyntheticAddressImpl>()), random_(random) {}
 
   /**
    * Attempts to open a new stream to the remote. Note that this function is asynchronous and

--- a/test/common/http/client_test.cc
+++ b/test/common/http/client_test.cc
@@ -61,7 +61,7 @@ public:
   NiceMock<Event::MockProvisionalDispatcher> dispatcher_;
   envoy_http_callbacks bridge_callbacks_;
   std::atomic<envoy_network_t> preferred_network_{ENVOY_NET_GENERIC};
-  bool alt_cluster_ = false;
+  uint64_t alt_cluster_ = 0;
   NiceMock<Random::MockRandomGenerator> random_;
   Stats::IsolatedStoreImpl stats_store_;
   Client http_client_{api_listener_, dispatcher_, stats_store_, preferred_network_, random_};
@@ -88,7 +88,7 @@ TEST_F(ClientTest, SetDestinationCluster) {
     return nullptr;
   };
 
-  ON_CALL(random_, bernoulli(_)).WillByDefault(ReturnPointee(&alt_cluster_));
+  ON_CALL(random_, random()).WillByDefault(ReturnPointee(&alt_cluster_));
 
   // Create a stream.
   ON_CALL(dispatcher_, isThreadSafe()).WillByDefault(Return(true));

--- a/test/common/http/client_test.cc
+++ b/test/common/http/client_test.cc
@@ -131,13 +131,14 @@ TEST_F(ClientTest, SetDestinationCluster) {
   envoy_headers c_headers2 = Utility::toBridgeHeaders(headers2);
 
   preferred_network_.store(ENVOY_NET_WLAN);
+  alt_cluster_ = 1;
 
   TestRequestHeaderMapImpl expected_headers2{
       {":scheme", "https"},
       {":method", "GET"},
       {":authority", "host"},
       {":path", "/"},
-      {"x-envoy-mobile-cluster", "base_wlan"},
+      {"x-envoy-mobile-cluster", "base_wlan_alt"},
       {"x-forwarded-proto", "https"},
   };
   EXPECT_CALL(request_decoder_, decodeHeaders_(HeaderMapEqual(&expected_headers2), false));
@@ -149,6 +150,7 @@ TEST_F(ClientTest, SetDestinationCluster) {
   envoy_headers c_headers3 = Utility::toBridgeHeaders(headers3);
 
   preferred_network_.store(ENVOY_NET_WWAN);
+  alt_cluster_ = 0;
 
   TestRequestHeaderMapImpl expected_headers3{
       {":scheme", "https"},
@@ -191,6 +193,8 @@ TEST_F(ClientTest, SetDestinationClusterUpstreamProtocol) {
     return nullptr;
   };
 
+  ON_CALL(random_, random()).WillByDefault(ReturnPointee(&alt_cluster_));
+
   // Create a stream.
   ON_CALL(dispatcher_, isThreadSafe()).WillByDefault(Return(true));
 
@@ -214,13 +218,14 @@ TEST_F(ClientTest, SetDestinationClusterUpstreamProtocol) {
   envoy_headers c_headers1 = Utility::toBridgeHeaders(headers1);
 
   preferred_network_.store(ENVOY_NET_GENERIC);
+  alt_cluster_ = 1;
 
   TestResponseHeaderMapImpl expected_headers1{
       {":scheme", "https"},
       {":method", "GET"},
       {":authority", "host"},
       {":path", "/"},
-      {"x-envoy-mobile-cluster", "base_h2"},
+      {"x-envoy-mobile-cluster", "base_h2_alt"},
       {"x-forwarded-proto", "https"},
   };
   EXPECT_CALL(request_decoder_, decodeHeaders_(HeaderMapEqual(&expected_headers1), false));
@@ -232,6 +237,7 @@ TEST_F(ClientTest, SetDestinationClusterUpstreamProtocol) {
   envoy_headers c_headers2 = Utility::toBridgeHeaders(headers2);
 
   preferred_network_.store(ENVOY_NET_WLAN);
+  alt_cluster_ = 0;
 
   TestResponseHeaderMapImpl expected_headers2{
       {":scheme", "https"},
@@ -250,13 +256,14 @@ TEST_F(ClientTest, SetDestinationClusterUpstreamProtocol) {
   envoy_headers c_headers3 = Utility::toBridgeHeaders(headers3);
 
   preferred_network_.store(ENVOY_NET_WWAN);
+  alt_cluster_ = 1;
 
   TestResponseHeaderMapImpl expected_headers3{
       {":scheme", "https"},
       {":method", "GET"},
       {":authority", "host"},
       {":path", "/"},
-      {"x-envoy-mobile-cluster", "base_wwan_h2"},
+      {"x-envoy-mobile-cluster", "base_wwan_h2_alt"},
       {"x-forwarded-proto", "https"},
   };
   EXPECT_CALL(request_decoder_, decodeHeaders_(HeaderMapEqual(&expected_headers3), true));
@@ -269,6 +276,7 @@ TEST_F(ClientTest, SetDestinationClusterUpstreamProtocol) {
   envoy_headers c_headers4 = Utility::toBridgeHeaders(headers4);
 
   preferred_network_.store(ENVOY_NET_WWAN);
+  alt_cluster_ = 0;
 
   TestResponseHeaderMapImpl expected_headers4{
       {":scheme", "https"},

--- a/test/common/integration/client_integration_test.cc
+++ b/test/common/integration/client_integration_test.cc
@@ -120,7 +120,8 @@ TEST_P(ClientIntegrationTest, Basic) {
   test_server_->server().dispatcher().post([this, &server_started]() -> void {
     http_client_ = std::make_unique<Http::Client>(
         test_server_->server().listenerManager().apiListener()->get().http()->get(), *dispatcher_,
-        test_server_->statStore(), preferred_network_);
+        test_server_->statStore(), preferred_network_,
+        test_server_->server().api().randomGenerator());
     dispatcher_->drain(test_server_->server().dispatcher());
     server_started.setReady();
   });
@@ -197,7 +198,8 @@ TEST_P(ClientIntegrationTest, BasicNon2xx) {
   test_server_->server().dispatcher().post([this, &server_started]() -> void {
     http_client_ = std::make_unique<Http::Client>(
         test_server_->server().listenerManager().apiListener()->get().http()->get(), *dispatcher_,
-        test_server_->statStore(), preferred_network_);
+        test_server_->statStore(), preferred_network_,
+        test_server_->server().api().randomGenerator());
     dispatcher_->drain(test_server_->server().dispatcher());
     server_started.setReady();
   });
@@ -261,7 +263,8 @@ TEST_P(ClientIntegrationTest, BasicReset) {
   test_server_->server().dispatcher().post([this, &server_started]() -> void {
     http_client_ = std::make_unique<Http::Client>(
         test_server_->server().listenerManager().apiListener()->get().http()->get(), *dispatcher_,
-        test_server_->statStore(), preferred_network_);
+        test_server_->statStore(), preferred_network_,
+        test_server_->server().api().randomGenerator());
     dispatcher_->drain(test_server_->server().dispatcher());
     server_started.setReady();
   });


### PR DESCRIPTION
Description: The objective here is to make it less likely for a given connection class to suffer "catastrophic" failure of all outbound requests due to a network blip, by distributing requests across a minimum of two potential connections per connection class.
Risk Level: Low
Testing: Local, In-App, Unit, CI

Signed-off-by: Mike Schore <mike.schore@gmail.com>