### PR TITLE
build: bumping boring to HTTP/3 compatible version

### DIFF
--- a/bazel/envoy_mobile_repositories.bzl
+++ b/bazel/envoy_mobile_repositories.bzl
@@ -42,9 +42,9 @@ def upstream_envoy_overrides():
     http_archive(
         name = "boringssl",
         patches = ["@envoy_mobile//bazel:boringssl.patch"],
-        sha256 = "d78f7b11b8665feea1b6def8e6f235ad8671db8de950f5429f1bf2b3503b3894",
-        strip_prefix = "boringssl-b049eae83d25977661556dcd913b35fbafb3a93a",
-        urls = ["https://github.com/google/boringssl/archive/b049eae83d25977661556dcd913b35fbafb3a93a.tar.gz"],
+        sha256 = "70e9d8737e35d67f94b9e742ca59c02c36f30f1d822d5a3706511a23798d8049",
+        strip_prefix = "boringssl-75edea1922aefe415e0e60ac576116634b0a94f8",
+        urls = ["https://github.com/google/boringssl/archive/75edea1922aefe415e0e60ac576116634b0a94f8.tar.gz"],
     )
 
     # Envoy uses rules_python v0.1.0, which does not include tooling for packaging Python.  The


### PR DESCRIPTION
Risk Level: low  (Envoy upstream uses this version)
Testing: assuming extra tests validate
Docs Changes: n/a
Release Notes: n/a
