### PR TITLE
filters: ensure PBFs pending destruction can't be resumed async

### DIFF
--- a/library/common/extensions/filters/http/platform_bridge/filter.cc
+++ b/library/common/extensions/filters/http/platform_bridge/filter.cc
@@ -133,6 +133,8 @@ void PlatformBridgeFilter::setEncoderFilterCallbacks(
 
 void PlatformBridgeFilter::onDestroy() {
   ENVOY_LOG(trace, "PlatformBridgeFilter({})::onDestroy", filter_name_);
+  alive_ = false;
+
   // If the filter chain is destroyed before a response is received, treat as cancellation.
   if (!response_filter_base_->stream_complete_ && platform_filter_.on_cancel) {
     ENVOY_LOG(trace, "PlatformBridgeFilter({})->on_cancel", filter_name_);
@@ -459,6 +461,9 @@ void PlatformBridgeFilter::resumeEncoding() {
 
 void PlatformBridgeFilter::FilterBase::onResume() {
   ENVOY_LOG(debug, "PlatformBridgeFilter({})::onResume", parent_.filter_name_);
+  if (!parent_.isAlive()) {
+    return;
+  }
 
   if (iteration_state_ == IterationState::Ongoing) {
     return;

--- a/library/common/extensions/filters/http/platform_bridge/filter.h
+++ b/library/common/extensions/filters/http/platform_bridge/filter.h
@@ -78,6 +78,8 @@ public:
   Http::FilterDataStatus encodeData(Buffer::Instance& data, bool end_stream) override;
   Http::FilterTrailersStatus encodeTrailers(Http::ResponseTrailerMap& trailers) override;
 
+  bool isAlive() { return alive_; }
+
 private:
   /**
    * Internal delegate for managing logic and state that exists for both the request (decoding)
@@ -160,6 +162,7 @@ private:
   envoy_http_filter_callbacks platform_request_callbacks_{};
   envoy_http_filter_callbacks platform_response_callbacks_{};
   bool error_response_{};
+  bool alive_{true};
 };
 
 using PlatformBridgeFilterSharedPtr = std::shared_ptr<PlatformBridgeFilter>;


### PR DESCRIPTION
Description: Previously asynchronous filter resumption of a bridged platform filter was guarded in the PBF by a weak_ptr that ensured the object was still around. It turns out this is not sufficient, as filters are submitted for delayed destruction and the presence of the object isn't enough to ensure it's still associated with a functional stream. This fix adds an additional check to ensure we don't attempt to resume iteration on a PlatformBridgeFilter that is pending destruction.
Risk Level: Low
Testing: Unit and CI

Signed-off-by: Mike Schore <mike.schore@gmail.com>