### PR TITLE
Revert "extending propercasing to legacy clusters, header sanitization to all routes (#1621)"

### DIFF
--- a/library/common/config/config.cc
+++ b/library/common/config/config.cc
@@ -65,17 +65,6 @@ const std::string config_header = R"(
       address:
         socket_address: { address: *statsd_host, port_value: *statsd_port }
 
-!ignore http1_protocol_defs: &http1_protocol_options_defs
-    envoy.extensions.upstreams.http.v3.HttpProtocolOptions:
-      "@type": type.googleapis.com/envoy.extensions.upstreams.http.v3.HttpProtocolOptions
-      explicit_http_config:
-        http_protocol_options:
-          header_key_format:
-            stateful_formatter:
-              name: preserve_case
-              typed_config:
-                "@type": type.googleapis.com/envoy.extensions.http.header_formatters.preserve_case.v3.PreserveCaseFormatterConfig
-
 !ignore protocol_defs: &base_protocol_options_defs
     envoy.extensions.upstreams.http.v3.HttpProtocolOptions:
       "@type": type.googleapis.com/envoy.extensions.upstreams.http.v3.HttpProtocolOptions
@@ -191,9 +180,6 @@ static_resources:
               routes:
 #{custom_routes}
               - match: { prefix: "/" }
-                request_headers_to_remove:
-                - x-forwarded-proto
-                - x-envoy-mobile-cluster
                 route:
                   cluster_header: x-envoy-mobile-cluster
                   timeout: 0s
@@ -266,7 +252,6 @@ static_resources:
             budget_percent:
               value: 100
             min_retry_concurrency: 0xffffffff # uint32 max
-    typed_extension_protocol_options: *http1_protocol_options_defs
   - name: base_alt
     connect_timeout: *connect_timeout
     lb_policy: CLUSTER_PROVIDED
@@ -274,7 +259,6 @@ static_resources:
     transport_socket: *base_tls_socket
     upstream_connection_options: *upstream_opts
     circuit_breakers: *circuit_breakers_settings
-    typed_extension_protocol_options: *http1_protocol_options_defs
   - name: base_wlan
     connect_timeout: *connect_timeout
     lb_policy: CLUSTER_PROVIDED
@@ -282,7 +266,6 @@ static_resources:
     transport_socket: *base_tls_socket
     upstream_connection_options: *upstream_opts
     circuit_breakers: *circuit_breakers_settings
-    typed_extension_protocol_options: *http1_protocol_options_defs
   - name: base_wlan_alt
     connect_timeout: *connect_timeout
     lb_policy: CLUSTER_PROVIDED
@@ -290,7 +273,6 @@ static_resources:
     transport_socket: *base_tls_socket
     upstream_connection_options: *upstream_opts
     circuit_breakers: *circuit_breakers_settings
-    typed_extension_protocol_options: *http1_protocol_options_defs
   - name: base_wwan
     connect_timeout: *connect_timeout
     lb_policy: CLUSTER_PROVIDED
@@ -298,7 +280,6 @@ static_resources:
     transport_socket: *base_tls_socket
     upstream_connection_options: *upstream_opts
     circuit_breakers: *circuit_breakers_settings
-    typed_extension_protocol_options: *http1_protocol_options_defs
   - name: base_wwan_alt
     connect_timeout: *connect_timeout
     lb_policy: CLUSTER_PROVIDED
@@ -306,7 +287,6 @@ static_resources:
     transport_socket: *base_tls_socket
     upstream_connection_options: *upstream_opts
     circuit_breakers: *circuit_breakers_settings
-    typed_extension_protocol_options: *http1_protocol_options_defs
   - name: base_clear
     connect_timeout: *connect_timeout
     lb_policy: CLUSTER_PROVIDED
@@ -314,7 +294,6 @@ static_resources:
     transport_socket: { name: envoy.transport_sockets.raw_buffer }
     upstream_connection_options: *upstream_opts
     circuit_breakers: *circuit_breakers_settings
-    typed_extension_protocol_options: *http1_protocol_options_defs
   - name: base_clear_alt
     connect_timeout: *connect_timeout
     lb_policy: CLUSTER_PROVIDED
@@ -322,7 +301,6 @@ static_resources:
     transport_socket: { name: envoy.transport_sockets.raw_buffer }
     upstream_connection_options: *upstream_opts
     circuit_breakers: *circuit_breakers_settings
-    typed_extension_protocol_options: *http1_protocol_options_defs
   - name: base_wlan_clear
     connect_timeout: *connect_timeout
     lb_policy: CLUSTER_PROVIDED
@@ -330,7 +308,6 @@ static_resources:
     transport_socket: { name: envoy.transport_sockets.raw_buffer }
     upstream_connection_options: *upstream_opts
     circuit_breakers: *circuit_breakers_settings
-    typed_extension_protocol_options: *http1_protocol_options_defs
   - name: base_wlan_clear_alt
     connect_timeout: *connect_timeout
     lb_policy: CLUSTER_PROVIDED
@@ -338,7 +315,6 @@ static_resources:
     transport_socket: { name: envoy.transport_sockets.raw_buffer }
     upstream_connection_options: *upstream_opts
     circuit_breakers: *circuit_breakers_settings
-    typed_extension_protocol_options: *http1_protocol_options_defs
   - name: base_wwan_clear
     connect_timeout: *connect_timeout
     lb_policy: CLUSTER_PROVIDED
@@ -346,7 +322,6 @@ static_resources:
     transport_socket: { name: envoy.transport_sockets.raw_buffer }
     upstream_connection_options: *upstream_opts
     circuit_breakers: *circuit_breakers_settings
-    typed_extension_protocol_options: *http1_protocol_options_defs
   - name: base_wwan_clear_alt
     connect_timeout: *connect_timeout
     lb_policy: CLUSTER_PROVIDED
@@ -354,7 +329,6 @@ static_resources:
     transport_socket: { name: envoy.transport_sockets.raw_buffer }
     upstream_connection_options: *upstream_opts
     circuit_breakers: *circuit_breakers_settings
-    typed_extension_protocol_options: *http1_protocol_options_defs
   - name: base_h2
     http2_protocol_options: {}
     connect_timeout: *connect_timeout

--- a/test/java/org/chromium/net/CronetUrlRequestTest.java
+++ b/test/java/org/chromium/net/CronetUrlRequestTest.java
@@ -54,6 +54,7 @@ import org.robolectric.RobolectricTestRunner;
 /**
  * Test functionality of CronetUrlRequest.
  */
+@Ignore("ignoreing due to https://github.com/envoyproxy/envoy-mobile/pull/1710")
 @RunWith(RobolectricTestRunner.class)
 public class CronetUrlRequestTest {
 

--- a/test/java/org/chromium/net/CronetUrlRequestTest.java
+++ b/test/java/org/chromium/net/CronetUrlRequestTest.java
@@ -54,7 +54,7 @@ import org.robolectric.RobolectricTestRunner;
 /**
  * Test functionality of CronetUrlRequest.
  */
-@Ignore("ignoreing due to https://github.com/envoyproxy/envoy-mobile/pull/1710")
+@Ignore("ignoring due to https://github.com/envoyproxy/envoy-mobile/pull/1710")
 @RunWith(RobolectricTestRunner.class)
 public class CronetUrlRequestTest {
 


### PR DESCRIPTION
This is causing some TLS errors:
```upstream connect error or disconnect/reset before headers. reset reason: connection failure, transport failure reason: TLS error: 268435703:SSL routines:OPENSSL_internal:WRONG_VERSION_NUMBER```

This reverts commit 6e507d3e753a0725eef6398d10dd1503c5dc3010.

Signed-off-by: Alan Chiu <achiu@lyft.com>

For an explanation of how to fill out the fields, please see the relevant section
in [PULL_REQUESTS.md](https://github.com/envoyproxy/envoy/blob/master/PULL_REQUESTS.md)

Description: Revert "extending propercasing to legacy clusters, header sanitization to all routes (#1621)"
Risk Level: medium
Testing: manual testing
Docs Changes: n/a
Release Notes: n/a
[Optional Fixes #Issue]
[Optional Deprecated:]
