### PR TITLE
java: add missing docstrings to EnvoyHTTPFilterCallbacks

### DIFF
--- a/library/java/io/envoyproxy/envoymobile/engine/types/EnvoyHTTPFilterCallbacks.java
+++ b/library/java/io/envoyproxy/envoymobile/engine/types/EnvoyHTTPFilterCallbacks.java
@@ -1,6 +1,19 @@
 package io.envoyproxy.envoymobile.engine.types;
 
+/**
+ * Callbacks for asynchronous interaction with the filter.
+ */
 public interface EnvoyHTTPFilterCallbacks {
+  /**
+   * Resume filter iteration asynchronously. This will result in an on-resume invocation of the
+   * filter.
+   */
   void resumeIteration();
+
+  /**
+   * Reset the underlying stream idle timeout to its configured threshold. This may be useful if
+   * a filter stops iteration for an extended period of time, since ordinarily timeouts will still
+   * apply. This may be called periodically to continue to indicate "activity" on the stream.
+   */
   void resetIdleTimer();
 }


### PR DESCRIPTION
Signed-off-by: Mike Schore <mike.schore@gmail.com>
