### PR TITLE
ci: explicitly use stable channel for downloads

### DIFF
--- a/ci/mac_start_emulator.sh
+++ b/ci/mac_start_emulator.sh
@@ -3,6 +3,6 @@
 set -e
 
 echo "y" | $ANDROID_SDK_ROOT/cmdline-tools/latest/bin/sdkmanager --install 'system-images;android-29;google_apis;x86' --channel=0
-echo "no" | $ANDROID_HOME/tools/bin/avdmanager create avd -n test_android_emulator -k 'system-images;android-29;google_apis;x86' --force 
+echo "no" | $ANDROID_HOME/tools/bin/avdmanager create avd -n test_android_emulator -k 'system-images;android-29;google_apis;x86' --force
 ls $ANDROID_HOME/tools/bin/
 nohup $ANDROID_HOME/emulator/emulator -partition-size 1024 -avd test_android_emulator -no-snapshot > /dev/null 2>&1 & $ANDROID_HOME/platform-tools/adb wait-for-device shell 'while [[ -z $(getprop sys.boot_completed | tr -d '\r') ]]; do sleep 1; done; input keyevent 82'

--- a/ci/mac_start_emulator.sh
+++ b/ci/mac_start_emulator.sh
@@ -2,7 +2,7 @@
 
 set -e
 
-echo "y" | $ANDROID_SDK_ROOT/cmdline-tools/latest/bin/sdkmanager --install 'system-images;android-29;google_apis;x86'
-echo "no" | $ANDROID_HOME/tools/bin/avdmanager create avd -n test_android_emulator -k 'system-images;android-29;google_apis;x86' --force
+echo "y" | $ANDROID_SDK_ROOT/cmdline-tools/latest/bin/sdkmanager --install 'system-images;android-29;google_apis;x86' --channel=0
+echo "no" | $ANDROID_HOME/tools/bin/avdmanager create avd -n test_android_emulator -k 'system-images;android-29;google_apis;x86' --force 
 ls $ANDROID_HOME/tools/bin/
 nohup $ANDROID_HOME/emulator/emulator -partition-size 1024 -avd test_android_emulator -no-snapshot > /dev/null 2>&1 & $ANDROID_HOME/platform-tools/adb wait-for-device shell 'while [[ -z $(getprop sys.boot_completed | tr -d '\r') ]]; do sleep 1; done; input keyevent 82'


### PR DESCRIPTION
Signed-off-by: Snow Pettersen <snowp@lyft.com>

This should resolve the CI issue of the system image depending on a beta emulator.

Risk Level: Low
Testing: n/a
Docs Changes: n/a
Release Notes: n/a
