### PR TITLE
common: allow TLS 1.3 for upstream connections

### DIFF
--- a/library/common/config/config.cc
+++ b/library/common/config/config.cc
@@ -95,6 +95,8 @@ R"(
   typed_config:
     "@type": type.googleapis.com/envoy.extensions.transport_sockets.tls.v3.UpstreamTlsContext
     common_tls_context:
+      tls_params:
+        tls_maximum_protocol_version: TLSv1_3
       validation_context:
         trusted_ca:
           inline_string: *tls_root_certs


### PR DESCRIPTION
This updates the TLS configuration to allow TLS 1.3 (up from a max of 1.2)

Signed-off-by: Snow Pettersen <snowp@lyft.com>

Risk Level: Medium
Testing: n/a
Docs Changes: n/a
Release Notes: n/a
