### PR TITLE
engine: convert Envoy exceptions to crashes

### DIFF
--- a/library/common/engine.cc
+++ b/library/common/engine.cc
@@ -59,14 +59,11 @@ envoy_status_t Engine::main(const std::string config, const std::string log_leve
 
       cv_.notifyAll();
     } catch (const Envoy::NoServingException& e) {
-      std::cerr << e.what() << std::endl;
-      return ENVOY_FAILURE;
+      PANIC(e.what());
     } catch (const Envoy::MalformedArgvException& e) {
-      std::cerr << e.what() << std::endl;
-      return ENVOY_FAILURE;
+      PANIC(e.what());
     } catch (const Envoy::EnvoyException& e) {
-      std::cerr << e.what() << std::endl;
-      return ENVOY_FAILURE;
+      PANIC(e.what());
     }
 
     // Note: We're waiting longer than we might otherwise to drain to the main thread's dispatcher.


### PR DESCRIPTION
Description: More than once we've been bitten by a complete failure to start up manifesting as a simple log statement and then broken software that simply continues to run without networking. There's maybe an argument to be made for making this configurable, but for now, making exceptions fatal seems like a saner default.
Risk Level: Moderate
Testing: Local & CI

Signed-off-by: Mike Schore <mike.schore@gmail.com>