### PR TITLE
swift: Make EngineBuilder open to allow for subclassing

### DIFF
--- a/library/swift/EngineBuilder.swift
+++ b/library/swift/EngineBuilder.swift
@@ -3,7 +3,7 @@ import Foundation
 
 /// Builder used for creating and running a new Engine instance.
 @objcMembers
-public class EngineBuilder: NSObject {
+open class EngineBuilder: NSObject {
   private let base: BaseConfiguration
   private var engineType: EnvoyEngine.Type = EnvoyEngineImpl.self
   private var logLevel: LogLevel = .info


### PR DESCRIPTION
This matches what the Kotlin version allows

Risk Level: Low
Testing: n/a
Docs Changes: n/a
Release Notes: n/a
Signed-off-by: Snow Pettersen <snowp@lyft.com>