### PR TITLE
ci: update path to android sdk and use build-tools 30.0.3 for android build

### DIFF
--- a/ci/mac_ci_setup.sh
+++ b/ci/mac_ci_setup.sh
@@ -60,7 +60,7 @@ sudo xcode-select --switch /Applications/Xcode_12.4.app
 ls $ANDROID_SDK_ROOT
 echo "---"
 ls $ANDROID_SDK_ROOT/cmdline-tools/latest/bin/sdkmanager
-ANDROID_HOME=$ANDROID_SDK_ROOT/cmdline-tools/latest/bin/
+ANDROID_HOME=$ANDROID_SDK_ROOT
 SDKMANAGER=$ANDROID_SDK_ROOT/cmdline-tools/latest/bin/sdkmanager
 
 $SDKMANAGER --uninstall "ndk-bundle"

--- a/ci/mac_ci_setup.sh
+++ b/ci/mac_ci_setup.sh
@@ -66,15 +66,9 @@ SDKMANAGER=$ANDROID_SDK_ROOT/cmdline-tools/latest/bin/sdkmanager
 
 $SDKMANAGER --uninstall "ndk-bundle"
 
-echo "--- $SDKMANAGER"
-ls $SDKMANAGER
-
 $SDKMANAGER --install "ndk;21.3.6528147"
 
-echo "--- $ANDROID_HOME/tools/bin/"
-ls $ANDROID_HOME/tools/bin/
-
-echo "--- $ANDROID_HOME/ndk/"
-ls $ANDROID_HOME/ndk/
+$SDKMANAGER --uninstall "build-tools;31.0.0"
+$SDKMANAGER --install "build-tools;30.0.3"
 
 export ANDROID_NDK_HOME=$ANDROID_HOME/ndk/21.3.6528147

--- a/ci/mac_ci_setup.sh
+++ b/ci/mac_ci_setup.sh
@@ -57,11 +57,18 @@ pip3 install slackclient
 sudo xcode-select --switch /Applications/Xcode_12.4.app
 
 # Download and set up ndk 21. Github upgraded to ndk 22 for their Mac image.
+ls $ANDROID_SDK_ROOT
+echo "---"
+ls $ANDROID_SDK_ROOT/cmdline-tools/latest/bin/sdkmanager
 ANDROID_HOME=$ANDROID_SDK_ROOT/cmdline-tools/latest/bin/
 SDKMANAGER=$ANDROID_SDK_ROOT/cmdline-tools/latest/bin/sdkmanager
 
 $SDKMANAGER --uninstall "ndk-bundle"
 
+ls $SDKMANAGER
+
 $SDKMANAGER --install "ndk;21.3.6528147"
+
+ls $ANDROID_HOME/tools/bin/
 
 export ANDROID_NDK_HOME=$ANDROID_HOME/ndk/21.3.6528147

--- a/ci/mac_ci_setup.sh
+++ b/ci/mac_ci_setup.sh
@@ -57,17 +57,13 @@ pip3 install slackclient
 sudo xcode-select --switch /Applications/Xcode_12.4.app
 
 # Download and set up ndk 21. Github upgraded to ndk 22 for their Mac image.
-echo "--- $ANDROID_SDK_ROOT"
-ls $ANDROID_SDK_ROOT
-echo "--- $ANDROID_SDK_ROOT/cmdline-tools/latest/bin/sdkmanager"
-ls $ANDROID_SDK_ROOT/cmdline-tools/latest/bin/sdkmanager
 ANDROID_HOME=$ANDROID_SDK_ROOT
 SDKMANAGER=$ANDROID_SDK_ROOT/cmdline-tools/latest/bin/sdkmanager
 
 $SDKMANAGER --uninstall "ndk-bundle"
-
 $SDKMANAGER --install "ndk;21.3.6528147"
 
+# Download and set up build-tools 30.0.3, 31.0.0 is missing dx.jar.
 $SDKMANAGER --uninstall "build-tools;31.0.0"
 $SDKMANAGER --install "build-tools;30.0.3"
 

--- a/ci/mac_ci_setup.sh
+++ b/ci/mac_ci_setup.sh
@@ -57,8 +57,8 @@ pip3 install slackclient
 sudo xcode-select --switch /Applications/Xcode_12.4.app
 
 # Download and set up ndk 21. Github upgraded to ndk 22 for their Mac image.
-ANDROID_HOME=$HOME/Library/Android/sdk
-SDKMANAGER=$ANDROID_HOME/tools/bin/sdkmanager
+ANDROID_HOME=$ANDROID_SDK_ROOT/cmdline-tools/latest/bin/
+SDKMANAGER=$ANDROID_SDK_ROOT/cmdline-tools/latest/bin/sdkmanager
 
 $SDKMANAGER --uninstall "ndk-bundle"
 

--- a/ci/mac_ci_setup.sh
+++ b/ci/mac_ci_setup.sh
@@ -57,18 +57,24 @@ pip3 install slackclient
 sudo xcode-select --switch /Applications/Xcode_12.4.app
 
 # Download and set up ndk 21. Github upgraded to ndk 22 for their Mac image.
+echo "--- $ANDROID_SDK_ROOT"
 ls $ANDROID_SDK_ROOT
-echo "---"
+echo "--- $ANDROID_SDK_ROOT/cmdline-tools/latest/bin/sdkmanager"
 ls $ANDROID_SDK_ROOT/cmdline-tools/latest/bin/sdkmanager
 ANDROID_HOME=$ANDROID_SDK_ROOT
 SDKMANAGER=$ANDROID_SDK_ROOT/cmdline-tools/latest/bin/sdkmanager
 
 $SDKMANAGER --uninstall "ndk-bundle"
 
+echo "--- $SDKMANAGER"
 ls $SDKMANAGER
 
 $SDKMANAGER --install "ndk;21.3.6528147"
 
+echo "--- $ANDROID_HOME/tools/bin/"
 ls $ANDROID_HOME/tools/bin/
+
+echo "--- $ANDROID_HOME/ndk/"
+ls $ANDROID_HOME/ndk/
 
 export ANDROID_NDK_HOME=$ANDROID_HOME/ndk/21.3.6528147

--- a/ci/mac_start_emulator.sh
+++ b/ci/mac_start_emulator.sh
@@ -2,6 +2,7 @@
 
 set -e
 
-echo "y" | $ANDROID_HOME/tools/bin/sdkmanager --install 'system-images;android-29;google_apis;x86'
+echo "y" | $ANDROID_SDK_ROOT/cmdline-tools/latest/bin/sdkmanager --install 'system-images;android-29;google_apis;x86'
 echo "no" | $ANDROID_HOME/tools/bin/avdmanager create avd -n test_android_emulator -k 'system-images;android-29;google_apis;x86' --force
+ls $ANDROID_HOME/tools/bin/
 nohup $ANDROID_HOME/emulator/emulator -partition-size 1024 -avd test_android_emulator -no-snapshot > /dev/null 2>&1 & $ANDROID_HOME/platform-tools/adb wait-for-device shell 'while [[ -z $(getprop sys.boot_completed | tr -d '\r') ]]; do sleep 1; done; input keyevent 82'


### PR DESCRIPTION
Description: 

1) github made a [change](https://github.com/actions/virtual-environments/issues/3638) on android sdkmanager, this pr follows the migration step from the announced change.
2) android build-tools 31.0.0 (the version installed on the ci machines for now) is missing dx.jar, which causes android build to fail, this pr uninstalls 31.0.0 and installs 30.0.3 for the android build to complete.

Risk Level: Low
Testing: CI

Signed-off-by: Jingwei Hao <jingwei.hao@gmail.com>