### PR TITLE
filters: prevent spurious cancellation callbacks from the gRPC error path

### DIFF
--- a/library/common/extensions/filters/http/platform_bridge/filter.cc
+++ b/library/common/extensions/filters/http/platform_bridge/filter.cc
@@ -392,42 +392,42 @@ Http::FilterHeadersStatus PlatformBridgeFilter::encodeHeaders(Http::ResponseHead
   // Presence of internal error header indicates an error that should be surfaced as an
   // error callback (rather than an HTTP response).
   const auto error_code_header = headers.get(Http::InternalHeaders::get().ErrorCode);
-  if (!error_code_header.empty()) {
-    // This must be set here, since we won't be delegating to FilterBase.
-    response_filter_base_->state_.stream_complete_ = end_stream;
-    error_response_ = true;
-
-    envoy_error_code_t error_code;
-    bool parsed_code = absl::SimpleAtoi(error_code_header[0]->value().getStringView(), &error_code);
-    RELEASE_ASSERT(parsed_code, "parse error reading error code");
-
-    envoy_data error_message = envoy_nodata;
-    const auto error_message_header = headers.get(Http::InternalHeaders::get().ErrorMessage);
-    if (!error_message_header.empty()) {
-      error_message =
-          Data::Utility::copyToBridgeData(error_message_header[0]->value().getStringView());
-    }
-
-    int32_t attempt_count;
-    if (headers.EnvoyAttemptCount()) {
-      bool parsed_attempts =
-          absl::SimpleAtoi(headers.EnvoyAttemptCount()->value().getStringView(), &attempt_count);
-      RELEASE_ASSERT(parsed_attempts, "parse error reading attempt count");
-    }
-
-    if (platform_filter_.on_error) {
-      platform_filter_.on_error({error_code, error_message, attempt_count},
-                                platform_filter_.instance_context);
-    } else {
-      error_message.release(error_message.context);
-    }
-
-    response_filter_base_->state_.headers_forwarded_ = true;
-    return Http::FilterHeadersStatus::Continue;
+  if (error_code_header.empty()) {
+    // No error, so delegate to base implementation for request and response path.
+    return response_filter_base_->onHeaders(headers, end_stream);
   }
 
-  // Delegate to base implementation for request and response path.
-  return response_filter_base_->onHeaders(headers, end_stream);
+  // Update stream state, since we won't be delegating to FilterBase.
+  response_filter_base_->state_.stream_complete_ = end_stream;
+  error_response_ = true;
+
+  envoy_error_code_t error_code;
+  bool parsed_code = absl::SimpleAtoi(error_code_header[0]->value().getStringView(), &error_code);
+  RELEASE_ASSERT(parsed_code, "parse error reading error code");
+
+  envoy_data error_message = envoy_nodata;
+  const auto error_message_header = headers.get(Http::InternalHeaders::get().ErrorMessage);
+  if (!error_message_header.empty()) {
+    error_message =
+        Data::Utility::copyToBridgeData(error_message_header[0]->value().getStringView());
+  }
+
+  int32_t attempt_count;
+  if (headers.EnvoyAttemptCount()) {
+    bool parsed_attempts =
+        absl::SimpleAtoi(headers.EnvoyAttemptCount()->value().getStringView(), &attempt_count);
+    RELEASE_ASSERT(parsed_attempts, "parse error reading attempt count");
+  }
+
+  if (platform_filter_.on_error) {
+    platform_filter_.on_error({error_code, error_message, attempt_count},
+                              platform_filter_.instance_context);
+  } else {
+    error_message.release(error_message.context);
+  }
+
+  response_filter_base_->state_.headers_forwarded_ = true;
+  return Http::FilterHeadersStatus::Continue;
 }
 
 Http::FilterDataStatus PlatformBridgeFilter::decodeData(Buffer::Instance& data, bool end_stream) {

--- a/test/swift/integration/GRPCReceiveErrorTest.swift
+++ b/test/swift/integration/GRPCReceiveErrorTest.swift
@@ -45,7 +45,8 @@ static_resources:
 """
 
     struct ErrorValidationFilter: ResponseFilter {
-      let expectation: XCTestExpectation
+      let receivedError: XCTestExpectation
+      let notCancelled: XCTestExpectation
 
       func onResponseHeaders(_ headers: ResponseHeaders, endStream: Bool)
         -> FilterHeadersStatus<ResponseHeaders>
@@ -64,20 +65,26 @@ static_resources:
 
       func onError(_ error: EnvoyError) {
         XCTAssertEqual(error.errorCode, 2) // 503/Connection Failure
-        self.expectation.fulfill()
+        self.receivedError.fulfill()
       }
 
-      func onCancel() {}
+      func onCancel() {
+        XCTFail("Unexpected call to onCancel filter callback")
+        self.notCancelled.fulfill()
+      }
     }
 
-    let runExpectation = self.expectation(description: "Run called with expected error")
-    let filterExpectation = self.expectation(description: "Filter called with expected error")
+    let callbackReceivedError = self.expectation(description: "Run called with expected error")
+    let filterReceivedError = self.expectation(description: "Filter called with expected error")
+    let filterNotCancelled = self.expectation(description: "Filter called with unexpected cancellation")
+    filterNotCancelled.isInverted = true
+    let expectations = [filterReceivedError, filterNotCancelled, callbackReceivedError]
 
     let httpStreamClient = EngineBuilder(yaml: config)
       .addLogLevel(.trace)
       .addPlatformFilter(
         name: filterName,
-        factory: { ErrorValidationFilter(expectation: filterExpectation) }
+        factory: { ErrorValidationFilter(receivedError: filterReceivedError, notCancelled: filterNotCancelled) }
       )
       .build()
       .streamClient()
@@ -100,12 +107,15 @@ static_resources:
       // an error.
       .setOnError { error in
          XCTAssertEqual(error.errorCode, 2) // 503/Connection Failure
-         runExpectation.fulfill()
+         callbackReceivedError.fulfill()
+      }
+      .setOnCancel {
+        XCTFail("Unexpected call to onCancel response callback")
       }
       .start()
       .sendHeaders(requestHeaders, endStream: false)
       .sendMessage(message)
 
-    XCTAssertEqual(XCTWaiter.wait(for: [filterExpectation, runExpectation], timeout: 1), .completed)
+    XCTAssertEqual(XCTWaiter.wait(for: expectations, timeout: 1), .completed)
   }
 }

--- a/test/swift/integration/GRPCReceiveErrorTest.swift
+++ b/test/swift/integration/GRPCReceiveErrorTest.swift
@@ -76,7 +76,8 @@ static_resources:
 
     let callbackReceivedError = self.expectation(description: "Run called with expected error")
     let filterReceivedError = self.expectation(description: "Filter called with expected error")
-    let filterNotCancelled = self.expectation(description: "Filter called with unexpected cancellation")
+    let filterNotCancelled =
+      self.expectation(description: "Filter called with unexpected cancellation")
     filterNotCancelled.isInverted = true
     let expectations = [filterReceivedError, filterNotCancelled, callbackReceivedError]
 
@@ -84,7 +85,10 @@ static_resources:
       .addLogLevel(.trace)
       .addPlatformFilter(
         name: filterName,
-        factory: { ErrorValidationFilter(receivedError: filterReceivedError, notCancelled: filterNotCancelled) }
+        factory: {
+          ErrorValidationFilter(receivedError: filterReceivedError,
+                                notCancelled: filterNotCancelled)
+        }
       )
       .build()
       .streamClient()

--- a/test/swift/integration/ReceiveErrorTest.swift
+++ b/test/swift/integration/ReceiveErrorTest.swift
@@ -76,7 +76,8 @@ static_resources:
 
     let callbackReceivedError = self.expectation(description: "Run called with expected error")
     let filterReceivedError = self.expectation(description: "Filter called with expected error")
-    let filterNotCancelled = self.expectation(description: "Filter called with unexpected cancellation")
+    let filterNotCancelled =
+      self.expectation(description: "Filter called with unexpected cancellation")
     filterNotCancelled.isInverted = true
     let expectations = [filterReceivedError, filterNotCancelled, callbackReceivedError]
 
@@ -84,7 +85,10 @@ static_resources:
       .addLogLevel(.trace)
       .addPlatformFilter(
         name: filterName,
-        factory: { ErrorValidationFilter(receivedError: filterReceivedError, notCancelled: filterNotCancelled) }
+        factory: {
+          ErrorValidationFilter(receivedError: filterReceivedError,
+                                notCancelled: filterNotCancelled)
+        }
       )
       .build()
       .streamClient()

--- a/test/swift/integration/ReceiveErrorTest.swift
+++ b/test/swift/integration/ReceiveErrorTest.swift
@@ -45,7 +45,8 @@ static_resources:
 """
 
     struct ErrorValidationFilter: ResponseFilter {
-      let expectation: XCTestExpectation
+      let receivedError: XCTestExpectation
+      let notCancelled: XCTestExpectation
 
       func onResponseHeaders(_ headers: ResponseHeaders, endStream: Bool)
         -> FilterHeadersStatus<ResponseHeaders>
@@ -64,20 +65,26 @@ static_resources:
 
       func onError(_ error: EnvoyError) {
         XCTAssertEqual(error.errorCode, 2) // 503/Connection Failure
-        self.expectation.fulfill()
+        self.receivedError.fulfill()
       }
 
-      func onCancel() {}
+      func onCancel() {
+        XCTFail("Unexpected call to onCancel filter callback")
+        self.notCancelled.fulfill()
+      }
     }
 
-    let runExpectation = self.expectation(description: "Run called with expected error")
-    let filterExpectation = self.expectation(description: "Filter called with expected error")
+    let callbackReceivedError = self.expectation(description: "Run called with expected error")
+    let filterReceivedError = self.expectation(description: "Filter called with expected error")
+    let filterNotCancelled = self.expectation(description: "Filter called with unexpected cancellation")
+    filterNotCancelled.isInverted = true
+    let expectations = [filterReceivedError, filterNotCancelled, callbackReceivedError]
 
     let client = EngineBuilder(yaml: config)
       .addLogLevel(.trace)
       .addPlatformFilter(
         name: filterName,
-        factory: { ErrorValidationFilter(expectation: filterExpectation) }
+        factory: { ErrorValidationFilter(receivedError: filterReceivedError, notCancelled: filterNotCancelled) }
       )
       .build()
       .streamClient()
@@ -99,11 +106,14 @@ static_resources:
       // an error.
       .setOnError { error in
          XCTAssertEqual(error.errorCode, 2) // 503/Connection Failure
-         runExpectation.fulfill()
+         callbackReceivedError.fulfill()
+      }
+      .setOnCancel {
+        XCTFail("Unexpected call to onCancel response callback")
       }
       .start()
       .sendHeaders(requestHeaders, endStream: true)
 
-    XCTAssertEqual(XCTWaiter.wait(for: [filterExpectation, runExpectation], timeout: 1), .completed)
+    XCTAssertEqual(XCTWaiter.wait(for: expectations, timeout: 1), .completed)
   }
 }


### PR DESCRIPTION
Description: Platform filters could fail to correctly transition to a completed state due to the lack of a response body on gRPC error responses. This resulted in spurious cancellation callbacks when the filter was scheduled for destruction due to the invalid "incomplete" status of the stream.
Risk Level: Low
Testing: Integration, Local & CI

Signed-off-by: Mike Schore <mike.schore@gmail.com>