### PR TITLE
header handling: delete splitting comma-separated header values and add specific logic to the RetryPolicy classes

### DIFF
--- a/library/java/io/envoyproxy/envoymobile/engine/JvmBridgeUtility.java
+++ b/library/java/io/envoyproxy/envoymobile/engine/JvmBridgeUtility.java
@@ -47,18 +47,7 @@ class JvmBridgeUtility {
       values = new ArrayList(1);
       headerAccumulator.put(headerKey, values);
     }
-
-    // These headers may contain commas in single values, in contravention of the RFC.
-    if (headerKey.equals("cookie") || headerKey.equals("proxy-authenticate") ||
-        headerKey.equals("set-cookie") || headerKey.equals("www-authenticate")) {
-      values.add(headerValue);
-    } else {
-      // Add trimmed, comma-separated values as individual members of the list.
-      String[] newValues = headerValue.split(",");
-      for (int i = 0; i < newValues.length; i++) {
-        values.add(newValues[i].trim());
-      }
-    }
+    values.add(headerValue);
 
     headerCount++;
   }

--- a/library/objective-c/EnvoyBridgeUtility.h
+++ b/library/objective-c/EnvoyBridgeUtility.h
@@ -133,22 +133,7 @@ static inline EnvoyHeaders *to_ios_headers(envoy_headers headers) {
       headerValueList = [NSMutableArray new];
       headerDict[headerKey] = headerValueList;
     }
-
-    // These headers may contain commas in single values, in contravention of the RFC.
-    if ([headerKey caseInsensitiveCompare:@"cookie"] == NSOrderedSame ||
-        [headerKey caseInsensitiveCompare:@"proxy-authenticate"] == NSOrderedSame ||
-        [headerKey caseInsensitiveCompare:@"set-cookie"] == NSOrderedSame ||
-        [headerKey caseInsensitiveCompare:@"www-authenticate"] == NSOrderedSame) {
-      [headerValueList addObject:headerValue];
-    } else {
-      // Add trimmed, comma-separated values as individual members of the list.
-      NSArray *newValueList = [headerValue componentsSeparatedByString:@","];
-      for (NSString *value in newValueList) {
-        NSString *trimmedValue =
-            [value stringByTrimmingCharactersInSet:[NSCharacterSet whitespaceCharacterSet]];
-        [headerValueList addObject:trimmedValue];
-      }
-    }
+    [headerValueList addObject:headerValue];
   }
   // The C envoy_headers struct can be released now because the headers have been copied.
   release_envoy_headers(headers);

--- a/test/java/io/envoyproxy/envoymobile/engine/JvmBridgeUtilityTest.kt
+++ b/test/java/io/envoyproxy/envoymobile/engine/JvmBridgeUtilityTest.kt
@@ -24,23 +24,6 @@ class JvmBridgeUtilityTest {
   }
 
   @Test
-  fun `retrieveHeaders splits list-encoded header values when producing the Map`() {
-    val utility = JvmBridgeUtility()
-    utility.passHeader("test-0".toByteArray(), "value-0".toByteArray(), true)
-    utility.passHeader("test-1".toByteArray(), "value-1, value-2".toByteArray(), false)
-
-    val headers = utility.retrieveHeaders()
-    val expectedHeaders = mapOf(
-      "test-0" to listOf("value-0"),
-      "test-1" to listOf("value-1", "value-2")
-    )
-
-    assertThat(headers)
-      .hasSize(2) // Two keys / header name
-      .usingRecursiveComparison().isEqualTo(expectedHeaders)
-  }
-
-  @Test
   fun `validateCount checks if the expected number of header values in the map matches the actual`() {
     val utility = JvmBridgeUtility()
     assertThat(utility.validateCount(1)).isFalse()

--- a/test/kotlin/io/envoyproxy/envoymobile/RetryPolicyMapperTest.kt
+++ b/test/kotlin/io/envoyproxy/envoymobile/RetryPolicyMapperTest.kt
@@ -37,6 +37,35 @@ class RetryPolicyMapperTest {
   }
 
   @Test
+  fun `converting from header values delimited with comma yields individual enum values`() {
+    val retryPolicy = RetryPolicy(
+      maxRetryCount = 3,
+      retryOn = listOf(
+        RetryRule.STATUS_5XX,
+        RetryRule.GATEWAY_ERROR,
+      ),
+      retryStatusCodes = listOf(400, 422, 500),
+      perRetryTimeoutMS = 15000,
+      totalUpstreamTimeoutMS = 60000
+    )
+
+    val headers = RequestHeadersBuilder(
+      method = RequestMethod.POST, scheme = "https",
+      authority = "envoyproxy.io", path = "/mock"
+    )
+      .add("x-envoy-max-retries", "3")
+      .add("x-envoy-retriable-status-codes", "400,422,500")
+      .add("x-envoy-retry-on", "5xx,gateway-error")
+      .add("x-envoy-upstream-rq-per-try-timeout-ms", "15000")
+      .add("x-envoy-upstream-rq-timeout-ms", "60000")
+      .build()
+
+    val retryPolicyFromHeaders = RetryPolicy.from(headers)!!
+
+    assertThat(retryPolicy).isEqualTo(retryPolicyFromHeaders)
+  }
+
+  @Test
   fun `converting to headers without retry timeout excludes per retry timeout header`() {
     val retryPolicy = RetryPolicy(
       maxRetryCount = 123,

--- a/test/kotlin/io/envoyproxy/envoymobile/RetryPolicyMapperTest.kt
+++ b/test/kotlin/io/envoyproxy/envoymobile/RetryPolicyMapperTest.kt
@@ -42,7 +42,7 @@ class RetryPolicyMapperTest {
       maxRetryCount = 3,
       retryOn = listOf(
         RetryRule.STATUS_5XX,
-        RetryRule.GATEWAY_ERROR,
+        RetryRule.GATEWAY_ERROR
       ),
       retryStatusCodes = listOf(400, 422, 500),
       perRetryTimeoutMS = 15000,


### PR DESCRIPTION
Description: reverts earlier logic that splits comma-separated headers introduced in #1212 #1213. Upon further inspection of the Envoy code we now understand that the Envoy behavior to coalesce headers with multiple appearances in the header map is limited to Envoy's inline headers. Thus this PR reverts the Envoy Mobile logic to split up headers which should have no semantic impact in headers per RFC. However, we do add logic to the Envoy Mobile RetryPolicy classes which need individual values in order to correctly map to the swift/kotlin enum cases specific to those classes.
Risk Level: med - changes header handling logic
Testing: added unit tests

Signed-off-by: Jose Nino <jnino@lyft.com>
