### PR TITLE
CI: update authentication + config

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -83,11 +83,11 @@ build:coverage --host_javabase=@bazel_tools//tools/jdk:remote_jdk11
 build:coverage --javabase=@bazel_tools//tools/jdk:remote_jdk11
 
 # Experimental EngFlow Remote Execution Config
-# TODO: Use --config=remote if that makes sense.
-build:remote-ci-macos --spawn_strategy=remote,sandboxed,local
-build:remote-ci-macos --strategy=Javac=remote,sandboxed,local
-build:remote-ci-macos --strategy=Closure=remote,sandboxed,local
-build:remote-ci-macos --strategy=Genrule=remote,sandboxed,local
+# --config=remote also sets --auth_enabled=true to enable GCP authentication.
+# We are not using GCP authentication for the MacOS remote execution cluster,
+# so we have to override it to false here.
+build:remote-ci-macos --config=remote
+build:remote-ci-macos --auth_enabled=false
 build:remote-ci-macos --remote_executor=grpcs://envoy.cluster.engflow.com
 build:remote-ci-macos --bes_backend=grpcs://envoy.cluster.engflow.com/
 build:remote-ci-macos --bes_results_url=https://envoy.cluster.engflow.com/invocation/

--- a/.bazelrc
+++ b/.bazelrc
@@ -92,7 +92,5 @@ build:remote-ci-macos --remote_executor=grpcs://envoy.cluster.engflow.com
 build:remote-ci-macos --bes_backend=grpcs://envoy.cluster.engflow.com/
 build:remote-ci-macos --bes_results_url=https://envoy.cluster.engflow.com/invocation/
 build:remote-ci-macos --bes_lifecycle_events
-build:remote-ci-macos --jobs=72
+build:remote-ci-macos --jobs=40
 build:remote-ci-macos --verbose_failures
-build:remote-ci-macos --google_default_credentials
-build:remote-ci-macos --google_auth_scopes=email

--- a/.github/workflows/ios_build.yml
+++ b/.github/workflows/ios_build.yml
@@ -51,17 +51,10 @@ jobs:
         if: steps.check-cache.outputs.cache-hit != 'true'
         name: 'Install dependencies'
       - env:
-          CREDENTIALS: ${{ secrets.ENGFLOW_CREDENTIALS }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          echo "Skipping for backend update"
-          exit 0
-          if [[ -z $CREDENTIALS ]]; then echo "Empty CREDENTIALS"; exit 0; fi
-          echo "$CREDENTIALS" > .credentials
-          export GOOGLE_APPLICATION_CREDENTIALS=$(pwd)/.credentials
-          echo "$GOOGLE_APPLICATION_CREDENTIALS"
-          ls -l "$GOOGLE_APPLICATION_CREDENTIALS"
           bazelisk shutdown
-          bazelisk build --config=ios --config=remote-ci-macos //:ios_dist
+          bazelisk build --config=ios --config=remote-ci-macos --remote_header="Authorization=Bearer $GITHUB_TOKEN" //:ios_dist
         if: steps.check-cache.outputs.cache-hit != 'true'
         name: 'Build Envoy.framework distributable'
   swifthelloworld:


### PR DESCRIPTION
Description: Re-enable remote execution shadow build for iOS.
 - use GITHUB_TOKEN for authentication
 - use `--config=remote` for consistency with Envoy
 - reduce number of jobs to match the current layout

Risk Level: None
Testing: Manually tested
Docs Changes: N/A
Release Notes: N/A