### PR TITLE
python: envoy_requests depend on a specific version of protobuf

### DIFF
--- a/library/python/BUILD
+++ b/library/python/BUILD
@@ -75,6 +75,9 @@ py_wheel(
         "//bazel:linux_x86_64": "manylinux2010_x86_64",
     }),
     python_tag = python_tag(),
+    requires = [
+        "protobuf==3.17.*",
+    ],
     strip_path_prefixes = ["library/python"],
     version = "0.0.1a1",
     visibility = ["//visibility:public"],


### PR DESCRIPTION
Description: This PR introduces a requirement that consumers of envoy-requests must have `protobuf==3.17` to prevent crashes. I've been able to consistently reproduce crashes in Python applications on the main branch by:

1. Making a virtualenv
1. Building + installing a wheel built from `//library/python:envoy_requests_whl` on `main`
1. Install `protobuf==3.14` (previous version before envoy bump) or `protobuf==3.16` (current version after envoy bump)
1. Run the following script
1. Crashes with
    1. std::bad_optional_access on `protobuf==3.14`
    1. segfault on `protobuf==3.16`

```python
import google.protobuf.descriptor
from envoy_requests.common.engine import Engine
Engine.handle()
```

This succeeds when running `protobuf==3.17`, however, hence the version I've chosen to require.

I've narrowed this problem down to an indirect import of `google.protobuf.pyext._message`. Importing that module calls InitProto2MessageModule which does a lot of initialization, but I'm not sure which part causes the problem. I'm still struggling to understand how this all happens, so if anyone has any ideas I'd love to hear them!

Risk Level: Low
Testing: Documented above
Docs Changes: N/A
Release Notes: N/A