### PR TITLE
add vscode comp db script

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,4 @@ clang.bazelrc
 user.bazelrc
 tags
 tulsi-workspace
+compile_commands.json

--- a/tools/vscode_compdb.sh
+++ b/tools/vscode_compdb.sh
@@ -1,5 +1,9 @@
 #!/usr/bin/env bash
 
+# Generates a compile_commands.json file for use with the VS Code clangd plugin.
+# This is a modification of evnoy/tools/vscode/refresh_compdb.sh which hits
+# the correct envoy-mobile Bazel targets.
+
 # Setting TEST_TMPDIR here so the compdb headers won't be overwritten by another bazel run
 CC=clang TEST_TMPDIR=${BUILD_DIR:-/tmp}/envoy-mobile-compdb envoy/tools/gen_compilation_database.py --vscode //library/cc/... //library/common/... //test/cc/... //test/common/...
 

--- a/tools/vscode_compdb.sh
+++ b/tools/vscode_compdb.sh
@@ -1,0 +1,7 @@
+#!/usr/bin/env bash
+
+# Setting TEST_TMPDIR here so the compdb headers won't be overwritten by another bazel run
+CC=clang TEST_TMPDIR=${BUILD_DIR:-/tmp}/envoy-mobile-compdb envoy/tools/gen_compilation_database.py --vscode //library/cc/... //library/common/... //test/cc/... //test/common/...
+
+# Kill clangd to reload the compilation database
+pkill clangd || :


### PR DESCRIPTION
Adds a wrapper script that calls Envoy's comp db generation script suitable for envoy-mobile for use with VS Code.

This will create a compile_commands.json file in the root of the repo, allowing for the clangd plugin to pick this up and
provide intelisense for native code.

![image](https://user-images.githubusercontent.com/2023366/127489429-0a4beee3-ba18-43b6-bcf4-2e2e8c049b35.png)


Signed-off-by: Snow Pettersen <snowp@lyft.com>

Description:
Risk Level:
Testing:
Docs Changes:
Release Notes:
[Optional Fixes #Issue]
[Optional Deprecated:]
