### PR TITLE
android: try-catch network callback registration

### DIFF
--- a/library/java/io/envoyproxy/envoymobile/engine/AndroidNetworkMonitor.java
+++ b/library/java/io/envoyproxy/envoymobile/engine/AndroidNetworkMonitor.java
@@ -15,6 +15,7 @@ import android.net.NetworkInfo;
 import android.net.NetworkRequest;
 import android.os.Build;
 import androidx.core.content.ContextCompat;
+import org.assertj.core.internal.bytebuddy.implementation.bytecode.Throw;
 
 import java.util.Collections;
 
@@ -87,11 +88,17 @@ public class AndroidNetworkMonitor extends BroadcastReceiver {
       }
     };
 
-    connectivityManager.registerNetworkCallback(networkRequest, networkCallback);
+    try {
+      connectivityManager.registerNetworkCallback(networkRequest, networkCallback);
 
-    context.registerReceiver(this, new IntentFilter() {
-      { addAction(ConnectivityManager.CONNECTIVITY_ACTION); }
-    });
+      context.registerReceiver(this, new IntentFilter() {
+        {
+          addAction(ConnectivityManager.CONNECTIVITY_ACTION);
+        }
+      });
+    } catch(Throwable t) {
+      // no-op
+    }
   }
 
   @Override


### PR DESCRIPTION
For an explanation of how to fill out the fields, please see the relevant section
in [PULL_REQUESTS.md](https://github.com/envoyproxy/envoy/blob/master/PULL_REQUESTS.md)

Description: android: try-catch network callback registration
Risk Level: low
Testing: local
Docs Changes: n/a
Release Notes: n/a
[Optional Fixes #Issue]
[Optional Deprecated:]
