### PR TITLE
common: use RELEASE_ASSERT to verify API registration

### DIFF
--- a/library/common/api/external.cc
+++ b/library/common/api/external.cc
@@ -15,13 +15,16 @@ static absl::flat_hash_map<std::string, void*> registry_{};
 // TODO(goaway): To expose this for general usage, it will need to be made thread-safe. For now it
 // relies on the assumption that usage will occur only as part of Engine configuration, and thus be
 // limited to a single thread.
-void registerApi(std::string name, void* api) { registry_[name] = api; }
+void registerApi(std::string name, void* api) {
+  RELEASE_ASSERT(api != nullptr, "cannot register null API");
+  registry_[name] = api;
+}
 
 // TODO(goaway): This is not thread-safe, but the assumption here is that all writes will complete
 // before any reads occur.
 void* retrieveApi(std::string name) {
   void* api = registry_[name];
-  ASSERT(api, fmt::format("{} not registered", name));
+  RELEASE_ASSERT(api != nullptr, fmt::format("{} not registered", name));
   return api;
 }
 


### PR DESCRIPTION
Signed-off-by: Snow Pettersen <snowp@lyft.com>

Description: common: use RELEASE_ASSERT to verify API registration
Risk Level: Medium
Testing: Existing tests
Docs Changes: n/a
Release Notes: n/a
