### PR TITLE
python: don't run python benchmark in CI

### DIFF
--- a/test/python/BUILD
+++ b/test/python/BUILD
@@ -42,23 +42,26 @@ py_test(
     ],
 )
 
-py_test(
-    name = "benchmark_envoy_vs_requests",
-    srcs = [
-        "benchmark/__init__.py",
-        "benchmark/envoy_vs_requests.py",
-        "runner.py",
-    ],
-    args = [
-        "test/python/benchmark/envoy_vs_requests.py",
-        "-s",
-    ],
-    main = "runner.py",
-    python_version = "PY3",
-    deps = [
-        "//library/python:envoy_requests",
-        requirement("pytest"),
-        requirement("pytest-benchmark"),
-        requirement("requests"),
-    ],
-)
+# NOTE: these tests do not need to be run in CI by default
+# but we want to automatically detect new python tests
+# so uncomment to run locally
+# py_test(
+#     name = "benchmark_envoy_vs_requests",
+#     srcs = [
+#         "benchmark/__init__.py",
+#         "benchmark/envoy_vs_requests.py",
+#         "runner.py",
+#     ],
+#     args = [
+#         "test/python/benchmark/envoy_vs_requests.py",
+#         "-s",
+#     ],
+#     main = "runner.py",
+#     python_version = "PY3",
+#     deps = [
+#         "//library/python:envoy_requests",
+#         requirement("pytest"),
+#         requirement("pytest-benchmark"),
+#         requirement("requests"),
+#     ],
+# )


### PR DESCRIPTION
Description: Comments out the benchmark test so that we don't run it in CI. Alternate implementation is to change `.github/workflows/python_tests.yml` to not `bazel test //test/python...` and instead target specifics tests (i.e. `//test/python/runtest_unit` and `//test/python/runtest_integration`, since they auto-discover tests anyways). My take is that we'll more often want to have tests included than excluded, so its better to make this the one-off.

Risk Level: Low
Testing: N/A
Docs Changes: N/A
Release Notes: N/A