### PR TITLE
Remove deletion of the "server" header from CronetUrlRequest

### DIFF
--- a/library/java/org/chromium/net/impl/CronetUrlRequest.java
+++ b/library/java/org/chromium/net/impl/CronetUrlRequest.java
@@ -409,8 +409,7 @@ public final class CronetUrlRequest extends UrlRequestBase {
         selectedTransport = value;
       }
       if (!headerKey.startsWith(X_ANDROID) && !headerKey.startsWith(X_ENVOY) &&
-          !headerKey.equals("server") && !headerKey.equals("date") &&
-          !headerKey.equals(":status")) {
+          !headerKey.equals("date") && !headerKey.equals(":status")) {
         headerList.add(new SimpleEntry<>(headerKey.toLowerCase(), value));
       }
     }


### PR DESCRIPTION
[PR1541](https://github.com/envoyproxy/envoy-mobile/pull/1541) avoids the insertion of the "server" header in the response. Its removal performed by CronetUrlRequest is therefore not needed anymore.

Description: Adjust CronetUrlRequest to PR1541
Risk Level: none
Testing: unit tests still pass
Docs Changes: N/A
Release Notes: N/A
Signed-off-by: Charles Le Borgne <cleborgne@google.com>
