### PR TITLE
Use self-provided xcode_config target instead of relying on @local_config_xcode

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -16,7 +16,6 @@ build --ios_simulator_version=14.4
 build --spawn_strategy=local
 build --verbose_failures
 build --workspace_status_command=envoy/bazel/get_workspace_status
-build --xcode_version_config=//ci:xcode_config
 build --xcode_version=12.4
 build --javabase=@bazel_tools//tools/jdk:jdk
 build --define disable_known_issue_asserts=true
@@ -96,6 +95,7 @@ build:coverage --javabase=@bazel_tools//tools/jdk:remote_jdk11
 # however, the MacOS remote execution cluster doesn't use GCP auth
 # so we have to override it to 'false' here.
 build:remote-ci-macos --config=remote
+build:remote-ci-macos --xcode_version_config=//ci:xcode_config
 build:remote-ci-macos --auth_enabled=false
 build:remote-ci-macos --remote_executor=grpcs://envoy.cluster.engflow.com
 build:remote-ci-macos --bes_backend=grpcs://envoy.cluster.engflow.com/

--- a/.bazelrc
+++ b/.bazelrc
@@ -16,6 +16,7 @@ build --ios_simulator_version=14.4
 build --spawn_strategy=local
 build --verbose_failures
 build --workspace_status_command=envoy/bazel/get_workspace_status
+build --xcode_version_config=//ci:xcode_config
 build --xcode_version=12.4
 build --javabase=@bazel_tools//tools/jdk:jdk
 build --define disable_known_issue_asserts=true

--- a/ci/BUILD
+++ b/ci/BUILD
@@ -1,0 +1,30 @@
+xcode_version(
+    name = "xcode_12_4",
+    default_ios_sdk_version = "14.4",
+    default_macos_sdk_version = "11.1",
+    default_tvos_sdk_version = "14.3",
+    default_watchos_sdk_version = "7.2",
+    version = "12.4",
+)
+
+available_xcodes(
+    name = "local_xcodes",
+    default = ":xcode_12_4",
+    versions = [
+        ":xcode_12_4",
+    ],
+)
+
+available_xcodes(
+    name = "remote_xcodes",
+    default = ":xcode_12_4",
+    versions = [
+        ":xcode_12_4",
+    ],
+)
+
+xcode_config(
+    name = "xcode_config",
+    local_versions = ":local_xcodes",
+    remote_versions = ":remote_xcodes",
+)

--- a/ci/BUILD
+++ b/ci/BUILD
@@ -1,3 +1,5 @@
+licenses(["notice"])  # Apache 2
+
 xcode_version(
     name = "xcode_12_4",
     default_ios_sdk_version = "14.4",


### PR DESCRIPTION
Description:

With remote execution, envoy mobile spends a significant fraction
of its built time in loading/analysis phase, and specificaly, in a
7.5 minutes build, around 2.7 minutes in evaluating @local_config_xcode
which auto configures Bazel with the locally installed Xcode versions.
Since envoy mobile passes `--xcode_version=12.4` in its `.bazelrc`, thus
requires a specific Xcode version, we can make the build significantly
faster by creating our own `xcode_config` target instead of relying
on Bazel's auto configuration.

Example invocation: https://envoy.cluster.engflow.com/invocation/a23bd20b-f0b9-472b-9a07-b9e5bc629b30#performance


Risk Level: low
Testing: local/CI
Docs Changes: N/A
Release Notes: N/A
