### PR TITLE
build: allow reusing android test rule via submodule

### DIFF
--- a/bazel/kotlin_test.bzl
+++ b/bazel/kotlin_test.bzl
@@ -64,12 +64,12 @@ def envoy_mobile_kt_test(name, srcs, deps = [], repository = ""):
     _internal_kt_test(name, srcs, deps, repository = repository)
 
 # A basic macro to run android based (robolectric) tests with native dependencies
-def envoy_mobile_android_test(name, srcs, deps = [], native_deps = [], repository = ""):
+def envoy_mobile_android_test(name, srcs, deps = [], native_deps = [], repository = "", library_path = "library/common/jni"):
     lib_name = native_lib_name(native_deps[0])[3:]
     native.android_library(
         name = name + "_test_lib",
         custom_package = "io.envoyproxy.envoymobile.test",
-        manifest = "//bazel:test_manifest.xml",
+        manifest = repository + "//bazel:test_manifest.xml",
         visibility = ["//visibility:public"],
         data = native_deps,
         exports = deps,
@@ -103,7 +103,7 @@ def envoy_mobile_android_test(name, srcs, deps = [], native_deps = [], repositor
         custom_package = "io.envoyproxy.envoymobile.tests",
         test_class = "io.envoyproxy.envoymobile.bazel.EnvoyMobileTestSuite",
         jvm_flags = [
-            "-Djava.library.path=library/common/jni",
+            "-Djava.library.path={}".format(library_path),
             "-Denvoy_jni_library_name={}".format(lib_name),
         ],
     )


### PR DESCRIPTION
This should allow a repo that consumes envoy-mobile via a submodule to reuse this test rule.

Signed-off-by: Snow Pettersen <snowp@lyft.com>

Risk Level: Low
Testing: n/a
Docs Changes: n/a
Release Notes: n/a
