### PR TITLE
Keep response headers in same order as received.

### DIFF
--- a/library/java/io/envoyproxy/envoymobile/engine/JvmBridgeUtility.java
+++ b/library/java/io/envoyproxy/envoymobile/engine/JvmBridgeUtility.java
@@ -1,13 +1,9 @@
 package io.envoyproxy.envoymobile.engine;
 
-import java.nio.ByteBuffer;
-import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.ArrayList;
-import java.util.HashMap;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
-
-import io.envoyproxy.envoymobile.engine.types.EnvoyHTTPCallbacks;
 
 /**
  * Class to assist with passing types from native code over the JNI. Currently supports
@@ -31,7 +27,7 @@ class JvmBridgeUtility {
     if (start) {
       assert headerAccumulator == null;
       assert headerCount == 0;
-      headerAccumulator = new HashMap<>();
+      headerAccumulator = new LinkedHashMap<>();
     }
     assert headerAccumulator != null;
 


### PR DESCRIPTION
Many Cronet tests expect the response headers to be exposed in the same order as they were received. The existing implementation reorders those headers, based on the HashCode of the header name (they were put in a regular HashMap). The PR keeps the original order by rather using a LinkedHashMap.

Description: Avoid random ordering of response headers
Risk Level: Minimal
Testing: None
Docs Changes: N/A
Release Notes: N/A
Signed-off-by: Charles Le Borgne <cleborgne@google.com>
