### PR TITLE
CI: Move core workflow to Engflow's remote execution

### DIFF
--- a/.github/workflows/core.yml
+++ b/.github/workflows/core.yml
@@ -18,4 +18,6 @@ jobs:
       - name: 'Install dependencies'
         run: ./ci/mac_ci_setup.sh
       - name: 'Run tests'
-        run: bazelisk test --test_output=all //test/common/...
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: bazelisk test --test_output=all --config=remote-ci-macos --remote_header="Authorization=Bearer $GITHUB_TOKEN"  //test/common/...


### PR DESCRIPTION
Signed-off-by: Luis Fernando Pino Duque <luis@engflow.com>

Description: 
Move core workflow to Engflow's remote execution and reduce build times by 3x

Before (~1h30min):
![Before_cctests](https://user-images.githubusercontent.com/8587424/129558996-efbe3146-e027-4222-b70c-5218dbbeba89.png)

After(<30min):
![After_cctests](https://user-images.githubusercontent.com/8587424/129559001-52143548-4179-4b71-af2b-00377b969249.png)

Risk Level: Low
Testing: See core check
Docs Changes: N/A
Release Notes: N/A
