### PR TITLE
CI: Add clang configs for Engflow's remote execution

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -110,7 +110,7 @@ build:remote-ci-common --verbose_failures
 # sends a keepalive if we don't receive any messages (server updates every 60s).
 build:remote-ci-common --grpc_keepalive_time=61s
 #############################################################################
-# remote-ci-linux: These options are linux-only
+# remote-ci-linux: These options are linux-only using GCC by default
 # TODO(lfpino): Add --remote_default_exec_properties=Pool=linux once the pool is defined
 #############################################################################
 # Common engflow flags
@@ -133,6 +133,21 @@ build:remote-ci-linux --java_toolchain=@bazel_tools//tools/jdk:toolchain_java11
 build:remote-ci-linux --javabase=@engflow_remote_config//java:jdk
 build:remote-ci-linux --platforms=@engflow_remote_config//config:platform
 build:remote-ci-linux --config=remote-ci-common
+#############################################################################
+# remote-ci-linux-clang: These options are linux-only using Clang by default
+# TODO(lfpino): Add --remote_default_exec_properties=Pool=linux once the pool is defined
+#############################################################################
+build:remote-ci-linux-clang --action_env=BAZEL_DO_NOT_DETECT_CPP_TOOLCHAIN=1
+build:remote-ci-linux-clang --action_env=CC=/opt/llvm/bin/clang
+build:remote-ci-linux-clang --action_env=CXX=/opt/llvm/bin/clang++
+build:remote-ci-linux-clang --crosstool_top=@engflow_remote_config_clang//cc:toolchain
+build:remote-ci-linux-clang --extra_execution_platforms=@engflow_remote_config_clang//config:platform
+build:remote-ci-linux-clang --extra_toolchains=@engflow_remote_config_clang//config:cc-toolchain
+build:remote-ci-linux-clang --host_java_toolchain=@bazel_tools//tools/jdk:toolchain_java11
+build:remote-ci-linux-clang --host_platform=@engflow_remote_config_clang//config:platform
+build:remote-ci-linux-clang --java_toolchain=@bazel_tools//tools/jdk:toolchain_java11
+build:remote-ci-linux-clang --platforms=@engflow_remote_config_clang//config:platform
+build:remote-ci-linux-clang --config=remote-ci-common
 #############################################################################
 # remote-ci-macos: These options are macOS-only
 # TODO(lfpino): Add --remote_default_exec_properties=Pool=macos once the pool is defined

--- a/.bazelrc
+++ b/.bazelrc
@@ -135,7 +135,6 @@ build:remote-ci-linux --platforms=@engflow_remote_config//config:platform
 build:remote-ci-linux --config=remote-ci-common
 #############################################################################
 # remote-ci-linux-clang: These options are linux-only using Clang by default
-# TODO(lfpino): Add --remote_default_exec_properties=Pool=linux once the pool is defined
 #############################################################################
 build:remote-ci-linux-clang --action_env=BAZEL_DO_NOT_DETECT_CPP_TOOLCHAIN=1
 build:remote-ci-linux-clang --action_env=CC=/opt/llvm/bin/clang

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -67,3 +67,19 @@ rbe_autoconfig(
         "Pool": "linux",
     },
 )
+
+rbe_autoconfig(
+    name = "engflow_remote_config_clang",
+    digest = "sha256:375bf44de0d891f881fd38d7732db411f1f34ec6200eac2f1c9fedf4ad0e474d",
+    registry = "docker.io",
+    repository = "envoyproxy/envoy-build-ubuntu",
+    use_legacy_platform_definition = False,
+    env = {
+        "CC": "/opt/llvm/bin/clang",
+        "CXX": "/opt/llvm/bin/clang++",
+    },
+    exec_properties = {
+        "Pool": "linux",
+    },
+    create_java_configs = False,
+)


### PR DESCRIPTION
Signed-off-by: Luis Fernando Pino Duque <luis@engflow.com>

Description:
CI: Add clang configs for Engflow's remote execution.

This change is a no-op that will be used for switching more CI workflows to Engflow's remote execution.

See https://github.com/envoyproxy/envoy-mobile/pull/1745 for preliminary results.

Risk Level: Low
Testing: Manually tested
Docs Changes: N/A
Release Notes: N/A
