### PR TITLE
ci: use channel 3

### DIFF
--- a/ci/mac_start_emulator.sh
+++ b/ci/mac_start_emulator.sh
@@ -2,7 +2,7 @@
 
 set -e
 
-echo "y" | $ANDROID_SDK_ROOT/cmdline-tools/latest/bin/sdkmanager --install 'system-images;android-29;google_apis;x86'
+echo "y" | $ANDROID_SDK_ROOT/cmdline-tools/latest/bin/sdkmanager --install 'system-images;android-29;google_apis;x86' --channel=3
 echo "no" | $ANDROID_HOME/tools/bin/avdmanager create avd -n test_android_emulator -k 'system-images;android-29;google_apis;x86' --force
 ls $ANDROID_HOME/tools/bin/
 nohup $ANDROID_HOME/emulator/emulator -partition-size 1024 -avd test_android_emulator -no-snapshot > /dev/null 2>&1 & $ANDROID_HOME/platform-tools/adb wait-for-device shell 'while [[ -z $(getprop sys.boot_completed | tr -d '\r') ]]; do sleep 1; done; input keyevent 82'


### PR DESCRIPTION
Signed-off-by: Rafal Augustyniak <raugustyniak@lyft.com>



Description:  Fixing Android emulator as it currently fails with `Package "Android Emulator" with revision at least 30.8.2 not available.` when CI jobs for Android hello world apps (Java and Kotlin) are run.
Risk Level: None
Testing: N/A
Docs Changes: N/A
Release Notes: N/A
