### PR TITLE
config: enable TLS 1.3 on forced H2 socket

### DIFF
--- a/library/common/config/config.cc
+++ b/library/common/config/config.cc
@@ -106,6 +106,8 @@ R"(
     "@type": type.googleapis.com/envoy.extensions.transport_sockets.tls.v3.UpstreamTlsContext
     common_tls_context:
       alpn_protocols: [h2]
+      tls_params:
+        tls_maximum_protocol_version: TLSv1_3
       validation_context:
         trusted_ca:
           inline_string: *tls_root_certs


### PR DESCRIPTION
Description: Allows TLS 1.3 in the case of the forced H2 clusters.
Risk Level: Moderate
Testing: CI

Signed-off-by: Mike Schore <mike.schore@gmail.com>