### PR TITLE
jni: null terminate strings before passing to NewStringUTF

### DIFF
--- a/library/common/jni/jni_utility.cc
+++ b/library/common/jni/jni_utility.cc
@@ -62,7 +62,9 @@ envoy_data array_to_native_data(JNIEnv* env, jbyteArray j_data) {
 }
 
 jstring native_data_to_string(JNIEnv* env, envoy_data data) {
-  jstring jstrBuf = env->NewStringUTF(const_cast<char*>(reinterpret_cast<const char*>(data.bytes)));
+  // Ensure we get a null-terminated string, the data coming in via envoy_data might not be.
+  std::string str(reinterpret_cast<const char*>(data.bytes), data.length);
+  jstring jstrBuf = env->NewStringUTF(str.c_str());
   return jstrBuf;
 }
 


### PR DESCRIPTION
The data coming in from the logging interface doesn't seem to be null terminated in all cases. This constructs
a std::string and uses c_str() to get a null terminated version of the data that honors the specified length.

Risk Level: Medium, JNI changes
Testing: Existing tests
Docs Changes: n/a
Release Notes: n/a
