### PR TITLE
cc: remove designated initializer

### DIFF
--- a/library/cc/engine_builder.cc
+++ b/library/cc/engine_builder.cc
@@ -109,12 +109,12 @@ std::string EngineBuilder::generateConfigStr() {
 }
 
 EngineSharedPtr EngineBuilder::build() {
+  envoy_logger null_logger;
+  null_logger.log = nullptr;
+  null_logger.release = envoy_noop_const_release;
+  null_logger.context = nullptr;
+
   auto config_str = this->generateConfigStr();
-  envoy_logger null_logger{
-      .log = nullptr,
-      .release = envoy_noop_const_release,
-      .context = nullptr,
-  };
   auto envoy_engine = init_engine(this->callbacks_->asEnvoyEngineCallbacks(), null_logger);
   run_engine(envoy_engine, config_str.c_str(), logLevelToString(this->log_level_).c_str());
 


### PR DESCRIPTION
Description: Remove the designated initializer I used in `engine_builder.cc` and instead populate `null_logger` field-by-field. Turns out this syntax is one of this parts of C++ that's _not_ the same as C.
Risk Level: Low
Testing: `bazel test //test/...`
Docs Changes: N/A
Release Notes: N/A