### PR TITLE
android: try-catch network callback registration

### DIFF
--- a/library/java/io/envoyproxy/envoymobile/engine/AndroidNetworkMonitor.java
+++ b/library/java/io/envoyproxy/envoymobile/engine/AndroidNetworkMonitor.java
@@ -15,7 +15,6 @@ import android.net.NetworkInfo;
 import android.net.NetworkRequest;
 import android.os.Build;
 import androidx.core.content.ContextCompat;
-import org.assertj.core.internal.bytebuddy.implementation.bytecode.Throw;
 
 import java.util.Collections;
 

--- a/library/java/io/envoyproxy/envoymobile/engine/AndroidNetworkMonitor.java
+++ b/library/java/io/envoyproxy/envoymobile/engine/AndroidNetworkMonitor.java
@@ -91,9 +91,7 @@ public class AndroidNetworkMonitor extends BroadcastReceiver {
       connectivityManager.registerNetworkCallback(networkRequest, networkCallback);
 
       context.registerReceiver(this, new IntentFilter() {
-        {
-          addAction(ConnectivityManager.CONNECTIVITY_ACTION);
-        }
+        { addAction(ConnectivityManager.CONNECTIVITY_ACTION); }
       });
     } catch(Throwable t) {
       // no-op

--- a/library/java/io/envoyproxy/envoymobile/engine/AndroidNetworkMonitor.java
+++ b/library/java/io/envoyproxy/envoymobile/engine/AndroidNetworkMonitor.java
@@ -15,6 +15,7 @@ import android.net.NetworkInfo;
 import android.net.NetworkRequest;
 import android.os.Build;
 import androidx.core.content.ContextCompat;
+import org.assertj.core.internal.bytebuddy.implementation.bytecode.Throw;
 
 import java.util.Collections;
 
@@ -87,11 +88,17 @@ public class AndroidNetworkMonitor extends BroadcastReceiver {
       }
     };
 
-    connectivityManager.registerNetworkCallback(networkRequest, networkCallback);
+    try {
+      connectivityManager.registerNetworkCallback(networkRequest, networkCallback);
 
-    context.registerReceiver(this, new IntentFilter() {
-      { addAction(ConnectivityManager.CONNECTIVITY_ACTION); }
-    });
+      context.registerReceiver(this, new IntentFilter() {
+        {
+          addAction(ConnectivityManager.CONNECTIVITY_ACTION);
+        }
+      });
+    } catch(Throwable t) {
+      // no-op
+    }
   }
 
   @Override

--- a/library/java/io/envoyproxy/envoymobile/engine/AndroidNetworkMonitor.java
+++ b/library/java/io/envoyproxy/envoymobile/engine/AndroidNetworkMonitor.java
@@ -93,7 +93,7 @@ public class AndroidNetworkMonitor extends BroadcastReceiver {
       context.registerReceiver(this, new IntentFilter() {
         { addAction(ConnectivityManager.CONNECTIVITY_ACTION); }
       });
-    } catch(Throwable t) {
+    } catch (Throwable t) {
       // no-op
     }
   }


### PR DESCRIPTION
Adding a full try-catch as there are observations on users still trips on the permission error despite our check in the [method](https://github.com/envoyproxy/envoy-mobile/pull/1607/files#diff-7c0801593adac06d1a4d2a0239de95d28b977d9007dc4d23f4c9a86a9766a457R56-R63) (there are only two [states](https://github.com/envoyproxy/envoy-mobile/pull/1607/files#diff-7c0801593adac06d1a4d2a0239de95d28b977d9007dc4d23f4c9a86a9766a457R56-R63) to check)


Signed-off-by: Alan Chiu <achiu@lyft.com>

For an explanation of how to fill out the fields, please see the relevant section
in [PULL_REQUESTS.md](https://github.com/envoyproxy/envoy/blob/master/PULL_REQUESTS.md)

Description: android: try-catch network callback registration
Risk Level: low
Testing: local
Docs Changes: n/a
Release Notes: n/a
[Optional Fixes #Issue]
[Optional Deprecated:]
