### PR TITLE
filters: enable reset idle timer in filters

### DIFF
--- a/library/common/extensions/filters/http/platform_bridge/filter.cc
+++ b/library/common/extensions/filters/http/platform_bridge/filter.cc
@@ -521,7 +521,7 @@ void PlatformBridgeFilter::resetIdleTimer() {
   dispatcher_.post([weak_self]() -> void {
     if (auto self = weak_self.lock()) {
       // Stream idle timeout is nondirectional.
-      // self->decoder_callbacks_->resetIdleTimer();
+      self->decoder_callbacks_->resetIdleTimer();
     }
   });
 }


### PR DESCRIPTION
Description: Unit/integration tests are still coming, but this will let us validate in the wild in parallel.
Risk Level: Moderate
Testing: Ongoing

Signed-off-by: Mike Schore <mike.schore@gmail.com>
