### PR TITLE
config: use LOGICAL_DNS instead of STATIC for fake remote clusters

### DIFF
--- a/library/common/config_template.cc
+++ b/library/common/config_template.cc
@@ -46,7 +46,7 @@ const char* fake_remote_listener_template = R"(
 const char* fake_remote_cluster_template = R"(
   - name: fake_remote
     connect_timeout: 1.0s
-    type: STATIC
+    type: LOGICAL_DNS
     lb_policy: ROUND_ROBIN
     load_assignment:
       cluster_name: fake_remote


### PR DESCRIPTION
This should prevent us from having to force-register `envoy.cluster.static` to run tests that have direct responses with dead stripping enabled (`-all_load` removed).

Signed-off-by: Michael Rebello <me@michaelrebello.com>