### PR TITLE
pbf: update builder to allow both shorthand and block form factories

### DIFF
--- a/examples/kotlin/hello_world/MainActivity.kt
+++ b/examples/kotlin/hello_world/MainActivity.kt
@@ -47,9 +47,9 @@ class MainActivity : Activity() {
 
     engine = AndroidEngineBuilder(application)
       .addLogLevel(LogLevel.DEBUG)
-      .addPlatformFilter { DemoFilter() }
-      .addPlatformFilter { BufferDemoFilter() }
-      .addPlatformFilter { AsyncDemoFilter() }
+      .addPlatformFilter(::DemoFilter)
+      .addPlatformFilter(::BufferDemoFilter)
+      .addPlatformFilter(::AsyncDemoFilter)
       .addNativeFilter("envoy.filters.http.buffer", "{\"@type\":\"type.googleapis.com/envoy.extensions.filters.http.buffer.v3.Buffer\",\"max_request_bytes\":5242880}")
       .addNativeFilter("envoy.filters.http.test_accessor", "{\"@type\":\"type.googleapis.com/envoymobile.extensions.filters.http.test_accessor.TestAccessor\",\"accessor_name\":\"demo-accessor\",\"expected_string\":\"PlatformString\"}")
       .addStringAccessor("demo-accessor", { "PlatformString" })

--- a/examples/swift/hello_world/ViewController.swift
+++ b/examples/swift/hello_world/ViewController.swift
@@ -19,9 +19,9 @@ final class ViewController: UITableViewController {
 
     let engine = EngineBuilder()
       .addLogLevel(.debug)
-      .addPlatformFilter(factory: DemoFilter.init)
-      .addPlatformFilter(factory: BufferDemoFilter.init)
-      .addPlatformFilter(factory: AsyncDemoFilter.init)
+      .addPlatformFilter(DemoFilter.init)
+      .addPlatformFilter(BufferDemoFilter.init)
+      .addPlatformFilter(AsyncDemoFilter.init)
       // swiftlint:disable:next line_length
       .addNativeFilter(name: "envoy.filters.http.buffer", typedConfig: "{\"@type\":\"type.googleapis.com/envoy.extensions.filters.http.buffer.v3.Buffer\",\"max_request_bytes\":5242880}")
       // swiftlint:disable:next line_length

--- a/library/kotlin/io/envoyproxy/envoymobile/EngineBuilder.kt
+++ b/library/kotlin/io/envoyproxy/envoymobile/EngineBuilder.kt
@@ -152,9 +152,22 @@ open class EngineBuilder(
    *
    * @return this builder.
    */
-  fun addPlatformFilter(name: String = UUID.randomUUID().toString(), factory: () -> Filter):
+  fun addPlatformFilter(name: String, factory: () -> Filter):
     EngineBuilder {
       this.platformFilterChain.add(FilterFactory(name, factory))
+      return this
+    }
+
+  /**
+   * Add an HTTP filter factory used to create platform filters for streams sent by this client.
+   *
+   * @param factory closure returning an instantiated filter.
+   *
+   * @return this builder.
+   */
+  fun addPlatformFilter(factory: () -> Filter):
+    EngineBuilder {
+      this.platformFilterChain.add(FilterFactory(UUID.randomUUID().toString(), factory))
       return this
     }
 

--- a/library/swift/EngineBuilder.swift
+++ b/library/swift/EngineBuilder.swift
@@ -135,10 +135,24 @@ public class EngineBuilder: NSObject {
   ///
   /// - returns: This builder.
   @discardableResult
-  public func addPlatformFilter(name: String = UUID().uuidString,
+  public func addPlatformFilter(name: String,
                                 factory: @escaping () -> Filter) -> Self
   {
     self.platformFilterChain.append(EnvoyHTTPFilterFactory(filterName: name, factory: factory))
+    return self
+  }
+
+  /// Add an HTTP platfom filter factory used to construct filters for streams sent by this client.
+  ///
+  /// - parameter factory: Closure returning an instantiated filter. Called once per stream.
+  ///
+  /// - returns: This builder.
+  @discardableResult
+  public func addPlatformFilter(_ factory: @escaping () -> Filter) -> Self
+  {
+    self.platformFilterChain.append(
+      EnvoyHTTPFilterFactory(filterName: UUID().uuidString, factory: factory)
+    )
     return self
   }
 

--- a/library/swift/EngineBuilder.swift
+++ b/library/swift/EngineBuilder.swift
@@ -142,7 +142,7 @@ public class EngineBuilder: NSObject {
     return self
   }
 
-  /// Add an HTTP platfom filter factory used to construct filters for streams sent by this client.
+  /// Add an HTTP platform filter factory used to construct filters for streams sent by this client.
   ///
   /// - parameter factory: Closure returning an instantiated filter. Called once per stream.
   ///

--- a/test/swift/EngineBuilderTests.swift
+++ b/test/swift/EngineBuilderTests.swift
@@ -104,7 +104,7 @@ final class EngineBuilderTests: XCTestCase {
 
     _ = EngineBuilder()
       .addEngineType(MockEnvoyEngine.self)
-      .addPlatformFilter(factory: TestFilter.init)
+      .addPlatformFilter(TestFilter.init)
       .build()
     self.waitForExpectations(timeout: 0.01)
   }

--- a/test/swift/integration/ReceiveDataTest.swift
+++ b/test/swift/integration/ReceiveDataTest.swift
@@ -52,7 +52,7 @@ static_resources:
 """
     let client = EngineBuilder(yaml: config)
       .addLogLevel(.debug)
-      .addPlatformFilter(factory: DemoFilter.init)
+      .addPlatformFilter(DemoFilter.init)
       .build()
       .streamClient()
 

--- a/test/swift/integration/SendDataTest.swift
+++ b/test/swift/integration/SendDataTest.swift
@@ -54,7 +54,7 @@ static_resources:
     let expectation = self.expectation(description: "Run called with expected http status")
     let client = EngineBuilder(yaml: config)
       .addLogLevel(.debug)
-      .addPlatformFilter(factory: DemoFilter.init)
+      .addPlatformFilter(DemoFilter.init)
       .build()
       .streamClient()
 

--- a/test/swift/integration/SendHeadersTest.swift
+++ b/test/swift/integration/SendHeadersTest.swift
@@ -50,7 +50,7 @@ static_resources:
     let expectation = self.expectation(description: "Run called with expected http status")
     let client = EngineBuilder(yaml: config)
       .addLogLevel(.debug)
-      .addPlatformFilter(factory: DemoFilter.init)
+      .addPlatformFilter(DemoFilter.init)
       .build()
       .streamClient()
 

--- a/test/swift/integration/SendTrailersTest.swift
+++ b/test/swift/integration/SendTrailersTest.swift
@@ -56,7 +56,7 @@ static_resources:
     let expectation = self.expectation(description: "Run called with expected http status")
     let client = EngineBuilder(yaml: config)
       .addLogLevel(.debug)
-      .addPlatformFilter(factory: DemoFilter.init)
+      .addPlatformFilter(DemoFilter.init)
       .build()
       .streamClient()
 


### PR DESCRIPTION
Description: Updates builder to allow Kotlin constructor shorthand for specifying filter factory methods, while still supporting block long-form if needed.
Risk Level: Low
Testing: Local & CI

Signed-off-by: Mike Schore <mike.schore@gmail.com>