### PR TITLE
add alpn option for UpstreamHttpProtocol enum

### DIFF
--- a/docs/root/api/http.rst
+++ b/docs/root/api/http.rst
@@ -145,6 +145,13 @@ For full documentation of how these retry rules perform, see Envoy's documentati
 - `Automatic retries <https://www.envoyproxy.io/learn/automatic-retries>`_
 - `Retry semantics <https://www.envoyproxy.io/docs/envoy/latest/intro/arch_overview/http/http_routing.html?highlight=exponential#retry-semantics>`_
 
+------------------------
+``UpstreamHttpProtocol``
+------------------------
+
+The ``UpstreamHttpProtocol`` enum specifies the protocol used for a specific request. By default, Envoy Mobile uses auto-http or ALPN to determine
+HTTP1.1 or HTTP2. To specify a protocol, use the `RequestHeadersBuilder` method `addUpstreamHttpProtocol(...)`.
+
 ----------
 ``Stream``
 ----------

--- a/library/cc/request_headers.cc
+++ b/library/cc/request_headers.cc
@@ -21,10 +21,10 @@ absl::optional<RetryPolicy> RequestHeaders::retryPolicy() const {
   }
 }
 
-absl::optional<UpstreamHttpProtocol> RequestHeaders::upstreamHttpProtocol() const {
+UpstreamHttpProtocol RequestHeaders::upstreamHttpProtocol() const {
   const auto header_name = "x-envoy-mobile-upstream-protocol";
   if (!this->contains(header_name)) {
-    return absl::optional<UpstreamHttpProtocol>();
+    return UpstreamHttpProtocol::ALPN;
   }
   return upstreamHttpProtocolFromString((*this)[header_name][0]);
 }

--- a/library/cc/request_headers.h
+++ b/library/cc/request_headers.h
@@ -21,7 +21,7 @@ public:
   const std::string& authority() const;
   const std::string& path() const;
   absl::optional<RetryPolicy> retryPolicy() const;
-  absl::optional<UpstreamHttpProtocol> upstreamHttpProtocol() const;
+  UpstreamHttpProtocol upstreamHttpProtocol() const;
 
   RequestHeadersBuilder toRequestHeadersBuilder() const;
 

--- a/library/cc/upstream_http_protocol.cc
+++ b/library/cc/upstream_http_protocol.cc
@@ -6,6 +6,7 @@ namespace Envoy {
 namespace Platform {
 
 static const std::pair<UpstreamHttpProtocol, std::string> UPSTREAM_HTTP_PROTOCOL_LOOKUP[]{
+    {UpstreamHttpProtocol::ALPN, "alpn"},
     {UpstreamHttpProtocol::HTTP1, "http1"},
     {UpstreamHttpProtocol::HTTP2, "http2"},
 };

--- a/library/cc/upstream_http_protocol.h
+++ b/library/cc/upstream_http_protocol.h
@@ -6,6 +6,7 @@ namespace Envoy {
 namespace Platform {
 
 enum UpstreamHttpProtocol {
+  ALPN,
   HTTP1,
   HTTP2,
 };

--- a/library/kotlin/io/envoyproxy/envoymobile/UpstreamHttpProtocol.kt
+++ b/library/kotlin/io/envoyproxy/envoymobile/UpstreamHttpProtocol.kt
@@ -13,7 +13,7 @@ enum class UpstreamHttpProtocol(internal val stringValue: String) {
   companion object {
     internal fun enumValue(stringRepresentation: String): UpstreamHttpProtocol {
       return when (stringRepresentation) {
-        "alpn"  -> UpstreamHttpProtocol.ALPN
+        "alpn" -> UpstreamHttpProtocol.ALPN
         "http1" -> UpstreamHttpProtocol.HTTP1
         "http2" -> UpstreamHttpProtocol.HTTP2
         else -> throw IllegalArgumentException("invalid value $stringRepresentation")

--- a/library/kotlin/io/envoyproxy/envoymobile/UpstreamHttpProtocol.kt
+++ b/library/kotlin/io/envoyproxy/envoymobile/UpstreamHttpProtocol.kt
@@ -6,12 +6,14 @@ import java.lang.IllegalArgumentException
  * Available upstream HTTP protocols.
  */
 enum class UpstreamHttpProtocol(internal val stringValue: String) {
+  ALPN("alpn"),
   HTTP1("http1"),
   HTTP2("http2");
 
   companion object {
     internal fun enumValue(stringRepresentation: String): UpstreamHttpProtocol {
       return when (stringRepresentation) {
+        "alpn"  -> UpstreamHttpProtocol.ALPN
         "http1" -> UpstreamHttpProtocol.HTTP1
         "http2" -> UpstreamHttpProtocol.HTTP2
         else -> throw IllegalArgumentException("invalid value $stringRepresentation")

--- a/library/swift/UpstreamHttpProtocol.swift
+++ b/library/swift/UpstreamHttpProtocol.swift
@@ -3,12 +3,15 @@ import Foundation
 /// Available upstream HTTP protocols.
 @objc
 public enum UpstreamHttpProtocol: Int, CaseIterable {
+  case alpn
   case http1
   case http2
 
   /// String representation of the protocol.
   var stringValue: String {
     switch self {
+    case .alpn:
+      return "alpn"
     case .http1:
       return "http1"
     case .http2:
@@ -21,6 +24,8 @@ public enum UpstreamHttpProtocol: Int, CaseIterable {
   /// - parameter stringValue: Case-insensitive string value to use for initialization.
   init(stringValue: String) {
     switch stringValue.lowercased() {
+    case "alpn"
+      self = .alpn
     case "http1":
       self = .http1
     case "http2":

--- a/library/swift/UpstreamHttpProtocol.swift
+++ b/library/swift/UpstreamHttpProtocol.swift
@@ -24,7 +24,7 @@ public enum UpstreamHttpProtocol: Int, CaseIterable {
   /// - parameter stringValue: Case-insensitive string value to use for initialization.
   init(stringValue: String) {
     switch stringValue.lowercased() {
-    case "alpn"
+    case "alpn":
       self = .alpn
     case "http1":
       self = .http1


### PR DESCRIPTION
For: https://github.com/envoyproxy/envoy-mobile/issues/1548

Signed-off-by: Alan Chiu <achiu@lyft.com>

For an explanation of how to fill out the fields, please see the relevant section
in [PULL_REQUESTS.md](https://github.com/envoyproxy/envoy/blob/master/PULL_REQUESTS.md)

Description: add alpn option for UpstreamHttpProtocol
Risk Level: low
Testing: local
Docs Changes: n/a
Release Notes: n/a
[Optional Fixes #Issue]
[Optional Deprecated:]
