### PR TITLE
connection behavior: drain connections on application foreground

### DIFF
--- a/library/common/jni/android_jni_interface.cc
+++ b/library/common/jni/android_jni_interface.cc
@@ -29,3 +29,13 @@ Java_io_envoyproxy_envoymobile_engine_AndroidJniLibrary_setPreferredNetwork(JNIE
   jni_log("[Envoy]", "setting preferred network");
   return set_preferred_network(static_cast<envoy_network_t>(network));
 }
+
+extern "C" JNIEXPORT void JNICALL
+Java_io_envoyproxy_envoymobile_engine_AndroidJniLibrary_drainConnections(JNIEnv* env,
+                                                                         jclass // class
+) {
+  jni_log("[Envoy]", "draining connections on foreground");
+  // TODO: use specific engine once multiple engine support is in place.
+  // https://github.com/lyft/envoy-mobile/issues/332
+  drain_connections(1);
+}

--- a/library/java/io/envoyproxy/envoymobile/engine/AndroidAppLifecycleMonitor.java
+++ b/library/java/io/envoyproxy/envoymobile/engine/AndroidAppLifecycleMonitor.java
@@ -1,0 +1,49 @@
+package io.envoyproxy.envoymobile.engine;
+
+import android.app.Activity;
+import android.app.Application.ActivityLifecycleCallbacks;
+import android.annotation.TargetApi;
+import android.os.Build;
+import android.os.Bundle;
+
+/*
+ * This class may be registered to an app's lifecycle callbacks in order to perform custom handling
+ * of lifecycle events, such as flushing stats when the app is paused.
+ */
+@TargetApi(Build.VERSION_CODES.LOLLIPOP)
+public class AndroidAppLifecycleMonitor implements ActivityLifecycleCallbacks {
+  @Override
+  public void onActivityCreated(Activity activity, Bundle savedInstanceState) {
+    /* Required override for interface implementation */
+  }
+
+  @Override
+  public void onActivityStarted(Activity activity) {
+    /* Required override for interface implementation */
+  }
+
+  @Override
+  public void onActivityResumed(Activity activity) {
+    AndroidJniLibrary.drainConnections();
+  }
+
+  @Override
+  public void onActivitySaveInstanceState(Activity activity, Bundle outState) {
+    /* Required override for interface implementation */
+  }
+
+  @Override
+  public void onActivityPaused(Activity activity) {
+    /* Required override for interface implementation */
+  }
+
+  @Override
+  public void onActivityStopped(Activity activity) {
+    /* Required override for interface implementation */
+  }
+
+  @Override
+  public void onActivityDestroyed(Activity activity) {
+    /* Required override for interface implementation */
+  }
+}

--- a/library/java/io/envoyproxy/envoymobile/engine/AndroidEngineImpl.java
+++ b/library/java/io/envoyproxy/envoymobile/engine/AndroidEngineImpl.java
@@ -1,5 +1,6 @@
 package io.envoyproxy.envoymobile.engine;
 
+import android.app.Application;
 import android.content.Context;
 import io.envoyproxy.envoymobile.engine.types.EnvoyEventTracker;
 import io.envoyproxy.envoymobile.engine.types.EnvoyHTTPCallbacks;
@@ -30,11 +31,15 @@ public class AndroidEngineImpl implements EnvoyEngine {
 
   public int runWithTemplate(String configurationYAML, EnvoyConfiguration envoyConfiguration,
                              String logLevel) {
+    AndroidAppLifecycleMonitor monitor = new AndroidAppLifecycleMonitor();
+    application.registerActivityLifecycleCallbacks(monitor);
     return envoyEngine.runWithTemplate(configurationYAML, envoyConfiguration, logLevel);
   }
 
   @Override
   public int runWithConfig(EnvoyConfiguration envoyConfiguration, String logLevel) {
+    AndroidAppLifecycleMonitor monitor = new AndroidAppLifecycleMonitor();
+    application.registerActivityLifecycleCallbacks(monitor);
     return envoyEngine.runWithConfig(envoyConfiguration, logLevel);
   }
 

--- a/library/java/io/envoyproxy/envoymobile/engine/BUILD
+++ b/library/java/io/envoyproxy/envoymobile/engine/BUILD
@@ -5,6 +5,7 @@ licenses(["notice"])  # Apache 2
 android_library(
     name = "envoy_engine_lib",
     srcs = [
+        "AndroidAppLifecycleMonitor.java",
         "AndroidEngineImpl.java",
         "AndroidJniLibrary.java",
         "AndroidNetworkMonitor.java",

--- a/library/objective-c/EnvoyEngineImpl.m
+++ b/library/objective-c/EnvoyEngineImpl.m
@@ -554,11 +554,21 @@ static void ios_track_event(envoy_map map, const void *context) {
                          selector:@selector(terminateNotification:)
                              name:UIApplicationWillTerminateNotification
                            object:nil];
+
+  [notificationCenter addObserver:self
+                         selector:@selector(foregroundNotification:)
+                             name:UIApplicationWillEnterForegroundNotification
+                           object:nil];
 }
 
 - (void)terminateNotification:(NSNotification *)notification {
   NSLog(@"[Envoy %ld] terminating engine (%@)", _engineHandle, notification.name);
   terminate_engine(_engineHandle);
+}
+
+- (void)foregroundNotification:(NSNotification *)notification {
+  NSLog(@"[Envoy %ld] draining connections on foreground (%@)", _engineHandle, notification.name);
+  drain_connections(_engineHandle);
 }
 
 @end


### PR DESCRIPTION
Description: this PR uses the main interface API exposed in #1729 to drain engine connections on application foreground. 
Risk Level: high. Changes network behavior based on application lifecycle
Testing: PENDING LANDING THE NECESSARY ENVOY AND ENVOY MOBILE CHANGES.

Signed-off-by: Jose Nino <jnino@lyft.com>
