### PR TITLE
Bazel: enable keepalive ~once / minute

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -106,6 +106,9 @@ build:remote-ci-common --bes_results_url=https://envoy.cluster.engflow.com/invoc
 build:remote-ci-common --bes_lifecycle_events
 build:remote-ci-common --jobs=40
 build:remote-ci-common --verbose_failures
+# Avoid hanging if the remote side closes the connection without a TCP RST. Only
+# sends a keepalive if we don't receive any messages (server updates every 60s).
+build:remote-ci-common --grpc_keepalive_time=61s
 #############################################################################
 # remote-ci-linux: These options are linux-only
 # TODO(lfpino): Add --remote_default_exec_properties=Pool=linux once the pool is defined


### PR DESCRIPTION
Description: Enable gRPC keepalives. We have seen cases where the
    connection is closed without a TCP RST, in which case Bazel
    can wait (almost) indefinitely for a response from the server. This
    avoids that by sending a keepalive after a 61s of not receiving any
    messages from the server. Note that the server is configured to
    send one update per minute for execute calls, so this should
    generate very little additional traffic in most cases.
Risk Level: Low
Testing: CI
Docs Changes: N/A
Release Notes: N/A

Signed-off-by: Ulf Adams <ulf@engflow.com>