### PR TITLE
testing: add repository argument

### DIFF
--- a/bazel/apple_test.bzl
+++ b/bazel/apple_test.bzl
@@ -18,14 +18,14 @@ load("@rules_cc//cc:defs.bzl", "objc_library")
 #     ],
 # )
 #
-def envoy_mobile_swift_test(name, srcs, data = [], deps = []):
+def envoy_mobile_swift_test(name, srcs, data = [], deps = [], repository = ""):
     test_lib_name = name + "_lib"
     swift_library(
         name = test_lib_name,
         srcs = srcs,
         data = data,
         deps = [
-            "@envoy_mobile//library/swift:ios_framework_archive",
+            repository + "//library/swift:ios_framework_archive",
         ] + deps,
         linkopts = ["-lresolv.9"],
         visibility = ["//visibility:private"],

--- a/bazel/apple_test.bzl
+++ b/bazel/apple_test.bzl
@@ -25,7 +25,7 @@ def envoy_mobile_swift_test(name, srcs, data = [], deps = []):
         srcs = srcs,
         data = data,
         deps = [
-            "//library/swift:ios_framework_archive",
+            "@envoy_mobile//library/swift:ios_framework_archive",
         ] + deps,
         linkopts = ["-lresolv.9"],
         visibility = ["//visibility:private"],


### PR DESCRIPTION
Similar to some other envoy rules add a way to specify a repository when invoking `envoy_mobile_swift_test` rule. This is needed for cases when `envoy_mobile_swift_test` is invoked from outside of `envoy_mobile`.

Description:
Risk Level: Low (testing only, additive)
Testing: Manual
Docs Changes: None
Release Notes: None
