### PR TITLE
CI: Move artifacts workflow to Engflow's remote execution

### DIFF
--- a/.github/workflows/artifacts.yml
+++ b/.github/workflows/artifacts.yml
@@ -2,8 +2,9 @@ name: artifacts
 
 on:
   push:
-    tags:
-      - v*
+    branches:
+      - main
+  pull_request:
 
 jobs:
   main_android_dist_ci:

--- a/.github/workflows/artifacts.yml
+++ b/.github/workflows/artifacts.yml
@@ -22,9 +22,13 @@ jobs:
       - run: ./ci/mac_ci_setup.sh
         name: 'Install dependencies'
       - name: 'Build envoy.aar distributable'
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           current_release_version=$(git describe --tag --abbrev=0)
           bazelisk build \
+              --config=remote-ci-macos \
+              --remote_header="Authorization=Bearer $GITHUB_TOKEN" \
               --config=release-android \
               --fat_apk_cpu=x86 \
               --define=pom_version=$current_release_version \
@@ -107,7 +111,9 @@ jobs:
       - name: 'Install dependencies'
         run: ./ci/mac_ci_setup.sh
       - name: 'Build Envoy.framework distributable'
-        run: bazelisk build --config=release-ios --ios_multi_cpus=i386,x86_64,armv7,arm64 //:ios_dist
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: bazelisk build --config=release-ios --ios_multi_cpus=i386,x86_64,armv7,arm64 --config=remote-ci-macos --remote_header="Authorization=Bearer $GITHUB_TOKEN" //:ios_dist
       - name: 'Create temporary directory for artifact to produce properly named zip'
         run: mkdir -p dist/ios_artifact/Envoy.framework
       - name: 'Move artifact to directory for zipping'


### PR DESCRIPTION
Signed-off-by: Luis Fernando Pino Duque <luis@engflow.com>

Description:
Move artifacts workflow to Engflow's remote execution.

TODO: Add build times when available

Risk Level: Low
Testing: TODO
Docs Changes: N/A
Release Notes: N/A
