### PR TITLE
http: expose StreamIntel on stream callbacks

### DIFF
--- a/examples/java/hello_world/MainActivity.java
+++ b/examples/java/hello_world/MainActivity.java
@@ -103,7 +103,7 @@ public class MainActivity extends Activity {
                                         .build();
     engine.streamClient()
         .newStreamPrototype()
-        .setOnResponseHeaders((responseHeaders, endStream) -> {
+        .setOnResponseHeaders((responseHeaders, endStream, ignored) -> {
           Integer status = responseHeaders.getHttpStatus();
           String message = "received headers with status " + status;
 
@@ -125,7 +125,7 @@ public class MainActivity extends Activity {
           }
           return Unit.INSTANCE;
         })
-        .setOnError((error) -> {
+        .setOnError((error, ignored) -> {
           String message = "failed with error after " + error.getAttemptCount() +
                            " attempts: " + error.getMessage();
           Log.d("MainActivity", message);

--- a/examples/kotlin/hello_world/MainActivity.kt
+++ b/examples/kotlin/hello_world/MainActivity.kt
@@ -104,7 +104,7 @@ class MainActivity : Activity() {
     engine
       .streamClient()
       .newStreamPrototype()
-      .setOnResponseHeaders { responseHeaders, _ ->
+      .setOnResponseHeaders { responseHeaders, _, _ ->
         val status = responseHeaders.httpStatus ?: 0L
         val message = "received headers with status $status"
 
@@ -127,7 +127,7 @@ class MainActivity : Activity() {
           recyclerView.post { viewAdapter.add(Failure(message)) }
         }
       }
-      .setOnError { error ->
+      .setOnError { error, _ ->
         val attemptCount = error.attemptCount ?: -1
         val message = "failed with error after $attemptCount attempts: ${error.message}"
         Log.d("MainActivity", message)

--- a/examples/objective-c/hello_world/ViewController.m
+++ b/examples/objective-c/hello_world/ViewController.m
@@ -84,11 +84,8 @@ NSString *_REQUEST_SCHEME = @"https";
 
   __weak ViewController *weakSelf = self;
   StreamPrototype *prototype = [self.streamClient newStreamPrototype];
-  [prototype setOnResponseHeadersWithClosure:^(
-    ResponseHeaders *headers,
-    BOOL endStream,
-    StreamIntel *ignored
-  ) {
+  [prototype setOnResponseHeadersWithClosure:^(ResponseHeaders *headers, BOOL endStream,
+                                               StreamIntel *ignored) {
     int statusCode = [[[headers valueForName:@":status"] firstObject] intValue];
     NSString *message = [NSString stringWithFormat:@"received headers with status %i", statusCode];
 

--- a/examples/objective-c/hello_world/ViewController.m
+++ b/examples/objective-c/hello_world/ViewController.m
@@ -84,7 +84,11 @@ NSString *_REQUEST_SCHEME = @"https";
 
   __weak ViewController *weakSelf = self;
   StreamPrototype *prototype = [self.streamClient newStreamPrototype];
-  [prototype setOnResponseHeadersWithClosure:^(ResponseHeaders *headers, BOOL endStream) {
+  [prototype setOnResponseHeadersWithClosure:^(
+    ResponseHeaders *headers,
+    BOOL endStream,
+    StreamIntel *ignored
+  ) {
     int statusCode = [[[headers valueForName:@":status"] firstObject] intValue];
     NSString *message = [NSString stringWithFormat:@"received headers with status %i", statusCode];
 
@@ -102,7 +106,7 @@ NSString *_REQUEST_SCHEME = @"https";
 
     [weakSelf addResponseMessage:message headerMessage:headerMessage error:nil];
   }];
-  [prototype setOnErrorWithClosure:^(EnvoyError *error) {
+  [prototype setOnErrorWithClosure:^(EnvoyError *error, StreamIntel *ignored) {
     // TODO: expose attemptCount. https://github.com/lyft/envoy-mobile/issues/823
     NSString *message =
         [NSString stringWithFormat:@"failed within Envoy library %@", error.message];

--- a/examples/swift/hello_world/ViewController.swift
+++ b/examples/swift/hello_world/ViewController.swift
@@ -68,7 +68,7 @@ final class ViewController: UITableViewController {
 
     streamClient
       .newStreamPrototype()
-      .setOnResponseHeaders { [weak self] headers, _ in
+      .setOnResponseHeaders { [weak self] headers, _, _ in
         let statusCode = headers.httpStatus.map(String.init) ?? "nil"
         let message = "received headers with status \(statusCode)"
 
@@ -89,7 +89,7 @@ final class ViewController: UITableViewController {
                                 headerMessage: headerMessage)
         self?.add(result: .success(response))
       }
-      .setOnError { [weak self] error in
+      .setOnError { [weak self] error, _ in
         let message: String
         if let attemptCount = error.attemptCount {
           message = "failed within Envoy library after \(attemptCount) attempts: \(error.message)"

--- a/library/cc/stream_callbacks.cc
+++ b/library/cc/stream_callbacks.cc
@@ -10,7 +10,7 @@ namespace Platform {
 
 namespace {
 
-void* c_on_headers(envoy_headers headers, bool end_stream, void* context) {
+void* c_on_headers(envoy_headers headers, bool end_stream, envoy_stream_intel, void* context) {
   auto stream_callbacks = *static_cast<StreamCallbacksSharedPtr*>(context);
   if (stream_callbacks->on_headers.has_value()) {
     auto raw_headers = envoyHeadersAsRawHeaderMap(headers);
@@ -27,7 +27,7 @@ void* c_on_headers(envoy_headers headers, bool end_stream, void* context) {
   return context;
 }
 
-void* c_on_data(envoy_data data, bool end_stream, void* context) {
+void* c_on_data(envoy_data data, bool end_stream, envoy_stream_intel, void* context) {
   auto stream_callbacks = *static_cast<StreamCallbacksSharedPtr*>(context);
   if (stream_callbacks->on_data.has_value()) {
     auto on_data = stream_callbacks->on_data.value();
@@ -36,7 +36,7 @@ void* c_on_data(envoy_data data, bool end_stream, void* context) {
   return context;
 }
 
-void* c_on_trailers(envoy_headers metadata, void* context) {
+void* c_on_trailers(envoy_headers metadata, envoy_stream_intel, void* context) {
   auto stream_callbacks = *static_cast<StreamCallbacksSharedPtr*>(context);
   if (stream_callbacks->on_trailers.has_value()) {
     auto raw_headers = envoyHeadersAsRawHeaderMap(metadata);
@@ -50,7 +50,7 @@ void* c_on_trailers(envoy_headers metadata, void* context) {
   return context;
 }
 
-void* c_on_error(envoy_error raw_error, void* context) {
+void* c_on_error(envoy_error raw_error, envoy_stream_intel, void* context) {
   auto stream_callbacks_ptr = static_cast<StreamCallbacksSharedPtr*>(context);
   auto stream_callbacks = *stream_callbacks_ptr;
   if (stream_callbacks->on_error.has_value()) {
@@ -65,7 +65,7 @@ void* c_on_error(envoy_error raw_error, void* context) {
   return nullptr;
 }
 
-void* c_on_complete(void* context) {
+void* c_on_complete(envoy_stream_intel, void* context) {
   auto stream_callbacks_ptr = static_cast<StreamCallbacksSharedPtr*>(context);
   auto stream_callbacks = *stream_callbacks_ptr;
   if (stream_callbacks->on_complete.has_value()) {
@@ -76,7 +76,7 @@ void* c_on_complete(void* context) {
   return nullptr;
 }
 
-void* c_on_cancel(void* context) {
+void* c_on_cancel(envoy_stream_intel, void* context) {
   auto stream_callbacks_ptr = static_cast<StreamCallbacksSharedPtr*>(context);
   auto stream_callbacks = *stream_callbacks_ptr;
   if (stream_callbacks->on_cancel.has_value()) {

--- a/library/common/http/client.cc
+++ b/library/common/http/client.cc
@@ -79,8 +79,8 @@ void Client::DirectStreamCallbacks::encodeHeaders(const ResponseHeaderMap& heade
 
   ENVOY_LOG(debug, "[S{}] dispatching to platform response headers for stream (end_stream={}):\n{}",
             direct_stream_.stream_handle_, end_stream, headers);
-  bridge_callbacks_.on_headers(Utility::toBridgeHeaders(headers), end_stream,
-                               envoy_stream_intel{}, bridge_callbacks_.context);
+  bridge_callbacks_.on_headers(Utility::toBridgeHeaders(headers), end_stream, envoy_stream_intel{},
+                               bridge_callbacks_.context);
   response_headers_forwarded_ = true;
   if (end_stream) {
     onComplete();

--- a/library/common/http/client.cc
+++ b/library/common/http/client.cc
@@ -80,7 +80,7 @@ void Client::DirectStreamCallbacks::encodeHeaders(const ResponseHeaderMap& heade
   ENVOY_LOG(debug, "[S{}] dispatching to platform response headers for stream (end_stream={}):\n{}",
             direct_stream_.stream_handle_, end_stream, headers);
   bridge_callbacks_.on_headers(Utility::toBridgeHeaders(headers), end_stream,
-                               bridge_callbacks_.context);
+                               envoy_stream_intel{}, bridge_callbacks_.context);
   response_headers_forwarded_ = true;
   if (end_stream) {
     onComplete();
@@ -149,7 +149,7 @@ void Client::DirectStreamCallbacks::sendDataToBridge(Buffer::Instance& data, boo
             direct_stream_.stream_handle_, bytes_to_send, send_end_stream);
 
   bridge_callbacks_.on_data(Data::Utility::toBridgeData(data, bytes_to_send), end_stream,
-                            bridge_callbacks_.context);
+                            envoy_stream_intel{}, bridge_callbacks_.context);
   if (send_end_stream) {
     onComplete();
   }
@@ -181,7 +181,8 @@ void Client::DirectStreamCallbacks::sendTrailersToBridge(const ResponseTrailerMa
   ENVOY_LOG(debug, "[S{}] dispatching to platform response trailers for stream:\n{}",
             direct_stream_.stream_handle_, trailers);
 
-  bridge_callbacks_.on_trailers(Utility::toBridgeHeaders(trailers), bridge_callbacks_.context);
+  bridge_callbacks_.on_trailers(Utility::toBridgeHeaders(trailers), envoy_stream_intel{},
+                                bridge_callbacks_.context);
   onComplete();
 }
 
@@ -238,7 +239,7 @@ void Client::DirectStreamCallbacks::onComplete() {
   } else {
     http_client_.stats().stream_failure_.inc();
   }
-  bridge_callbacks_.on_complete(bridge_callbacks_.context);
+  bridge_callbacks_.on_complete(envoy_stream_intel{}, bridge_callbacks_.context);
 }
 
 void Client::DirectStreamCallbacks::onError() {
@@ -268,14 +269,15 @@ void Client::DirectStreamCallbacks::onError() {
   error_message_ = {};
   error_attempt_count_ = {};
 
-  bridge_callbacks_.on_error({code, message, attempt_count}, bridge_callbacks_.context);
+  bridge_callbacks_.on_error({code, message, attempt_count}, envoy_stream_intel{},
+                             bridge_callbacks_.context);
 }
 
 void Client::DirectStreamCallbacks::onCancel() {
   ScopeTrackerScopeState scope(&direct_stream_, http_client_.scopeTracker());
   ENVOY_LOG(debug, "[S{}] dispatching to platform cancel stream", direct_stream_.stream_handle_);
   http_client_.stats().stream_cancel_.inc();
-  bridge_callbacks_.on_cancel(bridge_callbacks_.context);
+  bridge_callbacks_.on_cancel(envoy_stream_intel{}, bridge_callbacks_.context);
 }
 
 Client::DirectStream::DirectStream(envoy_stream_t stream_handle, Client& http_client)

--- a/library/common/jni/jni_interface.cc
+++ b/library/common/jni/jni_interface.cc
@@ -255,15 +255,16 @@ static void* jvm_on_headers(const char* method, envoy_headers headers, bool end_
   return result;
 }
 
-static void* jvm_on_response_headers(envoy_headers headers, bool end_stream, envoy_stream_intel stream_intel, void* context) {
+static void* jvm_on_response_headers(envoy_headers headers, bool end_stream,
+                                     envoy_stream_intel stream_intel, void* context) {
   return jvm_on_headers("onResponseHeaders", headers, end_stream, stream_intel, context);
 }
 
 static envoy_filter_headers_status
 jvm_http_filter_on_request_headers(envoy_headers headers, bool end_stream, const void* context) {
   JNIEnv* env = get_env();
-  jobjectArray result = static_cast<jobjectArray>(
-      jvm_on_headers("onRequestHeaders", headers, end_stream, envoy_stream_intel{}, const_cast<void*>(context)));
+  jobjectArray result = static_cast<jobjectArray>(jvm_on_headers(
+      "onRequestHeaders", headers, end_stream, envoy_stream_intel{}, const_cast<void*>(context)));
 
   jobject status = env->GetObjectArrayElement(result, 0);
   jobjectArray j_headers = static_cast<jobjectArray>(env->GetObjectArrayElement(result, 1));
@@ -282,8 +283,8 @@ jvm_http_filter_on_request_headers(envoy_headers headers, bool end_stream, const
 static envoy_filter_headers_status
 jvm_http_filter_on_response_headers(envoy_headers headers, bool end_stream, const void* context) {
   JNIEnv* env = get_env();
-  jobjectArray result = static_cast<jobjectArray>(
-      jvm_on_headers("onResponseHeaders", headers, end_stream, envoy_stream_intel{}, const_cast<void*>(context)));
+  jobjectArray result = static_cast<jobjectArray>(jvm_on_headers(
+      "onResponseHeaders", headers, end_stream, envoy_stream_intel{}, const_cast<void*>(context)));
 
   jobject status = env->GetObjectArrayElement(result, 0);
   jobjectArray j_headers = static_cast<jobjectArray>(env->GetObjectArrayElement(result, 1));
@@ -299,7 +300,8 @@ jvm_http_filter_on_response_headers(envoy_headers headers, bool end_stream, cons
                                        /*headers*/ native_headers};
 }
 
-static void* jvm_on_data(const char* method, envoy_data data, bool end_stream, envoy_stream_intel stream_intel, void* context) {
+static void* jvm_on_data(const char* method, envoy_data data, bool end_stream,
+                         envoy_stream_intel stream_intel, void* context) {
   jni_log("[Envoy]", "jvm_on_data");
   JNIEnv* env = get_env();
   jobject j_context = static_cast<jobject>(context);
@@ -310,8 +312,8 @@ static void* jvm_on_data(const char* method, envoy_data data, bool end_stream, e
 
   jbyteArray j_data = native_data_to_array(env, data);
   jlongArray j_stream_intel = native_stream_intel_to_array(env, stream_intel);
-  jobject result =
-      env->CallObjectMethod(j_context, jmid_onData, j_data, j_stream_intel, end_stream ? JNI_TRUE : JNI_FALSE);
+  jobject result = env->CallObjectMethod(j_context, jmid_onData, j_data, j_stream_intel,
+                                         end_stream ? JNI_TRUE : JNI_FALSE);
 
   env->DeleteLocalRef(j_stream_intel);
   env->DeleteLocalRef(j_data);
@@ -321,15 +323,16 @@ static void* jvm_on_data(const char* method, envoy_data data, bool end_stream, e
   return result;
 }
 
-static void* jvm_on_response_data(envoy_data data, bool end_stream, envoy_stream_intel stream_intel, void* context) {
+static void* jvm_on_response_data(envoy_data data, bool end_stream, envoy_stream_intel stream_intel,
+                                  void* context) {
   return jvm_on_data("onResponseData", data, end_stream, stream_intel, context);
 }
 
 static envoy_filter_data_status jvm_http_filter_on_request_data(envoy_data data, bool end_stream,
                                                                 const void* context) {
   JNIEnv* env = get_env();
-  jobjectArray result = static_cast<jobjectArray>(
-      jvm_on_data("onRequestData", data, end_stream, envoy_stream_intel{}, const_cast<void*>(context)));
+  jobjectArray result = static_cast<jobjectArray>(jvm_on_data(
+      "onRequestData", data, end_stream, envoy_stream_intel{}, const_cast<void*>(context)));
 
   jobject status = env->GetObjectArrayElement(result, 0);
   jobject j_data = static_cast<jobjectArray>(env->GetObjectArrayElement(result, 1));
@@ -357,8 +360,8 @@ static envoy_filter_data_status jvm_http_filter_on_request_data(envoy_data data,
 static envoy_filter_data_status jvm_http_filter_on_response_data(envoy_data data, bool end_stream,
                                                                  const void* context) {
   JNIEnv* env = get_env();
-  jobjectArray result = static_cast<jobjectArray>(
-      jvm_on_data("onResponseData", data, end_stream, envoy_stream_intel{}, const_cast<void*>(context)));
+  jobjectArray result = static_cast<jobjectArray>(jvm_on_data(
+      "onResponseData", data, end_stream, envoy_stream_intel{}, const_cast<void*>(context)));
 
   jobject status = env->GetObjectArrayElement(result, 0);
   jobject j_data = static_cast<jobjectArray>(env->GetObjectArrayElement(result, 1));
@@ -383,13 +386,15 @@ static envoy_filter_data_status jvm_http_filter_on_response_data(envoy_data data
                                     /*pending_headers*/ pending_headers};
 }
 
-static void* jvm_on_metadata(envoy_headers metadata, envoy_stream_intel stream_intel, void* context) {
+static void* jvm_on_metadata(envoy_headers metadata, envoy_stream_intel stream_intel,
+                             void* context) {
   jni_log("[Envoy]", "jvm_on_metadata");
   jni_log("[Envoy]", std::to_string(metadata.length).c_str());
   return NULL;
 }
 
-static void* jvm_on_trailers(const char* method, envoy_headers trailers, envoy_stream_intel stream_intel, void* context) {
+static void* jvm_on_trailers(const char* method, envoy_headers trailers,
+                             envoy_stream_intel stream_intel, void* context) {
   jni_log("[Envoy]", "jvm_on_trailers");
 
   JNIEnv* env = get_env();
@@ -403,7 +408,8 @@ static void* jvm_on_trailers(const char* method, envoy_headers trailers, envoy_s
   jlongArray j_stream_intel = native_stream_intel_to_array(env, stream_intel);
   // Note: be careful of JVM types. Before we casted to jlong we were getting integer problems.
   // TODO: make this cast safer.
-  jobject result = env->CallObjectMethod(j_context, jmid_onTrailers, (jlong)trailers.length, j_stream_intel);
+  jobject result =
+      env->CallObjectMethod(j_context, jmid_onTrailers, (jlong)trailers.length, j_stream_intel);
 
   env->DeleteLocalRef(j_stream_intel);
   env->DeleteLocalRef(jcls_JvmCallbackContext);
@@ -411,15 +417,16 @@ static void* jvm_on_trailers(const char* method, envoy_headers trailers, envoy_s
   return result;
 }
 
-static void* jvm_on_response_trailers(envoy_headers trailers, envoy_stream_intel stream_intel, void* context) {
+static void* jvm_on_response_trailers(envoy_headers trailers, envoy_stream_intel stream_intel,
+                                      void* context) {
   return jvm_on_trailers("onResponseTrailers", trailers, stream_intel, context);
 }
 
 static envoy_filter_trailers_status jvm_http_filter_on_request_trailers(envoy_headers trailers,
                                                                         const void* context) {
   JNIEnv* env = get_env();
-  jobjectArray result = static_cast<jobjectArray>(
-      jvm_on_trailers("onRequestTrailers", trailers, envoy_stream_intel{}, const_cast<void*>(context)));
+  jobjectArray result = static_cast<jobjectArray>(jvm_on_trailers(
+      "onRequestTrailers", trailers, envoy_stream_intel{}, const_cast<void*>(context)));
 
   jobject status = env->GetObjectArrayElement(result, 0);
   jobjectArray j_trailers = static_cast<jobjectArray>(env->GetObjectArrayElement(result, 1));
@@ -453,8 +460,8 @@ static envoy_filter_trailers_status jvm_http_filter_on_request_trailers(envoy_he
 static envoy_filter_trailers_status jvm_http_filter_on_response_trailers(envoy_headers trailers,
                                                                          const void* context) {
   JNIEnv* env = get_env();
-  jobjectArray result = static_cast<jobjectArray>(
-      jvm_on_trailers("onResponseTrailers", trailers, envoy_stream_intel{}, const_cast<void*>(context)));
+  jobjectArray result = static_cast<jobjectArray>(jvm_on_trailers(
+      "onResponseTrailers", trailers, envoy_stream_intel{}, const_cast<void*>(context)));
 
   jobject status = env->GetObjectArrayElement(result, 0);
   jobjectArray j_trailers = static_cast<jobjectArray>(env->GetObjectArrayElement(result, 1));

--- a/library/common/jni/jni_interface.cc
+++ b/library/common/jni/jni_interface.cc
@@ -241,7 +241,7 @@ static void* jvm_on_headers(const char* method, envoy_headers headers, bool end_
 
   jclass jcls_JvmCallbackContext = env->GetObjectClass(j_context);
   jmethodID jmid_onHeaders =
-      env->GetMethodID(jcls_JvmCallbackContext, method, "(JZ)Ljava/lang/Object;");
+      env->GetMethodID(jcls_JvmCallbackContext, method, "(JZ[J)Ljava/lang/Object;");
 
   jlongArray j_stream_intel = native_stream_intel_to_array(env, stream_intel);
   // Note: be careful of JVM types. Before we casted to jlong we were getting integer problems.
@@ -308,12 +308,12 @@ static void* jvm_on_data(const char* method, envoy_data data, bool end_stream,
 
   jclass jcls_JvmCallbackContext = env->GetObjectClass(j_context);
   jmethodID jmid_onData =
-      env->GetMethodID(jcls_JvmCallbackContext, method, "([BZ)Ljava/lang/Object;");
+      env->GetMethodID(jcls_JvmCallbackContext, method, "([BZ[J)Ljava/lang/Object;");
 
   jbyteArray j_data = native_data_to_array(env, data);
   jlongArray j_stream_intel = native_stream_intel_to_array(env, stream_intel);
-  jobject result = env->CallObjectMethod(j_context, jmid_onData, j_data, j_stream_intel,
-                                         end_stream ? JNI_TRUE : JNI_FALSE);
+  jobject result = env->CallObjectMethod(j_context, jmid_onData, j_data,
+                                         end_stream ? JNI_TRUE : JNI_FALSE, j_stream_intel);
 
   env->DeleteLocalRef(j_stream_intel);
   env->DeleteLocalRef(j_data);
@@ -403,7 +403,7 @@ static void* jvm_on_trailers(const char* method, envoy_headers trailers,
 
   jclass jcls_JvmCallbackContext = env->GetObjectClass(j_context);
   jmethodID jmid_onTrailers =
-      env->GetMethodID(jcls_JvmCallbackContext, method, "(J)Ljava/lang/Object;");
+      env->GetMethodID(jcls_JvmCallbackContext, method, "(J[J)Ljava/lang/Object;");
 
   jlongArray j_stream_intel = native_stream_intel_to_array(env, stream_intel);
   // Note: be careful of JVM types. Before we casted to jlong we were getting integer problems.
@@ -617,7 +617,7 @@ static void* call_jvm_on_error(envoy_error error, envoy_stream_intel stream_inte
 
   jclass jcls_JvmObserverContext = env->GetObjectClass(j_context);
   jmethodID jmid_onError =
-      env->GetMethodID(jcls_JvmObserverContext, "onError", "(I[BI)Ljava/lang/Object;");
+      env->GetMethodID(jcls_JvmObserverContext, "onError", "(I[BI[J)Ljava/lang/Object;");
 
   jbyteArray j_error_message = native_data_to_array(env, error.message);
   jlongArray j_stream_intel = native_stream_intel_to_array(env, stream_intel);
@@ -646,7 +646,7 @@ static void* call_jvm_on_cancel(envoy_stream_intel stream_intel, void* context) 
 
   jclass jcls_JvmObserverContext = env->GetObjectClass(j_context);
   jmethodID jmid_onCancel =
-      env->GetMethodID(jcls_JvmObserverContext, "onCancel", "()Ljava/lang/Object;");
+      env->GetMethodID(jcls_JvmObserverContext, "onCancel", "([J)Ljava/lang/Object;");
 
   jlongArray j_stream_intel = native_stream_intel_to_array(env, stream_intel);
 

--- a/library/common/jni/jni_utility.cc
+++ b/library/common/jni/jni_utility.cc
@@ -80,6 +80,19 @@ jbyteArray native_data_to_array(JNIEnv* env, envoy_data data) {
   return j_data;
 }
 
+jlongArray native_stream_intel_to_array(JNIEnv* env, envoy_stream_intel stream_intel) {
+  jlongArray j_array = env->NewLongArray(3);
+  jlong* critical_array = static_cast<jlong*>(env->GetPrimitiveArrayCritical(j_array, nullptr));
+  RELEASE_ASSERT(critical_array != nullptr, "unable to allocate memory in jni_utility");
+  critical_array[0] = static_cast<jlong>(stream_intel.stream_id);
+  critical_array[1] = static_cast<jlong>(stream_intel.connection_id);
+  critical_array[2] = static_cast<jlong>(stream_intel.attempt_count);
+  // Here '0' (for which there is no named constant) indicates we want to commit the changes back
+  // to the JVM and free the c array, where applicable.
+  env->ReleasePrimitiveArrayCritical(j_array, critical_array, 0);
+  return j_array;
+}
+
 envoy_data buffer_to_native_data(JNIEnv* env, jobject j_data) {
   uint8_t* direct_address = static_cast<uint8_t*>(env->GetDirectBufferAddress(j_data));
 

--- a/library/common/jni/jni_utility.h
+++ b/library/common/jni/jni_utility.h
@@ -32,6 +32,8 @@ envoy_data array_to_native_data(JNIEnv* env, jbyteArray j_data);
  */
 jbyteArray native_data_to_array(JNIEnv* env, envoy_data data);
 
+jlongArray native_stream_intel_to_array(JNIEnv* env, envoy_stream_intel stream_intel);
+
 jstring native_data_to_string(JNIEnv* env, envoy_data data);
 
 envoy_data buffer_to_native_data(JNIEnv* env, jobject j_data);

--- a/library/common/types/c_types.h
+++ b/library/common/types/c_types.h
@@ -245,7 +245,8 @@ extern "C" { // function pointers
  * execution.
  * @return void*, return context (may be unused).
  */
-typedef void* (*envoy_on_headers_f)(envoy_headers headers, bool end_stream, envoy_stream_intel stream_intel, void* context);
+typedef void* (*envoy_on_headers_f)(envoy_headers headers, bool end_stream,
+                                    envoy_stream_intel stream_intel, void* context);
 
 /**
  * Callback signature for data on an HTTP stream.
@@ -259,7 +260,8 @@ typedef void* (*envoy_on_headers_f)(envoy_headers headers, bool end_stream, envo
  * execution.
  * @return void*, return context (may be unused).
  */
-typedef void* (*envoy_on_data_f)(envoy_data data, bool end_stream, envoy_stream_intel stream_intel, void* context);
+typedef void* (*envoy_on_data_f)(envoy_data data, bool end_stream, envoy_stream_intel stream_intel,
+                                 void* context);
 
 /**
  * Callback signature for metadata on an HTTP stream.
@@ -272,7 +274,8 @@ typedef void* (*envoy_on_data_f)(envoy_data data, bool end_stream, envoy_stream_
  * execution.
  * @return void*, return context (may be unused).
  */
-typedef void* (*envoy_on_metadata_f)(envoy_headers metadata, envoy_stream_intel stream_intel, void* context);
+typedef void* (*envoy_on_metadata_f)(envoy_headers metadata, envoy_stream_intel stream_intel,
+                                     void* context);
 
 /**
  * Callback signature for trailers on an HTTP stream.
@@ -285,7 +288,8 @@ typedef void* (*envoy_on_metadata_f)(envoy_headers metadata, envoy_stream_intel 
  * execution.
  * @return void*, return context (may be unused).
  */
-typedef void* (*envoy_on_trailers_f)(envoy_headers trailers, envoy_stream_intel stream_intel, void* context);
+typedef void* (*envoy_on_trailers_f)(envoy_headers trailers, envoy_stream_intel stream_intel,
+                                     void* context);
 
 /**
  * Callback signature for errors with an HTTP stream.
@@ -298,7 +302,8 @@ typedef void* (*envoy_on_trailers_f)(envoy_headers trailers, envoy_stream_intel 
  * execution.
  * @return void*, return context (may be unused).
  */
-typedef void* (*envoy_on_error_f)(envoy_error error, envoy_stream_intel stream_intel, void* context);
+typedef void* (*envoy_on_error_f)(envoy_error error, envoy_stream_intel stream_intel,
+                                  void* context);
 
 /**
  * Callback signature for when an HTTP stream bi-directionally completes without error.

--- a/library/common/types/c_types.h
+++ b/library/common/types/c_types.h
@@ -140,6 +140,20 @@ typedef struct {
   int32_t attempt_count;
 } envoy_error;
 
+/**
+ * Contains internal HTTP stream metrics, context, and other details.
+ *
+ * Note these values may change over the lifecycle of a stream.
+ */
+typedef struct {
+  // An internal identifier for the stream.
+  uint64_t stream_id;
+  // An internal identifier for the connection carrying the stream.
+  uint64_t connection_id;
+  // The number of internal attempts to carry out a request/operation.
+  uint64_t attempt_count;
+} envoy_stream_intel;
+
 #ifdef __cplusplus
 extern "C" { // utility functions
 #endif
@@ -226,11 +240,12 @@ extern "C" { // function pointers
  *
  * @param headers, the headers received.
  * @param end_stream, whether the response is headers-only.
+ * @param stream_intel, contains internal stream metrics, context, and other details.
  * @param context, contains the necessary state to carry out platform-specific dispatch and
  * execution.
  * @return void*, return context (may be unused).
  */
-typedef void* (*envoy_on_headers_f)(envoy_headers headers, bool end_stream, void* context);
+typedef void* (*envoy_on_headers_f)(envoy_headers headers, bool end_stream, envoy_stream_intel stream_intel, void* context);
 
 /**
  * Callback signature for data on an HTTP stream.
@@ -239,11 +254,12 @@ typedef void* (*envoy_on_headers_f)(envoy_headers headers, bool end_stream, void
  *
  * @param data, the data received.
  * @param end_stream, whether the data is the last data frame.
+ * @param stream_intel, contains internal stream metrics, context, and other details.
  * @param context, contains the necessary state to carry out platform-specific dispatch and
  * execution.
  * @return void*, return context (may be unused).
  */
-typedef void* (*envoy_on_data_f)(envoy_data data, bool end_stream, void* context);
+typedef void* (*envoy_on_data_f)(envoy_data data, bool end_stream, envoy_stream_intel stream_intel, void* context);
 
 /**
  * Callback signature for metadata on an HTTP stream.
@@ -251,11 +267,12 @@ typedef void* (*envoy_on_data_f)(envoy_data data, bool end_stream, void* context
  * Note that metadata frames are prohibited from ending a stream.
  *
  * @param metadata, the metadata received.
+ * @param stream_intel, contains internal stream metrics, context, and other details.
  * @param context, contains the necessary state to carry out platform-specific dispatch and
  * execution.
  * @return void*, return context (may be unused).
  */
-typedef void* (*envoy_on_metadata_f)(envoy_headers metadata, void* context);
+typedef void* (*envoy_on_metadata_f)(envoy_headers metadata, envoy_stream_intel stream_intel, void* context);
 
 /**
  * Callback signature for trailers on an HTTP stream.
@@ -263,11 +280,12 @@ typedef void* (*envoy_on_metadata_f)(envoy_headers metadata, void* context);
  * Note that end stream is implied when on_trailers is called.
  *
  * @param trailers, the trailers received.
+ * @param stream_intel, contains internal stream metrics, context, and other details.
  * @param context, contains the necessary state to carry out platform-specific dispatch and
  * execution.
  * @return void*, return context (may be unused).
  */
-typedef void* (*envoy_on_trailers_f)(envoy_headers trailers, void* context);
+typedef void* (*envoy_on_trailers_f)(envoy_headers trailers, envoy_stream_intel stream_intel, void* context);
 
 /**
  * Callback signature for errors with an HTTP stream.
@@ -275,33 +293,36 @@ typedef void* (*envoy_on_trailers_f)(envoy_headers trailers, void* context);
  * This is a TERMINAL callback. Exactly one terminal callback will be called per stream.
  *
  * @param envoy_error, the error received/caused by the async HTTP stream.
+ * @param stream_intel, contains internal stream metrics, context, and other details.
  * @param context, contains the necessary state to carry out platform-specific dispatch and
  * execution.
  * @return void*, return context (may be unused).
  */
-typedef void* (*envoy_on_error_f)(envoy_error error, void* context);
+typedef void* (*envoy_on_error_f)(envoy_error error, envoy_stream_intel stream_intel, void* context);
 
 /**
  * Callback signature for when an HTTP stream bi-directionally completes without error.
  *
  * This is a TERMINAL callback. Exactly one terminal callback will be called per stream.
  *
+ * @param stream_intel, contains internal stream metrics, context, and other details.
  * @param context, contains the necessary state to carry out platform-specific dispatch and
  * execution.
  * @return void*, return context (may be unused).
  */
-typedef void* (*envoy_on_complete_f)(void* context);
+typedef void* (*envoy_on_complete_f)(envoy_stream_intel stream_intel, void* context);
 
 /**
  * Callback signature for when an HTTP stream is cancelled.
  *
  * This is a TERMINAL callback. Exactly one terminal callback will be called per stream.
  *
+ * @param stream_intel, contains internal stream metrics, context, and other details.
  * @param context, contains the necessary state to carry out platform-specific dispatch and
  * execution.
  * @return void*, return context (may be unused).
  */
-typedef void* (*envoy_on_cancel_f)(void* context);
+typedef void* (*envoy_on_cancel_f)(envoy_stream_intel stream_intel, void* context);
 
 /**
  * Called when the envoy engine is exiting.

--- a/library/java/io/envoyproxy/envoymobile/engine/BUILD
+++ b/library/java/io/envoyproxy/envoymobile/engine/BUILD
@@ -31,6 +31,7 @@ java_library(
         "EnvoyNativeResourceRegistry.java",
         "EnvoyNativeResourceReleaser.java",
         "EnvoyNativeResourceWrapper.java",
+        "EnvoyStreamIntelImpl.java",
         "JniBridgeUtility.java",
         "JniLibrary.java",
         "JvmBridgeUtility.java",

--- a/library/java/io/envoyproxy/envoymobile/engine/EnvoyStreamIntelImpl.java
+++ b/library/java/io/envoyproxy/envoymobile/engine/EnvoyStreamIntelImpl.java
@@ -1,0 +1,24 @@
+package io.envoyproxy.envoymobile.engine;
+
+import io.envoyproxy.envoymobile.engine.types.EnvoyStreamIntel;
+
+class EnvoyStreamIntelImpl implements EnvoyStreamIntel {
+  private long streamId;
+  private long connectionId;
+  private long attemptCount;
+
+  EnvoyStreamIntelImpl(long[] values) {
+    streamId = values[0];
+    connectionId = values[1];
+    attemptCount = values[2];
+  }
+
+  @Override
+  public long getStreamId() { return streamId; }
+
+  @Override
+  public long getConnectionId() { return connectionId; }
+
+  @Override
+  public long getAttemptCount() { return attemptCount; }
+}

--- a/library/java/io/envoyproxy/envoymobile/engine/EnvoyStreamIntelImpl.java
+++ b/library/java/io/envoyproxy/envoymobile/engine/EnvoyStreamIntelImpl.java
@@ -14,11 +14,17 @@ class EnvoyStreamIntelImpl implements EnvoyStreamIntel {
   }
 
   @Override
-  public long getStreamId() { return streamId; }
+  public long getStreamId() {
+    return streamId;
+  }
 
   @Override
-  public long getConnectionId() { return connectionId; }
+  public long getConnectionId() {
+    return connectionId;
+  }
 
   @Override
-  public long getAttemptCount() { return attemptCount; }
+  public long getAttemptCount() {
+    return attemptCount;
+  }
 }

--- a/library/java/io/envoyproxy/envoymobile/engine/JvmCallbackContext.java
+++ b/library/java/io/envoyproxy/envoymobile/engine/JvmCallbackContext.java
@@ -34,6 +34,7 @@ class JvmCallbackContext {
    *
    * @param headerCount, the total number of headers included in this header block.
    * @param endStream,   whether this header block is the final remote frame.
+   * @param streamIntel, internal HTTP stream metrics, context, and other details.
    * @return Object,     not used for response callbacks.
    */
   public Object onResponseHeaders(long headerCount, boolean endStream, long[] streamIntel) {
@@ -53,6 +54,7 @@ class JvmCallbackContext {
    * Invokes onTrailers callback using trailers passed via passHeaders.
    *
    * @param trailerCount, the total number of trailers included in this header block.
+   * @param streamIntel,  internal HTTP stream metrics, context, and other details.
    * @return Object,      not used for response callbacks.
    */
   public Object onResponseTrailers(long trailerCount, long[] streamIntel) {
@@ -69,9 +71,10 @@ class JvmCallbackContext {
   /**
    * Dispatches data received from the JNI layer up to the platform.
    *
-   * @param data,      chunk of body data from the HTTP response.
-   * @param endStream, indicates this is the last remote frame of the stream.
-   * @return Object,   not used for response callbacks.
+   * @param data,        chunk of body data from the HTTP response.
+   * @param endStream,   indicates this is the last remote frame of the stream.
+   * @param streamIntel, internal HTTP stream metrics, context, and other details.
+   * @return Object,     not used for response callbacks.
    */
   public Object onResponseData(byte[] data, boolean endStream, long[] streamIntel) {
     callbacks.getExecutor().execute(new Runnable() {
@@ -90,6 +93,7 @@ class JvmCallbackContext {
    * @param errorCode,    the error code.
    * @param message,      the error message.
    * @param attemptCount, the number of times an operation was attempted before firing this error.
+   * @param streamIntel,  internal HTTP stream metrics, context, and other details.
    * @return Object,      not used for response callbacks.
    */
   public Object onError(int errorCode, byte[] message, int attemptCount, long[] streamIntel) {
@@ -107,6 +111,7 @@ class JvmCallbackContext {
   /**
    * Dispatches cancellation notice up to the platform
    *
+   * @param streamIntel, internal HTTP stream metrics, context, and other details.
    * @return Object, not used for response callbacks.
    */
   public Object onCancel(long[] streamIntel) {

--- a/library/java/io/envoyproxy/envoymobile/engine/JvmCallbackContext.java
+++ b/library/java/io/envoyproxy/envoymobile/engine/JvmCallbackContext.java
@@ -41,7 +41,9 @@ class JvmCallbackContext {
     final Map headers = bridgeUtility.retrieveHeaders();
 
     callbacks.getExecutor().execute(new Runnable() {
-      public void run() { callbacks.onHeaders(headers, endStream, new EnvoyStreamIntelImpl(streamIntel)); }
+      public void run() {
+        callbacks.onHeaders(headers, endStream, new EnvoyStreamIntelImpl(streamIntel));
+      }
     });
 
     return null;
@@ -94,7 +96,8 @@ class JvmCallbackContext {
     callbacks.getExecutor().execute(new Runnable() {
       public void run() {
         String errorMessage = new String(message);
-        callbacks.onError(errorCode, errorMessage, attemptCount, new EnvoyStreamIntelImpl(streamIntel));
+        callbacks.onError(errorCode, errorMessage, attemptCount,
+                          new EnvoyStreamIntelImpl(streamIntel));
       }
     });
 

--- a/library/java/io/envoyproxy/envoymobile/engine/JvmFilterContext.java
+++ b/library/java/io/envoyproxy/envoymobile/engine/JvmFilterContext.java
@@ -49,7 +49,7 @@ class JvmFilterContext {
    * @param endStream,   whether this header block is the final remote frame.
    * @return Object[],   pair of HTTP filter status and optional modified headers.
    */
-  public Object onRequestHeaders(long headerCount, boolean endStream) {
+  public Object onRequestHeaders(long headerCount, boolean endStream, long[] ignored) {
     assert headerUtility.validateCount(headerCount);
     final Map headers = headerUtility.retrieveHeaders();
     return toJniFilterHeadersStatus(filter.onRequestHeaders(headers, endStream));
@@ -62,7 +62,7 @@ class JvmFilterContext {
    * @param endStream, indicates this is the last remote frame of the stream.
    * @return Object[], pair of HTTP filter status and optional modified data.
    */
-  public Object onRequestData(byte[] data, boolean endStream) {
+  public Object onRequestData(byte[] data, boolean endStream, long[] ignored) {
     ByteBuffer dataBuffer = ByteBuffer.wrap(data);
     return toJniFilterDataStatus(filter.onRequestData(dataBuffer, endStream));
   }
@@ -73,7 +73,7 @@ class JvmFilterContext {
    * @param trailerCount, the total number of trailers included in this header block.
    * @return Object[],    pair of HTTP filter status and optional modified trailers.
    */
-  public Object onRequestTrailers(long trailerCount) {
+  public Object onRequestTrailers(long trailerCount, long[] ignored) {
     assert headerUtility.validateCount(trailerCount);
     final Map trailers = headerUtility.retrieveHeaders();
     return toJniFilterTrailersStatus(filter.onRequestTrailers(trailers));
@@ -86,7 +86,7 @@ class JvmFilterContext {
    * @param endStream,   whether this header block is the final remote frame.
    * @return Object[],   pair of HTTP filter status and optional modified headers.
    */
-  public Object onResponseHeaders(long headerCount, boolean endStream) {
+  public Object onResponseHeaders(long headerCount, boolean endStream, long[] ignored) {
     assert headerUtility.validateCount(headerCount);
     final Map headers = headerUtility.retrieveHeaders();
     return toJniFilterHeadersStatus(filter.onResponseHeaders(headers, endStream));
@@ -99,7 +99,7 @@ class JvmFilterContext {
    * @param endStream, indicates this is the last remote frame of the stream.
    * @return Object[], pair of HTTP filter status and optional modified data.
    */
-  public Object onResponseData(byte[] data, boolean endStream) {
+  public Object onResponseData(byte[] data, boolean endStream, long[] ignored) {
     ByteBuffer dataBuffer = ByteBuffer.wrap(data);
     return toJniFilterDataStatus(filter.onResponseData(dataBuffer, endStream));
   }
@@ -110,7 +110,7 @@ class JvmFilterContext {
    * @param trailerCount, the total number of trailers included in this header block.
    * @return Object[],    pair of HTTP filter status and optional modified trailers.
    */
-  public Object onResponseTrailers(long trailerCount) {
+  public Object onResponseTrailers(long trailerCount, long[] ignored) {
     assert headerUtility.validateCount(trailerCount);
     final Map trailers = headerUtility.retrieveHeaders();
     return toJniFilterTrailersStatus(filter.onResponseTrailers(trailers));
@@ -198,7 +198,7 @@ class JvmFilterContext {
    * @param attemptCount, the number of times an operation was attempted before firing this error.
    * @return Object,      not used in HTTP filters.
    */
-  public Object onError(int errorCode, byte[] message, int attemptCount) {
+  public Object onError(int errorCode, byte[] message, int attemptCount, long[] ignored) {
     String errorMessage = new String(message);
     filter.onError(errorCode, errorMessage, attemptCount);
     return null;
@@ -209,7 +209,7 @@ class JvmFilterContext {
    *
    * @return Object, not used in HTTP filters.
    */
-  public Object onCancel() {
+  public Object onCancel(long[] ignored) {
     filter.onCancel();
     return null;
   }

--- a/library/java/io/envoyproxy/envoymobile/engine/JvmFilterContext.java
+++ b/library/java/io/envoyproxy/envoymobile/engine/JvmFilterContext.java
@@ -47,6 +47,7 @@ class JvmFilterContext {
    *
    * @param headerCount, the total number of headers included in this header block.
    * @param endStream,   whether this header block is the final remote frame.
+   * @param ignored,     StreamIntel not yet supported by filter callbacks.
    * @return Object[],   pair of HTTP filter status and optional modified headers.
    */
   public Object onRequestHeaders(long headerCount, boolean endStream, long[] ignored) {
@@ -60,6 +61,7 @@ class JvmFilterContext {
    *
    * @param data,      chunk of body data from the HTTP request.
    * @param endStream, indicates this is the last remote frame of the stream.
+   * @param ignored,   StreamIntel not yet supported by filter callbacks.
    * @return Object[], pair of HTTP filter status and optional modified data.
    */
   public Object onRequestData(byte[] data, boolean endStream, long[] ignored) {
@@ -71,6 +73,7 @@ class JvmFilterContext {
    * Invokes onTrailers callback using trailers passed via passHeaders.
    *
    * @param trailerCount, the total number of trailers included in this header block.
+   * @param ignored,      StreamIntel not yet supported by filter callbacks.
    * @return Object[],    pair of HTTP filter status and optional modified trailers.
    */
   public Object onRequestTrailers(long trailerCount, long[] ignored) {
@@ -84,6 +87,7 @@ class JvmFilterContext {
    *
    * @param headerCount, the total number of headers included in this header block.
    * @param endStream,   whether this header block is the final remote frame.
+   * @param ignored,     StreamIntel not yet supported by filter callbacks.
    * @return Object[],   pair of HTTP filter status and optional modified headers.
    */
   public Object onResponseHeaders(long headerCount, boolean endStream, long[] ignored) {
@@ -97,6 +101,7 @@ class JvmFilterContext {
    *
    * @param data,      chunk of body data from the HTTP response.
    * @param endStream, indicates this is the last remote frame of the stream.
+   * @param ignored,   StreamIntel not yet supported by filter callbacks.
    * @return Object[], pair of HTTP filter status and optional modified data.
    */
   public Object onResponseData(byte[] data, boolean endStream, long[] ignored) {
@@ -108,6 +113,7 @@ class JvmFilterContext {
    * Invokes onTrailers callback using trailers passed via passHeaders.
    *
    * @param trailerCount, the total number of trailers included in this header block.
+   * @param ignored,      StreamIntel not yet supported by filter callbacks.
    * @return Object[],    pair of HTTP filter status and optional modified trailers.
    */
   public Object onResponseTrailers(long trailerCount, long[] ignored) {
@@ -196,6 +202,7 @@ class JvmFilterContext {
    * @param errorCode,    the error code.
    * @param message,      the error message.
    * @param attemptCount, the number of times an operation was attempted before firing this error.
+   * @param ignored,      StreamIntel not yet supported by filter callbacks.
    * @return Object,      not used in HTTP filters.
    */
   public Object onError(int errorCode, byte[] message, int attemptCount, long[] ignored) {
@@ -207,6 +214,7 @@ class JvmFilterContext {
   /**
    * Dispatches cancellation notice up to the platform.
    *
+   * @param ignored  StreamIntel not yet supported by filter callbacks.
    * @return Object, not used in HTTP filters.
    */
   public Object onCancel(long[] ignored) {

--- a/library/java/io/envoyproxy/envoymobile/engine/types/BUILD
+++ b/library/java/io/envoyproxy/envoymobile/engine/types/BUILD
@@ -12,6 +12,7 @@ java_library(
         "EnvoyLogger.java",
         "EnvoyOnEngineRunning.java",
         "EnvoyStatus.java",
+        "EnvoyStreamIntel.java",
         "EnvoyStringAccessor.java",
     ],
     visibility = ["//visibility:public"],

--- a/library/java/io/envoyproxy/envoymobile/engine/types/EnvoyHTTPCallbacks.java
+++ b/library/java/io/envoyproxy/envoymobile/engine/types/EnvoyHTTPCallbacks.java
@@ -12,27 +12,30 @@ public interface EnvoyHTTPCallbacks {
   /**
    * Called when all headers get received on the async HTTP stream.
    *
-   * @param headers,   the headers received.
-   * @param endStream, whether the response is headers-only.
+   * @param headers,     the headers received.
+   * @param endStream,   whether the response is headers-only.
+   * @param streamIntel, contains internal HTTP stream metrics, context, and other details.
    */
-  void onHeaders(Map<String, List<String>> headers, boolean endStream);
+  void onHeaders(Map<String, List<String>> headers, boolean endStream, EnvoyStreamIntel streamIntel);
 
   /**
    * Called when a data frame gets received on the async HTTP stream. This
    * callback can be invoked multiple times if the data gets streamed.
    *
-   * @param data,      the buffer of the data received.
-   * @param endStream, whether the data is the last data frame.
+   * @param data,        the buffer of the data received.
+   * @param endStream,   whether the data is the last data frame.
+   * @param streamIntel, contains internal HTTP stream metrics, context, and other details.
    */
-  void onData(ByteBuffer data, boolean endStream);
+  void onData(ByteBuffer data, boolean endStream, EnvoyStreamIntel streamIntel);
 
   /**
    * Called when all trailers get received on the async HTTP stream. Note that end
    * stream is implied when on_trailers is called.
    *
-   * @param trailers, the trailers received.
+   * @param trailers,    the trailers received.
+   * @param streamIntel, contains internal HTTP stream metrics, context, and other details.
    */
-  void onTrailers(Map<String, List<String>> trailers);
+  void onTrailers(Map<String, List<String>> trailers, EnvoyStreamIntel streamIntel);
 
   /**
    * Called when the async HTTP stream has an error.
@@ -43,11 +46,12 @@ public interface EnvoyHTTPCallbacks {
    *                      -1 is used in scenarios where it does not make sense to have an attempt
    *                      count for an error. This is different from 0, which intentionally conveys
    *                      that the action was _not_ executed.
+   * @param streamIntel,  contains internal HTTP stream metrics, context, and other details.
    */
-  void onError(int errorCode, String message, int attemptCount);
+  void onError(int errorCode, String message, int attemptCount, EnvoyStreamIntel streamIntel);
 
   /**
    * Called when the async HTTP stream is canceled.
    */
-  void onCancel();
+  void onCancel(EnvoyStreamIntel streamIntel);
 }

--- a/library/java/io/envoyproxy/envoymobile/engine/types/EnvoyHTTPCallbacks.java
+++ b/library/java/io/envoyproxy/envoymobile/engine/types/EnvoyHTTPCallbacks.java
@@ -16,7 +16,8 @@ public interface EnvoyHTTPCallbacks {
    * @param endStream,   whether the response is headers-only.
    * @param streamIntel, contains internal HTTP stream metrics, context, and other details.
    */
-  void onHeaders(Map<String, List<String>> headers, boolean endStream, EnvoyStreamIntel streamIntel);
+  void onHeaders(Map<String, List<String>> headers, boolean endStream,
+                 EnvoyStreamIntel streamIntel);
 
   /**
    * Called when a data frame gets received on the async HTTP stream. This

--- a/library/java/io/envoyproxy/envoymobile/engine/types/EnvoyStreamIntel.java
+++ b/library/java/io/envoyproxy/envoymobile/engine/types/EnvoyStreamIntel.java
@@ -1,0 +1,21 @@
+package io.envoyproxy.envoymobile.engine.types;
+
+/**
+ * Exposes internal HTTP stream metrics, context, and other details.
+ */
+public interface EnvoyStreamIntel {
+  /**
+   * An internal identifier for the stream.
+   */
+  public long getStreamId();
+
+  /**
+   * An internal identifier for the connection carrying the stream.
+   */
+  public long getConnectionId();
+
+  /**
+   * The number of internal attempts to carry out a request/operation.
+   */
+  public long getAttemptCount();
+}

--- a/library/java/org/chromium/net/impl/CronetUrlRequest.java
+++ b/library/java/org/chromium/net/impl/CronetUrlRequest.java
@@ -500,11 +500,11 @@ public final class CronetUrlRequest extends UrlRequestBase {
       mStream = mCronvoyEngine.getEnvoyEngine()
                     .streamClient()
                     .newStreamPrototype()
-                    .setOnResponseHeaders((responseHeaders, lastCallback) -> {
+                    .setOnResponseHeaders((responseHeaders, lastCallback, ignored) -> {
                       onResponseHeaders(responseHeaders, lastCallback);
                       return null;
                     })
-                    .setOnResponseData((data, lastCallback) -> {
+                    .setOnResponseData((data, lastCallback, ignored) -> {
                       mEnvoyCallbackExecutor.pause();
                       mEndStream = lastCallback;
                       if (!mMostRecentBufferRead.compareAndSet(null, data)) {
@@ -513,7 +513,7 @@ public final class CronetUrlRequest extends UrlRequestBase {
                       processReadResult();
                       return null;
                     })
-                    .setOnError(error -> {
+                    .setOnError((error, ignored) -> {
                       String message = "failed with error after " + error.getAttemptCount() +
                                        " attempts. Message=[" + error.getMessage() + "] Code=[" +
                                        error.getErrorCode() + "]";
@@ -521,7 +521,7 @@ public final class CronetUrlRequest extends UrlRequestBase {
                       mCronvoyExecutor.execute(() -> enterCronetErrorState(throwable));
                       return null;
                     })
-                    .setOnCancel(() -> {
+                    .setOnCancel((ignored) -> {
                       mCancelCalled.set(true);
                       cancel();
                       return null;

--- a/library/kotlin/io/envoyproxy/envoymobile/StreamCallbacks.kt
+++ b/library/kotlin/io/envoyproxy/envoymobile/StreamCallbacks.kt
@@ -14,7 +14,9 @@ typealias StreamIntel = EnvoyStreamIntel
  * `StreamCallbacks` are bridged through to `EnvoyHTTPCallbacks` to communicate with the engine.
  */
 internal class StreamCallbacks {
-  var onHeaders: ((headers: ResponseHeaders, endStream: Boolean, streamIntel: StreamIntel) -> Unit)? = null
+  var onHeaders: (
+    (headers: ResponseHeaders, endStream: Boolean, streamIntel: StreamIntel) -> Unit
+  )? = null
   var onData: ((data: ByteBuffer, endStream: Boolean, streamIntel: StreamIntel) -> Unit)? = null
   var onTrailers: ((trailers: ResponseTrailers, streamIntel: StreamIntel) -> Unit)? = null
   var onCancel: ((streamIntel: StreamIntel) -> Unit)? = null
@@ -33,7 +35,11 @@ internal class EnvoyHTTPCallbacksAdapter(
     return executor
   }
 
-  override fun onHeaders(headers: Map<String, List<String>>, endStream: Boolean, streamIntel: StreamIntel) {
+  override fun onHeaders(
+    headers: Map<String, List<String>>,
+    endStream: Boolean,
+    streamIntel: StreamIntel
+  ) {
     callbacks.onHeaders?.invoke(ResponseHeaders(headers), endStream, streamIntel)
   }
 
@@ -45,7 +51,12 @@ internal class EnvoyHTTPCallbacksAdapter(
     callbacks.onTrailers?.invoke(ResponseTrailers((trailers)), streamIntel)
   }
 
-  override fun onError(errorCode: Int, message: String, attemptCount: Int, streamIntel: StreamIntel) {
+  override fun onError(
+    errorCode: Int,
+    message: String,
+    attemptCount: Int,
+    streamIntel: StreamIntel
+  ) {
     callbacks.onError?.invoke(EnvoyError(errorCode, message, attemptCount), streamIntel)
   }
 

--- a/library/kotlin/io/envoyproxy/envoymobile/StreamCallbacks.kt
+++ b/library/kotlin/io/envoyproxy/envoymobile/StreamCallbacks.kt
@@ -1,8 +1,11 @@
 package io.envoyproxy.envoymobile
 
 import io.envoyproxy.envoymobile.engine.types.EnvoyHTTPCallbacks
+import io.envoyproxy.envoymobile.engine.types.EnvoyStreamIntel
 import java.nio.ByteBuffer
 import java.util.concurrent.Executor
+
+typealias StreamIntel = EnvoyStreamIntel
 
 /**
  * A collection of platform-level callbacks that are specified by consumers
@@ -11,11 +14,11 @@ import java.util.concurrent.Executor
  * `StreamCallbacks` are bridged through to `EnvoyHTTPCallbacks` to communicate with the engine.
  */
 internal class StreamCallbacks {
-  var onHeaders: ((headers: ResponseHeaders, endStream: Boolean) -> Unit)? = null
-  var onData: ((data: ByteBuffer, endStream: Boolean) -> Unit)? = null
-  var onTrailers: ((trailers: ResponseTrailers) -> Unit)? = null
-  var onCancel: (() -> Unit)? = null
-  var onError: ((error: EnvoyError) -> Unit)? = null
+  var onHeaders: ((headers: ResponseHeaders, endStream: Boolean, streamIntel: StreamIntel) -> Unit)? = null
+  var onData: ((data: ByteBuffer, endStream: Boolean, streamIntel: StreamIntel) -> Unit)? = null
+  var onTrailers: ((trailers: ResponseTrailers, streamIntel: StreamIntel) -> Unit)? = null
+  var onCancel: ((streamIntel: StreamIntel) -> Unit)? = null
+  var onError: ((error: EnvoyError, streamIntel: StreamIntel) -> Unit)? = null
 }
 
 /**
@@ -30,23 +33,23 @@ internal class EnvoyHTTPCallbacksAdapter(
     return executor
   }
 
-  override fun onHeaders(headers: Map<String, List<String>>, endStream: Boolean) {
-    callbacks.onHeaders?.invoke(ResponseHeaders(headers), endStream)
+  override fun onHeaders(headers: Map<String, List<String>>, endStream: Boolean, streamIntel: StreamIntel) {
+    callbacks.onHeaders?.invoke(ResponseHeaders(headers), endStream, streamIntel)
   }
 
-  override fun onData(byteBuffer: ByteBuffer, endStream: Boolean) {
-    callbacks.onData?.invoke(byteBuffer, endStream)
+  override fun onData(byteBuffer: ByteBuffer, endStream: Boolean, streamIntel: StreamIntel) {
+    callbacks.onData?.invoke(byteBuffer, endStream, streamIntel)
   }
 
-  override fun onTrailers(trailers: Map<String, List<String>>) {
-    callbacks.onTrailers?.invoke(ResponseTrailers((trailers)))
+  override fun onTrailers(trailers: Map<String, List<String>>, streamIntel: StreamIntel) {
+    callbacks.onTrailers?.invoke(ResponseTrailers((trailers)), streamIntel)
   }
 
-  override fun onError(errorCode: Int, message: String, attemptCount: Int) {
-    callbacks.onError?.invoke(EnvoyError(errorCode, message, attemptCount))
+  override fun onError(errorCode: Int, message: String, attemptCount: Int, streamIntel: StreamIntel) {
+    callbacks.onError?.invoke(EnvoyError(errorCode, message, attemptCount), streamIntel)
   }
 
-  override fun onCancel() {
-    callbacks.onCancel?.invoke()
+  override fun onCancel(streamIntel: StreamIntel) {
+    callbacks.onCancel?.invoke(streamIntel)
   }
 }

--- a/library/kotlin/io/envoyproxy/envoymobile/StreamPrototype.kt
+++ b/library/kotlin/io/envoyproxy/envoymobile/StreamPrototype.kt
@@ -52,7 +52,7 @@ open class StreamPrototype(private val engine: EnvoyEngine) {
    * @return This stream, for chaining syntax.
    */
   fun setOnResponseHeaders(
-    closure: (headers: ResponseHeaders, endStream: Boolean) -> Unit
+    closure: (headers: ResponseHeaders, endStream: Boolean, streamIntel: StreamIntel) -> Unit
   ): StreamPrototype {
     callbacks.onHeaders = closure
     return this
@@ -67,7 +67,7 @@ open class StreamPrototype(private val engine: EnvoyEngine) {
    * @return This stream, for chaining syntax.
    */
   fun setOnResponseData(
-    closure: (data: ByteBuffer, endStream: Boolean) -> Unit
+    closure: (data: ByteBuffer, endStream: Boolean, streamIntel: StreamIntel) -> Unit
   ): StreamPrototype {
     callbacks.onData = closure
     return this
@@ -81,7 +81,7 @@ open class StreamPrototype(private val engine: EnvoyEngine) {
    * @return This stream, for chaining syntax.
    */
   fun setOnResponseTrailers(
-    closure: (trailers: ResponseTrailers) -> Unit
+    closure: (trailers: ResponseTrailers, streamIntel: StreamIntel) -> Unit
   ): StreamPrototype {
     callbacks.onTrailers = closure
     return this
@@ -95,7 +95,7 @@ open class StreamPrototype(private val engine: EnvoyEngine) {
    * @return This stream, for chaining syntax.
    */
   fun setOnError(
-    closure: (error: EnvoyError) -> Unit
+    closure: (error: EnvoyError, streamIntel: StreamIntel) -> Unit
   ): StreamPrototype {
     callbacks.onError = closure
     return this
@@ -109,7 +109,7 @@ open class StreamPrototype(private val engine: EnvoyEngine) {
    * @return This stream, for chaining syntax.
    */
   fun setOnCancel(
-    closure: () -> Unit
+    closure: (streamIntel: StreamIntel) -> Unit
   ): StreamPrototype {
     callbacks.onCancel = closure
     return this

--- a/library/kotlin/io/envoyproxy/envoymobile/mocks/MockStream.kt
+++ b/library/kotlin/io/envoyproxy/envoymobile/mocks/MockStream.kt
@@ -9,6 +9,12 @@ import java.nio.ByteBuffer
 class MockStream internal constructor(underlyingStream: MockEnvoyHTTPStream) : Stream(underlyingStream) {
   private val mockStream: MockEnvoyHTTPStream = underlyingStream
 
+  private val mockStreamIntel = object : StreamIntel {
+    override fun getStreamId(): Long { return 0 }
+    override fun getConnectionId(): Long { return 0 }
+    override fun getAttemptCount(): Long { return 0 }
+  }
+
   /**
    * Closure that will be called when request headers are sent.
    */
@@ -55,7 +61,7 @@ class MockStream internal constructor(underlyingStream: MockEnvoyHTTPStream) : S
    * @param endStream Whether this is a headers-only response.
    */
   fun receiveHeaders(headers: ResponseHeaders, endStream: Boolean) {
-    mockStream.callbacks.onHeaders(headers.allHeaders(), endStream)
+    mockStream.callbacks.onHeaders(headers.allHeaders(), endStream, mockStreamIntel)
   }
 
   /**
@@ -65,7 +71,7 @@ class MockStream internal constructor(underlyingStream: MockEnvoyHTTPStream) : S
    * @param endStream Whether this is the last data frame.
    */
   fun receiveData(data: ByteBuffer, endStream: Boolean) {
-    mockStream.callbacks.onData(data, endStream)
+    mockStream.callbacks.onData(data, endStream, mockStreamIntel)
   }
 
   /**
@@ -74,14 +80,14 @@ class MockStream internal constructor(underlyingStream: MockEnvoyHTTPStream) : S
    * @param trailers Response trailers to receive.
    */
   fun receiveTrailers(trailers: ResponseTrailers) {
-    mockStream.callbacks.onTrailers(trailers.allHeaders())
+    mockStream.callbacks.onTrailers(trailers.allHeaders(), mockStreamIntel)
   }
 
   /**
    * Simulate the stream receiving a cancellation signal from Envoy.
    */
   fun receiveCancel() {
-    mockStream.callbacks.onCancel()
+    mockStream.callbacks.onCancel(mockStreamIntel)
   }
 
   /**
@@ -90,6 +96,6 @@ class MockStream internal constructor(underlyingStream: MockEnvoyHTTPStream) : S
    * @param error The error to receive.
    */
   fun receiveError(error: EnvoyError) {
-    mockStream.callbacks.onError(error.errorCode, error.message, error.attemptCount ?: 0)
+    mockStream.callbacks.onError(error.errorCode, error.message, error.attemptCount ?: 0, mockStreamIntel)
   }
 }

--- a/library/objective-c/EnvoyEngine.h
+++ b/library/objective-c/EnvoyEngine.h
@@ -49,8 +49,8 @@ typedef envoy_stream_intel EnvoyStreamIntel;
  * Note that end stream is implied when on_trailers is called.
  * @param trailers the trailers received.
  */
-@property (nonatomic, copy) void (^onTrailers)(EnvoyHeaders *trailers, EnvoyStreamIntel streamIntel)
-    ;
+@property (nonatomic, copy) void (^onTrailers)
+    (EnvoyHeaders *trailers, EnvoyStreamIntel streamIntel);
 
 /**
  * Called when the async HTTP stream has an error.
@@ -156,9 +156,9 @@ extern const int kEnvoyFilterResumeStatusResumeIteration;
 /// 1 - EnvoyHeaders *, optional pending headers
 /// 2 - NSData *, optional pending data
 /// 3 - EnvoyHeaders *, optional pending trailers
-@property (nonatomic, copy)
-    NSArray * (^onResumeRequest)(EnvoyHeaders *_Nullable headers, NSData *_Nullable data,
-                                 EnvoyHeaders *_Nullable trailers, BOOL endStream);
+@property (nonatomic, copy) NSArray * (^onResumeRequest)
+    (EnvoyHeaders *_Nullable headers, NSData *_Nullable data, EnvoyHeaders *_Nullable trailers,
+     BOOL endStream);
 
 @property (nonatomic, copy) void (^setResponseFilterCallbacks)
     (id<EnvoyHTTPFilterCallbacks> callbacks);
@@ -168,9 +168,9 @@ extern const int kEnvoyFilterResumeStatusResumeIteration;
 /// 1 - EnvoyHeaders *, optional pending headers
 /// 2 - NSData *, optional pending data
 /// 3 - EnvoyHeaders *, optional pending trailers
-@property (nonatomic, copy)
-    NSArray * (^onResumeResponse)(EnvoyHeaders *_Nullable headers, NSData *_Nullable data,
-                                  EnvoyHeaders *_Nullable trailers, BOOL endStream);
+@property (nonatomic, copy) NSArray * (^onResumeResponse)
+    (EnvoyHeaders *_Nullable headers, NSData *_Nullable data,  EnvoyHeaders *_Nullable trailers,
+     BOOL endStream);
 
 @end
 

--- a/library/objective-c/EnvoyEngine.h
+++ b/library/objective-c/EnvoyEngine.h
@@ -32,7 +32,8 @@ typedef envoy_stream_intel EnvoyStreamIntel;
  * @param headers the headers received.
  * @param endStream whether the response is headers-only.
  */
-@property (nonatomic, copy) void (^onHeaders)(EnvoyHeaders *headers, BOOL endStream, EnvoyStreamIntel streamIntel);
+@property (nonatomic, copy) void (^onHeaders)
+    (EnvoyHeaders *headers, BOOL endStream, EnvoyStreamIntel streamIntel);
 
 /**
  * Called when a data frame gets received on the async HTTP stream.
@@ -40,14 +41,16 @@ typedef envoy_stream_intel EnvoyStreamIntel;
  * @param data the data received.
  * @param endStream whether the data is the last data frame.
  */
-@property (nonatomic, copy) void (^onData)(NSData *data, BOOL endStream, EnvoyStreamIntel streamIntel);
+@property (nonatomic, copy) void (^onData)
+    (NSData *data, BOOL endStream, EnvoyStreamIntel streamIntel);
 
 /**
  * Called when all trailers get received on the async HTTP stream.
  * Note that end stream is implied when on_trailers is called.
  * @param trailers the trailers received.
  */
-@property (nonatomic, copy) void (^onTrailers)(EnvoyHeaders *trailers, EnvoyStreamIntel streamIntel);
+@property (nonatomic, copy) void (^onTrailers)
+    (EnvoyHeaders *trailers, EnvoyStreamIntel streamIntel);
 
 /**
  * Called when the async HTTP stream has an error.

--- a/library/objective-c/EnvoyEngine.h
+++ b/library/objective-c/EnvoyEngine.h
@@ -14,6 +14,9 @@ typedef NSDictionary<NSString *, NSString *> EnvoyTags;
 /// A set of key-value pairs describing an event.
 typedef NSDictionary<NSString *, NSString *> EnvoyEvent;
 
+/// Contains internal HTTP stream metrics, context, and other details.
+typedef envoy_stream_intel EnvoyStreamIntel;
+
 #pragma mark - EnvoyHTTPCallbacks
 
 /// Interface that can handle callbacks from an HTTP stream.
@@ -29,7 +32,7 @@ typedef NSDictionary<NSString *, NSString *> EnvoyEvent;
  * @param headers the headers received.
  * @param endStream whether the response is headers-only.
  */
-@property (nonatomic, copy) void (^onHeaders)(EnvoyHeaders *headers, BOOL endStream);
+@property (nonatomic, copy) void (^onHeaders)(EnvoyHeaders *headers, BOOL endStream, EnvoyStreamIntel streamIntel);
 
 /**
  * Called when a data frame gets received on the async HTTP stream.
@@ -37,20 +40,20 @@ typedef NSDictionary<NSString *, NSString *> EnvoyEvent;
  * @param data the data received.
  * @param endStream whether the data is the last data frame.
  */
-@property (nonatomic, copy) void (^onData)(NSData *data, BOOL endStream);
+@property (nonatomic, copy) void (^onData)(NSData *data, BOOL endStream, EnvoyStreamIntel streamIntel);
 
 /**
  * Called when all trailers get received on the async HTTP stream.
  * Note that end stream is implied when on_trailers is called.
  * @param trailers the trailers received.
  */
-@property (nonatomic, copy) void (^onTrailers)(EnvoyHeaders *trailers);
+@property (nonatomic, copy) void (^onTrailers)(EnvoyHeaders *trailers, EnvoyStreamIntel streamIntel);
 
 /**
  * Called when the async HTTP stream has an error.
  */
 @property (nonatomic, copy) void (^onError)
-    (uint64_t errorCode, NSString *message, int32_t attemptCount);
+    (uint64_t errorCode, NSString *message, int32_t attemptCount, EnvoyStreamIntel streamIntel);
 
 /**
  * Called when the async HTTP stream is canceled.
@@ -58,7 +61,7 @@ typedef NSDictionary<NSString *, NSString *> EnvoyEvent;
  * response is already complete. It will fire no more than once, and no other callbacks for the
  * stream will be issued afterwards.
  */
-@property (nonatomic, copy) void (^onCancel)(void);
+@property (nonatomic, copy) void (^onCancel)(EnvoyStreamIntel streamIntel);
 
 @end
 

--- a/library/objective-c/EnvoyEngine.h
+++ b/library/objective-c/EnvoyEngine.h
@@ -49,8 +49,8 @@ typedef envoy_stream_intel EnvoyStreamIntel;
  * Note that end stream is implied when on_trailers is called.
  * @param trailers the trailers received.
  */
-@property (nonatomic, copy) void (^onTrailers)
-    (EnvoyHeaders *trailers, EnvoyStreamIntel streamIntel);
+@property (nonatomic, copy) void (^onTrailers)(EnvoyHeaders *trailers, EnvoyStreamIntel streamIntel)
+    ;
 
 /**
  * Called when the async HTTP stream has an error.
@@ -156,9 +156,9 @@ extern const int kEnvoyFilterResumeStatusResumeIteration;
 /// 1 - EnvoyHeaders *, optional pending headers
 /// 2 - NSData *, optional pending data
 /// 3 - EnvoyHeaders *, optional pending trailers
-@property (nonatomic, copy) NSArray * (^onResumeRequest)
-    (EnvoyHeaders *_Nullable headers, NSData *_Nullable data, EnvoyHeaders *_Nullable trailers,
-     BOOL endStream);
+@property (nonatomic, copy)
+    NSArray * (^onResumeRequest)(EnvoyHeaders *_Nullable headers, NSData *_Nullable data,
+                                 EnvoyHeaders *_Nullable trailers, BOOL endStream);
 
 @property (nonatomic, copy) void (^setResponseFilterCallbacks)
     (id<EnvoyHTTPFilterCallbacks> callbacks);
@@ -168,9 +168,9 @@ extern const int kEnvoyFilterResumeStatusResumeIteration;
 /// 1 - EnvoyHeaders *, optional pending headers
 /// 2 - NSData *, optional pending data
 /// 3 - EnvoyHeaders *, optional pending trailers
-@property (nonatomic, copy) NSArray * (^onResumeResponse)
-    (EnvoyHeaders *_Nullable headers, NSData *_Nullable data, EnvoyHeaders *_Nullable trailers,
-     BOOL endStream);
+@property (nonatomic, copy)
+    NSArray * (^onResumeResponse)(EnvoyHeaders *_Nullable headers, NSData *_Nullable data,
+                                  EnvoyHeaders *_Nullable trailers, BOOL endStream);
 
 @end
 

--- a/library/objective-c/EnvoyEngine.h
+++ b/library/objective-c/EnvoyEngine.h
@@ -44,6 +44,7 @@ typedef envoy_stream_intel EnvoyStreamIntel;
 @property (nonatomic, copy) void (^onData)
     (NSData *data, BOOL endStream, EnvoyStreamIntel streamIntel);
 
+// clang-format off
 /**
  * Called when all trailers get received on the async HTTP stream.
  * Note that end stream is implied when on_trailers is called.
@@ -51,6 +52,7 @@ typedef envoy_stream_intel EnvoyStreamIntel;
  */
 @property (nonatomic, copy) void (^onTrailers)
     (EnvoyHeaders *trailers, EnvoyStreamIntel streamIntel);
+// clang-format on
 
 /**
  * Called when the async HTTP stream has an error.
@@ -151,6 +153,7 @@ extern const int kEnvoyFilterResumeStatusResumeIteration;
 @property (nonatomic, copy) void (^setRequestFilterCallbacks)
     (id<EnvoyHTTPFilterCallbacks> callbacks);
 
+// clang-format off
 /// Returns tuple of:
 /// 0 - NSNumber *,filter status
 /// 1 - EnvoyHeaders *, optional pending headers
@@ -171,6 +174,7 @@ extern const int kEnvoyFilterResumeStatusResumeIteration;
 @property (nonatomic, copy) NSArray * (^onResumeResponse)
     (EnvoyHeaders *_Nullable headers, NSData *_Nullable data, EnvoyHeaders *_Nullable trailers,
      BOOL endStream);
+//clang-format on
 
 @end
 

--- a/library/objective-c/EnvoyEngine.h
+++ b/library/objective-c/EnvoyEngine.h
@@ -31,6 +31,7 @@ typedef envoy_stream_intel EnvoyStreamIntel;
  * Called when all headers get received on the async HTTP stream.
  * @param headers the headers received.
  * @param endStream whether the response is headers-only.
+ * @param streamIntel internal HTTP stream metrics, context, and other details.
  */
 @property (nonatomic, copy) void (^onHeaders)
     (EnvoyHeaders *headers, BOOL endStream, EnvoyStreamIntel streamIntel);
@@ -40,6 +41,7 @@ typedef envoy_stream_intel EnvoyStreamIntel;
  * This callback can be invoked multiple times if the data gets streamed.
  * @param data the data received.
  * @param endStream whether the data is the last data frame.
+ * @param streamIntel internal HTTP stream metrics, context, and other details.
  */
 @property (nonatomic, copy) void (^onData)
     (NSData *data, BOOL endStream, EnvoyStreamIntel streamIntel);
@@ -49,6 +51,7 @@ typedef envoy_stream_intel EnvoyStreamIntel;
  * Called when all trailers get received on the async HTTP stream.
  * Note that end stream is implied when on_trailers is called.
  * @param trailers the trailers received.
+ * @param streamIntel internal HTTP stream metrics, context, and other details.
  */
 @property (nonatomic, copy) void (^onTrailers)
     (EnvoyHeaders *trailers, EnvoyStreamIntel streamIntel);
@@ -56,6 +59,7 @@ typedef envoy_stream_intel EnvoyStreamIntel;
 
 /**
  * Called when the async HTTP stream has an error.
+ * @param streamIntel internal HTTP stream metrics, context, and other details.
  */
 @property (nonatomic, copy) void (^onError)
     (uint64_t errorCode, NSString *message, int32_t attemptCount, EnvoyStreamIntel streamIntel);
@@ -65,6 +69,7 @@ typedef envoy_stream_intel EnvoyStreamIntel;
  * Note this callback will ALWAYS be fired if a stream is canceled, even if the request and/or
  * response is already complete. It will fire no more than once, and no other callbacks for the
  * stream will be issued afterwards.
+ * @param streamIntel internal HTTP stream metrics, context, and other details.
  */
 @property (nonatomic, copy) void (^onCancel)(EnvoyStreamIntel streamIntel);
 

--- a/library/objective-c/EnvoyEngine.h
+++ b/library/objective-c/EnvoyEngine.h
@@ -174,7 +174,7 @@ extern const int kEnvoyFilterResumeStatusResumeIteration;
 @property (nonatomic, copy) NSArray * (^onResumeResponse)
     (EnvoyHeaders *_Nullable headers, NSData *_Nullable data, EnvoyHeaders *_Nullable trailers,
      BOOL endStream);
-//clang-format on
+// clang-format on
 
 @end
 

--- a/library/objective-c/EnvoyEngine.h
+++ b/library/objective-c/EnvoyEngine.h
@@ -169,7 +169,7 @@ extern const int kEnvoyFilterResumeStatusResumeIteration;
 /// 2 - NSData *, optional pending data
 /// 3 - EnvoyHeaders *, optional pending trailers
 @property (nonatomic, copy) NSArray * (^onResumeResponse)
-    (EnvoyHeaders *_Nullable headers, NSData *_Nullable data,  EnvoyHeaders *_Nullable trailers,
+    (EnvoyHeaders *_Nullable headers, NSData *_Nullable data, EnvoyHeaders *_Nullable trailers,
      BOOL endStream);
 
 @end

--- a/library/objective-c/EnvoyHTTPStreamImpl.m
+++ b/library/objective-c/EnvoyHTTPStreamImpl.m
@@ -21,7 +21,8 @@ typedef struct {
 
 #pragma mark - C callbacks
 
-static void *ios_on_headers(envoy_headers headers, bool end_stream, envoy_stream_intel stream_intel, void *context) {
+static void *ios_on_headers(envoy_headers headers, bool end_stream, envoy_stream_intel stream_intel,
+                            void *context) {
   ios_context *c = (ios_context *)context;
   EnvoyHTTPCallbacks *callbacks = c->callbacks;
   dispatch_async(callbacks.dispatchQueue, ^{
@@ -32,7 +33,8 @@ static void *ios_on_headers(envoy_headers headers, bool end_stream, envoy_stream
   return NULL;
 }
 
-static void *ios_on_data(envoy_data data, bool end_stream, envoy_stream_intel stream_intel, void *context) {
+static void *ios_on_data(envoy_data data, bool end_stream, envoy_stream_intel stream_intel,
+                         void *context) {
   ios_context *c = (ios_context *)context;
   EnvoyHTTPCallbacks *callbacks = c->callbacks;
   dispatch_async(callbacks.dispatchQueue, ^{
@@ -43,9 +45,13 @@ static void *ios_on_data(envoy_data data, bool end_stream, envoy_stream_intel st
   return NULL;
 }
 
-static void *ios_on_metadata(envoy_headers metadata, envoy_stream_intel stream_intel, void *context) { return NULL; }
+static void *ios_on_metadata(envoy_headers metadata, envoy_stream_intel stream_intel,
+                             void *context) {
+  return NULL;
+}
 
-static void *ios_on_trailers(envoy_headers trailers, envoy_stream_intel stream_intel, void *context) {
+static void *ios_on_trailers(envoy_headers trailers, envoy_stream_intel stream_intel,
+                             void *context) {
   ios_context *c = (ios_context *)context;
   EnvoyHTTPCallbacks *callbacks = c->callbacks;
   dispatch_async(callbacks.dispatchQueue, ^{

--- a/library/objective-c/EnvoyHTTPStreamImpl.m
+++ b/library/objective-c/EnvoyHTTPStreamImpl.m
@@ -21,42 +21,42 @@ typedef struct {
 
 #pragma mark - C callbacks
 
-static void *ios_on_headers(envoy_headers headers, bool end_stream, void *context) {
+static void *ios_on_headers(envoy_headers headers, bool end_stream, envoy_stream_intel stream_intel, void *context) {
   ios_context *c = (ios_context *)context;
   EnvoyHTTPCallbacks *callbacks = c->callbacks;
   dispatch_async(callbacks.dispatchQueue, ^{
     if (callbacks.onHeaders) {
-      callbacks.onHeaders(to_ios_headers(headers), end_stream);
+      callbacks.onHeaders(to_ios_headers(headers), end_stream, stream_intel);
     }
   });
   return NULL;
 }
 
-static void *ios_on_data(envoy_data data, bool end_stream, void *context) {
+static void *ios_on_data(envoy_data data, bool end_stream, envoy_stream_intel stream_intel, void *context) {
   ios_context *c = (ios_context *)context;
   EnvoyHTTPCallbacks *callbacks = c->callbacks;
   dispatch_async(callbacks.dispatchQueue, ^{
     if (callbacks.onData) {
-      callbacks.onData(to_ios_data(data), end_stream);
+      callbacks.onData(to_ios_data(data), end_stream, stream_intel);
     }
   });
   return NULL;
 }
 
-static void *ios_on_metadata(envoy_headers metadata, void *context) { return NULL; }
+static void *ios_on_metadata(envoy_headers metadata, envoy_stream_intel stream_intel, void *context) { return NULL; }
 
-static void *ios_on_trailers(envoy_headers trailers, void *context) {
+static void *ios_on_trailers(envoy_headers trailers, envoy_stream_intel stream_intel, void *context) {
   ios_context *c = (ios_context *)context;
   EnvoyHTTPCallbacks *callbacks = c->callbacks;
   dispatch_async(callbacks.dispatchQueue, ^{
     if (callbacks.onTrailers) {
-      callbacks.onTrailers(to_ios_headers(trailers));
+      callbacks.onTrailers(to_ios_headers(trailers), stream_intel);
     }
   });
   return NULL;
 }
 
-static void *ios_on_complete(void *context) {
+static void *ios_on_complete(envoy_stream_intel stream_intel, void *context) {
   ios_context *c = (ios_context *)context;
   EnvoyHTTPCallbacks *callbacks = c->callbacks;
   EnvoyHTTPStreamImpl *stream = c->stream;
@@ -68,7 +68,7 @@ static void *ios_on_complete(void *context) {
   return NULL;
 }
 
-static void *ios_on_cancel(void *context) {
+static void *ios_on_cancel(envoy_stream_intel stream_intel, void *context) {
   // This call is atomically gated at the call-site and will only happen once. It may still fire
   // after a complete response or error callback, but no other callbacks for the stream will ever
   // fire AFTER the cancellation callback.
@@ -77,7 +77,7 @@ static void *ios_on_cancel(void *context) {
   EnvoyHTTPStreamImpl *stream = c->stream;
   dispatch_async(callbacks.dispatchQueue, ^{
     if (callbacks.onCancel) {
-      callbacks.onCancel();
+      callbacks.onCancel(stream_intel);
     }
 
     // TODO: If the callback queue is not serial, clean up is not currently thread-safe.
@@ -87,7 +87,7 @@ static void *ios_on_cancel(void *context) {
   return NULL;
 }
 
-static void *ios_on_error(envoy_error error, void *context) {
+static void *ios_on_error(envoy_error error, envoy_stream_intel stream_intel, void *context) {
   ios_context *c = (ios_context *)context;
   EnvoyHTTPCallbacks *callbacks = c->callbacks;
   EnvoyHTTPStreamImpl *stream = c->stream;
@@ -97,7 +97,7 @@ static void *ios_on_error(envoy_error error, void *context) {
                                                         length:error.message.length
                                                       encoding:NSUTF8StringEncoding];
       release_envoy_error(error);
-      callbacks.onError(error.error_code, errorMessage, error.attempt_count);
+      callbacks.onError(error.error_code, errorMessage, error.attempt_count, stream_intel);
     }
 
     // TODO: If the callback queue is not serial, clean up is not currently thread-safe.

--- a/library/swift/BUILD
+++ b/library/swift/BUILD
@@ -33,6 +33,7 @@ swift_library(
         "StreamCallbacks.swift",
         "StreamClient.swift",
         "StreamClientImpl.swift",
+        "StreamIntel.swift",
         "StreamPrototype.swift",
         "TestEngineBuilder.swift",
         "Trailers.swift",

--- a/library/swift/StreamCallbacks.swift
+++ b/library/swift/StreamCallbacks.swift
@@ -7,11 +7,11 @@ import Foundation
 ///
 /// `StreamCallbacks` are bridged through to `EnvoyHTTPCallbacks` to communicate with the engine.
 final class StreamCallbacks {
-  var onHeaders: ((_ headers: ResponseHeaders, _ endStream: Bool) -> Void)?
-  var onData: ((_ body: Data, _ endStream: Bool) -> Void)?
-  var onTrailers: ((_ trailers: ResponseTrailers) -> Void)?
-  var onCancel: (() -> Void)?
-  var onError: ((_ error: EnvoyError) -> Void)?
+  var onHeaders: ((_ headers: ResponseHeaders, _ endStream: Bool, _ streamIntel: StreamIntel) -> Void)?
+  var onData: ((_ body: Data, _ endStream: Bool, _ streamIntel: StreamIntel) -> Void)?
+  var onTrailers: ((_ trailers: ResponseTrailers, _ streamIntel: StreamIntel) -> Void)?
+  var onCancel: ((_ streamIntel: StreamIntel) -> Void)?
+  var onError: ((_ error: EnvoyError, _ streamIntel: StreamIntel) -> Void)?
 }
 
 extension EnvoyHTTPCallbacks {
@@ -22,16 +22,16 @@ extension EnvoyHTTPCallbacks {
   convenience init(callbacks: StreamCallbacks, queue: DispatchQueue) {
     self.init()
     self.dispatchQueue = queue
-    self.onHeaders = { callbacks.onHeaders?(ResponseHeaders(headers: $0), $1) }
-    self.onData = { callbacks.onData?($0, $1) }
-    self.onTrailers = { callbacks.onTrailers?(ResponseTrailers(headers: $0)) }
-    self.onCancel = { callbacks.onCancel?() }
-    self.onError = { errorCode, message, attemptCount in
+    self.onHeaders = { callbacks.onHeaders?(ResponseHeaders(headers: $0), $1, StreamIntel($2)) }
+    self.onData = { callbacks.onData?($0, $1, StreamIntel($2)) }
+    self.onTrailers = { callbacks.onTrailers?(ResponseTrailers(headers: $0), StreamIntel($1)) }
+    self.onCancel = { callbacks.onCancel?(StreamIntel($0)) }
+    self.onError = { errorCode, message, attemptCount, streamIntel in
       // The initializer below will return nil if `attemptCount` is negative.
       // This is the desired behavior because the bridge layer uses -1 to signify absence.
       let error = EnvoyError(errorCode: errorCode, message: message,
                              attemptCount: UInt32(exactly: attemptCount), cause: nil)
-      callbacks.onError?(error)
+      callbacks.onError?(error, StreamIntel(streamIntel))
     }
   }
 }

--- a/library/swift/StreamCallbacks.swift
+++ b/library/swift/StreamCallbacks.swift
@@ -7,7 +7,9 @@ import Foundation
 ///
 /// `StreamCallbacks` are bridged through to `EnvoyHTTPCallbacks` to communicate with the engine.
 final class StreamCallbacks {
-  var onHeaders: ((_ headers: ResponseHeaders, _ endStream: Bool, _ streamIntel: StreamIntel) -> Void)?
+  var onHeaders: (
+    (_ headers: ResponseHeaders, _ endStream: Bool, _ streamIntel: StreamIntel) -> Void
+  )?
   var onData: ((_ body: Data, _ endStream: Bool, _ streamIntel: StreamIntel) -> Void)?
   var onTrailers: ((_ trailers: ResponseTrailers, _ streamIntel: StreamIntel) -> Void)?
   var onCancel: ((_ streamIntel: StreamIntel) -> Void)?

--- a/library/swift/StreamIntel.swift
+++ b/library/swift/StreamIntel.swift
@@ -1,7 +1,7 @@
 @_implementationOnly import EnvoyEngine
 import Foundation
 
-/// Exposes internal HTTP stream metrics, context, and other details
+/// Exposes internal HTTP stream metrics, context, and other details.
 @objcMembers
 public final class StreamIntel: NSObject, Error {
   // An internal identifier for the stream.

--- a/library/swift/StreamIntel.swift
+++ b/library/swift/StreamIntel.swift
@@ -1,0 +1,27 @@
+@_implementationOnly import EnvoyEngine
+import Foundation
+
+/// Exposes internal HTTP stream metrics, context, and other details
+@objcMembers
+public final class StreamIntel: NSObject, Error {
+  // An internal identifier for the stream.
+  public let streamId: UInt64
+  // An internal identifier for the connection carrying the stream.
+  public let connectionId: UInt64
+  // The number of internal attempts to carry out a request/operation.
+  public let attemptCount: UInt64
+
+  public init(streamId: UInt64, connectionId: UInt64, attemptCount: UInt64) {
+    self.streamId = streamId
+    self.connectionId = connectionId
+    self.attemptCount = attemptCount
+  }
+}
+
+extension StreamIntel {
+  internal convenience init(_ cStruct: EnvoyStreamIntel) {
+    self.init(streamId: cStruct.stream_id,
+              connectionId: cStruct.connection_id,
+              attemptCount: cStruct.attempt_count)
+  }
+}

--- a/library/swift/StreamPrototype.swift
+++ b/library/swift/StreamPrototype.swift
@@ -66,7 +66,7 @@ public class StreamPrototype: NSObject {
   /// - returns: This stream, for chaining syntax.
   @discardableResult
   public func setOnResponseHeaders(
-    closure: @escaping (_ headers: ResponseHeaders, _ endStream: Bool) -> Void) -> StreamPrototype
+    closure: @escaping (_ headers: ResponseHeaders, _ endStream: Bool, _ streamIntel: StreamIntel) -> Void) -> StreamPrototype
   {
     self.callbacks.onHeaders = closure
     return self
@@ -81,7 +81,7 @@ public class StreamPrototype: NSObject {
   /// - returns: This stream, for chaining syntax.
   @discardableResult
   public func setOnResponseData(
-    closure: @escaping (_ body: Data, _ endStream: Bool) -> Void) -> StreamPrototype
+    closure: @escaping (_ body: Data, _ endStream: Bool, _ streamIntel: StreamIntel) -> Void) -> StreamPrototype
   {
     self.callbacks.onData = closure
     return self
@@ -95,7 +95,7 @@ public class StreamPrototype: NSObject {
   /// - returns: This stream, for chaining syntax.
   @discardableResult
   public func setOnResponseTrailers(
-    closure: @escaping (_ trailers: ResponseTrailers) -> Void) -> StreamPrototype
+    closure: @escaping (_ trailers: ResponseTrailers, _ streamIntel: StreamIntel) -> Void) -> StreamPrototype
   {
     self.callbacks.onTrailers = closure
     return self
@@ -109,7 +109,7 @@ public class StreamPrototype: NSObject {
   /// - returns: This stream, for chaining syntax.
   @discardableResult
   public func setOnError(
-    closure: @escaping (_ error: EnvoyError) -> Void) -> StreamPrototype
+    closure: @escaping (_ error: EnvoyError, _ streamIntel: StreamIntel) -> Void) -> StreamPrototype
   {
     self.callbacks.onError = closure
     return self
@@ -123,7 +123,7 @@ public class StreamPrototype: NSObject {
   /// - returns: This stream, for chaining syntax.
   @discardableResult
   public func setOnCancel(
-    closure: @escaping () -> Void) -> StreamPrototype
+    closure: @escaping (_ streamIntel: StreamIntel) -> Void) -> StreamPrototype
   {
     self.callbacks.onCancel = closure
     return self

--- a/library/swift/StreamPrototype.swift
+++ b/library/swift/StreamPrototype.swift
@@ -66,8 +66,9 @@ public class StreamPrototype: NSObject {
   /// - returns: This stream, for chaining syntax.
   @discardableResult
   public func setOnResponseHeaders(
-    closure: @escaping (_ headers: ResponseHeaders, _ endStream: Bool, _ streamIntel: StreamIntel) -> Void) -> StreamPrototype
-  {
+    closure: @escaping (_ headers: ResponseHeaders, _ endStream: Bool,
+                        _ streamIntel: StreamIntel) -> Void
+  ) -> StreamPrototype {
     self.callbacks.onHeaders = closure
     return self
   }
@@ -81,8 +82,8 @@ public class StreamPrototype: NSObject {
   /// - returns: This stream, for chaining syntax.
   @discardableResult
   public func setOnResponseData(
-    closure: @escaping (_ body: Data, _ endStream: Bool, _ streamIntel: StreamIntel) -> Void) -> StreamPrototype
-  {
+    closure: @escaping (_ body: Data, _ endStream: Bool, _ streamIntel: StreamIntel) -> Void
+  ) -> StreamPrototype {
     self.callbacks.onData = closure
     return self
   }
@@ -95,8 +96,8 @@ public class StreamPrototype: NSObject {
   /// - returns: This stream, for chaining syntax.
   @discardableResult
   public func setOnResponseTrailers(
-    closure: @escaping (_ trailers: ResponseTrailers, _ streamIntel: StreamIntel) -> Void) -> StreamPrototype
-  {
+    closure: @escaping (_ trailers: ResponseTrailers, _ streamIntel: StreamIntel) -> Void
+  ) -> StreamPrototype {
     self.callbacks.onTrailers = closure
     return self
   }
@@ -109,8 +110,8 @@ public class StreamPrototype: NSObject {
   /// - returns: This stream, for chaining syntax.
   @discardableResult
   public func setOnError(
-    closure: @escaping (_ error: EnvoyError, _ streamIntel: StreamIntel) -> Void) -> StreamPrototype
-  {
+    closure: @escaping (_ error: EnvoyError, _ streamIntel: StreamIntel) -> Void
+  ) -> StreamPrototype {
     self.callbacks.onError = closure
     return self
   }
@@ -123,8 +124,8 @@ public class StreamPrototype: NSObject {
   /// - returns: This stream, for chaining syntax.
   @discardableResult
   public func setOnCancel(
-    closure: @escaping (_ streamIntel: StreamIntel) -> Void) -> StreamPrototype
-  {
+    closure: @escaping (_ streamIntel: StreamIntel) -> Void
+  ) -> StreamPrototype {
     self.callbacks.onCancel = closure
     return self
   }

--- a/library/swift/grpc/GRPCStreamPrototype.swift
+++ b/library/swift/grpc/GRPCStreamPrototype.swift
@@ -36,9 +36,9 @@ public final class GRPCStreamPrototype: NSObject {
   /// - returns: This stream, for chaining syntax.
   @discardableResult
   public func setOnResponseHeaders(
-    closure: @escaping (_ headers: ResponseHeaders, _ endStream: Bool, _ streamIntel: StreamIntel) -> Void)
-    -> GRPCStreamPrototype
-  {
+    closure: @escaping (_ headers: ResponseHeaders, _ endStream: Bool,
+                        _ streamIntel: StreamIntel) -> Void
+  ) -> GRPCStreamPrototype {
     self.underlyingStream.setOnResponseHeaders(closure: closure)
     return self
   }
@@ -49,10 +49,9 @@ public final class GRPCStreamPrototype: NSObject {
   ///
   /// - returns: This handler, which may be used for chaining syntax.
   @discardableResult
-  public func setOnResponseMessage(_ closure:
-    @escaping (_ message: Data, _ streamIntel: StreamIntel) -> Void)
-    -> GRPCStreamPrototype
-  {
+  public func setOnResponseMessage(
+    _ closure: @escaping (_ message: Data, _ streamIntel: StreamIntel) -> Void
+  ) -> GRPCStreamPrototype {
     var buffer = Data()
     var state = GRPCMessageProcessor.State.expectingCompressionFlag
     self.underlyingStream.setOnResponseData { chunk, _, streamIntel in
@@ -61,7 +60,8 @@ public final class GRPCStreamPrototype: NSObject {
       // Appending might result in extra copying that can be optimized in the future.
       buffer.append(chunk)
       // gRPC always sends trailers, so the stream will not complete here.
-      GRPCMessageProcessor.processBuffer(&buffer, state: &state, streamIntel: streamIntel, onMessage: closure)
+      GRPCMessageProcessor.processBuffer(&buffer, state: &state, streamIntel: streamIntel,
+                                         onMessage: closure)
     }
 
     return self
@@ -75,9 +75,8 @@ public final class GRPCStreamPrototype: NSObject {
   /// - returns: This handler, which may be used for chaining syntax.
   @discardableResult
   public func setOnResponseTrailers(_ closure:
-    @escaping (_ trailers: ResponseTrailers, _ streamIntel: StreamIntel) -> Void)
-    -> GRPCStreamPrototype
-  {
+    @escaping (_ trailers: ResponseTrailers, _ streamIntel: StreamIntel) -> Void
+  ) -> GRPCStreamPrototype {
     self.underlyingStream.setOnResponseTrailers(closure: closure)
     return self
   }
@@ -89,10 +88,9 @@ public final class GRPCStreamPrototype: NSObject {
   ///
   /// - returns: This handler, which may be used for chaining syntax.
   @discardableResult
-  public func setOnError(_ closure:
-    @escaping (_ error: EnvoyError, _ streamIntel: StreamIntel) -> Void)
-    -> GRPCStreamPrototype
-  {
+  public func setOnError(
+    _ closure: @escaping (_ error: EnvoyError, _ streamIntel: StreamIntel) -> Void
+  ) -> GRPCStreamPrototype {
     self.underlyingStream.setOnError(closure: closure)
     return self
   }
@@ -105,8 +103,8 @@ public final class GRPCStreamPrototype: NSObject {
   /// - returns: This stream, for chaining syntax.
   @discardableResult
   public func setOnCancel(
-    closure: @escaping (_ streamInte: StreamIntel) -> Void) -> GRPCStreamPrototype
-  {
+    closure: @escaping (_ streamInte: StreamIntel) -> Void
+  ) -> GRPCStreamPrototype {
     self.underlyingStream.setOnCancel(closure: closure)
     return self
   }

--- a/library/swift/grpc/GRPCStreamPrototype.swift
+++ b/library/swift/grpc/GRPCStreamPrototype.swift
@@ -36,7 +36,7 @@ public final class GRPCStreamPrototype: NSObject {
   /// - returns: This stream, for chaining syntax.
   @discardableResult
   public func setOnResponseHeaders(
-    closure: @escaping (_ headers: ResponseHeaders, _ endStream: Bool) -> Void)
+    closure: @escaping (_ headers: ResponseHeaders, _ endStream: Bool, _ streamIntel: StreamIntel) -> Void)
     -> GRPCStreamPrototype
   {
     self.underlyingStream.setOnResponseHeaders(closure: closure)
@@ -50,18 +50,18 @@ public final class GRPCStreamPrototype: NSObject {
   /// - returns: This handler, which may be used for chaining syntax.
   @discardableResult
   public func setOnResponseMessage(_ closure:
-    @escaping (_ message: Data) -> Void)
+    @escaping (_ message: Data, _ streamIntel: StreamIntel) -> Void)
     -> GRPCStreamPrototype
   {
     var buffer = Data()
     var state = GRPCMessageProcessor.State.expectingCompressionFlag
-    self.underlyingStream.setOnResponseData { chunk, _ in
+    self.underlyingStream.setOnResponseData { chunk, _, streamIntel in
       // This closure deliberately retains `self` while the underlying handler's
       // `onData` closure is kept in memory so that messages/errors can be processed.
       // Appending might result in extra copying that can be optimized in the future.
       buffer.append(chunk)
       // gRPC always sends trailers, so the stream will not complete here.
-      GRPCMessageProcessor.processBuffer(&buffer, state: &state, onMessage: closure)
+      GRPCMessageProcessor.processBuffer(&buffer, state: &state, streamIntel: streamIntel, onMessage: closure)
     }
 
     return self
@@ -75,7 +75,7 @@ public final class GRPCStreamPrototype: NSObject {
   /// - returns: This handler, which may be used for chaining syntax.
   @discardableResult
   public func setOnResponseTrailers(_ closure:
-    @escaping (_ trailers: ResponseTrailers) -> Void)
+    @escaping (_ trailers: ResponseTrailers, _ streamIntel: StreamIntel) -> Void)
     -> GRPCStreamPrototype
   {
     self.underlyingStream.setOnResponseTrailers(closure: closure)
@@ -90,7 +90,7 @@ public final class GRPCStreamPrototype: NSObject {
   /// - returns: This handler, which may be used for chaining syntax.
   @discardableResult
   public func setOnError(_ closure:
-    @escaping (_ error: EnvoyError) -> Void)
+    @escaping (_ error: EnvoyError, _ streamIntel: StreamIntel) -> Void)
     -> GRPCStreamPrototype
   {
     self.underlyingStream.setOnError(closure: closure)
@@ -105,7 +105,7 @@ public final class GRPCStreamPrototype: NSObject {
   /// - returns: This stream, for chaining syntax.
   @discardableResult
   public func setOnCancel(
-    closure: @escaping () -> Void) -> GRPCStreamPrototype
+    closure: @escaping (_ streamInte: StreamIntel) -> Void) -> GRPCStreamPrototype
   {
     self.underlyingStream.setOnCancel(closure: closure)
     return self
@@ -129,8 +129,8 @@ private enum GRPCMessageProcessor {
   /// - parameter buffer:    The buffer of data from which to determine state and messages.
   /// - parameter state:     The current state of the buffering.
   /// - parameter onMessage: Closure to call when a new message is available.
-  static func processBuffer(_ buffer: inout Data, state: inout State,
-                            onMessage: (_ message: Data) -> Void)
+  static func processBuffer(_ buffer: inout Data, state: inout State, streamIntel: StreamIntel,
+                            onMessage: (_ message: Data, _ streamIntel: StreamIntel) -> Void)
   {
     switch state {
     case .expectingCompressionFlag:
@@ -161,15 +161,15 @@ private enum GRPCMessageProcessor {
       }
 
       if messageLength > 0 {
-        onMessage(buffer.subdata(in: kGRPCPrefixLength..<prefixedLength))
+        onMessage(buffer.subdata(in: kGRPCPrefixLength..<prefixedLength), streamIntel)
       } else {
-        onMessage(Data())
+        onMessage(Data(), streamIntel)
       }
 
       buffer.removeSubrange(0..<prefixedLength)
       state = .expectingCompressionFlag
     }
 
-    self.processBuffer(&buffer, state: &state, onMessage: onMessage)
+    self.processBuffer(&buffer, state: &state, streamIntel: streamIntel, onMessage: onMessage)
   }
 }

--- a/library/swift/mocks/MockStream.swift
+++ b/library/swift/mocks/MockStream.swift
@@ -1,3 +1,4 @@
+@_implementationOnly import EnvoyEngine
 import Foundation
 
 /// Mock implementation of `Stream` that also provides an interface for sending
@@ -51,7 +52,7 @@ public final class MockStream: Stream {
   /// - parameter headers:   Response headers to receive.
   /// - parameter endStream: Whether this is a headers-only response.
   public func receiveHeaders(_ headers: ResponseHeaders, endStream: Bool) {
-    self.mockStream.callbacks.onHeaders(headers.headers, endStream)
+    self.mockStream.callbacks.onHeaders(headers.headers, endStream, EnvoyStreamIntel())
   }
 
   /// Simulate response data coming back over the stream.
@@ -59,19 +60,19 @@ public final class MockStream: Stream {
   /// - parameter data:      Response data to receive.
   /// - parameter endStream: Whether this is the last data frame.
   public func receiveData(_ data: Data, endStream: Bool) {
-    self.mockStream.callbacks.onData(data, endStream)
+    self.mockStream.callbacks.onData(data, endStream, EnvoyStreamIntel())
   }
 
   /// Simulate trailers coming back over the stream.
   ///
   /// - parameter trailers: Response trailers to receive.
   public func receiveTrailers(_ trailers: ResponseTrailers) {
-    self.mockStream.callbacks.onTrailers(trailers.headers)
+    self.mockStream.callbacks.onTrailers(trailers.headers, EnvoyStreamIntel())
   }
 
   /// Simulate the stream receiving a cancellation signal from Envoy.
   public func receiveCancel() {
-    self.mockStream.callbacks.onCancel()
+    self.mockStream.callbacks.onCancel(EnvoyStreamIntel())
   }
 
   /// Simulate Envoy returning an error.
@@ -79,6 +80,7 @@ public final class MockStream: Stream {
   /// - parameter error: The error to receive.
   public func receiveError(_ error: EnvoyError) {
     self.mockStream.callbacks.onError(error.errorCode, error.message,
-                                      Int32(error.attemptCount ?? 0))
+                                      Int32(error.attemptCount ?? 0),
+                                      EnvoyStreamIntel())
   }
 }

--- a/test/common/http/client_test.cc
+++ b/test/common/http/client_test.cc
@@ -62,13 +62,13 @@ public:
     bridge_callbacks_.context = &cc_;
 
     // Set up default bridge callbacks. Indivividual tests can override.
-    bridge_callbacks_.on_complete = [](void* context) -> void* {
+    bridge_callbacks_.on_complete = [](envoy_stream_intel, void* context) -> void* {
       callbacks_called* cc = static_cast<callbacks_called*>(context);
       cc->on_complete_calls++;
       return nullptr;
     };
     bridge_callbacks_.on_headers = [](envoy_headers c_headers, bool end_stream,
-                                      void* context) -> void* {
+                                      envoy_stream_intel, void* context) -> void* {
       ResponseHeaderMapPtr response_headers = toResponseHeaders(c_headers);
       callbacks_called* cc = static_cast<callbacks_called*>(context);
       EXPECT_EQ(end_stream, cc->end_stream_with_headers_);
@@ -76,24 +76,24 @@ public:
       cc->on_headers_calls++;
       return nullptr;
     };
-    bridge_callbacks_.on_error = [](envoy_error, void* context) -> void* {
+    bridge_callbacks_.on_error = [](envoy_error, envoy_stream_intel, void* context) -> void* {
       callbacks_called* cc = static_cast<callbacks_called*>(context);
       cc->on_error_calls++;
       return nullptr;
     };
-    bridge_callbacks_.on_data = [](envoy_data c_data, bool, void* context) -> void* {
+    bridge_callbacks_.on_data = [](envoy_data c_data, bool, envoy_stream_intel, void* context) -> void* {
       callbacks_called* cc = static_cast<callbacks_called*>(context);
       cc->on_data_calls++;
       cc->body_data_ += Data::Utility::copyToString(c_data);
       release_envoy_data(c_data);
       return nullptr;
     };
-    bridge_callbacks_.on_cancel = [](void* context) -> void* {
+    bridge_callbacks_.on_cancel = [](envoy_stream_intel, void* context) -> void* {
       callbacks_called* cc = static_cast<callbacks_called*>(context);
       cc->on_cancel_calls++;
       return nullptr;
     };
-    bridge_callbacks_.on_trailers = [](envoy_headers c_trailers, void* context) -> void* {
+    bridge_callbacks_.on_trailers = [](envoy_headers c_trailers, envoy_stream_intel, void* context) -> void* {
       ResponseHeaderMapPtr response_trailers = toResponseHeaders(c_trailers);
       EXPECT_TRUE(response_trailers.get() != nullptr);
       callbacks_called* cc = static_cast<callbacks_called*>(context);
@@ -385,7 +385,7 @@ TEST_P(ClientTest, BasicStreamHeaders) {
 TEST_P(ClientTest, BasicStreamData) {
   cc_.end_stream_with_headers_ = false;
 
-  bridge_callbacks_.on_data = [](envoy_data c_data, bool end_stream, void* context) -> void* {
+  bridge_callbacks_.on_data = [](envoy_data c_data, bool end_stream, envoy_stream_intel, void* context) -> void* {
     EXPECT_TRUE(end_stream);
     EXPECT_EQ(Data::Utility::copyToString(c_data), "response body");
     callbacks_called* cc = static_cast<callbacks_called*>(context);
@@ -421,7 +421,7 @@ TEST_P(ClientTest, BasicStreamData) {
 }
 
 TEST_P(ClientTest, BasicStreamTrailers) {
-  bridge_callbacks_.on_trailers = [](envoy_headers c_trailers, void* context) -> void* {
+  bridge_callbacks_.on_trailers = [](envoy_headers c_trailers, envoy_stream_intel, void* context) -> void* {
     ResponseHeaderMapPtr response_trailers = toResponseHeaders(c_trailers);
     EXPECT_EQ(response_trailers->get(LowerCaseString("x-test-trailer"))[0]->value().getStringView(),
               "test_trailer");
@@ -567,7 +567,7 @@ TEST_P(ClientTest, MultipleStreams) {
   callbacks_called cc2 = {0, 0, 0, 0, 0, 0, "200", true, ""};
   bridge_callbacks_2.context = &cc2;
   bridge_callbacks_2.on_headers = [](envoy_headers c_headers, bool end_stream,
-                                     void* context) -> void* {
+                                     envoy_stream_intel, void* context) -> void* {
     EXPECT_TRUE(end_stream);
     ResponseHeaderMapPtr response_headers = toResponseHeaders(c_headers);
     EXPECT_EQ(response_headers->Status()->value().getStringView(), "200");
@@ -575,7 +575,7 @@ TEST_P(ClientTest, MultipleStreams) {
     *on_headers_called2 = true;
     return nullptr;
   };
-  bridge_callbacks_2.on_complete = [](void* context) -> void* {
+  bridge_callbacks_2.on_complete = [](envoy_stream_intel, void* context) -> void* {
     callbacks_called* cc = static_cast<callbacks_called*>(context);
     cc->on_complete_calls++;
     return nullptr;
@@ -678,7 +678,7 @@ TEST_P(ClientTest, EnvoyLocalReplyNon503NotAnError) {
 TEST_P(ClientTest, EnvoyResponseWithErrorCode) {
   cc_.expected_status_ = "218";
   // Override the on_error default with some custom checks.
-  bridge_callbacks_.on_error = [](envoy_error error, void* context) -> void* {
+  bridge_callbacks_.on_error = [](envoy_error error, envoy_stream_intel, void* context) -> void* {
     EXPECT_EQ(error.error_code, ENVOY_CONNECTION_FAILURE);
     EXPECT_EQ(error.attempt_count, 123);
     callbacks_called* cc = static_cast<callbacks_called*>(context);
@@ -754,7 +754,7 @@ TEST_P(ClientTest, DoubleResetStreamLocal) {
 TEST_P(ClientTest, RemoteResetAfterStreamStart) {
   cc_.end_stream_with_headers_ = false;
 
-  bridge_callbacks_.on_error = [](envoy_error error, void* context) -> void* {
+  bridge_callbacks_.on_error = [](envoy_error error, envoy_stream_intel, void* context) -> void* {
     EXPECT_EQ(error.error_code, ENVOY_STREAM_RESET);
     EXPECT_EQ(error.message.length, 0);
     EXPECT_EQ(error.attempt_count, -1);

--- a/test/common/http/client_test.cc
+++ b/test/common/http/client_test.cc
@@ -67,8 +67,8 @@ public:
       cc->on_complete_calls++;
       return nullptr;
     };
-    bridge_callbacks_.on_headers = [](envoy_headers c_headers, bool end_stream,
-                                      envoy_stream_intel, void* context) -> void* {
+    bridge_callbacks_.on_headers = [](envoy_headers c_headers, bool end_stream, envoy_stream_intel,
+                                      void* context) -> void* {
       ResponseHeaderMapPtr response_headers = toResponseHeaders(c_headers);
       callbacks_called* cc = static_cast<callbacks_called*>(context);
       EXPECT_EQ(end_stream, cc->end_stream_with_headers_);
@@ -81,7 +81,8 @@ public:
       cc->on_error_calls++;
       return nullptr;
     };
-    bridge_callbacks_.on_data = [](envoy_data c_data, bool, envoy_stream_intel, void* context) -> void* {
+    bridge_callbacks_.on_data = [](envoy_data c_data, bool, envoy_stream_intel,
+                                   void* context) -> void* {
       callbacks_called* cc = static_cast<callbacks_called*>(context);
       cc->on_data_calls++;
       cc->body_data_ += Data::Utility::copyToString(c_data);
@@ -93,7 +94,8 @@ public:
       cc->on_cancel_calls++;
       return nullptr;
     };
-    bridge_callbacks_.on_trailers = [](envoy_headers c_trailers, envoy_stream_intel, void* context) -> void* {
+    bridge_callbacks_.on_trailers = [](envoy_headers c_trailers, envoy_stream_intel,
+                                       void* context) -> void* {
       ResponseHeaderMapPtr response_trailers = toResponseHeaders(c_trailers);
       EXPECT_TRUE(response_trailers.get() != nullptr);
       callbacks_called* cc = static_cast<callbacks_called*>(context);
@@ -385,7 +387,8 @@ TEST_P(ClientTest, BasicStreamHeaders) {
 TEST_P(ClientTest, BasicStreamData) {
   cc_.end_stream_with_headers_ = false;
 
-  bridge_callbacks_.on_data = [](envoy_data c_data, bool end_stream, envoy_stream_intel, void* context) -> void* {
+  bridge_callbacks_.on_data = [](envoy_data c_data, bool end_stream, envoy_stream_intel,
+                                 void* context) -> void* {
     EXPECT_TRUE(end_stream);
     EXPECT_EQ(Data::Utility::copyToString(c_data), "response body");
     callbacks_called* cc = static_cast<callbacks_called*>(context);
@@ -421,7 +424,8 @@ TEST_P(ClientTest, BasicStreamData) {
 }
 
 TEST_P(ClientTest, BasicStreamTrailers) {
-  bridge_callbacks_.on_trailers = [](envoy_headers c_trailers, envoy_stream_intel, void* context) -> void* {
+  bridge_callbacks_.on_trailers = [](envoy_headers c_trailers, envoy_stream_intel,
+                                     void* context) -> void* {
     ResponseHeaderMapPtr response_trailers = toResponseHeaders(c_trailers);
     EXPECT_EQ(response_trailers->get(LowerCaseString("x-test-trailer"))[0]->value().getStringView(),
               "test_trailer");
@@ -566,8 +570,8 @@ TEST_P(ClientTest, MultipleStreams) {
   envoy_http_callbacks bridge_callbacks_2;
   callbacks_called cc2 = {0, 0, 0, 0, 0, 0, "200", true, ""};
   bridge_callbacks_2.context = &cc2;
-  bridge_callbacks_2.on_headers = [](envoy_headers c_headers, bool end_stream,
-                                     envoy_stream_intel, void* context) -> void* {
+  bridge_callbacks_2.on_headers = [](envoy_headers c_headers, bool end_stream, envoy_stream_intel,
+                                     void* context) -> void* {
     EXPECT_TRUE(end_stream);
     ResponseHeaderMapPtr response_headers = toResponseHeaders(c_headers);
     EXPECT_EQ(response_headers->Status()->value().getStringView(), "200");

--- a/test/common/integration/client_integration_test.cc
+++ b/test/common/integration/client_integration_test.cc
@@ -62,26 +62,26 @@ public:
     });
 
     bridge_callbacks_.context = &cc_;
-    bridge_callbacks_.on_headers = [](envoy_headers c_headers, bool, void* context) -> void* {
+    bridge_callbacks_.on_headers = [](envoy_headers c_headers, bool, envoy_stream_intel, void* context) -> void* {
       Http::ResponseHeaderMapPtr response_headers = toResponseHeaders(c_headers);
       callbacks_called* cc_ = static_cast<callbacks_called*>(context);
       cc_->on_headers_calls++;
       cc_->status = response_headers->Status()->value().getStringView();
       return nullptr;
     };
-    bridge_callbacks_.on_data = [](envoy_data c_data, bool, void* context) -> void* {
+    bridge_callbacks_.on_data = [](envoy_data c_data, bool, envoy_stream_intel, void* context) -> void* {
       callbacks_called* cc_ = static_cast<callbacks_called*>(context);
       cc_->on_data_calls++;
       release_envoy_data(c_data);
       return nullptr;
     };
-    bridge_callbacks_.on_complete = [](void* context) -> void* {
+    bridge_callbacks_.on_complete = [](envoy_stream_intel, void* context) -> void* {
       callbacks_called* cc_ = static_cast<callbacks_called*>(context);
       cc_->on_complete_calls++;
       cc_->terminal_callback->setReady();
       return nullptr;
     };
-    bridge_callbacks_.on_error = [](envoy_error error, void* context) -> void* {
+    bridge_callbacks_.on_error = [](envoy_error error, envoy_stream_intel, void* context) -> void* {
       release_envoy_error(error);
       callbacks_called* cc_ = static_cast<callbacks_called*>(context);
       cc_->on_error_calls++;
@@ -161,7 +161,7 @@ TEST_P(ClientIntegrationTest, Basic) {
   server_started.waitReady();
 
   envoy_stream_t stream = 1;
-  bridge_callbacks_.on_data = [](envoy_data c_data, bool end_stream, void* context) -> void* {
+  bridge_callbacks_.on_data = [](envoy_data c_data, bool end_stream, envoy_stream_intel, void* context) -> void* {
     if (end_stream) {
       EXPECT_EQ(Data::Utility::copyToString(c_data), "");
     } else {
@@ -319,7 +319,7 @@ TEST_P(ClientIntegrationTest, CaseSensitive) {
   server_started.waitReady();
 
   envoy_stream_t stream = 1;
-  bridge_callbacks_.on_headers = [](envoy_headers c_headers, bool, void* context) -> void* {
+  bridge_callbacks_.on_headers = [](envoy_headers c_headers, bool, envoy_stream_intel, void* context) -> void* {
     Http::ResponseHeaderMapPtr response_headers = toResponseHeaders(c_headers);
     callbacks_called* cc_ = static_cast<callbacks_called*>(context);
     cc_->on_headers_calls++;

--- a/test/common/integration/client_integration_test.cc
+++ b/test/common/integration/client_integration_test.cc
@@ -62,14 +62,16 @@ public:
     });
 
     bridge_callbacks_.context = &cc_;
-    bridge_callbacks_.on_headers = [](envoy_headers c_headers, bool, envoy_stream_intel, void* context) -> void* {
+    bridge_callbacks_.on_headers = [](envoy_headers c_headers, bool, envoy_stream_intel,
+                                      void* context) -> void* {
       Http::ResponseHeaderMapPtr response_headers = toResponseHeaders(c_headers);
       callbacks_called* cc_ = static_cast<callbacks_called*>(context);
       cc_->on_headers_calls++;
       cc_->status = response_headers->Status()->value().getStringView();
       return nullptr;
     };
-    bridge_callbacks_.on_data = [](envoy_data c_data, bool, envoy_stream_intel, void* context) -> void* {
+    bridge_callbacks_.on_data = [](envoy_data c_data, bool, envoy_stream_intel,
+                                   void* context) -> void* {
       callbacks_called* cc_ = static_cast<callbacks_called*>(context);
       cc_->on_data_calls++;
       release_envoy_data(c_data);
@@ -161,7 +163,8 @@ TEST_P(ClientIntegrationTest, Basic) {
   server_started.waitReady();
 
   envoy_stream_t stream = 1;
-  bridge_callbacks_.on_data = [](envoy_data c_data, bool end_stream, envoy_stream_intel, void* context) -> void* {
+  bridge_callbacks_.on_data = [](envoy_data c_data, bool end_stream, envoy_stream_intel,
+                                 void* context) -> void* {
     if (end_stream) {
       EXPECT_EQ(Data::Utility::copyToString(c_data), "");
     } else {
@@ -319,7 +322,8 @@ TEST_P(ClientIntegrationTest, CaseSensitive) {
   server_started.waitReady();
 
   envoy_stream_t stream = 1;
-  bridge_callbacks_.on_headers = [](envoy_headers c_headers, bool, envoy_stream_intel, void* context) -> void* {
+  bridge_callbacks_.on_headers = [](envoy_headers c_headers, bool, envoy_stream_intel,
+                                    void* context) -> void* {
     Http::ResponseHeaderMapPtr response_headers = toResponseHeaders(c_headers);
     callbacks_called* cc_ = static_cast<callbacks_called*>(context);
     cc_->on_headers_calls++;

--- a/test/common/main_interface_test.cc
+++ b/test/common/main_interface_test.cc
@@ -123,7 +123,7 @@ TEST(MainInterfaceTest, BasicStream) {
 
   absl::Notification on_complete_notification;
   envoy_http_callbacks stream_cbs{
-      [](envoy_headers c_headers, bool end_stream, void*) -> void* {
+      [](envoy_headers c_headers, bool end_stream, envoy_stream_intel, void*) -> void* {
         auto response_headers = toResponseHeaders(c_headers);
         EXPECT_EQ(response_headers->Status()->value().getStringView(), "200");
         EXPECT_TRUE(end_stream);
@@ -133,7 +133,7 @@ TEST(MainInterfaceTest, BasicStream) {
       nullptr /* on_metadata */,
       nullptr /* on_trailers */,
       nullptr /* on_error */,
-      [](void* context) -> void* {
+      [](envoy_stream_intel, void* context) -> void* {
         auto* on_complete_notification = static_cast<absl::Notification*>(context);
         on_complete_notification->Notify();
         return nullptr;
@@ -230,7 +230,7 @@ TEST(MainInterfaceTest, ResetStream) {
                                   nullptr /* on_trailers */,
                                   nullptr /* on_error */,
                                   nullptr /* on_complete */,
-                                  [](void* context) -> void* {
+                                  [](envoy_stream_intel, void* context) -> void* {
                                     auto* on_cancel_notification =
                                         static_cast<absl::Notification*>(context);
                                     on_cancel_notification->Notify();

--- a/test/java/integration/AndroidEnvoyFlowTest.java
+++ b/test/java/integration/AndroidEnvoyFlowTest.java
@@ -189,31 +189,31 @@ public class AndroidEnvoyFlowTest {
 
     Stream stream = engine.streamClient()
                         .newStreamPrototype()
-                        .setOnResponseHeaders((responseHeaders, endStream) -> {
+                        .setOnResponseHeaders((responseHeaders, endStream, ignored) -> {
                           response.get().setHeaders(responseHeaders);
                           if (endStream) {
                             latch.countDown();
                           }
                           return null;
                         })
-                        .setOnResponseData((data, endStream) -> {
+                        .setOnResponseData((data, endStream, ignored) -> {
                           response.get().addBody(data);
                           if (endStream) {
                             latch.countDown();
                           }
                           return null;
                         })
-                        .setOnResponseTrailers(trailers -> {
+                        .setOnResponseTrailers((trailers, ignored) -> {
                           response.get().setTrailers(trailers);
                           latch.countDown();
                           return null;
                         })
-                        .setOnError(error -> {
+                        .setOnError((error, ignored) -> {
                           response.get().setEnvoyError(error);
                           latch.countDown();
                           return null;
                         })
-                        .setOnCancel(() -> {
+                        .setOnCancel((ignored) -> {
                           response.get().setCancelled();
                           latch.countDown();
                           return null;

--- a/test/kotlin/integration/GRPCReceiveErrorTest.kt
+++ b/test/kotlin/integration/GRPCReceiveErrorTest.kt
@@ -109,9 +109,9 @@ class GRPCReceiveErrorTest {
 
     GRPCClient(engine.streamClient())
       .newGRPCStreamPrototype()
-      .setOnResponseHeaders { headers, endStream -> }
-      .setOnResponseMessage { }
-      .setOnError {
+      .setOnResponseHeaders { _, _, _ -> }
+      .setOnResponseMessage { _, _ -> }
+      .setOnError { _, _ ->
         callbackReceivedError.countDown()
       }
       .setOnCancel { fail("Unexpected call to onCancel response callback") }

--- a/test/kotlin/integration/ReceiveDataTest.kt
+++ b/test/kotlin/integration/ReceiveDataTest.kt
@@ -85,15 +85,15 @@ class ReceiveDataTest {
     var status: Int? = null
     var body: ByteBuffer? = null
     client.newStreamPrototype()
-      .setOnResponseHeaders { responseHeaders, _ ->
+      .setOnResponseHeaders { responseHeaders, _, _ ->
         status = responseHeaders.httpStatus
         headersExpectation.countDown()
       }
-      .setOnResponseData { data, _ ->
+      .setOnResponseData { data, _, _ ->
         body = data
         dataExpectation.countDown()
       }
-      .setOnError { fail("Unexpected error") }
+      .setOnError { _, _ -> fail("Unexpected error") }
       .start()
       .sendHeaders(requestHeaders, true)
 

--- a/test/kotlin/integration/ReceiveErrorTest.kt
+++ b/test/kotlin/integration/ReceiveErrorTest.kt
@@ -108,11 +108,11 @@ class ReceiveErrorTest {
 
     engine.streamClient()
       .newStreamPrototype()
-      .setOnResponseHeaders { _, _ -> fail("Headers received instead of expected error") }
-      .setOnResponseData { _, _ -> fail("Data received instead of expected error") }
+      .setOnResponseHeaders { _, _, _ -> fail("Headers received instead of expected error") }
+      .setOnResponseData { _, _, _ -> fail("Data received instead of expected error") }
       // The unmatched expectation will cause a local reply which gets translated in Envoy Mobile to
       // an error.
-      .setOnError { error ->
+      .setOnError { error, _ ->
         errorCode = error.errorCode
         callbackReceivedError.countDown()
       }

--- a/test/kotlin/integration/SendDataTest.kt
+++ b/test/kotlin/integration/SendDataTest.kt
@@ -87,12 +87,12 @@ class SendDataTest {
     var responseStatus: Int? = null
     var responseHeadersEndStream = false
     client.newStreamPrototype()
-      .setOnResponseHeaders { headers, endStream ->
+      .setOnResponseHeaders { headers, endStream, _ ->
         responseStatus = headers.httpStatus
         responseHeadersEndStream = endStream
         expectation.countDown()
       }
-      .setOnError {
+      .setOnError { _, _ ->
         fail("Unexpected error")
       }
       .start()

--- a/test/kotlin/integration/SendHeadersTest.kt
+++ b/test/kotlin/integration/SendHeadersTest.kt
@@ -79,12 +79,12 @@ class SendHeadersTest {
     var resultHeaders: ResponseHeaders? = null
     var resultEndStream: Boolean? = null
     client.newStreamPrototype()
-      .setOnResponseHeaders { responseHeaders, endStream ->
+      .setOnResponseHeaders { responseHeaders, endStream, _ ->
         resultHeaders = responseHeaders
         resultEndStream = endStream
         headersExpectation.countDown()
       }
-      .setOnError { fail("Unexpected error") }
+      .setOnError { _, _ -> fail("Unexpected error") }
       .start()
       .sendHeaders(requestHeaders, true)
 

--- a/test/kotlin/integration/SendTrailersTest.kt
+++ b/test/kotlin/integration/SendTrailersTest.kt
@@ -93,11 +93,11 @@ class SendTrailersTest {
 
     var responseStatus: Int? = null
     client.newStreamPrototype()
-      .setOnResponseHeaders { headers, _ ->
+      .setOnResponseHeaders { headers, _, _ ->
         responseStatus = headers.httpStatus
         expectation.countDown()
       }
-      .setOnError {
+      .setOnError { _, _ ->
         fail("Unexpected error")
       }
       .start()

--- a/test/kotlin/io/envoyproxy/envoymobile/GRPCStreamTest.kt
+++ b/test/kotlin/io/envoyproxy/envoymobile/GRPCStreamTest.kt
@@ -103,7 +103,7 @@ class GRPCStreamTest {
 
     GRPCClient(streamClient)
       .newGRPCStreamPrototype()
-      .setOnResponseHeaders { headers, endStream ->
+      .setOnResponseHeaders { headers, endStream, _ ->
         assertThat(headers.allHeaders()).isEqualTo(expectedHeaders.allHeaders())
         assertThat(endStream).isTrue()
         countDownLatch.countDown()
@@ -123,7 +123,7 @@ class GRPCStreamTest {
 
     GRPCClient(streamClient)
       .newGRPCStreamPrototype()
-      .setOnResponseTrailers { trailers ->
+      .setOnResponseTrailers { trailers, _ ->
         assertThat(trailers.allHeaders()).isEqualTo(expectedTrailers.allHeaders())
         countDownLatch.countDown()
       }
@@ -141,7 +141,7 @@ class GRPCStreamTest {
 
     GRPCClient(streamClient)
       .newGRPCStreamPrototype()
-      .setOnResponseMessage { message ->
+      .setOnResponseMessage { message, _ ->
         assertThat(message.array()).isEqualTo(message1.array())
         countDownLatch.countDown()
       }
@@ -182,7 +182,7 @@ class GRPCStreamTest {
 
     GRPCClient(streamClient)
       .newGRPCStreamPrototype()
-      .setOnResponseMessage { message ->
+      .setOnResponseMessage { message, _ ->
         if (countDownLatch.count == 2L) {
           assertThat(message.array()).isEqualTo(firstMessage)
         } else {
@@ -206,7 +206,7 @@ class GRPCStreamTest {
 
     GRPCClient(streamClient)
       .newGRPCStreamPrototype()
-      .setOnResponseMessage { message ->
+      .setOnResponseMessage { message, _ ->
         assertThat(message.array()).hasSize(0)
         countDownLatch.countDown()
       }
@@ -246,7 +246,7 @@ class GRPCStreamTest {
 
     GRPCClient(streamClient)
       .newGRPCStreamPrototype()
-      .setOnResponseMessage { message ->
+      .setOnResponseMessage { message, _ ->
         if (countDownLatch.count == 2L) {
           assertThat(message.array()).hasSize(0)
         } else {

--- a/test/swift/GRPCStreamTests.swift
+++ b/test/swift/GRPCStreamTests.swift
@@ -95,7 +95,7 @@ final class GRPCStreamTests: XCTestCase {
 
     _ = GRPCClient(streamClient: streamClient)
       .newGRPCStreamPrototype()
-      .setOnResponseHeaders { headers, endStream in
+      .setOnResponseHeaders { headers, endStream, _ in
         XCTAssertEqual(expectedHeaders, headers)
         XCTAssertTrue(endStream)
         expectation.fulfill()
@@ -115,7 +115,7 @@ final class GRPCStreamTests: XCTestCase {
 
     _ = GRPCClient(streamClient: streamClient)
       .newGRPCStreamPrototype()
-      .setOnResponseTrailers { trailers in
+      .setOnResponseTrailers { trailers, _ in
         XCTAssertEqual(expectedTrailers, trailers)
         expectation.fulfill()
       }
@@ -137,7 +137,7 @@ final class GRPCStreamTests: XCTestCase {
 
     _ = GRPCClient(streamClient: streamClient)
       .newGRPCStreamPrototype()
-      .setOnResponseMessage { message in
+      .setOnResponseMessage { message, _ in
         XCTAssertEqual(kMessage1, message)
         expectation.fulfill()
       }
@@ -173,7 +173,7 @@ final class GRPCStreamTests: XCTestCase {
 
     _ = GRPCClient(streamClient: streamClient)
       .newGRPCStreamPrototype()
-      .setOnResponseMessage { message in
+      .setOnResponseMessage { message, _ in
         XCTAssertEqual(expectedMessages.removeFirst(), message)
         expectation.fulfill()
       }
@@ -199,7 +199,7 @@ final class GRPCStreamTests: XCTestCase {
 
     _ = GRPCClient(streamClient: streamClient)
       .newGRPCStreamPrototype()
-      .setOnResponseMessage { message in
+      .setOnResponseMessage { message, _ in
         XCTAssertTrue(message.isEmpty)
         expectation.fulfill()
       }
@@ -228,7 +228,7 @@ final class GRPCStreamTests: XCTestCase {
 
     _ = GRPCClient(streamClient: streamClient)
       .newGRPCStreamPrototype()
-      .setOnResponseMessage { message in
+      .setOnResponseMessage { message, _ in
         XCTAssertEqual(expectedMessages.removeFirst(), message)
         expectation.fulfill()
       }

--- a/test/swift/integration/CancelStreamTest.swift
+++ b/test/swift/integration/CancelStreamTest.swift
@@ -116,7 +116,7 @@ static_resources:
 
     client
       .newStreamPrototype()
-      .setOnCancel {
+      .setOnCancel { _ in
          runExpectation.fulfill()
       }
       .start()

--- a/test/swift/integration/DirectResponseContainsHeadersMatchIntegrationTest.swift
+++ b/test/swift/integration/DirectResponseContainsHeadersMatchIntegrationTest.swift
@@ -30,13 +30,13 @@ final class DirectResponseContainsHeadersMatchIntegrationTest: XCTestCase {
     engine
       .streamClient()
       .newStreamPrototype()
-      .setOnResponseHeaders { headers, endStream in
+      .setOnResponseHeaders { headers, endStream, _ in
         XCTAssertEqual(200, headers.httpStatus)
         XCTAssertEqual(["aaa"], headers.value(forName: "x-response-foo"))
         XCTAssertFalse(endStream)
         headersExpectation.fulfill()
       }
-      .setOnResponseData { data, endStream in
+      .setOnResponseData { data, endStream, _ in
         responseBuffer.append(contentsOf: data)
         if endStream {
           XCTAssertEqual("hello world", String(data: responseBuffer, encoding: .utf8))

--- a/test/swift/integration/DirectResponseExactHeadersMatchIntegrationTest.swift
+++ b/test/swift/integration/DirectResponseExactHeadersMatchIntegrationTest.swift
@@ -29,13 +29,13 @@ final class DirectResponseExactHeadersMatchIntegrationTest: XCTestCase {
     engine
       .streamClient()
       .newStreamPrototype()
-      .setOnResponseHeaders { headers, endStream in
+      .setOnResponseHeaders { headers, endStream, _ in
         XCTAssertEqual(200, headers.httpStatus)
         XCTAssertEqual(["aaa"], headers.value(forName: "x-response-foo"))
         XCTAssertFalse(endStream)
         headersExpectation.fulfill()
       }
-      .setOnResponseData { data, endStream in
+      .setOnResponseData { data, endStream, _ in
         responseBuffer.append(contentsOf: data)
         if endStream {
           XCTAssertEqual("hello world", String(data: responseBuffer, encoding: .utf8))

--- a/test/swift/integration/DirectResponseExactPathMatchIntegrationTest.swift
+++ b/test/swift/integration/DirectResponseExactPathMatchIntegrationTest.swift
@@ -23,13 +23,13 @@ final class DirectResponseExactPathMatchIntegrationTest: XCTestCase {
     engine
       .streamClient()
       .newStreamPrototype()
-      .setOnResponseHeaders { headers, endStream in
+      .setOnResponseHeaders { headers, endStream, _ in
         XCTAssertEqual(200, headers.httpStatus)
         XCTAssertEqual(["aaa"], headers.value(forName: "x-response-foo"))
         XCTAssertFalse(endStream)
         headersExpectation.fulfill()
       }
-      .setOnResponseData { data, endStream in
+      .setOnResponseData { data, endStream, _ in
         responseBuffer.append(contentsOf: data)
         if endStream {
           XCTAssertEqual("hello world", String(data: responseBuffer, encoding: .utf8))

--- a/test/swift/integration/DirectResponseFilterMutationIntegrationTest.swift
+++ b/test/swift/integration/DirectResponseFilterMutationIntegrationTest.swift
@@ -61,13 +61,13 @@ final class DirectResponseFilterMutationIntegrationTest: XCTestCase {
     engine
       .streamClient()
       .newStreamPrototype()
-      .setOnResponseHeaders { headers, endStream in
+      .setOnResponseHeaders { headers, endStream, _ in
         XCTAssertEqual(200, headers.httpStatus)
         XCTAssertEqual(["aaa"], headers.value(forName: "x-response-foo"))
         XCTAssertFalse(endStream)
         headersExpectation.fulfill()
       }
-      .setOnResponseData { data, endStream in
+      .setOnResponseData { data, endStream, _ in
         responseBuffer.append(contentsOf: data)
         if endStream {
           XCTAssertEqual("hello world", String(data: responseBuffer, encoding: .utf8))

--- a/test/swift/integration/DirectResponsePrefixHeadersMatchIntegrationTest.swift
+++ b/test/swift/integration/DirectResponsePrefixHeadersMatchIntegrationTest.swift
@@ -29,13 +29,13 @@ final class DirectResponsePrefixHeadersMatchIntegrationTest: XCTestCase {
     engine
       .streamClient()
       .newStreamPrototype()
-      .setOnResponseHeaders { headers, endStream in
+      .setOnResponseHeaders { headers, endStream, _ in
         XCTAssertEqual(200, headers.httpStatus)
         XCTAssertEqual(["aaa"], headers.value(forName: "x-response-foo"))
         XCTAssertFalse(endStream)
         headersExpectation.fulfill()
       }
-      .setOnResponseData { data, endStream in
+      .setOnResponseData { data, endStream, _ in
         responseBuffer.append(contentsOf: data)
         if endStream {
           XCTAssertEqual("hello world", String(data: responseBuffer, encoding: .utf8))

--- a/test/swift/integration/DirectResponsePrefixPathMatchIntegrationTest.swift
+++ b/test/swift/integration/DirectResponsePrefixPathMatchIntegrationTest.swift
@@ -23,13 +23,13 @@ final class DirectResponsePrefixPathMatchIntegrationTest: XCTestCase {
     engine
       .streamClient()
       .newStreamPrototype()
-      .setOnResponseHeaders { headers, endStream in
+      .setOnResponseHeaders { headers, endStream, _ in
         XCTAssertEqual(200, headers.httpStatus)
         XCTAssertEqual(["aaa"], headers.value(forName: "x-response-foo"))
         XCTAssertFalse(endStream)
         headersExpectation.fulfill()
       }
-      .setOnResponseData { data, endStream in
+      .setOnResponseData { data, endStream, _ in
         responseBuffer.append(contentsOf: data)
         if endStream {
           XCTAssertEqual("hello world", String(data: responseBuffer, encoding: .utf8))

--- a/test/swift/integration/DirectResponseSuffixHeadersMatchIntegrationTest.swift
+++ b/test/swift/integration/DirectResponseSuffixHeadersMatchIntegrationTest.swift
@@ -29,13 +29,13 @@ final class DirectResponseSuffixHeadersMatchIntegrationTest: XCTestCase {
     engine
       .streamClient()
       .newStreamPrototype()
-      .setOnResponseHeaders { headers, endStream in
+      .setOnResponseHeaders { headers, endStream, _ in
         XCTAssertEqual(200, headers.httpStatus)
         XCTAssertEqual(["aaa"], headers.value(forName: "x-response-foo"))
         XCTAssertFalse(endStream)
         headersExpectation.fulfill()
       }
-      .setOnResponseData { data, endStream in
+      .setOnResponseData { data, endStream, _ in
         responseBuffer.append(contentsOf: data)
         if endStream {
           XCTAssertEqual("hello world", String(data: responseBuffer, encoding: .utf8))

--- a/test/swift/integration/FilterResetIdleTest.swift
+++ b/test/swift/integration/FilterResetIdleTest.swift
@@ -181,7 +181,7 @@ static_resources:
 
     client
       .newStreamPrototype()
-      .setOnError { _ in
+      .setOnError { _, _ in
         timeoutExpectation.fulfill()
       }
       .start()

--- a/test/swift/integration/GRPCReceiveErrorTest.swift
+++ b/test/swift/integration/GRPCReceiveErrorTest.swift
@@ -101,19 +101,19 @@ static_resources:
 
     client
       .newGRPCStreamPrototype()
-      .setOnResponseHeaders { _, _ in
+      .setOnResponseHeaders { _, _, _ in
         XCTFail("Headers received instead of expected error")
       }
-      .setOnResponseMessage { _ in
+      .setOnResponseMessage { _, _ in
         XCTFail("Message received instead of expected error")
       }
       // The unmatched expecation will cause a local reply which gets translated in Envoy Mobile to
       // an error.
-      .setOnError { error in
+      .setOnError { error, _ in
          XCTAssertEqual(error.errorCode, 2) // 503/Connection Failure
          callbackReceivedError.fulfill()
       }
-      .setOnCancel {
+      .setOnCancel { _ in
         XCTFail("Unexpected call to onCancel response callback")
       }
       .start()

--- a/test/swift/integration/ReceiveDataTest.swift
+++ b/test/swift/integration/ReceiveDataTest.swift
@@ -66,16 +66,16 @@ static_resources:
 
     client
       .newStreamPrototype()
-      .setOnResponseHeaders { responseHeaders, _ in
+      .setOnResponseHeaders { responseHeaders, _, _ in
          XCTAssertEqual(200, responseHeaders.httpStatus)
          headersExpectation.fulfill()
       }
-      .setOnResponseData { data, _ in
+      .setOnResponseData { data, _, _ in
         let responseBody = String(data: data, encoding: .utf8)
         XCTAssertEqual(assertionResponseBody, responseBody)
         dataExpectation.fulfill()
       }
-      .setOnError { _ in
+      .setOnError { _, _ in
         XCTFail("Unexpected error")
       }
       .start()

--- a/test/swift/integration/ReceiveErrorTest.swift
+++ b/test/swift/integration/ReceiveErrorTest.swift
@@ -100,19 +100,19 @@ static_resources:
 
     client
       .newStreamPrototype()
-      .setOnResponseHeaders { _, _ in
+      .setOnResponseHeaders { _, _, _ in
         XCTFail("Headers received instead of expected error")
       }
-      .setOnResponseData { _, _ in
+      .setOnResponseData { _, _, _ in
         XCTFail("Data received instead of expected error")
       }
       // The unmatched expectation will cause a local reply which gets translated in Envoy Mobile to
       // an error.
-      .setOnError { error in
+      .setOnError { error, _ in
          XCTAssertEqual(error.errorCode, 2) // 503/Connection Failure
          callbackReceivedError.fulfill()
       }
-      .setOnCancel {
+      .setOnCancel { _ in
         XCTFail("Unexpected call to onCancel response callback")
       }
       .start()

--- a/test/swift/integration/SendDataTest.swift
+++ b/test/swift/integration/SendDataTest.swift
@@ -66,12 +66,12 @@ static_resources:
 
     client
       .newStreamPrototype()
-      .setOnResponseHeaders { responseHeaders, endStream in
+      .setOnResponseHeaders { responseHeaders, endStream, _ in
          XCTAssertEqual(200, responseHeaders.httpStatus)
          XCTAssertTrue(endStream)
          expectation.fulfill()
       }
-      .setOnError { _ in
+      .setOnError { _, _ in
         XCTFail("Unexpected error")
       }
       .start()

--- a/test/swift/integration/SendHeadersTest.swift
+++ b/test/swift/integration/SendHeadersTest.swift
@@ -60,12 +60,12 @@ static_resources:
       .build()
     client
       .newStreamPrototype()
-      .setOnResponseHeaders { responseHeaders, endStream in
+      .setOnResponseHeaders { responseHeaders, endStream, _ in
          XCTAssertEqual(200, responseHeaders.httpStatus)
          XCTAssertTrue(endStream)
          expectation.fulfill()
       }
-      .setOnError { _ in
+      .setOnError { _, _ in
         XCTFail("Unexpected error")
       }
       .start()

--- a/test/swift/integration/SendTrailersTest.swift
+++ b/test/swift/integration/SendTrailersTest.swift
@@ -71,11 +71,11 @@ static_resources:
 
     client
       .newStreamPrototype()
-      .setOnResponseHeaders { responseHeaders, _ in
+      .setOnResponseHeaders { responseHeaders, _, _ in
          XCTAssertEqual(200, responseHeaders.httpStatus)
          expectation.fulfill()
       }
-      .setOnError { _ in
+      .setOnError { _, _ in
         XCTFail("Unexpected error")
       }
       .start()


### PR DESCRIPTION
Description: Exposes a StreamIntel struct on all response callbacks. Currently set up to contain stream ID, connection ID and attempt count, but eventually can furnish a variety of stream properties, context, and metrics.
Risk Level: Moderate
Testing: Local & CI
Docs Changes: Upcoming in separate PR

Signed-off-by: Mike Schore <mike.schore@gmail.com>
