### PR TITLE
stats: add outlier detection stats

### DIFF
--- a/library/common/config/config.cc
+++ b/library/common/config/config.cc
@@ -443,6 +443,9 @@ stats_config:
             regex: '^cluster\.[\w]+?\.upstream_rq_[\w]+'
         - safe_regex:
             google_re2: {}
+            regex: '^cluster\.[\w]+?\.outlier_detection.*'
+        - safe_regex:
+            google_re2: {}
             regex: '^dns.apple.*'
         - safe_regex:
             google_re2: {}


### PR DESCRIPTION
Description: adds allow list for outlier detection stats to instrument #1718 
Risk Level: low - while the stats tree is somewhat wide, the current config only will emit stats for consecutive 5xx limiting the number of stats emitted.

Signed-off-by: Jose Nino <jnino@lyft.com>