### PR TITLE
Add tests related to the Connection response header

### DIFF
--- a/test/java/org/chromium/net/CronetUrlRequestTest.java
+++ b/test/java/org/chromium/net/CronetUrlRequestTest.java
@@ -152,7 +152,6 @@ public class CronetUrlRequestTest {
   @Test
   @SmallTest
   @Feature({"Cronet"})
-  @Ignore("https://github.com/envoyproxy/envoy-mobile/issues/1540")
   public void testSimpleGet() throws Exception {
     String url = NativeTestServer.getEchoMethodURL();
     TestUrlRequestCallback callback = startAndWaitForComplete(url);
@@ -200,7 +199,6 @@ public class CronetUrlRequestTest {
   @Test
   @SmallTest
   @Feature({"Cronet"})
-  @Ignore("https://github.com/envoyproxy/envoy-mobile/issues/1540")
   public void testRedirectAsync() throws Exception {
     // Start the request and wait to see the redirect.
     TestUrlRequestCallback callback = new TestUrlRequestCallback();
@@ -797,7 +795,6 @@ public class CronetUrlRequestTest {
   @Test
   @SmallTest
   @Feature({"Cronet"})
-  @Ignore("https://github.com/envoyproxy/envoy-mobile/issues/1540")
   public void testSimpleGetBufferUpdates() throws Exception {
     TestUrlRequestCallback callback = new TestUrlRequestCallback();
     callback.setAutoAdvance(false);


### PR DESCRIPTION
Remove 3 ```@ignore``` from CronetUrlRequestTest

Description: enable tests ensuring that the Connection header is returned with the response header
Risk Level: N/A
Testing: enables tests
Docs Changes: N/A
Release Notes: N/A
Signed-off-by: Charles Le Borgne <cleborgne@google.com>
