### PR TITLE
test: refactoring client_test

### DIFF
--- a/test/common/http/client_test.cc
+++ b/test/common/http/client_test.cc
@@ -53,55 +53,87 @@ public:
     uint32_t on_complete_calls;
     uint32_t on_error_calls;
     uint32_t on_cancel_calls;
+    std::string expected_status_;
+    bool end_stream_with_headers_;
   } callbacks_called;
+
+  ClientTest() {
+    bridge_callbacks_.context = &cc_;
+
+    // Set up default bridge callbacks. Indivividual tests can override.
+    bridge_callbacks_.on_complete = [](void* context) -> void* {
+      callbacks_called* cc = static_cast<callbacks_called*>(context);
+      cc->on_complete_calls++;
+      return nullptr;
+    };
+    bridge_callbacks_.on_headers = [](envoy_headers c_headers, bool end_stream,
+                                      void* context) -> void* {
+      ResponseHeaderMapPtr response_headers = toResponseHeaders(c_headers);
+      callbacks_called* cc = static_cast<callbacks_called*>(context);
+      EXPECT_EQ(end_stream, cc->end_stream_with_headers_);
+      EXPECT_EQ(response_headers->Status()->value().getStringView(), cc->expected_status_);
+      cc->on_headers_calls++;
+      return nullptr;
+    };
+    bridge_callbacks_.on_error = [](envoy_error, void* context) -> void* {
+      callbacks_called* cc = static_cast<callbacks_called*>(context);
+      cc->on_error_calls++;
+      return nullptr;
+    };
+    bridge_callbacks_.on_data = [](envoy_data c_data, bool, void* context) -> void* {
+      callbacks_called* cc = static_cast<callbacks_called*>(context);
+      cc->on_data_calls++;
+      c_data.release(c_data.context);
+      return nullptr;
+    };
+    bridge_callbacks_.on_cancel = [](void* context) -> void* {
+      callbacks_called* cc = static_cast<callbacks_called*>(context);
+      cc->on_cancel_calls++;
+      return nullptr;
+    };
+  }
+
+  envoy_headers defaultRequestHeaders() {
+    // Build a set of request headers.
+    TestRequestHeaderMapImpl headers;
+    HttpTestUtility::addDefaultHeaders(headers);
+    return Utility::toBridgeHeaders(headers);
+  }
+
+  void createStream() {
+    // Create a stream.
+    ON_CALL(dispatcher_, isThreadSafe()).WillByDefault(Return(true));
+
+    // Grab the response encoder in order to dispatch responses on the stream.
+    // Return the request decoder to make sure calls are dispatched to the decoder via the
+    // dispatcher API.
+    EXPECT_CALL(api_listener_, newStream(_, _))
+        .WillOnce(Invoke([&](ResponseEncoder& encoder, bool) -> RequestDecoder& {
+          response_encoder_ = &encoder;
+          return request_decoder_;
+        }));
+    EXPECT_EQ(http_client_.startStream(stream_, bridge_callbacks_), ENVOY_SUCCESS);
+  }
 
   MockApiListener api_listener_;
   MockRequestDecoder request_decoder_;
   ResponseEncoder* response_encoder_{};
   NiceMock<Event::MockProvisionalDispatcher> dispatcher_;
   envoy_http_callbacks bridge_callbacks_;
+  callbacks_called cc_ = {0, 0, 0, 0, 0, 0, "200", true};
   std::atomic<envoy_network_t> preferred_network_{ENVOY_NET_GENERIC};
   uint64_t alt_cluster_ = 0;
   NiceMock<Random::MockRandomGenerator> random_;
   Stats::IsolatedStoreImpl stats_store_;
   Client http_client_{api_listener_, dispatcher_, stats_store_, preferred_network_, random_};
+  envoy_stream_t stream_ = 1;
 };
 
 TEST_F(ClientTest, SetDestinationCluster) {
-  envoy_stream_t stream = 1;
-  // Setup bridge_callbacks to handle the response headers.
-  envoy_http_callbacks bridge_callbacks;
-  callbacks_called cc = {0, 0, 0, 0, 0, 0};
-  bridge_callbacks.context = &cc;
-  bridge_callbacks.on_headers = [](envoy_headers c_headers, bool end_stream,
-                                   void* context) -> void* {
-    EXPECT_TRUE(end_stream);
-    ResponseHeaderMapPtr response_headers = toResponseHeaders(c_headers);
-    EXPECT_EQ(response_headers->Status()->value().getStringView(), "200");
-    callbacks_called* cc = static_cast<callbacks_called*>(context);
-    cc->on_headers_calls++;
-    return nullptr;
-  };
-  bridge_callbacks.on_complete = [](void* context) -> void* {
-    callbacks_called* cc = static_cast<callbacks_called*>(context);
-    cc->on_complete_calls++;
-    return nullptr;
-  };
-
   ON_CALL(random_, random()).WillByDefault(ReturnPointee(&alt_cluster_));
 
-  // Create a stream.
-  ON_CALL(dispatcher_, isThreadSafe()).WillByDefault(Return(true));
-
-  // Grab the response encoder in order to dispatch responses on the stream.
-  // Return the request decoder to make sure calls are dispatched to the decoder via the dispatcher
-  // API.
-  EXPECT_CALL(api_listener_, newStream(_, _))
-      .WillOnce(Invoke([&](ResponseEncoder& encoder, bool) -> RequestDecoder& {
-        response_encoder_ = &encoder;
-        return request_decoder_;
-      }));
-  EXPECT_EQ(http_client_.startStream(stream, bridge_callbacks), ENVOY_SUCCESS);
+  // Create a stream, and set up request_decoder_ and response_encoder_
+  createStream();
 
   // Send request headers. Sending multiple headers is illegal and the upstream codec would not
   // accept it. However, given we are just trying to test preferred network headers and using mocks
@@ -123,7 +155,7 @@ TEST_F(ClientTest, SetDestinationCluster) {
       {"x-forwarded-proto", "https"},
   };
   EXPECT_CALL(request_decoder_, decodeHeaders_(HeaderMapEqual(&expected_headers1), false));
-  http_client_.sendHeaders(stream, c_headers1, false);
+  http_client_.sendHeaders(stream_, c_headers1, false);
 
   TestRequestHeaderMapImpl headers2;
   HttpTestUtility::addDefaultHeaders(headers2);
@@ -142,7 +174,7 @@ TEST_F(ClientTest, SetDestinationCluster) {
       {"x-forwarded-proto", "https"},
   };
   EXPECT_CALL(request_decoder_, decodeHeaders_(HeaderMapEqual(&expected_headers2), false));
-  http_client_.sendHeaders(stream, c_headers2, false);
+  http_client_.sendHeaders(stream_, c_headers2, false);
 
   TestRequestHeaderMapImpl headers3;
   HttpTestUtility::addDefaultHeaders(headers3);
@@ -161,52 +193,22 @@ TEST_F(ClientTest, SetDestinationCluster) {
       {"x-forwarded-proto", "https"},
   };
   EXPECT_CALL(request_decoder_, decodeHeaders_(HeaderMapEqual(&expected_headers3), true));
-  http_client_.sendHeaders(stream, c_headers3, true);
+  http_client_.sendHeaders(stream_, c_headers3, true);
 
   // Encode response headers.
   EXPECT_CALL(dispatcher_, deferredDelete_(_));
   TestResponseHeaderMapImpl response_headers{{":status", "200"}};
   response_encoder_->encodeHeaders(response_headers, true);
-  ASSERT_EQ(cc.on_headers_calls, 1);
-  // Ensure that the callbacks on the bridge_callbacks were called.
-  ASSERT_EQ(cc.on_complete_calls, 1);
+  ASSERT_EQ(cc_.on_headers_calls, 1);
+  // Ensure that the callbacks on the bridge_callbacks_ were called.
+  ASSERT_EQ(cc_.on_complete_calls, 1);
 }
 
 TEST_F(ClientTest, SetDestinationClusterUpstreamProtocol) {
-  envoy_stream_t stream = 1;
-  // Setup bridge_callbacks to handle the response headers.
-  envoy_http_callbacks bridge_callbacks;
-  callbacks_called cc = {0, 0, 0, 0, 0, 0};
-  bridge_callbacks.context = &cc;
-  bridge_callbacks.on_headers = [](envoy_headers c_headers, bool end_stream,
-                                   void* context) -> void* {
-    EXPECT_TRUE(end_stream);
-    ResponseHeaderMapPtr response_headers = toResponseHeaders(c_headers);
-    EXPECT_EQ(response_headers->Status()->value().getStringView(), "200");
-    callbacks_called* cc = static_cast<callbacks_called*>(context);
-    cc->on_headers_calls++;
-    return nullptr;
-  };
-  bridge_callbacks.on_complete = [](void* context) -> void* {
-    callbacks_called* cc = static_cast<callbacks_called*>(context);
-    cc->on_complete_calls++;
-    return nullptr;
-  };
-
   ON_CALL(random_, random()).WillByDefault(ReturnPointee(&alt_cluster_));
 
-  // Create a stream.
-  ON_CALL(dispatcher_, isThreadSafe()).WillByDefault(Return(true));
-
-  // Grab the response encoder in order to dispatch responses on the stream.
-  // Return the request decoder to make sure calls are dispatched to the decoder via the dispatcher
-  // API.
-  EXPECT_CALL(api_listener_, newStream(_, _))
-      .WillOnce(Invoke([&](ResponseEncoder& encoder, bool) -> RequestDecoder& {
-        response_encoder_ = &encoder;
-        return request_decoder_;
-      }));
-  EXPECT_EQ(http_client_.startStream(stream, bridge_callbacks), ENVOY_SUCCESS);
+  // Create a stream, and set up request_decoder_ and response_encoder_
+  createStream();
 
   // Send request headers. Sending multiple headers is illegal and the upstream codec would not
   // accept it. However, given we are just trying to test preferred network headers and using mocks
@@ -229,7 +231,7 @@ TEST_F(ClientTest, SetDestinationClusterUpstreamProtocol) {
       {"x-forwarded-proto", "https"},
   };
   EXPECT_CALL(request_decoder_, decodeHeaders_(HeaderMapEqual(&expected_headers1), false));
-  http_client_.sendHeaders(stream, c_headers1, false);
+  http_client_.sendHeaders(stream_, c_headers1, false);
 
   TestRequestHeaderMapImpl headers2{{"x-envoy-mobile-upstream-protocol", "http2"}};
   HttpTestUtility::addDefaultHeaders(headers2);
@@ -248,7 +250,7 @@ TEST_F(ClientTest, SetDestinationClusterUpstreamProtocol) {
       {"x-forwarded-proto", "https"},
   };
   EXPECT_CALL(request_decoder_, decodeHeaders_(HeaderMapEqual(&expected_headers2), false));
-  http_client_.sendHeaders(stream, c_headers2, false);
+  http_client_.sendHeaders(stream_, c_headers2, false);
 
   TestRequestHeaderMapImpl headers3{{"x-envoy-mobile-upstream-protocol", "http2"}};
   HttpTestUtility::addDefaultHeaders(headers3);
@@ -267,7 +269,7 @@ TEST_F(ClientTest, SetDestinationClusterUpstreamProtocol) {
       {"x-forwarded-proto", "https"},
   };
   EXPECT_CALL(request_decoder_, decodeHeaders_(HeaderMapEqual(&expected_headers3), true));
-  http_client_.sendHeaders(stream, c_headers3, true);
+  http_client_.sendHeaders(stream_, c_headers3, true);
 
   // Setting http1.
   TestRequestHeaderMapImpl headers4{{"x-envoy-mobile-upstream-protocol", "http1"}};
@@ -287,77 +289,40 @@ TEST_F(ClientTest, SetDestinationClusterUpstreamProtocol) {
       {"x-forwarded-proto", "https"},
   };
   EXPECT_CALL(request_decoder_, decodeHeaders_(HeaderMapEqual(&expected_headers4), true));
-  http_client_.sendHeaders(stream, c_headers4, true);
+  http_client_.sendHeaders(stream_, c_headers4, true);
 
   // Encode response headers.
   EXPECT_CALL(dispatcher_, deferredDelete_(_));
   TestResponseHeaderMapImpl response_headers{{":status", "200"}};
   response_encoder_->encodeHeaders(response_headers, true);
-  ASSERT_EQ(cc.on_headers_calls, 1);
-  // Ensure that the callbacks on the bridge_callbacks were called.
-  ASSERT_EQ(cc.on_complete_calls, 1);
+  ASSERT_EQ(cc_.on_headers_calls, 1);
+  // Ensure that the callbacks on the bridge_callbacks_ were called.
+  ASSERT_EQ(cc_.on_complete_calls, 1);
 }
 
 TEST_F(ClientTest, BasicStreamHeaders) {
-  envoy_stream_t stream = 1;
-  // Setup bridge_callbacks to handle the response headers.
-  envoy_http_callbacks bridge_callbacks;
-  callbacks_called cc = {0, 0, 0, 0, 0, 0};
-  bridge_callbacks.context = &cc;
-  bridge_callbacks.on_headers = [](envoy_headers c_headers, bool end_stream,
-                                   void* context) -> void* {
-    EXPECT_TRUE(end_stream);
-    ResponseHeaderMapPtr response_headers = toResponseHeaders(c_headers);
-    EXPECT_EQ(response_headers->Status()->value().getStringView(), "200");
-    callbacks_called* cc = static_cast<callbacks_called*>(context);
-    cc->on_headers_calls++;
-    return nullptr;
-  };
-  bridge_callbacks.on_complete = [](void* context) -> void* {
-    callbacks_called* cc = static_cast<callbacks_called*>(context);
-    cc->on_complete_calls++;
-    return nullptr;
-  };
+  envoy_headers c_headers = defaultRequestHeaders();
 
-  // Build a set of request headers.
-  TestRequestHeaderMapImpl headers;
-  HttpTestUtility::addDefaultHeaders(headers);
-  envoy_headers c_headers = Utility::toBridgeHeaders(headers);
-
-  // Create a stream.
-  ON_CALL(dispatcher_, isThreadSafe()).WillByDefault(Return(true));
-
-  // Grab the response encoder in order to dispatch responses on the stream.
-  // Return the request decoder to make sure calls are dispatched to the decoder via the dispatcher
-  // API.
-  EXPECT_CALL(api_listener_, newStream(_, _))
-      .WillOnce(Invoke([&](ResponseEncoder& encoder, bool) -> RequestDecoder& {
-        response_encoder_ = &encoder;
-        return request_decoder_;
-      }));
-  EXPECT_EQ(http_client_.startStream(stream, bridge_callbacks), ENVOY_SUCCESS);
+  // Create a stream, and set up request_decoder_ and response_encoder_
+  createStream();
 
   // Send request headers.
-
   EXPECT_CALL(request_decoder_, decodeHeaders_(_, true));
-  http_client_.sendHeaders(stream, c_headers, true);
+  http_client_.sendHeaders(stream_, c_headers, true);
 
   // Encode response headers.
   EXPECT_CALL(dispatcher_, deferredDelete_(_));
   TestResponseHeaderMapImpl response_headers{{":status", "200"}};
   response_encoder_->encodeHeaders(response_headers, true);
-  ASSERT_EQ(cc.on_headers_calls, 1);
-  // Ensure that the callbacks on the bridge_callbacks were called.
-  ASSERT_EQ(cc.on_complete_calls, 1);
+  ASSERT_EQ(cc_.on_headers_calls, 1);
+  // Ensure that the callbacks on the bridge_callbacks_ were called.
+  ASSERT_EQ(cc_.on_complete_calls, 1);
 }
 
 TEST_F(ClientTest, BasicStreamData) {
-  envoy_stream_t stream = 1;
-  // Setup bridge_callbacks to handle the response.
-  envoy_http_callbacks bridge_callbacks;
-  callbacks_called cc = {0, 0, 0, 0, 0, 0};
-  bridge_callbacks.context = &cc;
-  bridge_callbacks.on_data = [](envoy_data c_data, bool end_stream, void* context) -> void* {
+  cc_.end_stream_with_headers_ = false;
+
+  bridge_callbacks_.on_data = [](envoy_data c_data, bool end_stream, void* context) -> void* {
     EXPECT_TRUE(end_stream);
     EXPECT_EQ(Data::Utility::copyToString(c_data), "response body");
     callbacks_called* cc = static_cast<callbacks_called*>(context);
@@ -365,51 +330,30 @@ TEST_F(ClientTest, BasicStreamData) {
     c_data.release(c_data.context);
     return nullptr;
   };
-  bridge_callbacks.on_complete = [](void* context) -> void* {
-    callbacks_called* cc = static_cast<callbacks_called*>(context);
-    cc->on_complete_calls++;
-    return nullptr;
-  };
 
   // Build body data
   Buffer::OwnedImpl request_data = Buffer::OwnedImpl("request body");
   envoy_data c_data = Data::Utility::toBridgeData(request_data);
 
-  // Create a stream.
-  ON_CALL(dispatcher_, isThreadSafe()).WillByDefault(Return(true));
-
-  // Grab the response encoder in order to dispatch responses on the stream.
-  // Return the request decoder to make sure calls are dispatched to the decoder via the
-  // dispatcher API.
-  EXPECT_CALL(api_listener_, newStream(_, _))
-      .WillOnce(Invoke([&](ResponseEncoder& encoder, bool) -> RequestDecoder& {
-        response_encoder_ = &encoder;
-        return request_decoder_;
-      }));
-  EXPECT_EQ(http_client_.startStream(stream, bridge_callbacks), ENVOY_SUCCESS);
+  // Create a stream, and set up request_decoder_ and response_encoder_
+  createStream();
 
   // Send request data. Although HTTP would need headers before data this unit test only wants to
   // test data functionality.
-
   EXPECT_CALL(request_decoder_, decodeData(BufferStringEqual("request body"), true));
-  http_client_.sendData(stream, c_data, true);
+  http_client_.sendData(stream_, c_data, true);
 
   // Encode response data.
   EXPECT_CALL(dispatcher_, deferredDelete_(_));
   Buffer::InstancePtr response_data{new Buffer::OwnedImpl("response body")};
   response_encoder_->encodeData(*response_data, true);
-  ASSERT_EQ(cc.on_data_calls, 1);
-  // Ensure that the callbacks on the bridge_callbacks were called.
-  ASSERT_EQ(cc.on_complete_calls, 1);
+  ASSERT_EQ(cc_.on_data_calls, 1);
+  // Ensure that the callbacks on the bridge_callbacks_ were called.
+  ASSERT_EQ(cc_.on_complete_calls, 1);
 }
 
 TEST_F(ClientTest, BasicStreamTrailers) {
-  envoy_stream_t stream = 1;
-  // Setup bridge_callbacks to handle the response.
-  envoy_http_callbacks bridge_callbacks;
-  callbacks_called cc = {0, 0, 0, 0, 0, 0};
-  bridge_callbacks.context = &cc;
-  bridge_callbacks.on_trailers = [](envoy_headers c_trailers, void* context) -> void* {
+  bridge_callbacks_.on_trailers = [](envoy_headers c_trailers, void* context) -> void* {
     ResponseHeaderMapPtr response_trailers = toResponseHeaders(c_trailers);
     EXPECT_EQ(response_trailers->get(LowerCaseString("x-test-trailer"))[0]->value().getStringView(),
               "test_trailer");
@@ -417,76 +361,41 @@ TEST_F(ClientTest, BasicStreamTrailers) {
     cc->on_trailers_calls++;
     return nullptr;
   };
-  bridge_callbacks.on_complete = [](void* context) -> void* {
-    callbacks_called* cc = static_cast<callbacks_called*>(context);
-    cc->on_complete_calls++;
-    return nullptr;
-  };
 
   // Build a set of request trailers.
   TestRequestTrailerMapImpl trailers;
   envoy_headers c_trailers = Utility::toBridgeHeaders(trailers);
 
-  // Create a stream.
-  ON_CALL(dispatcher_, isThreadSafe()).WillByDefault(Return(true));
-
-  // Grab the response encoder in order to dispatch responses on the stream.
-  // Return the request decoder to make sure calls are dispatched to the decoder via the
-  // dispatcher API.
-  EXPECT_CALL(api_listener_, newStream(_, _))
-      .WillOnce(Invoke([&](ResponseEncoder& encoder, bool) -> RequestDecoder& {
-        response_encoder_ = &encoder;
-        return request_decoder_;
-      }));
-  EXPECT_EQ(http_client_.startStream(stream, bridge_callbacks), ENVOY_SUCCESS);
+  // Create a stream, and set up request_decoder_ and response_encoder_
+  createStream();
 
   // Send request trailers. Although HTTP would need headers before trailers this unit test only
   // wants to test trailers functionality.
 
   EXPECT_CALL(request_decoder_, decodeTrailers_(_));
-  http_client_.sendTrailers(stream, c_trailers);
+  http_client_.sendTrailers(stream_, c_trailers);
 
   // Encode response trailers.
   EXPECT_CALL(dispatcher_, deferredDelete_(_));
   TestResponseTrailerMapImpl response_trailers{{"x-test-trailer", "test_trailer"}};
   response_encoder_->encodeTrailers(response_trailers);
-  ASSERT_EQ(cc.on_trailers_calls, 1);
-  // Ensure that the callbacks on the bridge_callbacks were called.
-  ASSERT_EQ(cc.on_complete_calls, 1);
+  ASSERT_EQ(cc_.on_trailers_calls, 1);
+  // Ensure that the callbacks on the bridge_callbacks_ were called.
+  ASSERT_EQ(cc_.on_complete_calls, 1);
 }
 
 TEST_F(ClientTest, MultipleDataStream) {
-  envoy_stream_t stream = 1;
-  // Setup bridge_callbacks to handle the response.
-  envoy_http_callbacks bridge_callbacks;
-  callbacks_called cc = {0, 0, 0, 0, 0, 0};
-  bridge_callbacks.context = &cc;
-  bridge_callbacks.on_headers = [](envoy_headers c_headers, bool end_stream,
-                                   void* context) -> void* {
-    EXPECT_FALSE(end_stream);
-    ResponseHeaderMapPtr response_headers = toResponseHeaders(c_headers);
-    EXPECT_EQ(response_headers->Status()->value().getStringView(), "200");
-    callbacks_called* cc = static_cast<callbacks_called*>(context);
-    cc->on_headers_calls++;
-    return nullptr;
-  };
-  bridge_callbacks.on_data = [](envoy_data data, bool, void* context) -> void* {
+  cc_.end_stream_with_headers_ = false;
+
+  bridge_callbacks_.on_data = [](envoy_data data, bool, void* context) -> void* {
     // TODO: assert end_stream and contents of c_data for multiple calls of on_data.
     callbacks_called* cc = static_cast<callbacks_called*>(context);
     cc->on_data_calls++;
     data.release(data.context);
     return nullptr;
   };
-  bridge_callbacks.on_complete = [](void* context) -> void* {
-    callbacks_called* cc = static_cast<callbacks_called*>(context);
-    cc->on_complete_calls++;
-    return nullptr;
-  };
 
-  // Build a set of request headers.
-  TestRequestHeaderMapImpl headers;
-  HttpTestUtility::addDefaultHeaders(headers);
-  envoy_headers c_headers = Utility::toBridgeHeaders(headers);
+  envoy_headers c_headers = defaultRequestHeaders();
 
   // Build first body data
   Buffer::OwnedImpl request_data = Buffer::OwnedImpl("request body");
@@ -496,105 +405,60 @@ TEST_F(ClientTest, MultipleDataStream) {
   Buffer::OwnedImpl request_data2 = Buffer::OwnedImpl("request body2");
   envoy_data c_data2 = Data::Utility::toBridgeData(request_data2);
 
-  // Create a stream.
-  ON_CALL(dispatcher_, isThreadSafe()).WillByDefault(Return(true));
-
-  // Grab the response encoder in order to dispatch responses on the stream.
-  // Return the request decoder to make sure calls are dispatched to the decoder via the dispatcher
-  // API.
-  EXPECT_CALL(api_listener_, newStream(_, _))
-      .WillOnce(Invoke([&](ResponseEncoder& encoder, bool) -> RequestDecoder& {
-        response_encoder_ = &encoder;
-        return request_decoder_;
-      }));
-  EXPECT_EQ(http_client_.startStream(stream, bridge_callbacks), ENVOY_SUCCESS);
+  // Create a stream, and set up request_decoder_ and response_encoder_
+  createStream();
 
   // Send request headers.
-
   EXPECT_CALL(request_decoder_, decodeHeaders_(_, false));
-  http_client_.sendHeaders(stream, c_headers, false);
+  http_client_.sendHeaders(stream_, c_headers, false);
 
   // Send request data.
-
   EXPECT_CALL(request_decoder_, decodeData(BufferStringEqual("request body"), false));
-  http_client_.sendData(stream, c_data, false);
+  http_client_.sendData(stream_, c_data, false);
 
   // Send second request data.
-
   EXPECT_CALL(request_decoder_, decodeData(BufferStringEqual("request body2"), true));
-  http_client_.sendData(stream, c_data2, true);
+  http_client_.sendData(stream_, c_data2, true);
 
   // Encode response headers and data.
   TestResponseHeaderMapImpl response_headers{{":status", "200"}};
   response_encoder_->encodeHeaders(response_headers, false);
-  ASSERT_EQ(cc.on_headers_calls, 1);
+  ASSERT_EQ(cc_.on_headers_calls, 1);
   Buffer::InstancePtr response_data{new Buffer::OwnedImpl("response body")};
   response_encoder_->encodeData(*response_data, false);
-  ASSERT_EQ(cc.on_data_calls, 1);
+  ASSERT_EQ(cc_.on_data_calls, 1);
 
   EXPECT_CALL(dispatcher_, deferredDelete_(_));
   Buffer::InstancePtr response_data2{new Buffer::OwnedImpl("response body2")};
   response_encoder_->encodeData(*response_data2, true);
-  ASSERT_EQ(cc.on_data_calls, 2);
-  // Ensure that the callbacks on the bridge_callbacks were called.
-  ASSERT_EQ(cc.on_complete_calls, 1);
+  ASSERT_EQ(cc_.on_data_calls, 2);
+  // Ensure that the callbacks on the bridge_callbacks_ were called.
+  ASSERT_EQ(cc_.on_complete_calls, 1);
 }
 
 TEST_F(ClientTest, MultipleStreams) {
   envoy_stream_t stream1 = 1;
   envoy_stream_t stream2 = 2;
   // Start stream1.
-  // Setup bridge_callbacks to handle the response headers.
-  envoy_http_callbacks bridge_callbacks;
-  callbacks_called cc = {0, 0, 0, 0, 0, 0};
-  bridge_callbacks.context = &cc;
-  bridge_callbacks.on_headers = [](envoy_headers c_headers, bool end_stream,
-                                   void* context) -> void* {
-    EXPECT_TRUE(end_stream);
-    ResponseHeaderMapPtr response_headers = toResponseHeaders(c_headers);
-    EXPECT_EQ(response_headers->Status()->value().getStringView(), "200");
-    callbacks_called* cc = static_cast<callbacks_called*>(context);
-    cc->on_headers_calls++;
-    return nullptr;
-  };
-  bridge_callbacks.on_complete = [](void* context) -> void* {
-    callbacks_called* cc = static_cast<callbacks_called*>(context);
-    cc->on_complete_calls++;
-    return nullptr;
-  };
 
-  // Build a set of request headers.
-  TestRequestHeaderMapImpl headers;
-  HttpTestUtility::addDefaultHeaders(headers);
-  envoy_headers c_headers = Utility::toBridgeHeaders(headers);
+  envoy_headers c_headers = defaultRequestHeaders();
 
-  // Create a stream.
-  ON_CALL(dispatcher_, isThreadSafe()).WillByDefault(Return(true));
-
-  // Grab the response encoder in order to dispatch responses on the stream.
-  // Return the request decoder to make sure calls are dispatched to the decoder via the dispatcher
-  // API.
-  EXPECT_CALL(api_listener_, newStream(_, _))
-      .WillOnce(Invoke([&](ResponseEncoder& encoder, bool) -> RequestDecoder& {
-        response_encoder_ = &encoder;
-        return request_decoder_;
-      }));
-  EXPECT_EQ(http_client_.startStream(stream1, bridge_callbacks), ENVOY_SUCCESS);
+  // Create a stream, and set up request_decoder_ and response_encoder_
+  createStream();
 
   // Send request headers.
-
   EXPECT_CALL(request_decoder_, decodeHeaders_(_, true));
   http_client_.sendHeaders(stream1, c_headers, true);
 
   // Start stream2.
-  // Setup bridge_callbacks to handle the response headers.
+  // Setup bridge_callbacks_ to handle the response headers.
   NiceMock<MockRequestDecoder> request_decoder2;
   ResponseEncoder* response_encoder2{};
-  envoy_http_callbacks bridge_callbacks2;
-  callbacks_called cc2 = {0, 0, 0, 0, 0, 0};
-  bridge_callbacks2.context = &cc2;
-  bridge_callbacks2.on_headers = [](envoy_headers c_headers, bool end_stream,
-                                    void* context) -> void* {
+  envoy_http_callbacks bridge_callbacks_2;
+  callbacks_called cc2 = {0, 0, 0, 0, 0, 0, "200", true};
+  bridge_callbacks_2.context = &cc2;
+  bridge_callbacks_2.on_headers = [](envoy_headers c_headers, bool end_stream,
+                                     void* context) -> void* {
     EXPECT_TRUE(end_stream);
     ResponseHeaderMapPtr response_headers = toResponseHeaders(c_headers);
     EXPECT_EQ(response_headers->Status()->value().getStringView(), "200");
@@ -602,16 +466,13 @@ TEST_F(ClientTest, MultipleStreams) {
     *on_headers_called2 = true;
     return nullptr;
   };
-  bridge_callbacks2.on_complete = [](void* context) -> void* {
+  bridge_callbacks_2.on_complete = [](void* context) -> void* {
     callbacks_called* cc = static_cast<callbacks_called*>(context);
     cc->on_complete_calls++;
     return nullptr;
   };
 
-  // Build a set of request headers.
-  TestRequestHeaderMapImpl headers2;
-  HttpTestUtility::addDefaultHeaders(headers2);
-  envoy_headers c_headers2 = Utility::toBridgeHeaders(headers2);
+  envoy_headers c_headers2 = defaultRequestHeaders();
 
   // Create a stream.
   ON_CALL(dispatcher_, isThreadSafe()).WillByDefault(Return(true));
@@ -624,7 +485,7 @@ TEST_F(ClientTest, MultipleStreams) {
         response_encoder2 = &encoder;
         return request_decoder2;
       }));
-  EXPECT_EQ(http_client_.startStream(stream2, bridge_callbacks2), ENVOY_SUCCESS);
+  EXPECT_EQ(http_client_.startStream(stream2, bridge_callbacks_2), ENVOY_SUCCESS);
 
   // Send request headers.
 
@@ -636,162 +497,66 @@ TEST_F(ClientTest, MultipleStreams) {
   TestResponseHeaderMapImpl response_headers2{{":status", "200"}};
   response_encoder2->encodeHeaders(response_headers2, true);
   ASSERT_EQ(cc2.on_headers_calls, 1);
-  // Ensure that the on_headers on the bridge_callbacks was called.
+  // Ensure that the on_headers on the bridge_callbacks_ was called.
   ASSERT_EQ(cc2.on_complete_calls, 1);
 
   // Finish stream 1.
   EXPECT_CALL(dispatcher_, deferredDelete_(_));
   TestResponseHeaderMapImpl response_headers{{":status", "200"}};
   response_encoder_->encodeHeaders(response_headers, true);
-  ASSERT_EQ(cc.on_headers_calls, 1);
-  ASSERT_EQ(cc.on_complete_calls, 1);
+  ASSERT_EQ(cc_.on_headers_calls, 1);
+  ASSERT_EQ(cc_.on_complete_calls, 1);
 }
 
 TEST_F(ClientTest, EnvoyLocalReplyNotAnError) {
-  envoy_stream_t stream = 1;
-  // Setup bridge_callbacks to handle the response headers.
-  envoy_http_callbacks bridge_callbacks;
-  callbacks_called cc = {0, 0, 0, 0, 0, 0};
-  bridge_callbacks.context = &cc;
-  bridge_callbacks.on_headers = [](envoy_headers c_headers, bool end_stream,
-                                   void* context) -> void* {
-    EXPECT_TRUE(end_stream);
-    ResponseHeaderMapPtr response_headers = toResponseHeaders(c_headers);
-    EXPECT_EQ(response_headers->Status()->value().getStringView(), "503");
-    callbacks_called* cc = static_cast<callbacks_called*>(context);
-    cc->on_headers_calls++;
-    return nullptr;
-  };
-  bridge_callbacks.on_complete = [](void* context) -> void* {
-    callbacks_called* cc = static_cast<callbacks_called*>(context);
-    cc->on_complete_calls++;
-    return nullptr;
-  };
-  bridge_callbacks.on_error = [](envoy_error, void* context) -> void* {
-    callbacks_called* cc = static_cast<callbacks_called*>(context);
-    cc->on_error_calls++;
-    return nullptr;
-  };
+  cc_.expected_status_ = "503";
 
-  // Build a set of request headers.
-  TestRequestHeaderMapImpl headers;
-  HttpTestUtility::addDefaultHeaders(headers);
-  envoy_headers c_headers = Utility::toBridgeHeaders(headers);
+  envoy_headers c_headers = defaultRequestHeaders();
 
-  // Create a stream.
-  ON_CALL(dispatcher_, isThreadSafe()).WillByDefault(Return(true));
-
-  // Grab the response encoder in order to dispatch responses on the stream.
-  // Return the request decoder to make sure calls are dispatched to the decoder via the dispatcher
-  // API.
-  EXPECT_CALL(api_listener_, newStream(_, _))
-      .WillOnce(Invoke([&](ResponseEncoder& encoder, bool) -> RequestDecoder& {
-        response_encoder_ = &encoder;
-        return request_decoder_;
-      }));
-  EXPECT_EQ(http_client_.startStream(stream, bridge_callbacks), ENVOY_SUCCESS);
+  // Create a stream, and set up request_decoder_ and response_encoder_
+  createStream();
 
   // Send request headers.
-
   EXPECT_CALL(request_decoder_, decodeHeaders_(_, true));
-  http_client_.sendHeaders(stream, c_headers, true);
+  http_client_.sendHeaders(stream_, c_headers, true);
 
   // Encode response headers. A non-200 code triggers an on_error callback chain. In particular, a
   // 503 should have an ENVOY_CONNECTION_FAILURE error code.
   EXPECT_CALL(dispatcher_, deferredDelete_(_));
   TestResponseHeaderMapImpl response_headers{{":status", "503"}};
   response_encoder_->encodeHeaders(response_headers, true);
-  // Ensure that the callbacks on the bridge_callbacks were called.
-  ASSERT_EQ(cc.on_headers_calls, 1);
-  ASSERT_EQ(cc.on_complete_calls, 1);
-  ASSERT_EQ(cc.on_error_calls, 0);
+  // Ensure that the callbacks on the bridge_callbacks_ were called.
+  ASSERT_EQ(cc_.on_headers_calls, 1);
+  ASSERT_EQ(cc_.on_complete_calls, 1);
+  ASSERT_EQ(cc_.on_error_calls, 0);
 }
 
 TEST_F(ClientTest, EnvoyLocalReplyNon503NotAnError) {
-  envoy_stream_t stream = 1;
-  // Setup bridge_callbacks to handle the response headers.
-  envoy_http_callbacks bridge_callbacks;
-  callbacks_called cc = {0, 0, 0, 0, 0, 0};
-  bridge_callbacks.context = &cc;
-  bridge_callbacks.on_headers = [](envoy_headers c_headers, bool end_stream,
-                                   void* context) -> void* {
-    EXPECT_TRUE(end_stream);
-    ResponseHeaderMapPtr response_headers = toResponseHeaders(c_headers);
-    EXPECT_EQ(response_headers->Status()->value().getStringView(), "504");
-    callbacks_called* cc = static_cast<callbacks_called*>(context);
-    cc->on_headers_calls++;
-    return nullptr;
-  };
-  bridge_callbacks.on_complete = [](void* context) -> void* {
-    callbacks_called* cc = static_cast<callbacks_called*>(context);
-    cc->on_complete_calls++;
-    return nullptr;
-  };
-  bridge_callbacks.on_error = [](envoy_error, void* context) -> void* {
-    callbacks_called* cc = static_cast<callbacks_called*>(context);
-    cc->on_error_calls++;
-    return nullptr;
-  };
+  cc_.expected_status_ = "504";
 
-  // Build a set of request headers.
-  TestRequestHeaderMapImpl headers;
-  HttpTestUtility::addDefaultHeaders(headers);
-  envoy_headers c_headers = Utility::toBridgeHeaders(headers);
-
-  // Create a stream.
-  ON_CALL(dispatcher_, isThreadSafe()).WillByDefault(Return(true));
-
-  // Grab the response encoder in order to dispatch responses on the stream.
-  // Return the request decoder to make sure calls are dispatched to the decoder via the dispatcher
-  // API.
-  EXPECT_CALL(api_listener_, newStream(_, _))
-      .WillOnce(Invoke([&](ResponseEncoder& encoder, bool) -> RequestDecoder& {
-        response_encoder_ = &encoder;
-        return request_decoder_;
-      }));
-  EXPECT_EQ(http_client_.startStream(stream, bridge_callbacks), ENVOY_SUCCESS);
+  // Create a stream, and set up request_decoder_ and response_encoder_
+  createStream();
 
   // Send request headers.
-
+  envoy_headers c_headers = defaultRequestHeaders();
   EXPECT_CALL(request_decoder_, decodeHeaders_(_, true));
-  http_client_.sendHeaders(stream, c_headers, true);
+  http_client_.sendHeaders(stream_, c_headers, true);
 
   // Encode response headers. A non-200 code triggers an on_error callback chain. In particular, a
   // non-503 should have an ENVOY_UNDEFINED_ERROR error code.
   EXPECT_CALL(dispatcher_, deferredDelete_(_));
   TestResponseHeaderMapImpl response_headers{{":status", "504"}};
   response_encoder_->encodeHeaders(response_headers, true);
-  // Ensure that the callbacks on the bridge_callbacks were called.
-  ASSERT_EQ(cc.on_headers_calls, 1);
-  ASSERT_EQ(cc.on_complete_calls, 1);
-  ASSERT_EQ(cc.on_error_calls, 0);
+  // Ensure that the callbacks on the bridge_callbacks_ were called.
+  ASSERT_EQ(cc_.on_headers_calls, 1);
+  ASSERT_EQ(cc_.on_complete_calls, 1);
+  ASSERT_EQ(cc_.on_error_calls, 0);
 }
 
 TEST_F(ClientTest, EnvoyResponseWithErrorCode) {
-  envoy_stream_t stream = 1;
-  // Setup bridge_callbacks to handle the response headers.
-  envoy_http_callbacks bridge_callbacks;
-  callbacks_called cc = {0, 0, 0, 0, 0, 0};
-  bridge_callbacks.context = &cc;
-  bridge_callbacks.on_headers = [](envoy_headers c_headers, bool, void* context) -> void* {
-    ResponseHeaderMapPtr response_headers = toResponseHeaders(c_headers);
-    EXPECT_EQ(response_headers->Status()->value().getStringView(), "218");
-    callbacks_called* cc = static_cast<callbacks_called*>(context);
-    cc->on_headers_calls++;
-    return nullptr;
-  };
-  bridge_callbacks.on_data = [](envoy_data c_data, bool, void* context) -> void* {
-    callbacks_called* cc = static_cast<callbacks_called*>(context);
-    cc->on_data_calls++;
-    c_data.release(c_data.context);
-    return nullptr;
-  };
-  bridge_callbacks.on_complete = [](void* context) -> void* {
-    callbacks_called* cc = static_cast<callbacks_called*>(context);
-    cc->on_complete_calls++;
-    return nullptr;
-  };
-  bridge_callbacks.on_error = [](envoy_error error, void* context) -> void* {
+  cc_.expected_status_ = "218";
+  // Override the on_error default with some custom checks.
+  bridge_callbacks_.on_error = [](envoy_error error, void* context) -> void* {
     EXPECT_EQ(error.error_code, ENVOY_CONNECTION_FAILURE);
     EXPECT_EQ(error.attempt_count, 123);
     callbacks_called* cc = static_cast<callbacks_called*>(context);
@@ -800,28 +565,13 @@ TEST_F(ClientTest, EnvoyResponseWithErrorCode) {
     return nullptr;
   };
 
-  // Build a set of request headers.
-  TestRequestHeaderMapImpl headers;
-  HttpTestUtility::addDefaultHeaders(headers);
-  envoy_headers c_headers = Utility::toBridgeHeaders(headers);
-
-  // Create a stream.
-  ON_CALL(dispatcher_, isThreadSafe()).WillByDefault(Return(true));
-
-  // Grab the response encoder in order to dispatch responses on the stream.
-  // Return the request decoder to make sure calls are dispatched to the decoder via the dispatcher
-  // API.
-  EXPECT_CALL(api_listener_, newStream(_, _))
-      .WillOnce(Invoke([&](ResponseEncoder& encoder, bool) -> RequestDecoder& {
-        response_encoder_ = &encoder;
-        return request_decoder_;
-      }));
-  EXPECT_EQ(http_client_.startStream(stream, bridge_callbacks), ENVOY_SUCCESS);
+  // Create a stream, and set up request_decoder_ and response_encoder_
+  createStream();
 
   // Send request headers.
-
+  envoy_headers c_headers = defaultRequestHeaders();
   EXPECT_CALL(request_decoder_, decodeHeaders_(_, true));
-  http_client_.sendHeaders(stream, c_headers, true);
+  http_client_.sendHeaders(stream_, c_headers, true);
 
   // Encode response headers. A non-200 code triggers an on_error callback chain. In particular, a
   // 503 should have an ENVOY_CONNECTION_FAILURE error code.
@@ -833,119 +583,48 @@ TEST_F(ClientTest, EnvoyResponseWithErrorCode) {
       {"x-envoy-attempt-count", "123"},
   };
   response_encoder_->encodeHeaders(response_headers, true);
-  ASSERT_EQ(cc.on_headers_calls, 0);
-  // Ensure that the callbacks on the bridge_callbacks were called.
-  ASSERT_EQ(cc.on_complete_calls, 0);
-  ASSERT_EQ(cc.on_error_calls, 1);
+  ASSERT_EQ(cc_.on_headers_calls, 0);
+  // Ensure that the callbacks on the bridge_callbacks_ were called.
+  ASSERT_EQ(cc_.on_complete_calls, 0);
+  ASSERT_EQ(cc_.on_error_calls, 1);
 }
 
 TEST_F(ClientTest, ResetStreamLocal) {
-  envoy_stream_t stream = 1;
-  envoy_http_callbacks bridge_callbacks;
-  callbacks_called cc = {0, 0, 0, 0, 0, 0};
-  bridge_callbacks.context = &cc;
-  bridge_callbacks.on_error = [](envoy_error, void* context) -> void* {
-    callbacks_called* cc = static_cast<callbacks_called*>(context);
-    cc->on_error_calls++;
-    return nullptr;
-  };
-  bridge_callbacks.on_complete = [](void* context) -> void* {
-    callbacks_called* cc = static_cast<callbacks_called*>(context);
-    cc->on_complete_calls++;
-    return nullptr;
-  };
-  bridge_callbacks.on_cancel = [](void* context) -> void* {
-    callbacks_called* cc = static_cast<callbacks_called*>(context);
-    cc->on_cancel_calls++;
-    return nullptr;
-  };
-
   // Create a stream.
   ON_CALL(dispatcher_, isThreadSafe()).WillByDefault(Return(true));
 
-  // Grab the response encoder in order to dispatch responses on the stream.
-  // Return the request decoder to make sure calls are dispatched to the decoder via the dispatcher
-  // API.
-  EXPECT_CALL(api_listener_, newStream(_, _))
-      .WillOnce(Invoke([&](ResponseEncoder& encoder, bool) -> RequestDecoder& {
-        response_encoder_ = &encoder;
-        return request_decoder_;
-      }));
-  EXPECT_EQ(http_client_.startStream(stream, bridge_callbacks), ENVOY_SUCCESS);
+  // Create a stream, and set up request_decoder_ and response_encoder_
+  createStream();
 
   EXPECT_CALL(dispatcher_, deferredDelete_(_));
-  ASSERT_EQ(http_client_.cancelStream(stream), ENVOY_SUCCESS);
-  ASSERT_EQ(cc.on_cancel_calls, 1);
-  ASSERT_EQ(cc.on_error_calls, 0);
-  ASSERT_EQ(cc.on_complete_calls, 0);
+  ASSERT_EQ(http_client_.cancelStream(stream_), ENVOY_SUCCESS);
+  ASSERT_EQ(cc_.on_cancel_calls, 1);
+  ASSERT_EQ(cc_.on_error_calls, 0);
+  ASSERT_EQ(cc_.on_complete_calls, 0);
 }
 
 TEST_F(ClientTest, DoubleResetStreamLocal) {
-  envoy_stream_t stream = 1;
-  envoy_http_callbacks bridge_callbacks;
-  callbacks_called cc = {0, 0, 0, 0, 0, 0};
-  bridge_callbacks.context = &cc;
-  bridge_callbacks.on_error = [](envoy_error, void* context) -> void* {
-    callbacks_called* cc = static_cast<callbacks_called*>(context);
-    cc->on_error_calls++;
-    return nullptr;
-  };
-  bridge_callbacks.on_complete = [](void* context) -> void* {
-    callbacks_called* cc = static_cast<callbacks_called*>(context);
-    cc->on_complete_calls++;
-    return nullptr;
-  };
-  bridge_callbacks.on_cancel = [](void* context) -> void* {
-    callbacks_called* cc = static_cast<callbacks_called*>(context);
-    cc->on_cancel_calls++;
-    return nullptr;
-  };
-
   // Create a stream.
   ON_CALL(dispatcher_, isThreadSafe()).WillByDefault(Return(true));
 
-  // Grab the response encoder in order to dispatch responses on the stream.
-  // Return the request decoder to make sure calls are dispatched to the decoder via the dispatcher
-  // API.
-  EXPECT_CALL(api_listener_, newStream(_, _))
-      .WillOnce(Invoke([&](ResponseEncoder& encoder, bool) -> RequestDecoder& {
-        response_encoder_ = &encoder;
-        return request_decoder_;
-      }));
-  EXPECT_EQ(http_client_.startStream(stream, bridge_callbacks), ENVOY_SUCCESS);
+  // Create a stream, and set up request_decoder_ and response_encoder_
+  createStream();
 
   EXPECT_CALL(dispatcher_, deferredDelete_(_));
 
-  ASSERT_EQ(http_client_.cancelStream(stream), ENVOY_SUCCESS);
+  ASSERT_EQ(http_client_.cancelStream(stream_), ENVOY_SUCCESS);
   // Second cancel call has no effect because stream is already cancelled.
-  ASSERT_EQ(http_client_.cancelStream(stream), ENVOY_SUCCESS);
+  ASSERT_EQ(http_client_.cancelStream(stream_), ENVOY_SUCCESS);
 
-  ASSERT_EQ(cc.on_cancel_calls, 1);
-  ASSERT_EQ(cc.on_error_calls, 0);
-  ASSERT_EQ(cc.on_complete_calls, 0);
+  ASSERT_EQ(cc_.on_cancel_calls, 1);
+  ASSERT_EQ(cc_.on_error_calls, 0);
+  ASSERT_EQ(cc_.on_complete_calls, 0);
 }
 
 TEST_F(ClientTest, RemoteResetAfterStreamStart) {
-  envoy_stream_t stream = 1;
-  // Setup bridge_callbacks to handle the response headers.
-  envoy_http_callbacks bridge_callbacks;
-  callbacks_called cc = {0, 0, 0, 0, 0, 0};
-  bridge_callbacks.context = &cc;
-  bridge_callbacks.on_headers = [](envoy_headers c_headers, bool end_stream,
-                                   void* context) -> void* {
-    EXPECT_FALSE(end_stream);
-    ResponseHeaderMapPtr response_headers = toResponseHeaders(c_headers);
-    EXPECT_EQ(response_headers->Status()->value().getStringView(), "200");
-    callbacks_called* cc = static_cast<callbacks_called*>(context);
-    cc->on_headers_calls++;
-    return nullptr;
-  };
-  bridge_callbacks.on_complete = [](void* context) -> void* {
-    callbacks_called* cc = static_cast<callbacks_called*>(context);
-    cc->on_complete_calls++;
-    return nullptr;
-  };
-  bridge_callbacks.on_error = [](envoy_error error, void* context) -> void* {
+  cc_.end_stream_with_headers_ = false;
+
+  bridge_callbacks_.on_error = [](envoy_error error, void* context) -> void* {
     EXPECT_EQ(error.error_code, ENVOY_STREAM_RESET);
     EXPECT_EQ(error.message.length, 0);
     EXPECT_EQ(error.attempt_count, -1);
@@ -955,29 +634,9 @@ TEST_F(ClientTest, RemoteResetAfterStreamStart) {
     cc->on_error_calls++;
     return nullptr;
   };
-  bridge_callbacks.on_cancel = [](void* context) -> void* {
-    callbacks_called* cc = static_cast<callbacks_called*>(context);
-    cc->on_cancel_calls++;
-    return nullptr;
-  };
 
-  // Build a set of request headers.
-  TestRequestHeaderMapImpl headers;
-  HttpTestUtility::addDefaultHeaders(headers);
-  envoy_headers c_headers = Utility::toBridgeHeaders(headers);
-
-  // Create a stream.
-  ON_CALL(dispatcher_, isThreadSafe()).WillByDefault(Return(true));
-
-  // Grab the response encoder in order to dispatch responses on the stream.
-  // Return the request decoder to make sure calls are dispatched to the decoder via the dispatcher
-  // API.
-  EXPECT_CALL(api_listener_, newStream(_, _))
-      .WillOnce(Invoke([&](ResponseEncoder& encoder, bool) -> RequestDecoder& {
-        response_encoder_ = &encoder;
-        return request_decoder_;
-      }));
-  EXPECT_EQ(http_client_.startStream(stream, bridge_callbacks), ENVOY_SUCCESS);
+  // Create a stream, and set up request_decoder_ and response_encoder_
+  createStream();
 
   // Used to verify that when a reset is received, the Http::Client::DirectStream fires
   // runResetCallbacks. The Http::ConnectionManager depends on the Http::Client::DirectStream
@@ -986,14 +645,14 @@ TEST_F(ClientTest, RemoteResetAfterStreamStart) {
   response_encoder_->getStream().addCallbacks(callbacks);
 
   // Send request headers.
-
+  envoy_headers c_headers = defaultRequestHeaders();
   EXPECT_CALL(request_decoder_, decodeHeaders_(_, true));
-  http_client_.sendHeaders(stream, c_headers, true);
+  http_client_.sendHeaders(stream_, c_headers, true);
 
   // Encode response headers.
   TestResponseHeaderMapImpl response_headers{{":status", "200"}};
   response_encoder_->encodeHeaders(response_headers, false);
-  ASSERT_EQ(cc.on_headers_calls, 1);
+  ASSERT_EQ(cc_.on_headers_calls, 1);
 
   // Expect that when a reset is received, the Http::Client::DirectStream fires
   // runResetCallbacks. The Http::ConnectionManager depends on the Http::Client::DirectStream
@@ -1001,145 +660,57 @@ TEST_F(ClientTest, RemoteResetAfterStreamStart) {
   EXPECT_CALL(callbacks, onResetStream(StreamResetReason::RemoteReset, _));
   EXPECT_CALL(dispatcher_, deferredDelete_(_));
   response_encoder_->getStream().resetStream(StreamResetReason::RemoteReset);
-  // Ensure that the on_error on the bridge_callbacks was called.
-  ASSERT_EQ(cc.on_error_calls, 1);
-  ASSERT_EQ(cc.on_complete_calls, 0);
+  // Ensure that the on_error on the bridge_callbacks_ was called.
+  ASSERT_EQ(cc_.on_error_calls, 1);
+  ASSERT_EQ(cc_.on_complete_calls, 0);
 }
 
 TEST_F(ClientTest, StreamResetAfterOnComplete) {
-  envoy_stream_t stream = 1;
-  // Setup bridge_callbacks to handle the response headers.
-  envoy_http_callbacks bridge_callbacks;
-  callbacks_called cc = {0, 0, 0, 0, 0, 0};
-  bridge_callbacks.context = &cc;
-  bridge_callbacks.on_headers = [](envoy_headers c_headers, bool end_stream,
-                                   void* context) -> void* {
-    EXPECT_TRUE(end_stream);
-    ResponseHeaderMapPtr response_headers = toResponseHeaders(c_headers);
-    EXPECT_EQ(response_headers->Status()->value().getStringView(), "200");
-    callbacks_called* cc = static_cast<callbacks_called*>(context);
-    cc->on_headers_calls++;
-    return nullptr;
-  };
-  bridge_callbacks.on_complete = [](void* context) -> void* {
-    callbacks_called* cc = static_cast<callbacks_called*>(context);
-    cc->on_complete_calls++;
-    return nullptr;
-  };
-  bridge_callbacks.on_cancel = [](void* context) -> void* {
-    callbacks_called* cc = static_cast<callbacks_called*>(context);
-    cc->on_cancel_calls++;
-    return nullptr;
-  };
-
-  // Build a set of request headers.
-  TestRequestHeaderMapImpl headers;
-  HttpTestUtility::addDefaultHeaders(headers);
-  envoy_headers c_headers = Utility::toBridgeHeaders(headers);
-
-  // Create a stream.
-  ON_CALL(dispatcher_, isThreadSafe()).WillByDefault(Return(true));
-
-  // Grab the response encoder in order to dispatch responses on the stream.
-  // Return the request decoder to make sure calls are dispatched to the decoder via the dispatcher
-  // API.
-  EXPECT_CALL(api_listener_, newStream(_, _))
-      .WillOnce(Invoke([&](ResponseEncoder& encoder, bool) -> RequestDecoder& {
-        response_encoder_ = &encoder;
-        return request_decoder_;
-      }));
-  EXPECT_EQ(http_client_.startStream(stream, bridge_callbacks), ENVOY_SUCCESS);
+  // Create a stream, and set up request_decoder_ and response_encoder_
+  createStream();
 
   // Send request headers.
-
+  envoy_headers c_headers = defaultRequestHeaders();
   EXPECT_CALL(request_decoder_, decodeHeaders_(_, true));
-  http_client_.sendHeaders(stream, c_headers, true);
+  http_client_.sendHeaders(stream_, c_headers, true);
 
   // Encode response headers.
   EXPECT_CALL(dispatcher_, deferredDelete_(_));
   TestResponseHeaderMapImpl response_headers{{":status", "200"}};
   response_encoder_->encodeHeaders(response_headers, true);
-  ASSERT_EQ(cc.on_headers_calls, 1);
-  // Ensure that the callbacks on the bridge_callbacks were called.
-  ASSERT_EQ(cc.on_complete_calls, 1);
+  ASSERT_EQ(cc_.on_headers_calls, 1);
+  // Ensure that the callbacks on the bridge_callbacks_ were called.
+  ASSERT_EQ(cc_.on_complete_calls, 1);
 
   // Cancellation should have no effect as the stream should have already been cleaned up.
-  ASSERT_EQ(http_client_.cancelStream(stream), ENVOY_SUCCESS);
-  ASSERT_EQ(cc.on_cancel_calls, 0);
+  ASSERT_EQ(http_client_.cancelStream(stream_), ENVOY_SUCCESS);
+  ASSERT_EQ(cc_.on_cancel_calls, 0);
 }
 
 TEST_F(ClientTest, ResetWhenRemoteClosesBeforeLocal) {
-  envoy_stream_t stream = 1;
-  // Setup bridge_callbacks to handle the response headers.
-  envoy_http_callbacks bridge_callbacks;
-  callbacks_called cc = {0, 0, 0, 0, 0, 0};
-  bridge_callbacks.context = &cc;
-  bridge_callbacks.on_headers = [](envoy_headers c_headers, bool end_stream,
-                                   void* context) -> void* {
-    EXPECT_TRUE(end_stream);
-    ResponseHeaderMapPtr response_headers = toResponseHeaders(c_headers);
-    EXPECT_EQ(response_headers->Status()->value().getStringView(), "200");
-    callbacks_called* cc = static_cast<callbacks_called*>(context);
-    cc->on_headers_calls++;
-    return nullptr;
-  };
-  bridge_callbacks.on_complete = [](void* context) -> void* {
-    callbacks_called* cc = static_cast<callbacks_called*>(context);
-    cc->on_complete_calls++;
-    return nullptr;
-  };
-
-  // Create a stream.
-  ON_CALL(dispatcher_, isThreadSafe()).WillByDefault(Return(true));
-
-  // Grab the response encoder in order to dispatch responses on the stream.
-  // Return the request decoder to make sure calls are dispatched to the decoder via the dispatcher
-  // API.
-  EXPECT_CALL(api_listener_, newStream(_, _))
-      .WillOnce(Invoke([&](ResponseEncoder& encoder, bool) -> RequestDecoder& {
-        response_encoder_ = &encoder;
-        return request_decoder_;
-      }));
-  EXPECT_EQ(http_client_.startStream(stream, bridge_callbacks), ENVOY_SUCCESS);
+  // Create a stream, and set up request_decoder_ and response_encoder_
+  createStream();
 
   // Encode response headers.
   EXPECT_CALL(dispatcher_, deferredDelete_(_));
   TestResponseHeaderMapImpl response_headers{{":status", "200"}};
   response_encoder_->encodeHeaders(response_headers, true);
-  ASSERT_EQ(cc.on_headers_calls, 1);
-  ASSERT_EQ(cc.on_complete_calls, 1);
+  ASSERT_EQ(cc_.on_headers_calls, 1);
+  ASSERT_EQ(cc_.on_complete_calls, 1);
 
   // Fire stream reset because Envoy does not allow half-open streams on the local side.
   response_encoder_->getStream().resetStream(StreamResetReason::RemoteReset);
-  ASSERT_EQ(cc.on_error_calls, 0);
+  ASSERT_EQ(cc_.on_error_calls, 0);
 }
 
 TEST_F(ClientTest, Encode100Continue) {
-  envoy_stream_t stream = 1;
-  envoy_http_callbacks bridge_callbacks;
-
-  // Build a set of request headers.
-  TestRequestHeaderMapImpl headers;
-  HttpTestUtility::addDefaultHeaders(headers);
-  envoy_headers c_headers = Utility::toBridgeHeaders(headers);
-
-  // Create a stream.
-  ON_CALL(dispatcher_, isThreadSafe()).WillByDefault(Return(true));
-
-  // Grab the response encoder in order to dispatch responses on the stream.
-  // Return the request decoder to make sure calls are dispatched to the decoder via the dispatcher
-  // API.
-  EXPECT_CALL(api_listener_, newStream(_, _))
-      .WillOnce(Invoke([&](ResponseEncoder& encoder, bool) -> RequestDecoder& {
-        response_encoder_ = &encoder;
-        return request_decoder_;
-      }));
-  EXPECT_EQ(http_client_.startStream(stream, bridge_callbacks), ENVOY_SUCCESS);
+  // Create a stream, and set up request_decoder_ and response_encoder_
+  createStream();
 
   // Send request headers.
-
+  envoy_headers c_headers = defaultRequestHeaders();
   EXPECT_CALL(request_decoder_, decodeHeaders_(_, true));
-  http_client_.sendHeaders(stream, c_headers, true);
+  http_client_.sendHeaders(stream_, c_headers, true);
 
   // Encode 100 continue should blow up.
   TestResponseHeaderMapImpl response_headers{{":status", "200"}};
@@ -1148,48 +719,20 @@ TEST_F(ClientTest, Encode100Continue) {
 }
 
 TEST_F(ClientTest, EncodeMetadata) {
-  envoy_stream_t stream = 1;
-  // Setup bridge_callbacks to handle the response headers.
-  envoy_http_callbacks bridge_callbacks;
-  callbacks_called cc = {0, 0, 0, 0, 0, 0};
-  bridge_callbacks.context = &cc;
-  bridge_callbacks.on_headers = [](envoy_headers c_headers, bool end_stream,
-                                   void* context) -> void* {
-    EXPECT_FALSE(end_stream);
-    ResponseHeaderMapPtr response_headers = toResponseHeaders(c_headers);
-    EXPECT_EQ(response_headers->Status()->value().getStringView(), "200");
-    callbacks_called* cc = static_cast<callbacks_called*>(context);
-    cc->on_headers_calls++;
-    return nullptr;
-  };
+  cc_.end_stream_with_headers_ = false;
 
-  // Build a set of request headers.
-  TestRequestHeaderMapImpl headers;
-  HttpTestUtility::addDefaultHeaders(headers);
-  envoy_headers c_headers = Utility::toBridgeHeaders(headers);
-
-  // Create a stream.
-  ON_CALL(dispatcher_, isThreadSafe()).WillByDefault(Return(true));
-
-  // Grab the response encoder in order to dispatch responses on the stream.
-  // Return the request decoder to make sure calls are dispatched to the decoder via the dispatcher
-  // API.
-  EXPECT_CALL(api_listener_, newStream(_, _))
-      .WillOnce(Invoke([&](ResponseEncoder& encoder, bool) -> RequestDecoder& {
-        response_encoder_ = &encoder;
-        return request_decoder_;
-      }));
-  EXPECT_EQ(http_client_.startStream(stream, bridge_callbacks), ENVOY_SUCCESS);
+  // Create a stream, and set up request_decoder_ and response_encoder_
+  createStream();
 
   // Send request headers.
-
+  envoy_headers c_headers = defaultRequestHeaders();
   EXPECT_CALL(request_decoder_, decodeHeaders_(_, true));
-  http_client_.sendHeaders(stream, c_headers, true);
+  http_client_.sendHeaders(stream_, c_headers, true);
 
   // Encode response headers.
   TestResponseHeaderMapImpl response_headers{{":status", "200"}};
   response_encoder_->encodeHeaders(response_headers, false);
-  ASSERT_EQ(cc.on_headers_calls, 1);
+  ASSERT_EQ(cc_.on_headers_calls, 1);
 
   MetadataMap metadata_map = {{"key", "value"}};
   MetadataMapPtr metadata_map_ptr = std::make_unique<MetadataMap>(metadata_map);


### PR DESCRIPTION
I started writing tests for https://github.com/envoyproxy/envoy-mobile/pull/1513 and decided I wanted to do less copy-pasting

If this is Ok with envoy-mobile style I'll land test refactors here, so the test changes/additions are clean in 1513.

Risk Level: n/a (test only)
Testing: test passes
Docs Changes: n/a
Release Notes: n/a