### PR TITLE
CI: Create configuration for running Linux CI jobs on remote execution

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -82,15 +82,31 @@ build:coverage --instrumentation_filter="//library/common[/:]"
 build:coverage --host_javabase=@bazel_tools//tools/jdk:remote_jdk11
 build:coverage --javabase=@bazel_tools//tools/jdk:remote_jdk11
 
-# Experimental EngFlow Remote Execution Config
-# --config=remote also sets --auth_enabled=true to enable GCP authentication.
-# We are not using GCP authentication for the MacOS remote execution cluster,
-# so we have to override it to false here.
-build:remote-ci-macos --config=remote
+#############################################################################
+# Experimental EngFlow Remote Execution Configs                             
+#############################################################################
+# remote-ci: These options are valid for any platform, use the configs below
+# to add platform-specific options
+#############################################################################
+build:remote-ci --config=remote
+build:remote-ci --remote_executor=grpcs://envoy.cluster.engflow.com
+build:remote-ci --bes_backend=grpcs://envoy.cluster.engflow.com/
+build:remote-ci --bes_results_url=https://envoy.cluster.engflow.com/invocation/
+build:remote-ci --bes_lifecycle_events
+build:remote-ci --jobs=40
+build:remote-ci --verbose_failures
+#############################################################################
+# remote-ci-linux: These options are linux-only
+#############################################################################
+build:remote-ci-linux --config=remote
+#############################################################################
+# remote-ci-macos: These options are macOS-only
+#############################################################################
+build:remote-ci-macos --config=remote-ci
+# --config=remote sets --auth_enabled=true to enable GCP authentication,
+# however, the MacOS remote execution cluster doesn't use GCP auth
+# so we have to override it to 'false' here.
 build:remote-ci-macos --auth_enabled=false
-build:remote-ci-macos --remote_executor=grpcs://envoy.cluster.engflow.com
-build:remote-ci-macos --bes_backend=grpcs://envoy.cluster.engflow.com/
-build:remote-ci-macos --bes_results_url=https://envoy.cluster.engflow.com/invocation/
-build:remote-ci-macos --bes_lifecycle_events
-build:remote-ci-macos --jobs=40
-build:remote-ci-macos --verbose_failures
+#############################################################################
+# Experimental EngFlow Remote Execution Configs                             
+#############################################################################

--- a/.bazelrc
+++ b/.bazelrc
@@ -98,7 +98,7 @@ build:remote-ci --verbose_failures
 #############################################################################
 # remote-ci-linux: These options are linux-only
 #############################################################################
-build:remote-ci-linux --config=remote
+build:remote-ci-linux --config=remote-ci
 #############################################################################
 # remote-ci-macos: These options are macOS-only
 #############################################################################

--- a/.github/workflows/ios_build.yml
+++ b/.github/workflows/ios_build.yml
@@ -27,34 +27,7 @@ jobs:
       - run: ./ci/mac_ci_setup.sh
         if: steps.check-cache.outputs.cache-hit != 'true'
         name: 'Install dependencies'
-      - run: bazelisk build --config=ios //:ios_dist
-        if: steps.check-cache.outputs.cache-hit != 'true'
-        name: 'Build Envoy.framework distributable'
-  iosbuildshadow:
-    name: ios_build_shadow
-    runs-on: macOS-latest
-    timeout-minutes: 75
-    steps:
-      - uses: actions/checkout@v1
-        with:
-          submodules: true
-      - uses: actions/cache@v2
-        id: check-cache
-        with:
-          key: framework-shadow-${{ github.sha }}
-          path: dist/Envoy.framework
-        name: 'Check cache'
-      - run: echo "Found Envoy.framework from previous run!"
-        if: steps.check-cache.outputs.cache-hit == 'true'
-        name: 'Build cache hit'
-      - run: ./ci/mac_ci_setup.sh
-        if: steps.check-cache.outputs.cache-hit != 'true'
-        name: 'Install dependencies'
-      - env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: |
-          bazelisk shutdown
-          bazelisk build --config=ios --config=remote-ci-macos --remote_header="Authorization=Bearer $GITHUB_TOKEN" //:ios_dist
+      - run: bazelisk build --config=ios --config=remote-ci-macos --remote_header="Authorization=Bearer $GITHUB_TOKEN" //:ios_dist
         if: steps.check-cache.outputs.cache-hit != 'true'
         name: 'Build Envoy.framework distributable'
   swifthelloworld:
@@ -77,10 +50,10 @@ jobs:
       - run: exit 1
         if: steps.check-cache.outputs.cache-hit != 'true'
         name: 'Short-circuit'
-      - run: bazelisk build --config=ios //examples/swift/hello_world:app
+      - run: bazelisk build --config=ios --config=remote-ci-macos --remote_header="Authorization=Bearer $GITHUB_TOKEN" //examples/swift/hello_world:app
         name: 'Build swift app'
       # Run the app in the background and redirect logs.
-      - run: bazelisk run --config=ios //examples/swift/hello_world:app &> /tmp/envoy.log &
+      - run: bazelisk run --config=ios --config=remote-ci-macos --remote_header="Authorization=Bearer $GITHUB_TOKEN" //examples/swift/hello_world:app &> /tmp/envoy.log &
         name: 'Run swift app'
       - run: sed '/received headers with status 200/q' <(touch /tmp/envoy.log && tail -F /tmp/envoy.log)
         name: 'Check connectivity'
@@ -107,10 +80,10 @@ jobs:
       - run: exit 1
         if: steps.check-cache.outputs.cache-hit != 'true'
         name: 'Short-circuit'
-      - run: bazelisk build --config=ios //examples/objective-c/hello_world:app
+      - run: bazelisk build --config=ios --config=remote-ci-macos --remote_header="Authorization=Bearer $GITHUB_TOKEN" //examples/objective-c/hello_world:app
         name: 'Build objective-c app'
       # Run the app in the background and redirect logs.
-      - run: bazelisk run --config=ios //examples/objective-c/hello_world:app &> /tmp/envoy.log &
+      - run: bazelisk run --config=ios --config=remote-ci-macos --remote_header="Authorization=Bearer $GITHUB_TOKEN" //examples/objective-c/hello_world:app &> /tmp/envoy.log &
         name: 'Run objective-c app'
       - run: sed '/received headers with status 200/q' <(touch /tmp/envoy.log && tail -F /tmp/envoy.log)
         name: 'Check connectivity'

--- a/.github/workflows/ios_build.yml
+++ b/.github/workflows/ios_build.yml
@@ -27,7 +27,34 @@ jobs:
       - run: ./ci/mac_ci_setup.sh
         if: steps.check-cache.outputs.cache-hit != 'true'
         name: 'Install dependencies'
-      - run: bazelisk build --config=ios --config=remote-ci-macos --remote_header="Authorization=Bearer $GITHUB_TOKEN" //:ios_dist
+      - run: bazelisk build --config=ios //:ios_dist
+        if: steps.check-cache.outputs.cache-hit != 'true'
+        name: 'Build Envoy.framework distributable'
+  iosbuildshadow:
+    name: ios_build_shadow
+    runs-on: macOS-latest
+    timeout-minutes: 75
+    steps:
+      - uses: actions/checkout@v1
+        with:
+          submodules: true
+      - uses: actions/cache@v2
+        id: check-cache
+        with:
+          key: framework-shadow-${{ github.sha }}
+          path: dist/Envoy.framework
+        name: 'Check cache'
+      - run: echo "Found Envoy.framework from previous run!"
+        if: steps.check-cache.outputs.cache-hit == 'true'
+        name: 'Build cache hit'
+      - run: ./ci/mac_ci_setup.sh
+        if: steps.check-cache.outputs.cache-hit != 'true'
+        name: 'Install dependencies'
+      - env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          bazelisk shutdown
+          bazelisk build --config=ios --config=remote-ci-macos --remote_header="Authorization=Bearer $GITHUB_TOKEN" //:ios_dist
         if: steps.check-cache.outputs.cache-hit != 'true'
         name: 'Build Envoy.framework distributable'
   swifthelloworld:
@@ -50,10 +77,10 @@ jobs:
       - run: exit 1
         if: steps.check-cache.outputs.cache-hit != 'true'
         name: 'Short-circuit'
-      - run: bazelisk build --config=ios --config=remote-ci-macos --remote_header="Authorization=Bearer $GITHUB_TOKEN" //examples/swift/hello_world:app
+      - run: bazelisk build --config=ios //examples/swift/hello_world:app
         name: 'Build swift app'
       # Run the app in the background and redirect logs.
-      - run: bazelisk run --config=ios --config=remote-ci-macos --remote_header="Authorization=Bearer $GITHUB_TOKEN" //examples/swift/hello_world:app &> /tmp/envoy.log &
+      - run: bazelisk run --config=ios //examples/swift/hello_world:app &> /tmp/envoy.log &
         name: 'Run swift app'
       - run: sed '/received headers with status 200/q' <(touch /tmp/envoy.log && tail -F /tmp/envoy.log)
         name: 'Check connectivity'
@@ -80,10 +107,10 @@ jobs:
       - run: exit 1
         if: steps.check-cache.outputs.cache-hit != 'true'
         name: 'Short-circuit'
-      - run: bazelisk build --config=ios --config=remote-ci-macos --remote_header="Authorization=Bearer $GITHUB_TOKEN" //examples/objective-c/hello_world:app
+      - run: bazelisk build --config=ios //examples/objective-c/hello_world:app
         name: 'Build objective-c app'
       # Run the app in the background and redirect logs.
-      - run: bazelisk run --config=ios --config=remote-ci-macos --remote_header="Authorization=Bearer $GITHUB_TOKEN" //examples/objective-c/hello_world:app &> /tmp/envoy.log &
+      - run: bazelisk run --config=ios //examples/objective-c/hello_world:app &> /tmp/envoy.log &
         name: 'Run objective-c app'
       - run: sed '/received headers with status 200/q' <(touch /tmp/envoy.log && tail -F /tmp/envoy.log)
         name: 'Check connectivity'


### PR DESCRIPTION
Description: Some of the presubmit jobs run on Linux and as part of migrating CI to use remote execution we need to add a Linux-only config to the bazelrc that can be referenced by the corresponding Github actions.

Risk Level: Low
Testing: Locally
Docs Changes: N/A
Release Notes: N/A
