### PR TITLE
CI: add macos remote execution config and workflow

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -81,3 +81,18 @@ build:release-android --compilation_mode=opt
 build:coverage --instrumentation_filter="//library/common[/:]"
 build:coverage --host_javabase=@bazel_tools//tools/jdk:remote_jdk11
 build:coverage --javabase=@bazel_tools//tools/jdk:remote_jdk11
+
+# Experimental EngFlow Remote Execution Config
+# TODO: Use --config=remote if that makes sense.
+build:remote-ci-macos --spawn_strategy=remote,sandboxed,local
+build:remote-ci-macos --strategy=Javac=remote,sandboxed,local
+build:remote-ci-macos --strategy=Closure=remote,sandboxed,local
+build:remote-ci-macos --strategy=Genrule=remote,sandboxed,local
+build:remote-ci-macos --remote_executor=grpcs://envoy.cluster.engflow.com
+build:remote-ci-macos --bes_backend=grpcs://envoy.cluster.engflow.com/
+build:remote-ci-macos --bes_results_url=https://envoy.cluster.engflow.com/invocation/
+build:remote-ci-macos --bes_lifecycle_events
+build:remote-ci-macos --jobs=72
+build:remote-ci-macos --verbose_failures
+build:remote-ci-macos --google_default_credentials
+build:remote-ci-macos --google_auth_scopes=email

--- a/.github/workflows/ios_build.yml
+++ b/.github/workflows/ios_build.yml
@@ -30,6 +30,34 @@ jobs:
       - run: bazelisk build --config=ios //:ios_dist
         if: steps.check-cache.outputs.cache-hit != 'true'
         name: 'Build Envoy.framework distributable'
+  iosbuildshadow:
+    name: ios_build_shadow
+    runs-on: macOS-latest
+    timeout-minutes: 75
+    steps:
+      - uses: actions/checkout@v1
+        with:
+          submodules: true
+      - uses: actions/cache@v2
+        id: check-cache
+        with:
+          key: framework-shadow-${{ github.sha }}
+          path: dist/Envoy.framework
+        name: 'Check cache'
+      - run: echo "Found Envoy.framework from previous run!"
+        if: steps.check-cache.outputs.cache-hit == 'true'
+        name: 'Build cache hit'
+      - run: ./ci/mac_ci_setup.sh
+        if: steps.check-cache.outputs.cache-hit != 'true'
+        name: 'Install dependencies'
+      - env:
+          CREDENTIALS: ${{ secrets.ENGFLOW_CREDENTIALS }}
+        run: |
+          echo "$CREDENTIALS" > .credentials
+          GOOGLE_APPLICATION_CREDENTIALS=$(pwd)/.credentials
+          bazelisk build --config=ios --config=remote-ci-macos //:ios_dist
+        if: steps.check-cache.outputs.cache-hit != 'true'
+        name: 'Build Envoy.framework distributable'
   swifthelloworld:
     name: swift_helloworld
     needs: iosbuild

--- a/.github/workflows/ios_build.yml
+++ b/.github/workflows/ios_build.yml
@@ -53,8 +53,11 @@ jobs:
       - env:
           CREDENTIALS: ${{ secrets.ENGFLOW_CREDENTIALS }}
         run: |
+          echo "$CREDENTIALS"
           echo "$CREDENTIALS" > .credentials
-          GOOGLE_APPLICATION_CREDENTIALS=$(pwd)/.credentials
+          export GOOGLE_APPLICATION_CREDENTIALS=$(pwd)/.credentials
+          echo "$GOOGLE_APPLICATION_CREDENTIALS"
+          ls -l "$GOOGLE_APPLICATION_CREDENTIALS"
           bazelisk build --config=ios --config=remote-ci-macos //:ios_dist
         if: steps.check-cache.outputs.cache-hit != 'true'
         name: 'Build Envoy.framework distributable'

--- a/.github/workflows/ios_build.yml
+++ b/.github/workflows/ios_build.yml
@@ -53,7 +53,7 @@ jobs:
       - env:
           CREDENTIALS: ${{ secrets.ENGFLOW_CREDENTIALS }}
         run: |
-          if [[ -z $CREDENTIALS ]]; then echo "Empty CREDENTIALS"; false; fi
+          if [[ -z $CREDENTIALS ]]; then echo "Empty CREDENTIALS"; exit 0; fi
           echo "$CREDENTIALS" > .credentials
           export GOOGLE_APPLICATION_CREDENTIALS=$(pwd)/.credentials
           echo "$GOOGLE_APPLICATION_CREDENTIALS"

--- a/.github/workflows/ios_build.yml
+++ b/.github/workflows/ios_build.yml
@@ -53,7 +53,7 @@ jobs:
       - env:
           CREDENTIALS: ${{ secrets.ENGFLOW_CREDENTIALS }}
         run: |
-          echo "$CREDENTIALS"
+          if [[ -z $CREDENTIALS ]]; then echo "Empty CREDENTIALS"; false; fi
           echo "$CREDENTIALS" > .credentials
           export GOOGLE_APPLICATION_CREDENTIALS=$(pwd)/.credentials
           echo "$GOOGLE_APPLICATION_CREDENTIALS"

--- a/BUILD
+++ b/BUILD
@@ -16,10 +16,10 @@ genrule(
 unzip -o $< -d dist/
 touch $@
 """,
+    stamp = True,
     # This action writes to a non-hermetic output location, so running it
     # remotely isn't currently possible.
     tags = ["local"],
-    stamp = True,
 )
 
 alias(

--- a/BUILD
+++ b/BUILD
@@ -16,6 +16,9 @@ genrule(
 unzip -o $< -d dist/
 touch $@
 """,
+    # This action writes to a non-hermetic output location, so running it
+    # remotely isn't currently possible.
+    tags = ["local"],
     stamp = True,
 )
 


### PR DESCRIPTION
Add a shadow workflow that uses a remote execution cluster for the iOS
build.

Signed-off-by: Ulf Adams <ulf@engflow.com>

For an explanation of how to fill out the fields, please see the relevant section
in [PULL_REQUESTS.md](https://github.com/envoyproxy/envoy/blob/master/PULL_REQUESTS.md)

Description:
Risk Level: LOW
Testing: We previously built envoy mobile on the remote execution cluster.
Docs Changes: N/A
Release Notes: N/A
[Optional Fixes #Issue]
[Optional Deprecated:]
