### PR TITLE
provisional dispather: update isThreadSafe to be const

### DIFF
--- a/library/common/event/provisional_dispatcher.cc
+++ b/library/common/event/provisional_dispatcher.cc
@@ -36,7 +36,7 @@ envoy_status_t ProvisionalDispatcher::post(Event::PostCb callback) {
   return ENVOY_SUCCESS;
 }
 
-bool ProvisionalDispatcher::isThreadSafe() {
+bool ProvisionalDispatcher::isThreadSafe() const {
   // Doesn't require locking because if a thread has a stale view of drained_, then by definition
   // this wasn't a threadsafe call.
   ENVOY_LOG(trace, "ProvisionalDispatcher::isThreadSafe");

--- a/library/common/event/provisional_dispatcher.h
+++ b/library/common/event/provisional_dispatcher.h
@@ -41,7 +41,7 @@ public:
    * @return false before the Event::Dispatcher is running, otherwise the result of the
    * underlying call to Event::Dispatcher::isThreadSafe().
    */
-  virtual bool isThreadSafe();
+  virtual bool isThreadSafe() const;
 
   /**
    * Submits an item for deferred delete. Must be called from context where

--- a/test/common/mocks/event/mocks.h
+++ b/test/common/mocks/event/mocks.h
@@ -36,7 +36,7 @@ public:
   MOCK_METHOD(void, drain, (Event::Dispatcher & event_dispatcher));
   MOCK_METHOD(void, deferredDelete_, (DeferredDeletable * to_delete));
   MOCK_METHOD(envoy_status_t, post_, (std::function<void()> callback));
-  MOCK_METHOD(bool, isThreadSafe, ());
+  MOCK_METHOD(bool, isThreadSafe, (), (const));
 
   std::list<DeferredDeletablePtr> to_delete_;
   std::list<std::function<void()>> callbacks_;


### PR DESCRIPTION
Description: matches the Event::Dispatcher interface. 
Risk Level: low
Testing: existing

Signed-off-by: Jose Nino <jnino@lyft.com>