### PR TITLE
test: ensure we properly shut down the engine thread in test

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -60,6 +60,9 @@ build:tsan-dev --test_env=ENVOY_IP_TEST_VERSIONS=v4only
 build:tsan-dev --platform_suffix=-tsan
 # Needed due to https://github.com/libevent/libevent/issues/777
 build:tsan-dev --copt -DEVENT__DISABLE_DEBUG_MODE
+# https://github.com/abseil/abseil-cpp/issues/760
+# https://github.com/google/sanitizers/issues/953
+build:tsan-dev --test_env="TSAN_OPTIONS=report_atomic_races=0"
 
 # Exclude debug info from the release binary since it makes it too large to fit
 # into a zip file. This shouldn't affect crash reports.

--- a/test/common/engine_test.cc
+++ b/test/common/engine_test.cc
@@ -40,7 +40,23 @@ layered_runtime:
       overload: { global_downstream_max_connections: 50000 }
 )";
 
-class EngineTest : public testing::Test {};
+// RAII wrapper for the engine, ensuring that we properly shut down the engine. If the engine
+// thread is not torn down, we end up with TSAN failures during shutdown due to a data race
+// between the main thread and the engine thread both writing to the
+// Envoy::Logger::current_log_conetxt global.
+struct EngineHandle {
+  EngineHandle(envoy_engine_callbacks callbacks, const std::string& level) {
+    init_engine(callbacks, {});
+    run_engine(0, MINIMAL_TEST_CONFIG.c_str(), level.c_str());
+  }
+
+  ~EngineHandle() { terminate_engine(0); }
+};
+
+class EngineTest : public testing::Test {
+public:
+  std::unique_ptr<EngineHandle> engine_;
+};
 
 typedef struct {
   absl::Notification on_engine_running;
@@ -62,11 +78,10 @@ TEST_F(EngineTest, EarlyExit) {
                                    } /*on_exit*/,
                                    &test_context /*context*/};
 
-  init_engine(callbacks, {});
-  run_engine(0, MINIMAL_TEST_CONFIG.c_str(), level.c_str());
-  ASSERT_TRUE(test_context.on_engine_running.WaitForNotificationWithTimeout(absl::Seconds(3)));
+  engine_ = std::make_unique<EngineHandle>(callbacks, level);
+  ASSERT_TRUE(test_context.on_engine_running.WaitForNotificationWithTimeout(absl::Seconds(1)));
 
-  terminate_engine(0);
+  engine_.reset();
   ASSERT_TRUE(test_context.on_exit.WaitForNotificationWithTimeout(absl::Seconds(3)));
 
   start_stream(0, {});

--- a/test/common/engine_test.cc
+++ b/test/common/engine_test.cc
@@ -79,7 +79,7 @@ TEST_F(EngineTest, EarlyExit) {
                                    &test_context /*context*/};
 
   engine_ = std::make_unique<EngineHandle>(callbacks, level);
-  ASSERT_TRUE(test_context.on_engine_running.WaitForNotificationWithTimeout(absl::Seconds(1)));
+  ASSERT_TRUE(test_context.on_engine_running.WaitForNotificationWithTimeout(absl::Seconds(3)));
 
   engine_.reset();
   ASSERT_TRUE(test_context.on_exit.WaitForNotificationWithTimeout(absl::Seconds(3)));

--- a/test/common/engine_test.cc
+++ b/test/common/engine_test.cc
@@ -43,7 +43,7 @@ layered_runtime:
 // RAII wrapper for the engine, ensuring that we properly shut down the engine. If the engine
 // thread is not torn down, we end up with TSAN failures during shutdown due to a data race
 // between the main thread and the engine thread both writing to the
-// Envoy::Logger::current_log_conetxt global.
+// Envoy::Logger::current_log_context global.
 struct EngineHandle {
   EngineHandle(envoy_engine_callbacks callbacks, const std::string& level) {
     init_engine(callbacks, {});


### PR DESCRIPTION
Ensures that we shut down and join the engine thread in engine_test, preventing a data race from happening when the test runner
writes to Envoy::Logger::current_log_context during shutdown. 

Also updates the tsan-dev option to specify the same overrides as upstream Envoy, without this we see failures when using absl::Notification.

Signed-off-by: Snow Pettersen <snowp@lyft.com>

Description: n/a
Risk Level: Low, test only
Testing: Existing tests
Docs Changes: n/a
Release Notes: n/a
