### PR TITLE
http client: use void return type for external API

### DIFF
--- a/library/common/http/client.cc
+++ b/library/common/http/client.cc
@@ -187,8 +187,7 @@ void Client::DirectStream::resetStream(StreamResetReason reason) {
   callbacks_->onError();
 }
 
-void Client::startStream(envoy_stream_t new_stream_handle,
-                                   envoy_http_callbacks bridge_callbacks) {
+void Client::startStream(envoy_stream_t new_stream_handle, envoy_http_callbacks bridge_callbacks) {
   ASSERT(dispatcher_.isThreadSafe());
   Client::DirectStreamSharedPtr direct_stream{new DirectStream(new_stream_handle, *this)};
   direct_stream->callbacks_ =
@@ -260,9 +259,7 @@ void Client::sendData(envoy_stream_t stream, envoy_data data, bool end_stream) {
   }
 }
 
-void Client::sendMetadata(envoy_stream_t, envoy_headers) {
-  NOT_IMPLEMENTED_GCOVR_EXCL_LINE;
-}
+void Client::sendMetadata(envoy_stream_t, envoy_headers) { NOT_IMPLEMENTED_GCOVR_EXCL_LINE; }
 
 void Client::sendTrailers(envoy_stream_t stream, envoy_headers trailers) {
   ASSERT(dispatcher_.isThreadSafe());

--- a/library/common/http/client.cc
+++ b/library/common/http/client.cc
@@ -187,7 +187,7 @@ void Client::DirectStream::resetStream(StreamResetReason reason) {
   callbacks_->onError();
 }
 
-envoy_status_t Client::startStream(envoy_stream_t new_stream_handle,
+void Client::startStream(envoy_stream_t new_stream_handle,
                                    envoy_http_callbacks bridge_callbacks) {
   ASSERT(dispatcher_.isThreadSafe());
   Client::DirectStreamSharedPtr direct_stream{new DirectStream(new_stream_handle, *this)};
@@ -201,11 +201,9 @@ envoy_status_t Client::startStream(envoy_stream_t new_stream_handle,
 
   streams_.emplace(new_stream_handle, std::move(direct_stream));
   ENVOY_LOG(debug, "[S{}] start stream", new_stream_handle);
-
-  return ENVOY_SUCCESS;
 }
 
-envoy_status_t Client::sendHeaders(envoy_stream_t stream, envoy_headers headers, bool end_stream) {
+void Client::sendHeaders(envoy_stream_t stream, envoy_headers headers, bool end_stream) {
   ASSERT(dispatcher_.isThreadSafe());
   Client::DirectStreamSharedPtr direct_stream = getStream(stream);
   // If direct_stream is not found, it means the stream has already closed or been reset
@@ -239,11 +237,9 @@ envoy_status_t Client::sendHeaders(envoy_stream_t stream, envoy_headers headers,
               *internal_headers);
     direct_stream->request_decoder_->decodeHeaders(std::move(internal_headers), end_stream);
   }
-
-  return ENVOY_SUCCESS;
 }
 
-envoy_status_t Client::sendData(envoy_stream_t stream, envoy_data data, bool end_stream) {
+void Client::sendData(envoy_stream_t stream, envoy_data data, bool end_stream) {
   ASSERT(dispatcher_.isThreadSafe());
   Client::DirectStreamSharedPtr direct_stream = getStream(stream);
   // If direct_stream is not found, it means the stream has already closed or been reset
@@ -262,15 +258,13 @@ envoy_status_t Client::sendData(envoy_stream_t stream, envoy_data data, bool end
               data.length, end_stream);
     direct_stream->request_decoder_->decodeData(*buf, end_stream);
   }
-
-  return ENVOY_SUCCESS;
 }
 
-envoy_status_t Client::sendMetadata(envoy_stream_t, envoy_headers) {
+void Client::sendMetadata(envoy_stream_t, envoy_headers) {
   NOT_IMPLEMENTED_GCOVR_EXCL_LINE;
 }
 
-envoy_status_t Client::sendTrailers(envoy_stream_t stream, envoy_headers trailers) {
+void Client::sendTrailers(envoy_stream_t stream, envoy_headers trailers) {
   ASSERT(dispatcher_.isThreadSafe());
   Client::DirectStreamSharedPtr direct_stream = getStream(stream);
   // If direct_stream is not found, it means the stream has already closed or been reset
@@ -285,11 +279,9 @@ envoy_status_t Client::sendTrailers(envoy_stream_t stream, envoy_headers trailer
     ENVOY_LOG(debug, "[S{}] request trailers for stream:\n{}", stream, *internal_trailers);
     direct_stream->request_decoder_->decodeTrailers(std::move(internal_trailers));
   }
-
-  return ENVOY_SUCCESS;
 }
 
-envoy_status_t Client::cancelStream(envoy_stream_t stream) {
+void Client::cancelStream(envoy_stream_t stream) {
   ASSERT(dispatcher_.isThreadSafe());
   Client::DirectStreamSharedPtr direct_stream = getStream(stream);
   if (direct_stream) {
@@ -311,7 +303,6 @@ envoy_status_t Client::cancelStream(envoy_stream_t stream) {
     // reset from a wide variety of contexts without apparent issue.
     direct_stream->runResetCallbacks(StreamResetReason::RemoteReset);
   }
-  return ENVOY_SUCCESS;
 }
 
 const HttpClientStats& Client::stats() const { return stats_; }

--- a/library/common/http/client.h
+++ b/library/common/http/client.h
@@ -53,9 +53,8 @@ public:
    * there is no guarantee it will ever functionally represent an open stream.
    * @param stream, the stream to start.
    * @param bridge_callbacks, wrapper for callbacks for events on this stream.
-   * @return envoy_stream_t handle to the stream being created.
    */
-  envoy_status_t startStream(envoy_stream_t stream, envoy_http_callbacks bridge_callbacks);
+  void startStream(envoy_stream_t stream, envoy_http_callbacks bridge_callbacks);
 
   /**
    * Send headers over an open HTTP stream. This method can be invoked once and needs to be called
@@ -63,43 +62,38 @@ public:
    * @param stream, the stream to send headers over.
    * @param headers, the headers to send.
    * @param end_stream, indicates whether to close the stream locally after sending this frame.
-   * @return envoy_status_t, the resulting status of the operation.
    */
-  envoy_status_t sendHeaders(envoy_stream_t stream, envoy_headers headers, bool end_stream);
+  void sendHeaders(envoy_stream_t stream, envoy_headers headers, bool end_stream);
 
   /**
    * Send data over an open HTTP stream. This method can be invoked multiple times.
    * @param stream, the stream to send data over.
    * @param data, the data to send.
    * @param end_stream, indicates whether to close the stream locally after sending this frame.
-   * @return envoy_status_t, the resulting status of the operation.
    */
-  envoy_status_t sendData(envoy_stream_t stream, envoy_data data, bool end_stream);
+  void sendData(envoy_stream_t stream, envoy_data data, bool end_stream);
 
   /**
    * Send metadata over an HTTP stream. This method can be invoked multiple times.
    * @param stream, the stream to send metadata over.
    * @param metadata, the metadata to send.
-   * @return envoy_status_t, the resulting status of the operation.
    */
-  envoy_status_t sendMetadata(envoy_stream_t stream, envoy_headers metadata);
+  void sendMetadata(envoy_stream_t stream, envoy_headers metadata);
 
   /**
    * Send trailers over an open HTTP stream. This method can only be invoked once per stream.
    * Note that this method implicitly closes the stream locally.
    * @param stream, the stream to send trailers over.
    * @param trailers, the trailers to send.
-   * @return envoy_status_t, the resulting status of the operation.
    */
-  envoy_status_t sendTrailers(envoy_stream_t stream, envoy_headers trailers);
+  void sendTrailers(envoy_stream_t stream, envoy_headers trailers);
 
   /**
    * Reset an open HTTP stream. This operation closes the stream locally, and remote.
    * No further operations are valid on the stream.
    * @param stream, the stream to reset.
-   * @return envoy_status_t, the resulting status of the operation.
    */
-  envoy_status_t cancelStream(envoy_stream_t stream);
+  void cancelStream(envoy_stream_t stream);
 
   const HttpClientStats& stats() const;
 

--- a/test/common/http/client_test.cc
+++ b/test/common/http/client_test.cc
@@ -112,7 +112,7 @@ public:
           response_encoder_ = &encoder;
           return request_decoder_;
         }));
-    EXPECT_EQ(http_client_.startStream(stream_, bridge_callbacks_), ENVOY_SUCCESS);
+    http_client_.startStream(stream_, bridge_callbacks_);
   }
 
   MockApiListener api_listener_;
@@ -485,7 +485,7 @@ TEST_F(ClientTest, MultipleStreams) {
         response_encoder2 = &encoder;
         return request_decoder2;
       }));
-  EXPECT_EQ(http_client_.startStream(stream2, bridge_callbacks_2), ENVOY_SUCCESS);
+  http_client_.startStream(stream2, bridge_callbacks_2;
 
   // Send request headers.
 
@@ -597,7 +597,7 @@ TEST_F(ClientTest, ResetStreamLocal) {
   createStream();
 
   EXPECT_CALL(dispatcher_, deferredDelete_(_));
-  ASSERT_EQ(http_client_.cancelStream(stream_), ENVOY_SUCCESS);
+  http_client_.cancelStream(stream_);
   ASSERT_EQ(cc_.on_cancel_calls, 1);
   ASSERT_EQ(cc_.on_error_calls, 0);
   ASSERT_EQ(cc_.on_complete_calls, 0);
@@ -612,9 +612,9 @@ TEST_F(ClientTest, DoubleResetStreamLocal) {
 
   EXPECT_CALL(dispatcher_, deferredDelete_(_));
 
-  ASSERT_EQ(http_client_.cancelStream(stream_), ENVOY_SUCCESS);
+  http_client_.cancelStream(stream_);
   // Second cancel call has no effect because stream is already cancelled.
-  ASSERT_EQ(http_client_.cancelStream(stream_), ENVOY_SUCCESS);
+  http_client_.cancelStream(stream_);
 
   ASSERT_EQ(cc_.on_cancel_calls, 1);
   ASSERT_EQ(cc_.on_error_calls, 0);
@@ -683,7 +683,7 @@ TEST_F(ClientTest, StreamResetAfterOnComplete) {
   ASSERT_EQ(cc_.on_complete_calls, 1);
 
   // Cancellation should have no effect as the stream should have already been cleaned up.
-  ASSERT_EQ(http_client_.cancelStream(stream_), ENVOY_SUCCESS);
+  http_client_.cancelStream(stream_);
   ASSERT_EQ(cc_.on_cancel_calls, 0);
 }
 
@@ -756,7 +756,7 @@ TEST_F(ClientTest, NullAccessors) {
         response_encoder_ = &encoder;
         return request_decoder_;
       }));
-  EXPECT_EQ(http_client_.startStream(stream, bridge_callbacks), ENVOY_SUCCESS);
+  http_client_.startStream(stream, bridge_callbacks);
 
   EXPECT_FALSE(response_encoder_->http1StreamEncoderOptions().has_value());
   EXPECT_FALSE(response_encoder_->streamErrorOnInvalidHttpMessage());

--- a/test/common/http/client_test.cc
+++ b/test/common/http/client_test.cc
@@ -485,7 +485,7 @@ TEST_F(ClientTest, MultipleStreams) {
         response_encoder2 = &encoder;
         return request_decoder2;
       }));
-  http_client_.startStream(stream2, bridge_callbacks_2;
+  http_client_.startStream(stream2, bridge_callbacks_2);
 
   // Send request headers.
 

--- a/test/common/integration/client_integration_test.cc
+++ b/test/common/integration/client_integration_test.cc
@@ -178,7 +178,7 @@ TEST_P(ClientIntegrationTest, Basic) {
 
   // Create a stream.
   dispatcher_->post([&]() -> void {
-    EXPECT_EQ(http_client_->startStream(stream, bridge_callbacks), ENVOY_SUCCESS);
+    http_client_->startStream(stream, bridge_callbacks);
     http_client_->sendHeaders(stream, c_headers, false);
     http_client_->sendData(stream, c_data, false);
     http_client_->sendTrailers(stream, c_trailers);
@@ -245,7 +245,7 @@ TEST_P(ClientIntegrationTest, BasicNon2xx) {
 
   // Create a stream.
   dispatcher_->post([&]() -> void {
-    EXPECT_EQ(http_client_->startStream(stream, bridge_callbacks), ENVOY_SUCCESS);
+    http_client_->startStream(stream, bridge_callbacks);
     http_client_->sendHeaders(stream, c_headers, true);
   });
   terminal_callback.waitReady();
@@ -298,7 +298,7 @@ TEST_P(ClientIntegrationTest, BasicReset) {
 
   // Create a stream.
   dispatcher_->post([&]() -> void {
-    EXPECT_EQ(http_client_->startStream(stream, bridge_callbacks), ENVOY_SUCCESS);
+    http_client_->startStream(stream, bridge_callbacks);
     http_client_->sendHeaders(stream, c_headers, true);
   });
   terminal_callback.waitReady();


### PR DESCRIPTION
Description: These calls are always dispatched asynchronously, so nothing can consume a return value, and always returned ENVOY_SUCCESS, besides.
Risk Level: Low
Testing: CI

Signed-off-by: Mike Schore <mike.schore@gmail.com>
