### PR TITLE
CI: Move Kotlin workflow in format to Engflow's remote execution

### DIFF
--- a/.github/workflows/format.yml
+++ b/.github/workflows/format.yml
@@ -60,8 +60,11 @@ jobs:
       - run: ./ci/mac_ci_setup.sh
         name: 'Install dependencies'
       - name: 'Run Kotlin Lint (Detekt)'
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           bazel build \
+            --config=remote-ci-macos --remote_header="Authorization=Bearer $GITHUB_TOKEN" \
             //library/kotlin/io/envoyproxy/envoymobile:envoy_lib_lint \
             //examples/kotlin/hello_world:hello_envoy_kt_lint
       - name: 'Run Kotlin Formatter (ktlint)'


### PR DESCRIPTION
Signed-off-by: Luis Fernando Pino Duque <luis@engflow.com>

Description:
CI: Move Kotlin workflow in format to Engflow's remote execution and cut format workflow build time by a half.

Before:
![Screenshot from 2021-08-31 00-21-47](https://user-images.githubusercontent.com/8587424/131413520-dcea89ee-5f4c-4bf5-8f44-2ac7a5ad9bf4.png)

After:
![Screenshot from 2021-08-31 00-21-54](https://user-images.githubusercontent.com/8587424/131413534-5c1a624b-a2d0-4d6e-8599-270da6b53a98.png)

Risk Level: Low
Testing: See format workflow
Docs Changes: N/A
Release Notes: N/A