### PR TITLE
Swift static framework: add toolchain inputs

### DIFF
--- a/bazel/swift_static_framework.bzl
+++ b/bazel/swift_static_framework.bzl
@@ -99,7 +99,7 @@ def _swift_static_framework_impl(ctx):
         )
         apple_support.run(
             ctx,
-            inputs = depset(direct=archives, transitive=[ctx.attr._cc_toolchain.files]),
+            inputs = depset(direct = archives, transitive = [ctx.attr._cc_toolchain.files]),
             outputs = [platform_archive],
             mnemonic = "LibtoolLinkedLibraries",
             progress_message = "Combining libraries for {} on {}".format(module_name, platform),

--- a/bazel/swift_static_framework.bzl
+++ b/bazel/swift_static_framework.bzl
@@ -99,7 +99,7 @@ def _swift_static_framework_impl(ctx):
         )
         apple_support.run(
             ctx,
-            inputs = archives,
+            inputs = depset(direct=archives, transitive=[ctx.attr._cc_toolchain.files]),
             outputs = [platform_archive],
             mnemonic = "LibtoolLinkedLibraries",
             progress_message = "Combining libraries for {} on {}".format(module_name, platform),


### PR DESCRIPTION
Description: These inputs are required for remote execution - otherwise the remote machine doesn't stage them.
Risk Level: Low
Testing: bazel build with remote execution enabled
Docs Changes: N/A
Release Notes: N/A

See https://stackoverflow.com/questions/52769846/custom-c-rule-with-the-cc-common-api

Signed-off-by: Ulf Adams <ulf@engflow.com>