### PR TITLE
Comma headers

### DIFF
--- a/library/java/io/envoyproxy/envoymobile/engine/JvmBridgeUtility.java
+++ b/library/java/io/envoyproxy/envoymobile/engine/JvmBridgeUtility.java
@@ -49,8 +49,10 @@ class JvmBridgeUtility {
     }
 
     // These headers may contain commas in single values, in contravention of the RFC.
-    if (headerKey.equalsIgnoreCase​("cookie") || headerKey.equalsIgnoreCase​("proxy-authenticate") ||
-        headerKey.equalsIgnoreCase​("set-cookie") || headerKey.equalsIgnoreCase​("www-authenticate") ||
+    if (headerKey.equalsIgnoreCase​("cookie") ||
+        headerKey.equalsIgnoreCase​("proxy-authenticate") ||
+        headerKey.equalsIgnoreCase​("set-cookie") ||
+        headerKey.equalsIgnoreCase​("www-authenticate") ||
         headerKey.equalsIgnoreCase​("x-location")) {
       values.add(headerValue);
     } else {

--- a/library/java/io/envoyproxy/envoymobile/engine/JvmBridgeUtility.java
+++ b/library/java/io/envoyproxy/envoymobile/engine/JvmBridgeUtility.java
@@ -49,8 +49,9 @@ class JvmBridgeUtility {
     }
 
     // These headers may contain commas in single values, in contravention of the RFC.
-    if (headerKey.equals("cookie") || headerKey.equals("proxy-authenticate") ||
-        headerKey.equals("set-cookie") || headerKey.equals("www-authenticate")) {
+    if (headerKey.equalsIgnoreCase​("cookie") || headerKey.equalsIgnoreCase​("proxy-authenticate") ||
+        headerKey.equalsIgnoreCase​("set-cookie") || headerKey.equalsIgnoreCase​("www-authenticate") ||
+        headerKey.equalsIgnoreCase​("x-location")) {
       values.add(headerValue);
     } else {
       // Add trimmed, comma-separated values as individual members of the list.

--- a/library/objective-c/EnvoyBridgeUtility.h
+++ b/library/objective-c/EnvoyBridgeUtility.h
@@ -138,7 +138,8 @@ static inline EnvoyHeaders *to_ios_headers(envoy_headers headers) {
     if ([headerKey caseInsensitiveCompare:@"cookie"] == NSOrderedSame ||
         [headerKey caseInsensitiveCompare:@"proxy-authenticate"] == NSOrderedSame ||
         [headerKey caseInsensitiveCompare:@"set-cookie"] == NSOrderedSame ||
-        [headerKey caseInsensitiveCompare:@"www-authenticate"] == NSOrderedSame) {
+        [headerKey caseInsensitiveCompare:@"www-authenticate"] == NSOrderedSame ||
+        [headerKey caseInsensitiveCompare:@"x-location"] == NSOrderedSame) {
       [headerValueList addObject:headerValue];
     } else {
       // Add trimmed, comma-separated values as individual members of the list.


### PR DESCRIPTION
Description: Lyft uses x-location and sets them as `lat,long`. Currently Envoy Mobile incorrectly separates the header into two different values.
Risk Level: med
Testing: no existing test suite. Part of https://github.com/envoyproxy/envoy-mobile/issues/1215

