### PR TITLE
ci: revert EngFlow ios_build changes

### DIFF
--- a/.github/workflows/ios_build.yml
+++ b/.github/workflows/ios_build.yml
@@ -107,14 +107,10 @@ jobs:
       - run: exit 1
         if: steps.check-cache.outputs.cache-hit != 'true'
         name: 'Short-circuit'
-      - env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: bazelisk build --config=ios --config=remote-ci-macos --remote_header="Authorization=Bearer $GITHUB_TOKEN" //examples/objective-c/hello_world:app
+      - run: bazelisk build --config=ios //examples/objective-c/hello_world:app
         name: 'Build objective-c app'
       # Run the app in the background and redirect logs.
-      - env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: bazelisk run --config=ios --config=remote-ci-macos --remote_header="Authorization=Bearer $GITHUB_TOKEN" //examples/objective-c/hello_world:app &> /tmp/envoy.log &
+      - run: bazelisk run --config=ios //examples/objective-c/hello_world:app &> /tmp/envoy.log &
         name: 'Run objective-c app'
       - run: sed '/received headers with status 200/q' <(touch /tmp/envoy.log && tail -F /tmp/envoy.log)
         name: 'Check connectivity'

--- a/.github/workflows/ios_build.yml
+++ b/.github/workflows/ios_build.yml
@@ -27,6 +27,29 @@ jobs:
       - run: ./ci/mac_ci_setup.sh
         if: steps.check-cache.outputs.cache-hit != 'true'
         name: 'Install dependencies'
+      - run: bazelisk build --config=ios //:ios_dist
+        if: steps.check-cache.outputs.cache-hit != 'true'
+        name: 'Build Envoy.framework distributable'
+  iosbuildshadow:
+    name: ios_build_shadow
+    runs-on: macOS-latest
+    timeout-minutes: 75
+    steps:
+      - uses: actions/checkout@v1
+        with:
+          submodules: true
+      - uses: actions/cache@v2
+        id: check-cache
+        with:
+          key: framework-shadow-${{ github.sha }}
+          path: dist/Envoy.framework
+        name: 'Check cache'
+      - run: echo "Found Envoy.framework from previous run!"
+        if: steps.check-cache.outputs.cache-hit == 'true'
+        name: 'Build cache hit'
+      - run: ./ci/mac_ci_setup.sh
+        if: steps.check-cache.outputs.cache-hit != 'true'
+        name: 'Install dependencies'
       - env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |

--- a/.github/workflows/ios_build.yml
+++ b/.github/workflows/ios_build.yml
@@ -77,14 +77,10 @@ jobs:
       - run: exit 1
         if: steps.check-cache.outputs.cache-hit != 'true'
         name: 'Short-circuit'
-      - env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: bazelisk build --config=ios --config=remote-ci-macos --remote_header="Authorization=Bearer $GITHUB_TOKEN" //examples/swift/hello_world:app
+      - run: bazelisk build --config=ios //examples/swift/hello_world:app
         name: 'Build swift app'
       # Run the app in the background and redirect logs.
-      - env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: bazelisk run --config=ios --config=remote-ci-macos --remote_header="Authorization=Bearer $GITHUB_TOKEN" //examples/swift/hello_world:app &> /tmp/envoy.log &
+      - run: bazelisk run --config=ios //examples/swift/hello_world:app &> /tmp/envoy.log &
         name: 'Run swift app'
       - run: sed '/received headers with status 200/q' <(touch /tmp/envoy.log && tail -F /tmp/envoy.log)
         name: 'Check connectivity'


### PR DESCRIPTION
Description: Builds are failing with `java.io.IOException: io.grpc.StatusRuntimeException: RESOURCE_EXHAUSTED: RESOURCE_EXHAUSTED: Not enough space to create a replica`. Reverting to previous setup.
Risk Level: Low
Testing: CI

Signed-off-by: Mike Schore <mike.schore@gmail.com>