### PR TITLE
core: remove unsafe logging from ProvisionalDispatcher

### DIFF
--- a/library/common/event/provisional_dispatcher.cc
+++ b/library/common/event/provisional_dispatcher.cc
@@ -12,7 +12,6 @@ void ProvisionalDispatcher::drain(Event::Dispatcher& event_dispatcher) {
   // because of behavioral oddities in Event::Dispatcher: event_dispatcher_->isThreadSafe() will
   // crash.
   Thread::LockGuard lock(state_lock_);
-  ENVOY_LOG(trace, "ProvisionalDispatcher::drain");
   RELEASE_ASSERT(!drained_, "ProvisionalDispatcher::drain must only occur once");
   drained_ = true;
   event_dispatcher_ = &event_dispatcher;
@@ -26,12 +25,10 @@ envoy_status_t ProvisionalDispatcher::post(Event::PostCb callback) {
   Thread::LockGuard lock(state_lock_);
 
   if (drained_) {
-    ENVOY_LOG(trace, "ProvisionalDispatcher::post: pass-through");
     event_dispatcher_->post(callback);
     return ENVOY_SUCCESS;
   }
 
-  ENVOY_LOG(trace, "ProvisionalDispatcher::post: queueing");
   init_queue_.push_back(callback);
   return ENVOY_SUCCESS;
 }
@@ -39,7 +36,6 @@ envoy_status_t ProvisionalDispatcher::post(Event::PostCb callback) {
 bool ProvisionalDispatcher::isThreadSafe() const {
   // Doesn't require locking because if a thread has a stale view of drained_, then by definition
   // this wasn't a threadsafe call.
-  ENVOY_LOG(trace, "ProvisionalDispatcher::isThreadSafe");
   return TS_UNCHECKED_READ(drained_) && event_dispatcher_->isThreadSafe();
 }
 

--- a/library/common/event/provisional_dispatcher.h
+++ b/library/common/event/provisional_dispatcher.h
@@ -16,7 +16,7 @@ namespace Event {
  * versions may support correct calling semantics after the Event::Dispatcher has been
  * terminated/deleted or before it has been created.
  */
-class ProvisionalDispatcher : public Logger::Loggable<Logger::Id::main> {
+class ProvisionalDispatcher {
 public:
   ProvisionalDispatcher() = default;
   virtual ~ProvisionalDispatcher() = default;


### PR DESCRIPTION
Description: The dispatcher lives beyond the scope of EngineCommon, and so generic logger access is unsafe in this context.
Risk Level: Low
Testing: Local & CI

Signed-off-by: Mike Schore <mike.schore@gmail.com>