### PR TITLE
CI: shut down bazelisk before running it

### DIFF
--- a/.github/workflows/ios_build.yml
+++ b/.github/workflows/ios_build.yml
@@ -58,6 +58,7 @@ jobs:
           export GOOGLE_APPLICATION_CREDENTIALS=$(pwd)/.credentials
           echo "$GOOGLE_APPLICATION_CREDENTIALS"
           ls -l "$GOOGLE_APPLICATION_CREDENTIALS"
+          bazelisk shutdown
           bazelisk build --config=ios --config=remote-ci-macos //:ios_dist
         if: steps.check-cache.outputs.cache-hit != 'true'
         name: 'Build Envoy.framework distributable'


### PR DESCRIPTION
Description: It looks like Bazel doesn't pick up the credentials env
  variable if it is already running. Unfortunately, there isn't an easy
  way to test this hypothesis without merging a commit to main.
Risk Level: LOW
Testing: N/A
Docs Changes: N/A
Release Notes: N/A

Signed-off-by: Ulf Adams <ulf@engflow.com>