### PR TITLE
errors: consistently set attempt_count when missing

### DIFF
--- a/library/common/extensions/filters/http/platform_bridge/filter.cc
+++ b/library/common/extensions/filters/http/platform_bridge/filter.cc
@@ -404,11 +404,11 @@ Http::FilterHeadersStatus PlatformBridgeFilter::encodeHeaders(Http::ResponseHead
           Data::Utility::copyToBridgeData(error_message_header[0]->value().getStringView());
     }
 
-    int32_t attempt_count;
+    int32_t attempt_count = 1;
     if (headers.EnvoyAttemptCount()) {
-      bool parsed_attempts =
-          absl::SimpleAtoi(headers.EnvoyAttemptCount()->value().getStringView(), &attempt_count);
-      RELEASE_ASSERT(parsed_attempts, "parse error reading attempt count");
+      RELEASE_ASSERT(
+          absl::SimpleAtoi(headers.EnvoyAttemptCount()->value().getStringView(), &attempt_count),
+          "parse error reading attempt count");
     }
 
     if (platform_filter_.on_error) {

--- a/library/common/http/client.cc
+++ b/library/common/http/client.cc
@@ -60,11 +60,13 @@ void Client::DirectStreamCallbacks::encodeHeaders(const ResponseHeaderMap& heade
           Data::Utility::copyToBridgeData(error_message_header[0]->value().getStringView());
     }
 
-    uint32_t attempt_count;
-    if (headers.EnvoyAttemptCount() &&
-        absl::SimpleAtoi(headers.EnvoyAttemptCount()->value().getStringView(), &attempt_count)) {
-      error_attempt_count_ = attempt_count;
+    uint32_t attempt_count = 1;
+    if (headers.EnvoyAttemptCount()) {
+      RELEASE_ASSERT(
+          absl::SimpleAtoi(headers.EnvoyAttemptCount()->value().getStringView(), &attempt_count),
+          "parse error reading attempt count");
     }
+    error_attempt_count_ = attempt_count;
 
     if (end_stream) {
       onError();

--- a/test/common/extensions/filters/http/platform_bridge/platform_bridge_filter_test.cc
+++ b/test/common/extensions/filters/http/platform_bridge/platform_bridge_filter_test.cc
@@ -93,6 +93,8 @@ public:
     unsigned int on_resume_request_calls;
     unsigned int set_response_callbacks_calls;
     unsigned int on_resume_response_calls;
+    unsigned int on_cancel_calls;
+    unsigned int on_error_calls;
     unsigned int release_filter_calls;
   } filter_invocations;
 
@@ -638,6 +640,61 @@ platform_filter_name: StopAndBufferOnRequestData
   EXPECT_EQ(Http::FilterDataStatus::StopIterationNoBuffer, filter_->decodeData(third_chunk, false));
   // Manual update not required, because once iteration is stopped, data is added directly.
   EXPECT_EQ(invocations.on_request_data_calls, 3);
+}
+
+TEST_F(PlatformBridgeFilterTest, BasicError) {
+  envoy_http_filter platform_filter{};
+  filter_invocations invocations{};
+  platform_filter.static_context = &invocations;
+  platform_filter.init_filter = [](const void* context) -> const void* {
+    envoy_http_filter* c_filter = static_cast<envoy_http_filter*>(const_cast<void*>(context));
+    filter_invocations* invocations =
+        static_cast<filter_invocations*>(const_cast<void*>(c_filter->static_context));
+    invocations->init_filter_calls++;
+    return invocations;
+  };
+  platform_filter.on_response_headers = [](envoy_headers c_headers, bool, const void* context) -> envoy_filter_headers_status {
+    filter_invocations* invocations = static_cast<filter_invocations*>(const_cast<void*>(context));
+    invocations->on_response_headers_calls++;
+    ADD_FAILURE() << "on_headers should not get called for an error response.";
+    release_envoy_headers(c_headers);
+    return {kEnvoyFilterHeadersStatusStopIteration, envoy_noheaders};
+  };
+  platform_filter.on_response_data = [](envoy_data c_data, bool, const void* context) -> envoy_filter_data_status {
+    filter_invocations* invocations = static_cast<filter_invocations*>(const_cast<void*>(context));
+    invocations->on_response_data_calls++;
+    ADD_FAILURE() << "on_data should not get called for an error response.";
+    c_data.release(c_data.context);
+    return {kEnvoyFilterDataStatusStopIterationNoBuffer, envoy_nodata, nullptr};
+  };
+  platform_filter.on_error = [](envoy_error c_error, const void* context) -> void {
+    filter_invocations* invocations = static_cast<filter_invocations*>(const_cast<void*>(context));
+    invocations->on_error_calls++;
+    EXPECT_EQ(c_error.error_code, ENVOY_UNDEFINED_ERROR);
+    EXPECT_EQ(Data::Utility::copyToString(c_error.message), "busted");
+    EXPECT_EQ(c_error.attempt_count, 1);
+    c_error.message.release(c_error.message.context);
+  };
+
+  setUpFilter(R"EOF(
+platform_filter_name: BasicError
+)EOF",
+              &platform_filter);
+  EXPECT_EQ(invocations.init_filter_calls, 1);
+
+  Http::TestResponseHeaderMapImpl response_headers{
+    {"x-internal-error-code", "0"},
+    {"x-internal-error-message", "busted"},
+  };
+  EXPECT_EQ(Http::FilterHeadersStatus::Continue, filter_->encodeHeaders(response_headers, false));
+
+  Buffer::OwnedImpl response_data = Buffer::OwnedImpl("busted");
+
+  EXPECT_EQ(Http::FilterDataStatus::Continue, filter_->encodeData(response_data, true));
+
+  EXPECT_EQ(invocations.on_response_headers_calls, 0);
+  EXPECT_EQ(invocations.on_response_data_calls, 0);
+  EXPECT_EQ(invocations.on_error_calls, 1);
 }
 
 TEST_F(PlatformBridgeFilterTest, StopAndBufferThenResumeOnRequestData) {

--- a/test/common/extensions/filters/http/platform_bridge/platform_bridge_filter_test.cc
+++ b/test/common/extensions/filters/http/platform_bridge/platform_bridge_filter_test.cc
@@ -653,14 +653,16 @@ TEST_F(PlatformBridgeFilterTest, BasicError) {
     invocations->init_filter_calls++;
     return invocations;
   };
-  platform_filter.on_response_headers = [](envoy_headers c_headers, bool, const void* context) -> envoy_filter_headers_status {
+  platform_filter.on_response_headers = [](envoy_headers c_headers, bool,
+                                           const void* context) -> envoy_filter_headers_status {
     filter_invocations* invocations = static_cast<filter_invocations*>(const_cast<void*>(context));
     invocations->on_response_headers_calls++;
     ADD_FAILURE() << "on_headers should not get called for an error response.";
     release_envoy_headers(c_headers);
     return {kEnvoyFilterHeadersStatusStopIteration, envoy_noheaders};
   };
-  platform_filter.on_response_data = [](envoy_data c_data, bool, const void* context) -> envoy_filter_data_status {
+  platform_filter.on_response_data = [](envoy_data c_data, bool,
+                                        const void* context) -> envoy_filter_data_status {
     filter_invocations* invocations = static_cast<filter_invocations*>(const_cast<void*>(context));
     invocations->on_response_data_calls++;
     ADD_FAILURE() << "on_data should not get called for an error response.";
@@ -683,8 +685,8 @@ platform_filter_name: BasicError
   EXPECT_EQ(invocations.init_filter_calls, 1);
 
   Http::TestResponseHeaderMapImpl response_headers{
-    {"x-internal-error-code", "0"},
-    {"x-internal-error-message", "busted"},
+      {"x-internal-error-code", "0"},
+      {"x-internal-error-message", "busted"},
   };
   EXPECT_EQ(Http::FilterHeadersStatus::Continue, filter_->encodeHeaders(response_headers, false));
 


### PR DESCRIPTION
Description: Fixes an uninitialized value in filters when the attempt count header was missing, and sets attempt_count consistently to 1. Cleanup of "optional" attempt_counts coming in a subsequent PR.
Risk Level: Low
Testing: Unit, Local & CI

Signed-off-by: Mike Schore <mike.schore@gmail.com>