### PR TITLE
assert: emit events for assertions

### DIFF
--- a/library/cc/engine_builder.cc
+++ b/library/cc/engine_builder.cc
@@ -120,8 +120,13 @@ EngineSharedPtr EngineBuilder::build() {
   null_logger.release = envoy_noop_const_release;
   null_logger.context = nullptr;
 
+  envoy_event_tracker null_tracker;
+  null_tracker.track = nullptr;
+  null_tracker.context = nullptr;
+
   auto config_str = this->generateConfigStr();
-  auto envoy_engine = init_engine(this->callbacks_->asEnvoyEngineCallbacks(), null_logger);
+  auto envoy_engine =
+      init_engine(this->callbacks_->asEnvoyEngineCallbacks(), null_logger, null_tracker);
   run_engine(envoy_engine, config_str.c_str(), logLevelToString(this->log_level_).c_str());
 
   // we can't construct via std::make_shared

--- a/library/cc/engine_builder.cc
+++ b/library/cc/engine_builder.cc
@@ -120,9 +120,7 @@ EngineSharedPtr EngineBuilder::build() {
   null_logger.release = envoy_noop_const_release;
   null_logger.context = nullptr;
 
-  envoy_event_tracker null_tracker;
-  null_tracker.track = nullptr;
-  null_tracker.context = nullptr;
+  envoy_event_tracker null_tracker{};
 
   auto config_str = this->generateConfigStr();
   auto envoy_engine =

--- a/library/common/BUILD
+++ b/library/common/BUILD
@@ -24,6 +24,7 @@ envoy_cc_library(
     repository = "@envoy",
     deps = [
         ":engine_common_lib",
+        "//library/common/bridge:utility_lib",
         "//library/common/common:lambda_logger_delegate_lib",
         "//library/common/config:config_lib",
         "//library/common/data:utility_lib",
@@ -31,7 +32,6 @@ envoy_cc_library(
         "//library/common/http:client_lib",
         "//library/common/http:header_utility_lib",
         "//library/common/stats:utility_lib",
-        "//library/common/bridge:utility_lib",
         "//library/common/types:c_types_lib",
         "@envoy//envoy/server:lifecycle_notifier_interface",
         "@envoy_build_config//:extension_registry",

--- a/library/common/BUILD
+++ b/library/common/BUILD
@@ -31,6 +31,7 @@ envoy_cc_library(
         "//library/common/http:client_lib",
         "//library/common/http:header_utility_lib",
         "//library/common/stats:utility_lib",
+        "//library/common/bridge:utility_lib",
         "//library/common/types:c_types_lib",
         "@envoy//envoy/server:lifecycle_notifier_interface",
         "@envoy_build_config//:extension_registry",

--- a/library/common/engine.cc
+++ b/library/common/engine.cc
@@ -61,7 +61,7 @@ envoy_status_t Engine::main(const std::string config, const std::string log_leve
             Assert::addDebugAssertionFailureRecordAction([this](const char* location) {
               const auto event = Bridge::makeEnvoyMap(
                   {{"name", "assertion"}, {"location", std::string(location)}});
-              this->event_tracker_.track(event, this->event_tracker_.context);
+              event_tracker_.track(event, event_tracker_.context);
             });
       }
 

--- a/library/common/engine.cc
+++ b/library/common/engine.cc
@@ -4,16 +4,16 @@
 
 #include "source/common/common/lock_guard.h"
 
+#include "library/common/bridge/utility.h"
 #include "library/common/config/internal.h"
 #include "library/common/data/utility.h"
 #include "library/common/stats/utility.h"
-#include "library/common/bridge/utility.h"
 
 namespace Envoy {
 
 Engine::Engine(envoy_engine_callbacks callbacks, envoy_logger logger,
-               std::unique_ptr<envoy_event_tracker> event_tracker, std::atomic<envoy_network_t>& preferred_network)
-    : callbacks_(callbacks), logger_(logger), event_tracker_(std::move(event_tracker)),
+               envoy_event_tracker event_tracker, std::atomic<envoy_network_t>& preferred_network)
+    : callbacks_(callbacks), logger_(logger), event_tracker_(event_tracker),
       dispatcher_(std::make_unique<Event::ProvisionalDispatcher>()),
       preferred_network_(preferred_network) {
   // Ensure static factory registration occurs on time.
@@ -21,18 +21,19 @@ Engine::Engine(envoy_engine_callbacks callbacks, envoy_logger logger,
   // https://github.com/lyft/envoy-mobile/issues/332
   ExtensionRegistry::registerFactories();
 
-  Envoy::Api::External::registerApi(std::string(envoy_event_tracker_api_name), event_tracker_.get());
-  assert_handler_registration_ = Assert::addDebugAssertionFailureRecordAction(
-      [this](const char* location) {
-        if (event_tracker_->track == nullptr) {
+  // TODO(Augustyniak): Capturing an address of event_tracker_ and registering it in the API
+  // registry may lead to crashes at Engine shutdown. To be figured out as part of
+  // https://github.com/lyft/envoy-mobile/issues/332
+  Envoy::Api::External::registerApi(std::string(envoy_event_tracker_api_name), &event_tracker_);
+  assert_handler_registration_ =
+      Assert::addDebugAssertionFailureRecordAction([this](const char* location) {
+        if (this->event_tracker_.track == nullptr) {
           return;
         }
 
-        const auto event = Bridge::makeEnvoyMap({
-          {"name", "envoy_assertion"},
-          {"location", std::string(location)}
-        });
-        event_tracker_->track(event, event_tracker_->context);
+        const auto event = Bridge::makeEnvoyMap(
+            {{"name", "envoy_assertion"}, {"location", std::string(location)}});
+        this->event_tracker_.track(event, this->event_tracker_.context);
       });
 }
 

--- a/library/common/engine.h
+++ b/library/common/engine.h
@@ -23,8 +23,7 @@ public:
    * @param event_tracker, the event tracker to use for the emission of events.
    * @param preferred_network, hook to obtain the preferred network for new streams.
    */
-  Engine(envoy_engine_callbacks callbacks, envoy_logger logger,
-         std::unique_ptr<envoy_event_tracker> event_tracker,
+  Engine(envoy_engine_callbacks callbacks, envoy_logger logger, envoy_event_tracker event_tracker,
          std::atomic<envoy_network_t>& preferred_network);
 
   /**
@@ -116,7 +115,7 @@ private:
   Stats::StatNameSetPtr stat_name_set_;
   envoy_engine_callbacks callbacks_;
   envoy_logger logger_;
-  std::unique_ptr<envoy_event_tracker> event_tracker_;
+  envoy_event_tracker event_tracker_;
   Assert::ActionRegistrationPtr assert_handler_registration_;
   Thread::MutexBasicLockable mutex_;
   Thread::CondVar cv_;

--- a/library/common/engine.h
+++ b/library/common/engine.h
@@ -20,9 +20,11 @@ public:
    * Constructor for a new engine instance.
    * @param callbacks, the callbacks to use for engine lifecycle monitoring.
    * @param logger, the callbacks to use for engine logging.
+   * @param event_tracker, the event tracker to use for the emission of events.
    * @param preferred_network, hook to obtain the preferred network for new streams.
    */
   Engine(envoy_engine_callbacks callbacks, envoy_logger logger,
+         std::unique_ptr<envoy_event_tracker> event_tracker,
          std::atomic<envoy_network_t>& preferred_network);
 
   /**
@@ -114,6 +116,8 @@ private:
   Stats::StatNameSetPtr stat_name_set_;
   envoy_engine_callbacks callbacks_;
   envoy_logger logger_;
+  std::unique_ptr<envoy_event_tracker> event_tracker_;
+  Assert::ActionRegistrationPtr assert_handler_registration_;
   Thread::MutexBasicLockable mutex_;
   Thread::CondVar cv_;
   Http::ClientPtr http_client_;

--- a/library/common/extensions/filters/http/test_accessor/filter.cc
+++ b/library/common/extensions/filters/http/test_accessor/filter.cc
@@ -22,6 +22,7 @@ Http::FilterHeadersStatus TestAccessorFilter::decodeHeaders(Http::RequestHeaderM
                      Data::Utility::copyToString(
                          config_->accessor()->get_string(config_->accessor()->context)),
                  "accessed string is not equal to expected string");
+  ASSERT(1 == 2, "testowanie");
   return Http::FilterHeadersStatus::Continue;
 }
 

--- a/library/common/extensions/filters/http/test_accessor/filter.cc
+++ b/library/common/extensions/filters/http/test_accessor/filter.cc
@@ -22,7 +22,6 @@ Http::FilterHeadersStatus TestAccessorFilter::decodeHeaders(Http::RequestHeaderM
                      Data::Utility::copyToString(
                          config_->accessor()->get_string(config_->accessor()->context)),
                  "accessed string is not equal to expected string");
-  ASSERT(1 == 2, "testowanie");
   return Http::FilterHeadersStatus::Continue;
 }
 

--- a/library/common/extensions/filters/http/test_event_tracker/filter.h
+++ b/library/common/extensions/filters/http/test_event_tracker/filter.h
@@ -19,7 +19,11 @@ public:
           proto_config);
 
   std::vector<std::pair<std::string, std::string>> attributes() { return attributes_; };
-  void track(envoy_map event) { event_tracker_->track(event, event_tracker_->context); };
+  void track(envoy_map event) {
+    if (event_tracker_->track != nullptr) {
+      event_tracker_->track(event, event_tracker_->context);
+    }
+  };
 
 private:
   std::vector<std::pair<std::string, std::string>> attributes_;

--- a/library/common/jni/jni_interface.cc
+++ b/library/common/jni/jni_interface.cc
@@ -69,8 +69,27 @@ static void jvm_on_exit(void*) {
   jvm_detach_thread();
 }
 
+static void jvm_on_track(envoy_map events, const void* context) {
+  jni_log("[Envoy]", "jvm_on_track");
+  if (context == nullptr) {
+    return;
+  }
+
+  JNIEnv* env = get_env();
+  jobject events_hashmap = native_map_to_map(env, events);
+
+  jobject j_context = static_cast<jobject>(const_cast<void*>(context));
+  jclass jcls_EnvoyEventTracker = env->GetObjectClass(j_context);
+  jmethodID jmid_onTrack = env->GetMethodID(jcls_EnvoyEventTracker, "track", "(Ljava/util/Map;)V");
+  env->CallVoidMethod(j_context, jmid_onTrack, events_hashmap);
+
+  release_envoy_map(events);
+  env->DeleteLocalRef(events_hashmap);
+  env->DeleteLocalRef(jcls_EnvoyEventTracker);
+}
+
 extern "C" JNIEXPORT jlong JNICALL Java_io_envoyproxy_envoymobile_engine_JniLibrary_initEngine(
-    JNIEnv* env, jclass, jobject on_start_context, jobject envoy_logger_context) {
+    JNIEnv* env, jclass, jobject on_start_context, jobject envoy_logger_context, jobject j_event_tracker) {
   jobject retained_on_start_context =
       env->NewGlobalRef(on_start_context); // Required to keep context in memory
   envoy_engine_callbacks native_callbacks = {jvm_on_engine_running, jvm_on_exit,
@@ -81,7 +100,20 @@ extern "C" JNIEXPORT jlong JNICALL Java_io_envoyproxy_envoymobile_engine_JniLibr
   if (envoy_logger_context != nullptr) {
     logger = envoy_logger{jvm_on_log, jni_delete_const_global_ref, retained_logger_context};
   }
-  return init_engine(native_callbacks, logger);
+
+  // TODO(goaway): The retained_context leaks, but it's tied to the life of the engine.
+  // This will need to be updated for https://github.com/lyft/envoy-mobile/issues/332.
+  jobject retained_context = env->NewGlobalRef(j_event_tracker);
+  jni_log_fmt("[Envoy]", "retained_context: %p", retained_context);
+
+  envoy_event_tracker* event_tracker = (envoy_event_tracker*)safe_malloc(sizeof(envoy_event_tracker));
+  memset(event_tracker, 0, sizeof(envoy_event_tracker));
+  if (j_event_tracker != nullptr) {
+    event_tracker->track = jvm_on_track;
+    event_tracker->context = retained_context;
+  }
+
+  return init_engine(native_callbacks, logger, event_tracker);
 }
 
 extern "C" JNIEXPORT jint JNICALL Java_io_envoyproxy_envoymobile_engine_JniLibrary_runEngine(
@@ -891,45 +923,5 @@ Java_io_envoyproxy_envoymobile_engine_JniLibrary_registerStringAccessor(JNIEnv* 
   envoy_status_t result =
       register_platform_api(env->GetStringUTFChars(accessor_name, nullptr), string_accessor);
   env->DeleteLocalRef(jcls_JvmStringAccessorContext);
-  return result;
-}
-
-static void jvm_on_track(envoy_map events, const void* context) {
-  jni_log("[Envoy]", "jvm_on_track");
-  if (context == nullptr) {
-    return;
-  }
-
-  JNIEnv* env = get_env();
-  jobject events_hashmap = native_map_to_map(env, events);
-
-  jobject j_context = static_cast<jobject>(const_cast<void*>(context));
-  jclass jcls_EnvoyEventTracker = env->GetObjectClass(j_context);
-  jmethodID jmid_onTrack = env->GetMethodID(jcls_EnvoyEventTracker, "track", "(Ljava/util/Map;)V");
-  env->CallVoidMethod(j_context, jmid_onTrack, events_hashmap);
-
-  release_envoy_map(events);
-  env->DeleteLocalRef(events_hashmap);
-  env->DeleteLocalRef(jcls_EnvoyEventTracker);
-}
-
-// EnvoyEventTracker
-
-extern "C" JNIEXPORT jint JNICALL
-Java_io_envoyproxy_envoymobile_engine_JniLibrary_registerEventTracker(JNIEnv* env, jclass,
-                                                                      jobject j_event_tracker) {
-  jni_log("[Envoy]", "register event tracker");
-
-  // TODO(goaway): The retained_context leaks, but it's tied to the life of the engine.
-  // This will need to be updated for https://github.com/lyft/envoy-mobile/issues/332.
-  jobject retained_context = env->NewGlobalRef(j_event_tracker);
-  jni_log_fmt("[Envoy]", "retained_context: %p", retained_context);
-  envoy_event_tracker* event_tracker = nullptr;
-  if (j_event_tracker != nullptr) {
-    event_tracker = (envoy_event_tracker*)safe_malloc(sizeof(envoy_event_tracker));
-    event_tracker->track = jvm_on_track;
-    event_tracker->context = retained_context;
-  }
-  envoy_status_t result = register_platform_api(envoy_event_tracker_api_name, event_tracker);
   return result;
 }

--- a/library/common/jni/jni_interface.cc
+++ b/library/common/jni/jni_interface.cc
@@ -102,13 +102,12 @@ extern "C" JNIEXPORT jlong JNICALL Java_io_envoyproxy_envoymobile_engine_JniLibr
     logger = envoy_logger{jvm_on_log, jni_delete_const_global_ref, retained_logger_context};
   }
 
-  // TODO(goaway): The retained_context leaks, but it's tied to the life of the engine.
-  // This will need to be updated for https://github.com/lyft/envoy-mobile/issues/332.
-  jobject retained_context = env->NewGlobalRef(j_event_tracker);
-  jni_log_fmt("[Envoy]", "retained_context: %p", retained_context);
-
-  envoy_event_tracker event_tracker = {NULL, NULL};
+  envoy_event_tracker event_tracker = {nullptr, nullptr};
   if (j_event_tracker != nullptr) {
+    // TODO(goaway): The retained_context leaks, but it's tied to the life of the engine.
+    // This will need to be updated for https://github.com/lyft/envoy-mobile/issues/332.
+    jobject retained_context = env->NewGlobalRef(j_event_tracker);
+    jni_log_fmt("[Envoy]", "retained_context: %p", retained_context);
     event_tracker.track = jvm_on_track;
     event_tracker.context = retained_context;
   }

--- a/library/common/jni/jni_interface.cc
+++ b/library/common/jni/jni_interface.cc
@@ -89,7 +89,8 @@ static void jvm_on_track(envoy_map events, const void* context) {
 }
 
 extern "C" JNIEXPORT jlong JNICALL Java_io_envoyproxy_envoymobile_engine_JniLibrary_initEngine(
-    JNIEnv* env, jclass, jobject on_start_context, jobject envoy_logger_context, jobject j_event_tracker) {
+    JNIEnv* env, jclass, jobject on_start_context, jobject envoy_logger_context,
+    jobject j_event_tracker) {
   jobject retained_on_start_context =
       env->NewGlobalRef(on_start_context); // Required to keep context in memory
   envoy_engine_callbacks native_callbacks = {jvm_on_engine_running, jvm_on_exit,
@@ -106,11 +107,10 @@ extern "C" JNIEXPORT jlong JNICALL Java_io_envoyproxy_envoymobile_engine_JniLibr
   jobject retained_context = env->NewGlobalRef(j_event_tracker);
   jni_log_fmt("[Envoy]", "retained_context: %p", retained_context);
 
-  envoy_event_tracker* event_tracker = (envoy_event_tracker*)safe_malloc(sizeof(envoy_event_tracker));
-  memset(event_tracker, 0, sizeof(envoy_event_tracker));
+  envoy_event_tracker event_tracker = {NULL, NULL};
   if (j_event_tracker != nullptr) {
-    event_tracker->track = jvm_on_track;
-    event_tracker->context = retained_context;
+    event_tracker.track = jvm_on_track;
+    event_tracker.context = retained_context;
   }
 
   return init_engine(native_callbacks, logger, event_tracker);

--- a/library/common/main_interface.cc
+++ b/library/common/main_interface.cc
@@ -1,7 +1,6 @@
 #include "library/common/main_interface.h"
 
 #include <atomic>
-#include <memory>
 #include <string>
 
 #include "library/common/api/external.h"
@@ -174,12 +173,11 @@ envoy_status_t register_platform_api(const char* name, void* api) {
 }
 
 envoy_engine_t init_engine(envoy_engine_callbacks callbacks, envoy_logger logger,
-                           envoy_event_tracker* event_tracker) {
+                           envoy_event_tracker event_tracker) {
   // TODO(goaway): return new handle once multiple engine support is in place.
   // https://github.com/lyft/envoy-mobile/issues/332
-  strong_engine_ = std::make_shared<Envoy::Engine>(callbacks, logger,
-                                                   std::make_unique(*event_tracker),
-                                                   preferred_network_);
+  strong_engine_ =
+      std::make_shared<Envoy::Engine>(callbacks, logger, event_tracker, preferred_network_);
   engine_ = strong_engine_;
   return 1;
 }

--- a/library/common/main_interface.cc
+++ b/library/common/main_interface.cc
@@ -1,6 +1,7 @@
 #include "library/common/main_interface.h"
 
 #include <atomic>
+#include <memory>
 #include <string>
 
 #include "library/common/api/external.h"
@@ -172,10 +173,13 @@ envoy_status_t register_platform_api(const char* name, void* api) {
   return ENVOY_SUCCESS;
 }
 
-envoy_engine_t init_engine(envoy_engine_callbacks callbacks, envoy_logger logger) {
+envoy_engine_t init_engine(envoy_engine_callbacks callbacks, envoy_logger logger,
+                           envoy_event_tracker* event_tracker) {
   // TODO(goaway): return new handle once multiple engine support is in place.
   // https://github.com/lyft/envoy-mobile/issues/332
-  strong_engine_ = std::make_shared<Envoy::Engine>(callbacks, logger, preferred_network_);
+  strong_engine_ = std::make_shared<Envoy::Engine>(callbacks, logger,
+                                                   std::make_unique(*event_tracker),
+                                                   preferred_network_);
   engine_ = strong_engine_;
   return 1;
 }

--- a/library/common/main_interface.h
+++ b/library/common/main_interface.h
@@ -163,9 +163,11 @@ envoy_status_t register_platform_api(const char* name, void* api);
  * Initialize an engine for handling network streams.
  * @param callbacks, the callbacks that will run the engine callbacks.
  * @param logger, optional callbacks to handle logging.
+ * @param event_tracker, optional event tracker for the emission of events.
  * @return envoy_engine_t, handle to the underlying engine.
  */
-envoy_engine_t init_engine(envoy_engine_callbacks callbacks, envoy_logger logger);
+envoy_engine_t init_engine(envoy_engine_callbacks callbacks, envoy_logger logger,
+                           envoy_event_tracker* event_tracker);
 
 /**
  * External entry point for library.

--- a/library/common/main_interface.h
+++ b/library/common/main_interface.h
@@ -163,7 +163,7 @@ envoy_status_t register_platform_api(const char* name, void* api);
  * Initialize an engine for handling network streams.
  * @param callbacks, the callbacks that will run the engine callbacks.
  * @param logger, optional callbacks to handle logging.
- * @param event_tracker, optional event tracker for the emission of events.
+ * @param event_tracker, an event tracker for the emission of events.
  * @return envoy_engine_t, handle to the underlying engine.
  */
 envoy_engine_t init_engine(envoy_engine_callbacks callbacks, envoy_logger logger,

--- a/library/common/main_interface.h
+++ b/library/common/main_interface.h
@@ -167,7 +167,7 @@ envoy_status_t register_platform_api(const char* name, void* api);
  * @return envoy_engine_t, handle to the underlying engine.
  */
 envoy_engine_t init_engine(envoy_engine_callbacks callbacks, envoy_logger logger,
-                           envoy_event_tracker* event_tracker);
+                           envoy_event_tracker event_tracker);
 
 /**
  * External entry point for library.

--- a/library/java/io/envoyproxy/envoymobile/engine/EnvoyEngineImpl.java
+++ b/library/java/io/envoyproxy/envoymobile/engine/EnvoyEngineImpl.java
@@ -15,17 +15,16 @@ public class EnvoyEngineImpl implements EnvoyEngine {
   private static final int ENVOY_FAILURE = 1;
 
   private final long engineHandle;
-  private final EnvoyEventTracker eventTracker;
 
   /**
    * @param runningCallback Called when the engine finishes its async startup and begins running.
    * @param logger          The logging interface.
+   * @param eventTracker    The event tracking interface.
    */
   public EnvoyEngineImpl(EnvoyOnEngineRunning runningCallback, EnvoyLogger logger,
                          EnvoyEventTracker eventTracker) {
     JniLibrary.load();
-    this.engineHandle = JniLibrary.initEngine(runningCallback, logger);
-    this.eventTracker = eventTracker;
+    this.engineHandle = JniLibrary.initEngine(runningCallback, logger, eventTracker);
   }
 
   /**
@@ -77,7 +76,6 @@ public class EnvoyEngineImpl implements EnvoyEngine {
                                         new JvmStringAccessorContext(entry.getValue()));
     }
 
-    JniLibrary.registerEventTracker(this.eventTracker);
     return runWithResolvedYAML(envoyConfiguration.resolveTemplate(
                                    configurationYAML, JniLibrary.platformFilterTemplateString(),
                                    JniLibrary.nativeFilterTemplateString()),

--- a/library/java/io/envoyproxy/envoymobile/engine/JniLibrary.java
+++ b/library/java/io/envoyproxy/envoymobile/engine/JniLibrary.java
@@ -285,11 +285,4 @@ public class JniLibrary {
    */
   protected static native int registerStringAccessor(String accessorName,
                                                      JvmStringAccessorContext context);
-  /**
-   * Register an event tracker.
-   *
-   * @param eventTracker,  the event tracker to be registered.
-   * @return int, the resulting status of the operation.
-   */
-  protected static native int registerEventTracker(EnvoyEventTracker eventTracker);
 }

--- a/library/java/io/envoyproxy/envoymobile/engine/JniLibrary.java
+++ b/library/java/io/envoyproxy/envoymobile/engine/JniLibrary.java
@@ -147,9 +147,10 @@ public class JniLibrary {
    *
    * @param runningCallback, called when the engine finishes its async startup and begins running.
    * @param logger,          the logging interface.
+   * @param eventTracker     the event tracking interface.
    * @return envoy_engine_t, handle to the underlying engine.
    */
-  protected static native long initEngine(EnvoyOnEngineRunning runningCallback, EnvoyLogger logger);
+  protected static native long initEngine(EnvoyOnEngineRunning runningCallback, EnvoyLogger logger, EnvoyEventTracker eventTracker);
 
   /**
    * External entry point for library.

--- a/library/java/io/envoyproxy/envoymobile/engine/JniLibrary.java
+++ b/library/java/io/envoyproxy/envoymobile/engine/JniLibrary.java
@@ -150,7 +150,8 @@ public class JniLibrary {
    * @param eventTracker     the event tracking interface.
    * @return envoy_engine_t, handle to the underlying engine.
    */
-  protected static native long initEngine(EnvoyOnEngineRunning runningCallback, EnvoyLogger logger, EnvoyEventTracker eventTracker);
+  protected static native long initEngine(EnvoyOnEngineRunning runningCallback, EnvoyLogger logger,
+                                          EnvoyEventTracker eventTracker);
 
   /**
    * External entry point for library.

--- a/library/objective-c/EnvoyEngine.h
+++ b/library/objective-c/EnvoyEngine.h
@@ -346,9 +346,9 @@ extern const int kEnvoyFilterResumeStatusResumeIteration;
 
 @interface EnvoyEventTracker : NSObject
 
-@property (nonatomic, copy, nullable) void (^track)(EnvoyEvent *);
+@property (nonatomic, copy, nonnull) void (^track)(EnvoyEvent *);
 
-- (instancetype)initWithEventTrackingClosure:(nullable void (^)(EnvoyEvent *))track;
+- (instancetype)initWithEventTrackingClosure:(nonnull void (^)(EnvoyEvent *))track;
 
 @end
 

--- a/library/objective-c/EnvoyEngineImpl.m
+++ b/library/objective-c/EnvoyEngineImpl.m
@@ -370,12 +370,7 @@ static void ios_track_event(envoy_map map, const void *context) {
   // is necessary to act as a breaker for any Objective-C allocation that happens.
   @autoreleasepool {
     EnvoyEventTracker *eventTracker = (__bridge EnvoyEventTracker *)context;
-    // `to_ios_map` method releases `map`'s memory. Call it even if the tracking closure
-    // is not provided.
-    EnvoyEvent *platformMap = to_ios_map(map);
-    if (eventTracker.track) {
-      eventTracker.track(platformMap);
-    }
+    eventTracker.track(to_ios_map(map));
   }
 }
 
@@ -403,10 +398,18 @@ static void ios_track_event(envoy_map map, const void *context) {
     native_logger.context = CFBridgingRetain(objcLogger);
   }
 
-  EnvoyEventTracker *objcEventTracker =
+  // TODO(Augustyniak): Everything here leaks, but it's all tied to the life of the engine.
+  // This will need to be updated for https://github.com/lyft/envoy-mobile/issues/332.
+  envoy_event_tracker* native_event_tracker = safe_malloc(sizeof(envoy_event_tracker));
+  memset(native_event_tracker, 0, sizeof(envoy_event_tracker));
+  if (eventTracker) {
+    EnvoyEventTracker *objcEventTracker =
       [[EnvoyEventTracker alloc] initWithEventTrackingClosure:eventTracker];
-  [self registerEventTracker:objcEventTracker];
-  _engineHandle = init_engine(native_callbacks, native_logger);
+    native_event_tracker->track = ios_track_event;
+    native_event_tracker->context = CFBridgingRetain(objcEventTracker);
+  }
+
+  _engineHandle = init_engine(native_callbacks, native_logger, native_event_tracker);
   [EnvoyNetworkMonitor startReachabilityIfNeeded];
   return self;
 }
@@ -448,16 +451,6 @@ static void ios_track_event(envoy_map map, const void *context) {
   accessorStruct->context = CFBridgingRetain(accessor);
 
   return register_platform_api(name.UTF8String, accessorStruct);
-}
-
-- (int)registerEventTracker:(EnvoyEventTracker *)eventTracker {
-  // TODO(Augustyniak): Everything here leaks, but it's all tied to the life of the engine.
-  // This will need to be updated for https://github.com/lyft/envoy-mobile/issues/332.
-  envoy_event_tracker *eventTrackerStruct = safe_malloc(sizeof(envoy_event_tracker));
-  eventTrackerStruct->track = ios_track_event;
-  eventTrackerStruct->context = CFBridgingRetain(eventTracker);
-
-  return register_platform_api(envoy_event_tracker_api_name, eventTrackerStruct);
 }
 
 - (int)runWithConfig:(EnvoyConfiguration *)config logLevel:(NSString *)logLevel {

--- a/library/objective-c/EnvoyEngineImpl.m
+++ b/library/objective-c/EnvoyEngineImpl.m
@@ -400,13 +400,12 @@ static void ios_track_event(envoy_map map, const void *context) {
 
   // TODO(Augustyniak): Everything here leaks, but it's all tied to the life of the engine.
   // This will need to be updated for https://github.com/lyft/envoy-mobile/issues/332.
-  envoy_event_tracker* native_event_tracker = safe_malloc(sizeof(envoy_event_tracker));
-  memset(native_event_tracker, 0, sizeof(envoy_event_tracker));
+  envoy_event_tracker native_event_tracker = {NULL, NULL};
   if (eventTracker) {
     EnvoyEventTracker *objcEventTracker =
-      [[EnvoyEventTracker alloc] initWithEventTrackingClosure:eventTracker];
-    native_event_tracker->track = ios_track_event;
-    native_event_tracker->context = CFBridgingRetain(objcEventTracker);
+        [[EnvoyEventTracker alloc] initWithEventTrackingClosure:eventTracker];
+    native_event_tracker.track = ios_track_event;
+    native_event_tracker.context = CFBridgingRetain(objcEventTracker);
   }
 
   _engineHandle = init_engine(native_callbacks, native_logger, native_event_tracker);

--- a/library/objective-c/EnvoyEventTracker.m
+++ b/library/objective-c/EnvoyEventTracker.m
@@ -2,7 +2,7 @@
 
 @implementation EnvoyEventTracker
 
-- (instancetype)initWithEventTrackingClosure:(nullable void (^)(EnvoyEvent *))track {
+- (instancetype)initWithEventTrackingClosure:(nonnull void (^)(EnvoyEvent *))track {
   self = [super init];
   if (!self) {
     return nil;

--- a/test/common/engine_test.cc
+++ b/test/common/engine_test.cc
@@ -46,7 +46,7 @@ layered_runtime:
 // Envoy::Logger::current_log_context global.
 struct EngineHandle {
   EngineHandle(envoy_engine_callbacks callbacks, const std::string& level) {
-    init_engine(callbacks, {});
+    init_engine(callbacks, {}, {});
     run_engine(0, MINIMAL_TEST_CONFIG.c_str(), level.c_str());
   }
 

--- a/test/common/main_interface_test.cc
+++ b/test/common/main_interface_test.cc
@@ -315,7 +315,7 @@ TEST(MainInterfaceTest, InitEngineReturns1) {
                                       exit->on_exit.Notify();
                                     } /*on_exit*/,
                                     &test_context /*context*/};
-  ASSERT_EQ(1, init_engine(engine_cbs, {}));
+  ASSERT_EQ(1, init_engine(engine_cbs, {}, {}));
   run_engine(0, MINIMAL_TEST_CONFIG.c_str(), LEVEL_DEBUG.c_str());
   ASSERT_TRUE(test_context.on_engine_running.WaitForNotificationWithTimeout(absl::Seconds(3)));
   terminate_engine(0);

--- a/test/common/main_interface_test.cc
+++ b/test/common/main_interface_test.cc
@@ -115,7 +115,7 @@ TEST(MainInterfaceTest, BasicStream) {
                                       exit->on_exit.Notify();
                                     } /*on_exit*/,
                                     &engine_cbs_context /*context*/};
-  init_engine(engine_cbs, {});
+  init_engine(engine_cbs, {}, {});
   run_engine(0, BUFFERED_TEST_CONFIG.c_str(), level.c_str());
 
   ASSERT_TRUE(
@@ -180,7 +180,7 @@ TEST(MainInterfaceTest, SendMetadata) {
 
   // There is nothing functional about the config used to run the engine, as the created stream is
   // only used for send_metadata.
-  init_engine(engine_cbs, {});
+  init_engine(engine_cbs, {}, {});
   run_engine(0, MINIMAL_TEST_CONFIG.c_str(), LEVEL_DEBUG.c_str());
 
   ASSERT_TRUE(
@@ -217,7 +217,7 @@ TEST(MainInterfaceTest, ResetStream) {
 
   // There is nothing functional about the config used to run the engine, as the created stream is
   // immediately reset.
-  init_engine(engine_cbs, {});
+  init_engine(engine_cbs, {}, {});
   run_engine(0, MINIMAL_TEST_CONFIG.c_str(), LEVEL_DEBUG.c_str());
 
   ASSERT_TRUE(
@@ -288,7 +288,7 @@ TEST(MainInterfaceTest, RegisterPlatformApi) {
                                     &engine_cbs_context /*context*/};
 
   // Using the minimal envoy mobile config that allows for running the engine.
-  init_engine(engine_cbs, {});
+  init_engine(engine_cbs, {}, {});
   run_engine(0, MINIMAL_TEST_CONFIG.c_str(), LEVEL_DEBUG.c_str());
 
   ASSERT_TRUE(
@@ -339,7 +339,7 @@ TEST(EngineTest, RecordCounter) {
                                     } /*on_exit*/,
                                     &test_context /*context*/};
   EXPECT_EQ(ENVOY_FAILURE, record_counter_inc(0, "counter", envoy_stats_notags, 1));
-  init_engine(engine_cbs, {});
+  init_engine(engine_cbs, {}, {});
   run_engine(0, MINIMAL_TEST_CONFIG.c_str(), LEVEL_DEBUG.c_str());
   ASSERT_TRUE(test_context.on_engine_running.WaitForNotificationWithTimeout(absl::Seconds(3)));
   EXPECT_EQ(ENVOY_SUCCESS, record_counter_inc(0, "counter", envoy_stats_notags, 1));
@@ -361,7 +361,7 @@ TEST(EngineTest, SetGauge) {
                                     } /*on_exit*/,
                                     &test_context /*context*/};
   EXPECT_EQ(ENVOY_FAILURE, record_gauge_set(0, "gauge", envoy_stats_notags, 1));
-  init_engine(engine_cbs, {});
+  init_engine(engine_cbs, {}, {});
   run_engine(0, MINIMAL_TEST_CONFIG.c_str(), LEVEL_DEBUG.c_str());
 
   ASSERT_TRUE(test_context.on_engine_running.WaitForNotificationWithTimeout(absl::Seconds(3)));
@@ -386,7 +386,7 @@ TEST(EngineTest, AddToGauge) {
                                     &test_context /*context*/};
   EXPECT_EQ(ENVOY_FAILURE, record_gauge_add(0, "gauge", envoy_stats_notags, 30));
 
-  init_engine(engine_cbs, {});
+  init_engine(engine_cbs, {}, {});
   run_engine(0, MINIMAL_TEST_CONFIG.c_str(), LEVEL_DEBUG.c_str());
   ASSERT_TRUE(test_context.on_engine_running.WaitForNotificationWithTimeout(absl::Seconds(3)));
 
@@ -410,7 +410,7 @@ TEST(EngineTest, SubFromGauge) {
                                     &test_context /*context*/};
   EXPECT_EQ(ENVOY_FAILURE, record_gauge_sub(0, "gauge", envoy_stats_notags, 30));
 
-  init_engine(engine_cbs, {});
+  init_engine(engine_cbs, {}, {});
   run_engine(0, MINIMAL_TEST_CONFIG.c_str(), LEVEL_DEBUG.c_str());
   ASSERT_TRUE(test_context.on_engine_running.WaitForNotificationWithTimeout(absl::Seconds(3)));
 
@@ -437,7 +437,7 @@ TEST(EngineTest, RecordHistogramValue) {
   EXPECT_EQ(ENVOY_FAILURE,
             record_histogram_value(0, "histogram", envoy_stats_notags, 99, MILLISECONDS));
 
-  init_engine(engine_cbs, {});
+  init_engine(engine_cbs, {}, {});
   run_engine(0, MINIMAL_TEST_CONFIG.c_str(), LEVEL_DEBUG.c_str());
   ASSERT_TRUE(test_context.on_engine_running.WaitForNotificationWithTimeout(absl::Seconds(3)));
 
@@ -479,7 +479,7 @@ TEST(EngineTest, Logger) {
                       } /* release */,
                       &test_context};
 
-  init_engine(engine_cbs, logger);
+  init_engine(engine_cbs, logger, {});
   run_engine(0, MINIMAL_TEST_CONFIG.c_str(), LEVEL_DEBUG.c_str());
   ASSERT_TRUE(test_context.on_engine_running.WaitForNotificationWithTimeout(absl::Seconds(3)));
 

--- a/test/kotlin/integration/SetEventTrackerTest.kt
+++ b/test/kotlin/integration/SetEventTrackerTest.kt
@@ -53,7 +53,7 @@ class SetEventTrackerTest {
   }
 
   @Test
-  fun `engine should continue to run if no eventTracker is set`() {
+  fun `engine should continue to run if no eventTracker is set and event is emitted`() {
     val countDownLatch = CountDownLatch(1)
     val engine = EngineBuilder()
       .addNativeFilter(

--- a/test/kotlin/integration/SetEventTrackerTest.kt
+++ b/test/kotlin/integration/SetEventTrackerTest.kt
@@ -55,14 +55,33 @@ class SetEventTrackerTest {
   @Test
   fun `engine should continue to run if no eventTracker is set`() {
     val countDownLatch = CountDownLatch(1)
-    val client = EngineBuilder()
-      .setOnEngineRunning {
-        countDownLatch.countDown()
-      }
+    val engine = EngineBuilder()
+      .addNativeFilter(
+        "envoy.filters.http.test_event_tracker",
+        "{\"@type\":\"type.googleapis.com/envoymobile.extensions.filters.http.test_event_tracker.TestEventTracker\",\"attributes\":{\"foo\":\"bar\"}}"
+      )
       .build()
 
+    val client = engine.streamClient()
+
+    val requestHeaders = RequestHeadersBuilder(
+      method = RequestMethod.GET,
+      scheme = "https",
+      authority = "example.com",
+      path = "/test"
+    )
+      .build()
+
+    client
+      .newStreamPrototype()
+      .setOnResponseHeaders { _, _, _ ->
+        countDownLatch.countDown()
+      }
+      .start()
+      .sendHeaders(requestHeaders, true)
+
     countDownLatch.await(30, TimeUnit.SECONDS)
-    client.terminate()
+    engine.terminate()
     assertThat(countDownLatch.count).isEqualTo(0)
   }
 }

--- a/test/swift/integration/BUILD
+++ b/test/swift/integration/BUILD
@@ -167,3 +167,13 @@ envoy_mobile_swift_test(
         "//library/objective-c:envoy_engine_objc_lib",
     ],
 )
+
+envoy_mobile_swift_test(
+    name = "set_event_tracker_test_no_tracker",
+    srcs = [
+        "SetEventTrackerTestNoTracker.swift",
+    ],
+    deps = [
+        "//library/objective-c:envoy_engine_objc_lib",
+    ],
+)

--- a/test/swift/integration/SetEventTrackerTest.swift
+++ b/test/swift/integration/SetEventTrackerTest.swift
@@ -4,7 +4,7 @@ import Foundation
 import XCTest
 
 final class SetEventTrackerTest: XCTestCase {
-  func testSetEventTracker() throws {
+  func testEmitEventWithoutSettingEventTracker() throws {
     let eventExpectation =
       self.expectation(description: "Passed event tracker receives an event")
 

--- a/test/swift/integration/SetEventTrackerTest.swift
+++ b/test/swift/integration/SetEventTrackerTest.swift
@@ -5,13 +5,13 @@ import XCTest
 
 final class SetEventTrackerTest: XCTestCase {
   func testSetEventTracker() throws {
-    let eventTrackingExpectation =
+    let eventExpectation =
       self.expectation(description: "Passed event tracker receives an event")
 
     let client = EngineBuilder()
       .setEventTracker { event in
         XCTAssertEqual("bar", event["foo"])
-        eventTrackingExpectation.fulfill()
+        eventExpectation.fulfill()
       }
 
       .addNativeFilter(
@@ -30,6 +30,6 @@ final class SetEventTrackerTest: XCTestCase {
       .start()
       .sendHeaders(requestHeaders, endStream: true)
 
-    XCTAssertEqual(XCTWaiter.wait(for: [eventTrackingExpectation], timeout: 10), .completed)
+    XCTAssertEqual(XCTWaiter.wait(for: [eventExpectation], timeout: 10), .completed)
   }
 }

--- a/test/swift/integration/SetEventTrackerTestNoTracker.swift
+++ b/test/swift/integration/SetEventTrackerTestNoTracker.swift
@@ -5,7 +5,7 @@ import XCTest
 
 final class SetEventTrackerTestNoTracker: XCTestCase {
   func testSetEventTracker() throws {
-    let responseHeadersReceivedExpectation = self.expectation(description: "Response headers received")
+    let expectation = self.expectation(description: "Response headers received")
 
     let client = EngineBuilder()
       .addNativeFilter(
@@ -22,11 +22,11 @@ final class SetEventTrackerTestNoTracker: XCTestCase {
     client
       .newStreamPrototype()
       .setOnResponseHeaders { _, _, _ in
-        responseHeadersReceivedExpectation.fulfill()
+        expectation.fulfill()
       }
       .start()
       .sendHeaders(requestHeaders, endStream: true)
 
-    XCTAssertEqual(XCTWaiter.wait(for: [responseHeadersReceivedExpectation], timeout: 10), .completed)
+    XCTAssertEqual(XCTWaiter.wait(for: [expectation], timeout: 10), .completed)
   }
 }


### PR DESCRIPTION
Description: Send an envoy event with the use of envoy event tracker every time an assertion is hit. The event contains two fields: `name` equal to `assertion` and location which contains the information about the name of the file and line number for where the assertion was hit.
Risk Level: Low. Optional feature that's active only when `DENVOY_LOG_DEBUG_ASSERT_IN_RELEASE` compilation flag is specified.
Testing: Unit/Integration
Docs Changes: N/A
Release Notes: N/A
