### PR TITLE
CI: disable shadow build for upgrade

### DIFF
--- a/.github/workflows/ios_build.yml
+++ b/.github/workflows/ios_build.yml
@@ -53,6 +53,8 @@ jobs:
       - env:
           CREDENTIALS: ${{ secrets.ENGFLOW_CREDENTIALS }}
         run: |
+          echo "Skipping for backend update"
+          exit 0
           if [[ -z $CREDENTIALS ]]; then echo "Empty CREDENTIALS"; exit 0; fi
           echo "$CREDENTIALS" > .credentials
           export GOOGLE_APPLICATION_CREDENTIALS=$(pwd)/.credentials


### PR DESCRIPTION
Description: This is in preparation for changing the remote execution
    service authentication configuration. We could theoretically do
    it without downtime, but since this isn't on the critical path yet,
    let's go the easier route.
Risk Level: Low
Testing: n/a
Docs Changes: n/a
Release Notes: n/a
