### PR TITLE
ci: increase timeout for some jobs

### DIFF
--- a/.github/workflows/core.yml
+++ b/.github/workflows/core.yml
@@ -10,7 +10,7 @@ jobs:
   unittests:
     name: unit_tests
     runs-on: macOS-latest
-    timeout-minutes: 90
+    timeout-minutes: 120
     steps:
       - uses: actions/checkout@v1
         with:

--- a/.github/workflows/ios_build.yml
+++ b/.github/workflows/ios_build.yml
@@ -66,7 +66,7 @@ jobs:
     name: swift_helloworld
     needs: iosbuild
     runs-on: macOS-latest
-    timeout-minutes: 30
+    timeout-minutes: 25
     steps:
       - uses: actions/checkout@v1
         with:
@@ -96,7 +96,7 @@ jobs:
     name: objc_helloworld
     needs: iosbuild
     runs-on: macOS-latest
-    timeout-minutes: 15
+    timeout-minutes: 25
     steps:
       - uses: actions/checkout@v1
         with:


### PR DESCRIPTION
Description: I've noticed that these jobs are timing out making CI red on PRs and main. Being conservative, specially with the App runs because we don't want them to run _too_ long.

Signed-off-by: Jose Nino <jnino@lyft.com>