### PR TITLE
swift: expose `terminate()` interface

### DIFF
--- a/library/objective-c/EnvoyEngine.h
+++ b/library/objective-c/EnvoyEngine.h
@@ -408,6 +408,8 @@ extern const int kEnvoyFailure;
 
 - (void)flushStats;
 
+- (void)terminate;
+
 @end
 
 #pragma mark - EnvoyLogger

--- a/library/objective-c/EnvoyEngineImpl.m
+++ b/library/objective-c/EnvoyEngineImpl.m
@@ -509,6 +509,10 @@ static envoy_data ios_get_string(const void *context) {
   flush_stats(_engineHandle);
 }
 
+- (void)terminate {
+  terminate_engine(_engineHandle);
+}
+
 #pragma mark - Private
 
 - (void)startObservingLifecycleNotifications {

--- a/library/swift/Engine.swift
+++ b/library/swift/Engine.swift
@@ -14,4 +14,7 @@ public protocol Engine: AnyObject {
   /// Note: stat flushing is done asynchronously, this function will never block.
   /// This is a noop if called before the underlying EnvoyEngine has started.
   func flushStats()
+
+  /// Terminates the running engine.
+  func terminate()
 }

--- a/library/swift/EngineImpl.swift
+++ b/library/swift/EngineImpl.swift
@@ -13,8 +13,7 @@ final class EngineImpl: NSObject {
     case standard(config: EnvoyConfiguration)
   }
 
-  private init(configType: ConfigurationType, logLevel: LogLevel, engine: EnvoyEngine)
-  {
+  private init(configType: ConfigurationType, logLevel: LogLevel, engine: EnvoyEngine) {
     self.engine = engine
     self.pulseClientImpl = PulseClientImpl(engine: engine)
     self.streamClientImpl = StreamClientImpl(engine: engine)
@@ -33,8 +32,7 @@ final class EngineImpl: NSObject {
   /// - parameter config:          Configuration to use for starting Envoy.
   /// - parameter logLevel:        Log level to use for this instance.
   /// - parameter engine:          The underlying engine to use for starting Envoy.
-  convenience init(config: EnvoyConfiguration, logLevel: LogLevel = .info, engine: EnvoyEngine)
-  {
+  convenience init(config: EnvoyConfiguration, logLevel: LogLevel = .info, engine: EnvoyEngine) {
     self.init(configType: .standard(config: config), logLevel: logLevel, engine: engine)
   }
 
@@ -62,5 +60,9 @@ extension EngineImpl: Engine {
 
   func flushStats() {
     self.engine.flushStats()
+  }
+
+  func terminate() {
+    self.engine.terminate()
   }
 }

--- a/library/swift/mocks/MockEnvoyEngine.swift
+++ b/library/swift/mocks/MockEnvoyEngine.swift
@@ -13,6 +13,7 @@ final class MockEnvoyEngine: NSObject {
     _ config: EnvoyConfiguration,
     _ logLevel: String?
   ) -> Void)?
+
   /// Closure called when `recordCounterInc(_:tags:count:)` is called.
   static var onRecordCounter: (
     (_ elements: String, _ tags: [String: String], _ count: UInt) -> Void)?
@@ -35,14 +36,12 @@ final class MockEnvoyEngine: NSObject {
 }
 
 extension MockEnvoyEngine: EnvoyEngine {
-  func run(withConfig config: EnvoyConfiguration, logLevel: String) -> Int32
-  {
+  func run(withConfig config: EnvoyConfiguration, logLevel: String) -> Int32 {
     MockEnvoyEngine.onRunWithConfig?(config, logLevel)
     return kEnvoySuccess
   }
 
-  func run(withTemplate template: String, config: EnvoyConfiguration, logLevel: String) -> Int32
-  {
+  func run(withTemplate template: String, config: EnvoyConfiguration, logLevel: String) -> Int32 {
     MockEnvoyEngine.onRunWithTemplate?(template, config, logLevel)
     return kEnvoySuccess
   }
@@ -85,4 +84,6 @@ extension MockEnvoyEngine: EnvoyEngine {
   func flushStats() {
     MockEnvoyEngine.onFlushStats?()
   }
+
+  func terminate() {}
 }


### PR DESCRIPTION
This is already exposed in Kotlin/Java.

Signed-off-by: Michael Rebello <me@michaelrebello.com>