### PR TITLE
ci: extend cc test timeout

### DIFF
--- a/.github/workflows/cc_tests.yml
+++ b/.github/workflows/cc_tests.yml
@@ -10,7 +10,7 @@ jobs:
   cctests:
     name: cc_tests
     runs-on: ubuntu-18.04
-    timeout-minutes: 90
+    timeout-minutes: 120
     container:
       image: envoyproxy/envoy-build-ubuntu:e33c93e6d79804bf95ff80426d10bdcc9096c785
     steps:


### PR DESCRIPTION
Description: CC has been slower lately and this is another flow that's been timing out.

Signed-off-by: Mike Schore <mike.schore@gmail.com>
