### PR TITLE
http client: remove test synchronizer

### DIFF
--- a/library/common/http/BUILD
+++ b/library/common/http/BUILD
@@ -30,7 +30,6 @@ envoy_cc_library(
         "@envoy//source/common/common:minimal_logger_lib",
         "@envoy//source/common/common:random_generator_lib",
         "@envoy//source/common/common:thread_lib",
-        "@envoy//source/common/common:thread_synchronizer_lib",
         "@envoy//source/common/http:codec_helper_lib",
         "@envoy//source/common/http:codes_lib",
         "@envoy//source/common/http:headers_lib",

--- a/library/common/http/client.cc
+++ b/library/common/http/client.cc
@@ -72,9 +72,6 @@ void Client::DirectStreamCallbacks::encodeHeaders(const ResponseHeaderMap& heade
   // Track success for later bookkeeping (stream could still be reset).
   success_ = CodeUtility::is2xx(response_status);
 
-  // Testing hook.
-  http_client_.synchronizer_.syncPoint("dispatch_encode_headers");
-
   ENVOY_LOG(debug, "[S{}] dispatching to platform response headers for stream (end_stream={}):\n{}",
             direct_stream_.stream_handle_, end_stream, headers);
   bridge_callbacks_.on_headers(Utility::toBridgeHeaders(headers), end_stream,
@@ -96,11 +93,6 @@ void Client::DirectStreamCallbacks::encodeData(Buffer::Instance& data, bool end_
   if (error_code_) {
     onError();
     return;
-  }
-
-  // Testing hook.
-  if (end_stream) {
-    http_client_.synchronizer_.syncPoint("dispatch_encode_final_data");
   }
 
   ENVOY_LOG(debug,
@@ -151,9 +143,6 @@ void Client::DirectStreamCallbacks::onError() {
   envoy_error_code_t code = error_code_.value_or(ENVOY_STREAM_RESET);
   envoy_data message = error_message_.value_or(envoy_nodata);
   int32_t attempt_count = error_attempt_count_.value_or(-1);
-
-  // Testing hook.
-  http_client_.synchronizer_.syncPoint("dispatch_on_error");
 
   ENVOY_LOG(debug, "[S{}] dispatching to platform remote reset stream",
             direct_stream_.stream_handle_);
@@ -284,8 +273,6 @@ void Client::cancelStream(envoy_stream_t stream) {
   if (direct_stream) {
     removeStream(direct_stream->stream_handle_);
 
-    // Testing hook.
-    synchronizer_.syncPoint("dispatch_on_cancel");
     direct_stream->callbacks_->onCancel();
 
     // Since https://github.com/envoyproxy/envoy/pull/13052, the connection manager expects that

--- a/library/common/http/client.h
+++ b/library/common/http/client.h
@@ -102,9 +102,6 @@ public:
     CONSTRUCT_ON_FIRST_USE(std::string, "client cancelled stream");
   }
 
-  // Used for testing.
-  Thread::ThreadSynchronizer& synchronizer() { return synchronizer_; }
-
 private:
   class DirectStream;
 
@@ -222,7 +219,6 @@ private:
   // Shared synthetic address across DirectStreams.
   Network::Address::InstanceConstSharedPtr address_;
   Random::RandomGenerator& random_;
-  Thread::ThreadSynchronizer synchronizer_;
 };
 
 using ClientPtr = std::unique_ptr<Client>;


### PR DESCRIPTION
Description: The Http::Client is all single-threaded code now and this synchronizer is no longer used in tests.
Risk Level: Low
Testing: Local & CI

Signed-off-by: Mike Schore <mike.schore@gmail.com>