### PR TITLE
emit events based on ENVOY_LOG_EVENT 

### DIFF
--- a/envoy_build_config/BUILD
+++ b/envoy_build_config/BUILD
@@ -33,5 +33,6 @@ envoy_cc_library(
         "@envoy_mobile//library/common/extensions/filters/http/route_cache_reset:config",
         "@envoy_mobile//library/common/extensions/filters/http/test_accessor:config",
         "@envoy_mobile//library/common/extensions/filters/http/test_event_tracker:config",
+        "@envoy_mobile//library/common/extensions/filters/http/test_logger:config",
     ],
 )

--- a/envoy_build_config/extension_registry.cc
+++ b/envoy_build_config/extension_registry.cc
@@ -20,6 +20,7 @@
 #include "library/common/extensions/filters/http/platform_bridge/config.h"
 #include "library/common/extensions/filters/http/test_accessor/config.h"
 #include "library/common/extensions/filters/http/test_event_tracker/config.h"
+#include "library/common/extensions/filters/http/test_logger/config.h"
 
 namespace Envoy {
 
@@ -38,6 +39,7 @@ void ExtensionRegistry::registerFactories() {
   Envoy::Extensions::HttpFilters::RouterFilter::forceRegisterRouterFilterConfig();
   Envoy::Extensions::HttpFilters::TestAccessor::forceRegisterTestAccessorFilterFactory();
   Envoy::Extensions::HttpFilters::TestEventTracker::forceRegisterTestEventTrackerFilterFactory();
+  Envoy::Extensions::HttpFilters::TestLogger::forceRegisterFactory();
   Envoy::Extensions::NetworkFilters::HttpConnectionManager::
       forceRegisterHttpConnectionManagerFilterConfigFactory();
   Envoy::Extensions::StatSinks::MetricsService::forceRegisterMetricsServiceSinkFactory();

--- a/envoy_build_config/extension_registry.h
+++ b/envoy_build_config/extension_registry.h
@@ -22,6 +22,7 @@
 #include "library/common/extensions/filters/http/route_cache_reset/config.h"
 #include "library/common/extensions/filters/http/test_accessor/config.h"
 #include "library/common/extensions/filters/http/test_event_tracker/config.h"
+#include "library/common/extensions/filters/http/test_logger/config.h"
 
 namespace Envoy {
 class ExtensionRegistry {

--- a/library/common/common/BUILD
+++ b/library/common/common/BUILD
@@ -10,9 +10,10 @@ envoy_cc_library(
     hdrs = ["lambda_logger_delegate.h"],
     repository = "@envoy",
     deps = [
+        "//library/common/api:external_api_lib",
+        "//library/common/bridge:utility_lib",
         "//library/common/data:utility_lib",
         "//library/common/types:c_types_lib",
-        "//library/common/api:external_api_lib",
         "@envoy//source/common/common:macros",
         "@envoy//source/common/common:minimal_logger_lib",
     ],

--- a/library/common/common/BUILD
+++ b/library/common/common/BUILD
@@ -12,6 +12,7 @@ envoy_cc_library(
     deps = [
         "//library/common/data:utility_lib",
         "//library/common/types:c_types_lib",
+        "//library/common/api:external_api_lib",
         "@envoy//source/common/common:macros",
         "@envoy//source/common/common:minimal_logger_lib",
     ],

--- a/library/common/common/lambda_logger_delegate.cc
+++ b/library/common/common/lambda_logger_delegate.cc
@@ -10,7 +10,6 @@ namespace Logger {
 
 void EventTrackingDelegate::logWithStableName(absl::string_view stable_name, absl::string_view,
                                               absl::string_view, absl::string_view msg) {
-  std::cout << "logging stable name " << stable_name << std::endl;
   if (event_tracker_.track == nullptr) {
     return;
   }

--- a/library/common/common/lambda_logger_delegate.cc
+++ b/library/common/common/lambda_logger_delegate.cc
@@ -2,10 +2,24 @@
 
 #include <iostream>
 
+#include "library/common/bridge/utility.h"
 #include "library/common/data/utility.h"
 
 namespace Envoy {
 namespace Logger {
+
+void EventTrackingDelegate::logWithStableName(absl::string_view stable_name, absl::string_view,
+                                              absl::string_view, absl::string_view msg) {
+  std::cout << "logging stable name " << stable_name << std::endl;
+  if (event_tracker_.track == nullptr) {
+    return;
+  }
+
+  event_tracker_.track(Bridge::makeEnvoyMap({{"name", "envoy_event_log"},
+                                             {"log_name", std::string(stable_name)},
+                                             {"msg", std::string(msg)}}),
+                       event_tracker_.context);
+}
 
 LambdaDelegate::LambdaDelegate(envoy_logger logger, DelegatingLogSinkSharedPtr log_sink)
     : EventTrackingDelegate(log_sink), logger_(logger) {
@@ -20,6 +34,13 @@ LambdaDelegate::~LambdaDelegate() {
 void LambdaDelegate::log(absl::string_view msg) {
   logger_.log(Data::Utility::copyToBridgeData(msg), logger_.context);
 }
+
+DefaultDelegate::DefaultDelegate(absl::Mutex& mutex, DelegatingLogSinkSharedPtr log_sink)
+    : EventTrackingDelegate(log_sink), mutex_(mutex) {
+  setDelegate();
+}
+
+DefaultDelegate::~DefaultDelegate() { restoreDelegate(); }
 
 } // namespace Logger
 } // namespace Envoy

--- a/library/common/common/lambda_logger_delegate.cc
+++ b/library/common/common/lambda_logger_delegate.cc
@@ -8,7 +8,7 @@ namespace Envoy {
 namespace Logger {
 
 LambdaDelegate::LambdaDelegate(envoy_logger logger, DelegatingLogSinkSharedPtr log_sink)
-    : SinkDelegate(log_sink), logger_(logger) {
+    : EventTrackingDelegate(log_sink), logger_(logger) {
   setDelegate();
 }
 

--- a/library/common/common/lambda_logger_delegate.h
+++ b/library/common/common/lambda_logger_delegate.h
@@ -14,7 +14,7 @@ namespace Logger {
 
 class EventTrackingDelegate : public SinkDelegate {
 public:
-  EventTrackingDelegate(DelegatingLogSinkSharedPtr log_sink)
+  explicit EventTrackingDelegate(DelegatingLogSinkSharedPtr log_sink)
       : SinkDelegate(log_sink), event_tracker_(*static_cast<envoy_event_tracker*>(
                                     Api::External::retrieveApi(envoy_event_tracker_api_name))) {}
 

--- a/library/common/common/lambda_logger_delegate.h
+++ b/library/common/common/lambda_logger_delegate.h
@@ -1,12 +1,12 @@
 #pragma once
 
+#include <iostream>
 #include <string>
 
 #include "source/common/common/logger.h"
 
-#include "library/common/api/external.h"
-#include <iostream>
 #include "absl/strings/string_view.h"
+#include "library/common/api/external.h"
 #include "library/common/types/c_types.h"
 
 namespace Envoy {
@@ -18,16 +18,8 @@ public:
       : SinkDelegate(log_sink), event_tracker_(*static_cast<envoy_event_tracker*>(
                                     Api::External::retrieveApi(envoy_event_tracker_api_name))) {}
 
-  // void logWithStableName(absl::string_view stable_name, absl::string_view level,
-  // absl::string_view component, absl::string_view msg) override {
-  //   if (event_tracker_.track == nullptr) {
-  //     return;
-  //   }
-
-  //   if (stable_name == whatever) {
-  //     event_tracker_.track(makeEnvoyMap({{"name", stable_name}, {"msg", msg}}));
-  //   }
-  // }
+  void logWithStableName(absl::string_view stable_name, absl::string_view level,
+                         absl::string_view component, absl::string_view msg) override;
 
 private:
   envoy_event_tracker& event_tracker_;

--- a/library/common/common/lambda_logger_delegate.h
+++ b/library/common/common/lambda_logger_delegate.h
@@ -4,13 +4,37 @@
 
 #include "source/common/common/logger.h"
 
+#include "library/common/api/external.h"
+#include <iostream>
 #include "absl/strings/string_view.h"
 #include "library/common/types/c_types.h"
 
 namespace Envoy {
 namespace Logger {
 
-class LambdaDelegate : public SinkDelegate {
+class EventTrackingDelegate : public SinkDelegate {
+public:
+  EventTrackingDelegate(DelegatingLogSinkSharedPtr log_sink)
+      : SinkDelegate(log_sink), event_tracker_(*static_cast<envoy_event_tracker*>(
+                                    Api::External::retrieveApi(envoy_event_tracker_api_name))) {}
+
+  // void logWithStableName(absl::string_view stable_name, absl::string_view level,
+  // absl::string_view component, absl::string_view msg) override {
+  //   if (event_tracker_.track == nullptr) {
+  //     return;
+  //   }
+
+  //   if (stable_name == whatever) {
+  //     event_tracker_.track(makeEnvoyMap({{"name", stable_name}, {"msg", msg}}));
+  //   }
+  // }
+
+private:
+  envoy_event_tracker& event_tracker_;
+};
+
+using EventTrackingDelegatePtr = std::unique_ptr<EventTrackingDelegate>;
+class LambdaDelegate : public EventTrackingDelegate {
 public:
   LambdaDelegate(envoy_logger logger, DelegatingLogSinkSharedPtr log_sink);
   ~LambdaDelegate() override;
@@ -24,7 +48,28 @@ private:
   envoy_logger logger_;
 };
 
-using LambdaDelegatePtr = std::unique_ptr<LambdaDelegate>;
+// A default log delegate that logs to stderr, mimicing the default used by Envoy
+// when no logger has been installed. Using this default delegate allows us to
+// intercept the named log lines (used for analytic events) even if no platform
+// logger has been installed.
+class DefaultDelegate : public EventTrackingDelegate {
+public:
+  DefaultDelegate(absl::Mutex& mutex, DelegatingLogSinkSharedPtr log_sink);
+  ~DefaultDelegate() override;
+
+  // SinkDelegate
+  void log(absl::string_view msg) override {
+    absl::MutexLock l(&mutex_);
+    std::cerr << msg;
+  }
+  void flush() override {
+    absl::MutexLock l(&mutex_);
+    std::cerr << std::flush;
+  };
+
+private:
+  absl::Mutex& mutex_;
+};
 
 } // namespace Logger
 } // namespace Envoy

--- a/library/common/engine.cc
+++ b/library/common/engine.cc
@@ -73,9 +73,10 @@ envoy_status_t Engine::main(const std::string config, const std::string log_leve
       absl::Mutex log_mutex;
       if (logger_.log) {
         log_delegate_ptr_ =
-            std::make_unique<Logger::LambdaDelegate>(logger_);
+            std::make_unique<Logger::LambdaDelegate>(logger_, Logger::Registry::getSink());
       } else {
-        log_delegate_ptr_ = std::make_unique<Logger::DefaultDelegate>(log_mutex);
+        log_delegate_ptr_ =
+            std::make_unique<Logger::DefaultDelegate>(log_mutex, Logger::Registry::getSink());
       }
 
       cv_.notifyAll();

--- a/library/common/engine.h
+++ b/library/common/engine.h
@@ -126,7 +126,7 @@ private:
   Thread::CondVar cv_;
   Http::ClientPtr http_client_;
   Event::ProvisionalDispatcherPtr dispatcher_;
-  Logger::LambdaDelegatePtr lambda_logger_{};
+  Logger::EventTrackingDelegatePtr log_delegate_ptr_{};
   Server::Instance* server_{};
   Server::ServerLifecycleNotifier::HandlePtr postinit_callback_handler_;
   std::atomic<envoy_network_t>& preferred_network_;

--- a/library/common/extensions/filters/http/test_logger/BUILD
+++ b/library/common/extensions/filters/http/test_logger/BUILD
@@ -1,0 +1,40 @@
+load(
+    "@envoy//bazel:envoy_build_system.bzl",
+    "envoy_cc_extension",
+    "envoy_extension_package",
+    "envoy_proto_library",
+)
+
+licenses(["notice"])  # Apache 2
+
+envoy_extension_package()
+
+envoy_proto_library(
+    name = "filter",
+    srcs = ["filter.proto"],
+    deps = [
+        "@envoy_api//envoy/config/common/matcher/v3:pkg",
+    ],
+)
+
+envoy_cc_extension(
+    name = "test_event_tracker_filter_lib",
+    hdrs = ["filter.h"],
+    repository = "@envoy",
+    deps = [
+        "filter_cc_proto",
+        "@envoy//source/common/common:assert_lib",
+        "@envoy//source/extensions/filters/http/common:pass_through_filter_lib",
+    ],
+)
+
+envoy_cc_extension(
+    name = "config",
+    srcs = ["config.cc"],
+    hdrs = ["config.h"],
+    repository = "@envoy",
+    deps = [
+        ":test_event_tracker_filter_lib",
+        "@envoy//source/extensions/filters/http/common:factory_base_lib",
+    ],
+)

--- a/library/common/extensions/filters/http/test_logger/config.cc
+++ b/library/common/extensions/filters/http/test_logger/config.cc
@@ -1,0 +1,27 @@
+#include "library/common/extensions/filters/http/test_logger/config.h"
+
+#include "library/common/extensions/filters/http/test_logger/filter.h"
+
+namespace Envoy {
+namespace Extensions {
+namespace HttpFilters {
+namespace TestLogger {
+
+Http::FilterFactoryCb Factory::createFilterFactoryFromProtoTyped(
+    const envoymobile::extensions::filters::http::test_logger::TestLogger&, const std::string&,
+    Server::Configuration::FactoryContext&) {
+
+  return [](Http::FilterChainFactoryCallbacks& callbacks) -> void {
+    callbacks.addStreamFilter(std::make_shared<Filter>());
+  };
+}
+
+/**
+ * Static registration for the TestEventTracker filter. @see NamedHttpFilterConfigFactory.
+ */
+REGISTER_FACTORY(Factory, Server::Configuration::NamedHttpFilterConfigFactory);
+
+} // namespace TestLogger
+} // namespace HttpFilters
+} // namespace Extensions
+} // namespace Envoy

--- a/library/common/extensions/filters/http/test_logger/config.h
+++ b/library/common/extensions/filters/http/test_logger/config.h
@@ -1,0 +1,35 @@
+#pragma once
+
+#include <string>
+
+#include "source/extensions/filters/http/common/factory_base.h"
+
+#include "library/common/extensions/filters/http/test_logger/filter.h"
+#include "library/common/extensions/filters/http/test_logger/filter.pb.h"
+#include "library/common/extensions/filters/http/test_logger/filter.pb.validate.h"
+
+namespace Envoy {
+namespace Extensions {
+namespace HttpFilters {
+namespace TestLogger {
+
+/**
+ * Config registration for the TestLogger filter. @see NamedHttpFilterConfigFactory.
+ */
+class Factory
+    : public Common::FactoryBase<envoymobile::extensions::filters::http::test_logger::TestLogger> {
+public:
+  Factory() : FactoryBase("test_logger") {}
+
+private:
+  Envoy::Http::FilterFactoryCb createFilterFactoryFromProtoTyped(
+      const envoymobile::extensions::filters::http::test_logger::TestLogger& config,
+      const std::string& stats_prefix, Server::Configuration::FactoryContext& context) override;
+};
+
+DECLARE_FACTORY(Factory);
+
+} // namespace TestLogger
+} // namespace HttpFilters
+} // namespace Extensions
+} // namespace Envoy

--- a/library/common/extensions/filters/http/test_logger/filter.h
+++ b/library/common/extensions/filters/http/test_logger/filter.h
@@ -1,0 +1,23 @@
+#pragma once
+
+#include "envoy/http/filter.h"
+
+#include "source/extensions/filters/http/common/pass_through_filter.h"
+
+#include "library/common/extensions/filters/http/test_logger/filter.pb.h"
+
+namespace Envoy {
+namespace Extensions {
+namespace HttpFilters {
+namespace TestLogger {
+
+// A filter that emits an ENVOY_EVENT log, used for testing event tracker integration.
+class Filter : public Envoy::Http::PassThroughFilter, public Logger::Loggable<Logger::Id::filter> {
+public:
+  Filter() { ENVOY_LOG_EVENT(debug, "event_name", "test log"); }
+};
+
+} // namespace TestLogger
+} // namespace HttpFilters
+} // namespace Extensions
+} // namespace Envoy

--- a/library/common/extensions/filters/http/test_logger/filter.proto
+++ b/library/common/extensions/filters/http/test_logger/filter.proto
@@ -1,0 +1,8 @@
+syntax = "proto3";
+
+package envoymobile.extensions.filters.http.test_logger;
+
+import "validate/validate.proto";
+
+message TestLogger {
+}

--- a/test/common/engine_test.cc
+++ b/test/common/engine_test.cc
@@ -87,5 +87,4 @@ TEST_F(EngineTest, EarlyExit) {
 
   start_stream(0, {}, false);
 }
-
 } // namespace Envoy

--- a/test/common/engine_test.cc
+++ b/test/common/engine_test.cc
@@ -87,4 +87,5 @@ TEST_F(EngineTest, EarlyExit) {
 
   start_stream(0, {}, false);
 }
+
 } // namespace Envoy


### PR DESCRIPTION
Wires up the EM custom logger such that we intercept logs with stable names emitted by
ENVOY_LOG_EVENT, translating them into an event passed to the event tracker.

To maintain the original behavior when a logger is not installed, we end up having to partially
reimplement the Stderr logger.

For integration testing, we add a new test filter that emits an event, verifying that the engine
properly emits this both with and without a logger added.

Risk Level: Medium
Testing: Integration test
Docs Changes: n/a
Release Notes: n/a
