### PR TITLE
config: add outlier detection config

### DIFF
--- a/library/common/config/config.cc
+++ b/library/common/config/config.cc
@@ -252,6 +252,10 @@ static_resources:
             budget_percent:
               value: 100
             min_retry_concurrency: 0xffffffff # uint32 max
+    # Used to reap dead connections. In mobile devices it is less important to keep a "host" ejected
+    # a long period and more important to be able to cycle connections assigned to given hosts.
+    # Therefore, the ejection time is short and the interval for unejection is tight, but not too
+    # tight to cause unnecessary churn.
     outlier_detection: &base_outlier_detection
       consecutive_5xx: 3
       base_ejection_time: 0.001s

--- a/library/common/config/config.cc
+++ b/library/common/config/config.cc
@@ -252,6 +252,11 @@ static_resources:
             budget_percent:
               value: 100
             min_retry_concurrency: 0xffffffff # uint32 max
+    outlier_detection: &base_outlier_detection
+      consecutive_5xx: 3
+      base_ejection_time: 0.001s
+      max_ejection_time: 0.001s
+      interval: 1s
   - name: base_alt
     connect_timeout: *connect_timeout
     lb_policy: CLUSTER_PROVIDED
@@ -259,6 +264,7 @@ static_resources:
     transport_socket: *base_tls_socket
     upstream_connection_options: *upstream_opts
     circuit_breakers: *circuit_breakers_settings
+    outlier_detection: *base_outlier_detection
   - name: base_wlan
     connect_timeout: *connect_timeout
     lb_policy: CLUSTER_PROVIDED
@@ -266,6 +272,7 @@ static_resources:
     transport_socket: *base_tls_socket
     upstream_connection_options: *upstream_opts
     circuit_breakers: *circuit_breakers_settings
+    outlier_detection: *base_outlier_detection
   - name: base_wlan_alt
     connect_timeout: *connect_timeout
     lb_policy: CLUSTER_PROVIDED
@@ -273,6 +280,7 @@ static_resources:
     transport_socket: *base_tls_socket
     upstream_connection_options: *upstream_opts
     circuit_breakers: *circuit_breakers_settings
+    outlier_detection: *base_outlier_detection
   - name: base_wwan
     connect_timeout: *connect_timeout
     lb_policy: CLUSTER_PROVIDED
@@ -280,6 +288,7 @@ static_resources:
     transport_socket: *base_tls_socket
     upstream_connection_options: *upstream_opts
     circuit_breakers: *circuit_breakers_settings
+    outlier_detection: *base_outlier_detection
   - name: base_wwan_alt
     connect_timeout: *connect_timeout
     lb_policy: CLUSTER_PROVIDED
@@ -287,6 +296,7 @@ static_resources:
     transport_socket: *base_tls_socket
     upstream_connection_options: *upstream_opts
     circuit_breakers: *circuit_breakers_settings
+    outlier_detection: *base_outlier_detection
   - name: base_clear
     connect_timeout: *connect_timeout
     lb_policy: CLUSTER_PROVIDED
@@ -294,6 +304,7 @@ static_resources:
     transport_socket: { name: envoy.transport_sockets.raw_buffer }
     upstream_connection_options: *upstream_opts
     circuit_breakers: *circuit_breakers_settings
+    outlier_detection: *base_outlier_detection
   - name: base_clear_alt
     connect_timeout: *connect_timeout
     lb_policy: CLUSTER_PROVIDED
@@ -301,6 +312,7 @@ static_resources:
     transport_socket: { name: envoy.transport_sockets.raw_buffer }
     upstream_connection_options: *upstream_opts
     circuit_breakers: *circuit_breakers_settings
+    outlier_detection: *base_outlier_detection
   - name: base_wlan_clear
     connect_timeout: *connect_timeout
     lb_policy: CLUSTER_PROVIDED
@@ -308,6 +320,7 @@ static_resources:
     transport_socket: { name: envoy.transport_sockets.raw_buffer }
     upstream_connection_options: *upstream_opts
     circuit_breakers: *circuit_breakers_settings
+    outlier_detection: *base_outlier_detection
   - name: base_wlan_clear_alt
     connect_timeout: *connect_timeout
     lb_policy: CLUSTER_PROVIDED
@@ -315,6 +328,7 @@ static_resources:
     transport_socket: { name: envoy.transport_sockets.raw_buffer }
     upstream_connection_options: *upstream_opts
     circuit_breakers: *circuit_breakers_settings
+    outlier_detection: *base_outlier_detection
   - name: base_wwan_clear
     connect_timeout: *connect_timeout
     lb_policy: CLUSTER_PROVIDED
@@ -322,6 +336,7 @@ static_resources:
     transport_socket: { name: envoy.transport_sockets.raw_buffer }
     upstream_connection_options: *upstream_opts
     circuit_breakers: *circuit_breakers_settings
+    outlier_detection: *base_outlier_detection
   - name: base_wwan_clear_alt
     connect_timeout: *connect_timeout
     lb_policy: CLUSTER_PROVIDED
@@ -329,6 +344,7 @@ static_resources:
     transport_socket: { name: envoy.transport_sockets.raw_buffer }
     upstream_connection_options: *upstream_opts
     circuit_breakers: *circuit_breakers_settings
+    outlier_detection: *base_outlier_detection
   - name: base_h2
     http2_protocol_options: {}
     connect_timeout: *connect_timeout
@@ -337,6 +353,7 @@ static_resources:
     transport_socket: *base_tls_socket
     upstream_connection_options: *upstream_opts
     circuit_breakers: *circuit_breakers_settings
+    outlier_detection: *base_outlier_detection
   - name: base_h2_alt
     http2_protocol_options: {}
     connect_timeout: *connect_timeout
@@ -345,6 +362,7 @@ static_resources:
     transport_socket: *base_tls_socket
     upstream_connection_options: *upstream_opts
     circuit_breakers: *circuit_breakers_settings
+    outlier_detection: *base_outlier_detection
   - name: base_wlan_h2
     http2_protocol_options: {}
     connect_timeout: *connect_timeout
@@ -353,6 +371,7 @@ static_resources:
     transport_socket: *base_tls_socket
     upstream_connection_options: *upstream_opts
     circuit_breakers: *circuit_breakers_settings
+    outlier_detection: *base_outlier_detection
   - name: base_wlan_h2_alt
     http2_protocol_options: {}
     connect_timeout: *connect_timeout
@@ -361,6 +380,7 @@ static_resources:
     transport_socket: *base_tls_socket
     upstream_connection_options: *upstream_opts
     circuit_breakers: *circuit_breakers_settings
+    outlier_detection: *base_outlier_detection
   - name: base_wwan_h2
     http2_protocol_options: {}
     connect_timeout: *connect_timeout
@@ -369,6 +389,7 @@ static_resources:
     transport_socket: *base_tls_socket
     upstream_connection_options: *upstream_opts
     circuit_breakers: *circuit_breakers_settings
+    outlier_detection: *base_outlier_detection
   - name: base_wwan_h2_alt
     http2_protocol_options: {}
     connect_timeout: *connect_timeout
@@ -377,6 +398,7 @@ static_resources:
     transport_socket: *base_tls_socket
     upstream_connection_options: *upstream_opts
     circuit_breakers: *circuit_breakers_settings
+    outlier_detection: *base_outlier_detection
   - name: base_alpn
     connect_timeout: *connect_timeout
     lb_policy: CLUSTER_PROVIDED
@@ -384,6 +406,7 @@ static_resources:
     transport_socket: *base_tls_socket
     upstream_connection_options: *upstream_opts
     circuit_breakers: *circuit_breakers_settings
+    outlier_detection: *base_outlier_detection
     typed_extension_protocol_options: *base_protocol_options_defs
   - name: base_alpn_alt
     connect_timeout: *connect_timeout
@@ -392,6 +415,7 @@ static_resources:
     transport_socket: *base_tls_socket
     upstream_connection_options: *upstream_opts
     circuit_breakers: *circuit_breakers_settings
+    outlier_detection: *base_outlier_detection
     typed_extension_protocol_options: *base_protocol_options_defs
   - name: base_wlan_alpn
     http2_protocol_options: {}
@@ -401,6 +425,7 @@ static_resources:
     transport_socket: *base_tls_socket
     upstream_connection_options: *upstream_opts
     circuit_breakers: *circuit_breakers_settings
+    outlier_detection: *base_outlier_detection
     typed_extension_protocol_options: *base_protocol_options_defs
   - name: base_wlan_alpn_alt
     http2_protocol_options: {}
@@ -410,6 +435,7 @@ static_resources:
     transport_socket: *base_tls_socket
     upstream_connection_options: *upstream_opts
     circuit_breakers: *circuit_breakers_settings
+    outlier_detection: *base_outlier_detection
     typed_extension_protocol_options: *base_protocol_options_defs
   - name: base_wwan_alpn
     http2_protocol_options: {}
@@ -419,6 +445,7 @@ static_resources:
     transport_socket: *base_tls_socket
     upstream_connection_options: *upstream_opts
     circuit_breakers: *circuit_breakers_settings
+    outlier_detection: *base_outlier_detection
     typed_extension_protocol_options: *base_protocol_options_defs
   - name: base_wwan_alpn_alt
     http2_protocol_options: {}
@@ -428,6 +455,7 @@ static_resources:
     transport_socket: *base_tls_socket
     upstream_connection_options: *upstream_opts
     circuit_breakers: *circuit_breakers_settings
+    outlier_detection: *base_outlier_detection
     typed_extension_protocol_options: *base_protocol_options_defs
 stats_flush_interval: *stats_flush_interval
 stats_sinks: *stats_sinks


### PR DESCRIPTION
Description: This PR (which picks up work started on #1567) adds outlier detection to all configured clusters.

The main objective of this configuration is to drain connections that are perceived to be "dead" so that the cluster is forced to establish a new connection for future streams. 

Currently the outlier detector will not eject already ejected hosts. And host ejection is what causes connection drain. In mobile, the desire is not to keep hosts ejected, but rather to cycle the underlying upstream connections. Hence the short base/max ejection time and the the tight unejection interval. The unejection interval is not any tighter because to balance timer churn.

The idea with the current configuration is that most, if not all "dead" connections will be reaped without having any adverse performance issues. Lyft will deploy and analyze production data to further tune the configuration. If ultimately different detector behavior (drain connections even if host is ejected) is desired, we can work to add to upstream envoy.

Risk Level:
Testing: This configuration was tested with the existing example apps pointed to a server that continuously returns 503. Expected host ejection, connection drain, host unejection behavior was observed.

Signed-off-by: Jose Nino <jnino@lyft.com>
Co-authored-by: Mike Schore <mike.schore@gmail.com>
