### PR TITLE
core: rename EnvoyMobileMainCommon to EngineCommon

### DIFF
--- a/library/cc/BUILD
+++ b/library/cc/BUILD
@@ -71,6 +71,6 @@ envoy_cc_library(
     repository = "@envoy",
     deps = [
         ":envoy_engine_cc_lib_no_stamp",
-        "//library/common:envoy_mobile_main_common_lib_stamped",
+        "//library/common:engine_common_lib_stamped",
     ],
 )

--- a/library/common/BUILD
+++ b/library/common/BUILD
@@ -9,7 +9,7 @@ envoy_cc_library(
     repository = "@envoy",
     deps = [
         ":envoy_main_interface_lib_no_stamp",
-        ":envoy_mobile_main_common_lib_stamped",
+        ":engine_common_lib_stamped",
     ],
 )
 
@@ -25,7 +25,7 @@ envoy_cc_library(
     hdrs = ["main_interface.h"],
     repository = "@envoy",
     deps = [
-        ":envoy_mobile_main_common_lib",
+        ":engine_common_lib",
         "//library/common/common:lambda_logger_delegate_lib",
         "//library/common/data:utility_lib",
         "//library/common/event:provisional_dispatcher_lib",
@@ -39,9 +39,9 @@ envoy_cc_library(
 )
 
 envoy_cc_library(
-    name = "envoy_mobile_main_common_lib",
-    srcs = ["envoy_mobile_main_common.cc"],
-    hdrs = ["envoy_mobile_main_common.h"],
+    name = "engine_common_lib",
+    srcs = ["engine_common.cc"],
+    hdrs = ["engine_common.h"],
     repository = "@envoy",
     deps = [
         "@envoy//source/common/common:minimal_logger_lib",
@@ -52,10 +52,10 @@ envoy_cc_library(
 )
 
 envoy_cc_library(
-    name = "envoy_mobile_main_common_lib_stamped",
+    name = "engine_common_lib_stamped",
     repository = "@envoy",
     deps = [
-        ":envoy_mobile_main_common_lib",
+        ":engine_common_lib",
         "@envoy//source/exe:envoy_main_common_lib",
     ],
 )

--- a/library/common/BUILD
+++ b/library/common/BUILD
@@ -8,8 +8,8 @@ envoy_cc_library(
     name = "envoy_main_interface_lib",
     repository = "@envoy",
     deps = [
-        ":envoy_main_interface_lib_no_stamp",
         ":engine_common_lib_stamped",
+        ":envoy_main_interface_lib_no_stamp",
     ],
 )
 

--- a/library/common/engine.cc
+++ b/library/common/engine.cc
@@ -31,7 +31,7 @@ envoy_status_t Engine::run(const std::string config, const std::string log_level
 
 envoy_status_t Engine::main(const std::string config, const std::string log_level) {
   // Using unique_ptr ensures main_common's lifespan is strictly scoped to this function.
-  std::unique_ptr<MobileMainCommon> main_common;
+  std::unique_ptr<EngineCommon> main_common;
   {
     Thread::LockGuard lock(mutex_);
     try {
@@ -49,7 +49,7 @@ envoy_status_t Engine::main(const std::string config, const std::string log_leve
                                              log_level.c_str(),
                                              nullptr};
 
-      main_common = std::make_unique<MobileMainCommon>(envoy_argv.size() - 1, envoy_argv.data());
+      main_common = std::make_unique<EngineCommon>(envoy_argv.size() - 1, envoy_argv.data());
       server_ = main_common->server();
       event_dispatcher_ = &server_->dispatcher();
       if (logger_.log) {

--- a/library/common/engine.h
+++ b/library/common/engine.h
@@ -8,7 +8,7 @@
 #include "absl/base/call_once.h"
 #include "extension_registry.h"
 #include "library/common/common/lambda_logger_delegate.h"
-#include "library/common/envoy_mobile_main_common.h"
+#include "library/common/engine_common.h"
 #include "library/common/http/client.h"
 #include "library/common/types/c_types.h"
 

--- a/library/common/engine_common.cc
+++ b/library/common/engine_common.cc
@@ -1,11 +1,11 @@
-#include "library/common/envoy_mobile_main_common.h"
+#include "library/common/engine_common.h"
 
 #include "common/common/random_generator.h"
 #include "common/runtime/runtime_impl.h"
 
 namespace Envoy {
 
-MobileMainCommon::MobileMainCommon(int argc, const char* const* argv)
+EngineCommon::EngineCommon(int argc, const char* const* argv)
     : options_(argc, argv, &MainCommon::hotRestartVersion, spdlog::level::info),
       base_(options_, real_time_system_, default_listener_hooks_, prod_component_factory_,
             std::make_unique<PlatformImpl>(), std::make_unique<Random::RandomGeneratorImpl>(),

--- a/library/common/engine_common.h
+++ b/library/common/engine_common.h
@@ -17,9 +17,9 @@ namespace Envoy {
  * This class is used instead of Envoy::MainCommon to customize logic for the Envoy Mobile setting.
  * It largely leverages Envoy::MainCommonBase.
  */
-class MobileMainCommon {
+class EngineCommon {
 public:
-  MobileMainCommon(int argc, const char* const* argv);
+  EngineCommon(int argc, const char* const* argv);
   bool run() { return base_.run(); }
 
   /**

--- a/test/common/BUILD
+++ b/test/common/BUILD
@@ -5,11 +5,11 @@ licenses(["notice"])  # Apache 2
 envoy_package()
 
 envoy_cc_test(
-    name = "envoy_mobile_main_common_test",
-    srcs = ["envoy_mobile_main_common_test.cc"],
+    name = "engine_common_test",
+    srcs = ["engine_common_test.cc"],
     repository = "@envoy",
     deps = [
-        "//library/common:envoy_mobile_main_common_lib",
+        "//library/common:engine_common_lib",
     ],
 )
 

--- a/test/common/engine_common_test.cc
+++ b/test/common/engine_common_test.cc
@@ -1,15 +1,15 @@
 #include "gtest/gtest.h"
-#include "library/common/envoy_mobile_main_common.h"
+#include "library/common/engine_common.h"
 
 namespace Envoy {
 
-TEST(MobileMainCommonTest, SignalHandlingFalse) {
+TEST(EngineCommonTest, SignalHandlingFalse) {
   std::vector<const char*> envoy_argv{
       "envoy", "--config-yaml",
       "{\"layered_runtime\":{\"layers\":[{\"name\":\"static_layer_0\",\"static_layer\":{"
       "\"overload\":{\"global_downstream_max_connections\":50000}}}]}}",
       nullptr};
-  MobileMainCommon main_common{3, &envoy_argv[0]};
+  EngineCommon main_common{3, &envoy_argv[0]};
   ASSERT_FALSE(main_common.server()->options().signalHandlingEnabled());
 }
 


### PR DESCRIPTION
Description: This parallels the naming relationship between main and main_common in Envoy, and arguably better captures its purpose, especially as we move to add more library-specific logic here. Also, envoy_mobile_main_common is a mouthful.
Risk Level: Low
Testing: Local & CI

Signed-off-by: Mike Schore <mike.schore@gmail.com>