### PR TITLE
tests: fix flaky swift integration tests

### DIFF
--- a/test/swift/integration/CancelStreamTest.swift
+++ b/test/swift/integration/CancelStreamTest.swift
@@ -86,14 +86,15 @@ static_resources:
     let runExpectation = self.expectation(description: "Run called with expected cancellation")
     let filterExpectation = self.expectation(description: "Filter called with cancellation")
 
-    let client = EngineBuilder(yaml: config)
+    let engine = EngineBuilder(yaml: config)
       .addLogLevel(.trace)
       .addPlatformFilter(
         name: filterName,
         factory: { CancelValidationFilter(expectation: filterExpectation) }
       )
       .build()
-      .streamClient()
+
+    let client = engine.streamClient()
 
     let requestHeaders = RequestHeadersBuilder(method: .get, scheme: "https",
                                                authority: "example.com", path: "/test")
@@ -110,5 +111,7 @@ static_resources:
       .cancel()
 
     XCTAssertEqual(XCTWaiter.wait(for: [filterExpectation, runExpectation], timeout: 3), .completed)
+
+    engine.terminate()
   }
 }

--- a/test/swift/integration/CancelStreamTest.swift
+++ b/test/swift/integration/CancelStreamTest.swift
@@ -5,6 +5,7 @@ import XCTest
 
 final class CancelStreamTests: XCTestCase {
   func testCancelStream() {
+    let remotePort = Int.random(in: 10001...11000)
     // swiftlint:disable:next line_length
     let emhcmType = "type.googleapis.com/envoy.extensions.filters.network.http_connection_manager.v3.EnvoyMobileHttpConnectionManager"
     let lefType = "type.googleapis.com/envoymobile.extensions.filters.http.local_error.LocalError"
@@ -53,7 +54,7 @@ static_resources:
       - lb_endpoints:
         - endpoint:
             address:
-              socket_address: { address: 127.0.0.1, port_value: 10101 }
+              socket_address: { address: 127.0.0.1, port_value: \(remotePort) }
 """
 
     struct CancelValidationFilter: ResponseFilter {

--- a/test/swift/integration/DirectResponseContainsHeadersMatchIntegrationTest.swift
+++ b/test/swift/integration/DirectResponseContainsHeadersMatchIntegrationTest.swift
@@ -48,5 +48,7 @@ final class DirectResponseContainsHeadersMatchIntegrationTest: XCTestCase {
 
     let expectations = [headersExpectation, dataExpectation]
     XCTAssertEqual(.completed, XCTWaiter().wait(for: expectations, timeout: 10, enforceOrder: true))
+
+    engine.terminate()
   }
 }

--- a/test/swift/integration/DirectResponseExactHeadersMatchIntegrationTest.swift
+++ b/test/swift/integration/DirectResponseExactHeadersMatchIntegrationTest.swift
@@ -47,5 +47,7 @@ final class DirectResponseExactHeadersMatchIntegrationTest: XCTestCase {
 
     let expectations = [headersExpectation, dataExpectation]
     XCTAssertEqual(.completed, XCTWaiter().wait(for: expectations, timeout: 10, enforceOrder: true))
+
+    engine.terminate()
   }
 }

--- a/test/swift/integration/DirectResponseExactPathMatchIntegrationTest.swift
+++ b/test/swift/integration/DirectResponseExactPathMatchIntegrationTest.swift
@@ -41,5 +41,7 @@ final class DirectResponseExactPathMatchIntegrationTest: XCTestCase {
 
     let expectations = [headersExpectation, dataExpectation]
     XCTAssertEqual(.completed, XCTWaiter().wait(for: expectations, timeout: 10, enforceOrder: true))
+
+    engine.terminate()
   }
 }

--- a/test/swift/integration/DirectResponseFilterMutationIntegrationTest.swift
+++ b/test/swift/integration/DirectResponseFilterMutationIntegrationTest.swift
@@ -81,5 +81,7 @@ final class DirectResponseFilterMutationIntegrationTest: XCTestCase {
 
     let expectations = [headersExpectation, dataExpectation]
     XCTAssertEqual(.completed, XCTWaiter().wait(for: expectations, timeout: 10, enforceOrder: true))
+
+    engine.terminate()
   }
 }

--- a/test/swift/integration/DirectResponsePrefixHeadersMatchIntegrationTest.swift
+++ b/test/swift/integration/DirectResponsePrefixHeadersMatchIntegrationTest.swift
@@ -47,5 +47,7 @@ final class DirectResponsePrefixHeadersMatchIntegrationTest: XCTestCase {
 
     let expectations = [headersExpectation, dataExpectation]
     XCTAssertEqual(.completed, XCTWaiter().wait(for: expectations, timeout: 10, enforceOrder: true))
+
+    engine.terminate()
   }
 }

--- a/test/swift/integration/DirectResponsePrefixPathMatchIntegrationTest.swift
+++ b/test/swift/integration/DirectResponsePrefixPathMatchIntegrationTest.swift
@@ -41,5 +41,7 @@ final class DirectResponsePrefixPathMatchIntegrationTest: XCTestCase {
 
     let expectations = [headersExpectation, dataExpectation]
     XCTAssertEqual(.completed, XCTWaiter().wait(for: expectations, timeout: 10, enforceOrder: true))
+
+    engine.terminate()
   }
 }

--- a/test/swift/integration/DirectResponseSuffixHeadersMatchIntegrationTest.swift
+++ b/test/swift/integration/DirectResponseSuffixHeadersMatchIntegrationTest.swift
@@ -47,5 +47,7 @@ final class DirectResponseSuffixHeadersMatchIntegrationTest: XCTestCase {
 
     let expectations = [headersExpectation, dataExpectation]
     XCTAssertEqual(.completed, XCTWaiter().wait(for: expectations, timeout: 10, enforceOrder: true))
+
+    engine.terminate()
   }
 }

--- a/test/swift/integration/DrainConnectionsTest.swift
+++ b/test/swift/integration/DrainConnectionsTest.swift
@@ -52,8 +52,7 @@ static_resources:
       .addLogLevel(.debug)
       .build()
 
-    let client = engine
-      .streamClient()
+    let client = engine.streamClient()
 
     let requestHeaders = RequestHeadersBuilder(method: .get, scheme: "https",
                                                authority: "example.com", path: "/test")
@@ -97,5 +96,7 @@ static_resources:
       .sendHeaders(requestHeaders, endStream: true)
 
     XCTAssertEqual(XCTWaiter.wait(for: [expectation2], timeout: 1), .completed)
+
+    engine.terminate()
   }
 }

--- a/test/swift/integration/FilterResetIdleTest.swift
+++ b/test/swift/integration/FilterResetIdleTest.swift
@@ -6,6 +6,7 @@ import XCTest
 final class FilterResetIdleTests: XCTestCase {
   func testFilterResetIdle() {
     let idleTimeout = "0.5s"
+    let remotePort = Int.random(in: 10001...11000)
     // swiftlint:disable:next line_length
     let hcmType = "type.googleapis.com/envoy.extensions.filters.network.http_connection_manager.v3.HttpConnectionManager"
     // swiftlint:disable:next line_length
@@ -21,7 +22,7 @@ static_resources:
   listeners:
   - name: fake_remote_listener
     address:
-      socket_address: { protocol: TCP, address: 127.0.0.1, port_value: 10101 }
+      socket_address: { protocol: TCP, address: 127.0.0.1, port_value: \(remotePort) }
     filter_chains:
     - filters:
       - name: envoy.filters.network.http_connection_manager
@@ -79,7 +80,7 @@ static_resources:
       - lb_endpoints:
         - endpoint:
             address:
-              socket_address: { address: 127.0.0.1, port_value: 10101 }
+              socket_address: { address: 127.0.0.1, port_value: \(remotePort) }
 """
 
     class ResetIdleTestFilter: AsyncRequestFilter, ResponseFilter {
@@ -217,5 +218,7 @@ static_resources:
       XCTWaiter.wait(for: [cancelExpectation], timeout: 1),
       .completed
     )
+
+    engine.terminate()
   }
 }

--- a/test/swift/integration/FilterResetIdleTest.swift
+++ b/test/swift/integration/FilterResetIdleTest.swift
@@ -4,7 +4,7 @@ import Foundation
 import XCTest
 
 final class FilterResetIdleTests: XCTestCase {
-  func skipped_testFilterResetIdle() {
+  func testFilterResetIdle() {
     let idleTimeout = "0.5s"
     // swiftlint:disable:next line_length
     let hcmType = "type.googleapis.com/envoy.extensions.filters.network.http_connection_manager.v3.HttpConnectionManager"
@@ -180,7 +180,7 @@ static_resources:
       description: "Stream cancellation triggered incorrectly")
     cancelExpectation.isInverted = true
 
-    let client = EngineBuilder(yaml: config)
+    let engine = EngineBuilder(yaml: config)
       .addLogLevel(.trace)
       .addPlatformFilter(
         name: filterName,
@@ -190,7 +190,8 @@ static_resources:
         }
       )
       .build()
-      .streamClient()
+
+    let client = engine.streamClient()
 
     let requestHeaders = RequestHeadersBuilder(
       method: .get, scheme: "https",

--- a/test/swift/integration/GRPCReceiveErrorTest.swift
+++ b/test/swift/integration/GRPCReceiveErrorTest.swift
@@ -84,7 +84,7 @@ static_resources:
     filterNotCancelled.isInverted = true
     let expectations = [filterReceivedError, filterNotCancelled, callbackReceivedError]
 
-    let httpStreamClient = EngineBuilder(yaml: config)
+    let engine = EngineBuilder(yaml: config)
       .addLogLevel(.trace)
       .addPlatformFilter(
         name: filterName,
@@ -94,9 +94,8 @@ static_resources:
         }
       )
       .build()
-      .streamClient()
 
-    let client = Envoy.GRPCClient(streamClient: httpStreamClient)
+    let client = Envoy.GRPCClient(streamClient: engine.streamClient())
 
     let requestHeaders = GRPCRequestHeadersBuilder(scheme: "https", authority: "example.com",
                                                    path: "/pb.api.v1.Foo/GetBar").build()
@@ -124,5 +123,7 @@ static_resources:
       .sendMessage(message)
 
     XCTAssertEqual(XCTWaiter.wait(for: expectations, timeout: 1), .completed)
+
+    engine.terminate()
   }
 }

--- a/test/swift/integration/IdleTimeoutTest.swift
+++ b/test/swift/integration/IdleTimeoutTest.swift
@@ -6,6 +6,7 @@ import XCTest
 final class IdleTimeoutTests: XCTestCase {
   func testIdleTimeout() {
     let idleTimeout = "0.5s"
+    let remotePort = Int.random(in: 10001...11000)
     // swiftlint:disable:next line_length
     let hcmType = "type.googleapis.com/envoy.extensions.filters.network.http_connection_manager.v3.HttpConnectionManager"
     // swiftlint:disable:next line_length
@@ -21,7 +22,7 @@ static_resources:
   listeners:
   - name: fake_remote_listener
     address:
-      socket_address: { protocol: TCP, address: 127.0.0.1, port_value: 10101 }
+      socket_address: { protocol: TCP, address: 127.0.0.1, port_value: \(remotePort) }
     filter_chains:
     - filters:
       - name: envoy.filters.network.http_connection_manager
@@ -79,7 +80,7 @@ static_resources:
       - lb_endpoints:
         - endpoint:
             address:
-              socket_address: { address: 127.0.0.1, port_value: 10101 }
+              socket_address: { address: 127.0.0.1, port_value: \(remotePort) }
 """
 
     class IdleTimeoutValidationFilter: AsyncResponseFilter, ResponseFilter {

--- a/test/swift/integration/IdleTimeoutTest.swift
+++ b/test/swift/integration/IdleTimeoutTest.swift
@@ -138,14 +138,15 @@ static_resources:
     let callbackExpectation =
       self.expectation(description: "Stream idle timeout received by callbacks")
 
-    let client = EngineBuilder(yaml: config)
+    let engine = EngineBuilder(yaml: config)
       .addLogLevel(.trace)
       .addPlatformFilter(
         name: filterName,
         factory: { IdleTimeoutValidationFilter(timeoutExpectation: filterExpectation) }
       )
       .build()
-      .streamClient()
+
+    let client = engine.streamClient()
 
     let requestHeaders = RequestHeadersBuilder(method: .get, scheme: "https",
                                                authority: "example.com", path: "/test")
@@ -168,5 +169,7 @@ static_resources:
       XCTWaiter.wait(for: [filterExpectation, callbackExpectation], timeout: 2),
       .completed
     )
+
+    engine.terminate()
   }
 }

--- a/test/swift/integration/ReceiveDataTest.swift
+++ b/test/swift/integration/ReceiveDataTest.swift
@@ -51,10 +51,11 @@ static_resources:
               typed_config:
                 "@type": type.googleapis.com/envoy.extensions.filters.http.router.v3.Router
 """
-    let client = EngineBuilder(yaml: config)
+    let engine = EngineBuilder(yaml: config)
       .addLogLevel(.debug)
       .build()
-      .streamClient()
+
+    let client = engine.streamClient()
 
     let requestHeaders = RequestHeadersBuilder(method: .get, scheme: "https",
                                                authority: "example.com", path: "/test")
@@ -84,5 +85,7 @@ static_resources:
     XCTAssertEqual(XCTWaiter.wait(for: [headersExpectation, dataExpectation], timeout: 1,
                                   enforceOrder: true),
                    .completed)
+
+    engine.terminate()
   }
 }

--- a/test/swift/integration/ReceiveErrorTest.swift
+++ b/test/swift/integration/ReceiveErrorTest.swift
@@ -84,7 +84,7 @@ static_resources:
     filterNotCancelled.isInverted = true
     let expectations = [filterReceivedError, filterNotCancelled, callbackReceivedError]
 
-    let client = EngineBuilder(yaml: config)
+    let engine = EngineBuilder(yaml: config)
       .addLogLevel(.trace)
       .addPlatformFilter(
         name: filterName,
@@ -94,7 +94,8 @@ static_resources:
         }
       )
       .build()
-      .streamClient()
+
+    let client = engine.streamClient()
 
     let requestHeaders = RequestHeadersBuilder(method: .get, scheme: "https",
                                                authority: "example.com", path: "/test")
@@ -122,5 +123,7 @@ static_resources:
       .sendHeaders(requestHeaders, endStream: true)
 
     XCTAssertEqual(XCTWaiter.wait(for: expectations, timeout: 1), .completed)
+
+    engine.terminate()
   }
 }

--- a/test/swift/integration/SendDataTest.swift
+++ b/test/swift/integration/SendDataTest.swift
@@ -53,10 +53,11 @@ static_resources:
                 "@type": type.googleapis.com/envoy.extensions.filters.http.router.v3.Router
 """
     let expectation = self.expectation(description: "Run called with expected http status")
-    let client = EngineBuilder(yaml: config)
+    let engine = EngineBuilder(yaml: config)
       .addLogLevel(.debug)
       .build()
-      .streamClient()
+
+    let client = engine.streamClient()
 
     let requestHeaders = RequestHeadersBuilder(method: .get, scheme: "https",
                                                authority: "example.com", path: "/test")
@@ -79,5 +80,7 @@ static_resources:
       .close(data: body)
 
     XCTAssertEqual(XCTWaiter.wait(for: [expectation], timeout: 1), .completed)
+
+    engine.terminate()
   }
 }

--- a/test/swift/integration/SendHeadersTest.swift
+++ b/test/swift/integration/SendHeadersTest.swift
@@ -49,10 +49,11 @@ static_resources:
                 "@type": type.googleapis.com/envoy.extensions.filters.http.router.v3.Router
 """
     let expectation = self.expectation(description: "Run called with expected http status")
-    let client = EngineBuilder(yaml: config)
+    let engine = EngineBuilder(yaml: config)
       .addLogLevel(.debug)
       .build()
-      .streamClient()
+
+    let client = engine.streamClient()
 
     let requestHeaders = RequestHeadersBuilder(method: .get, scheme: "https",
                                                authority: "example.com", path: "/test")
@@ -72,5 +73,7 @@ static_resources:
       .sendHeaders(requestHeaders, endStream: true)
 
     XCTAssertEqual(XCTWaiter.wait(for: [expectation], timeout: 1), .completed)
+
+    engine.terminate()
   }
 }

--- a/test/swift/integration/SendTrailersTest.swift
+++ b/test/swift/integration/SendTrailersTest.swift
@@ -55,10 +55,11 @@ static_resources:
                 "@type": type.googleapis.com/envoy.extensions.filters.http.router.v3.Router
 """
     let expectation = self.expectation(description: "Run called with expected http status")
-    let client = EngineBuilder(yaml: config)
+    let engine = EngineBuilder(yaml: config)
       .addLogLevel(.debug)
       .build()
-      .streamClient()
+
+    let client = engine.streamClient()
 
     let requestHeaders = RequestHeadersBuilder(method: .get, scheme: "https",
                                                authority: "example.com", path: "/test")
@@ -84,5 +85,7 @@ static_resources:
       .close(trailers: requestTrailers)
 
     XCTAssertEqual(XCTWaiter.wait(for: [expectation], timeout: 1), .completed)
+
+    engine.terminate()
   }
 }

--- a/test/swift/integration/SetEventTrackerTest.swift
+++ b/test/swift/integration/SetEventTrackerTest.swift
@@ -11,18 +11,18 @@ final class SetEventTrackerTest: XCTestCase {
     let eventExpectation =
       self.expectation(description: "Passed event tracker receives an event")
 
-    let client = EngineBuilder()
+    let engine = EngineBuilder()
       .setEventTracker { event in
         XCTAssertEqual("bar", event["foo"])
         eventExpectation.fulfill()
       }
-
       .addNativeFilter(
         name: "envoy.filters.http.test_event_tracker",
         // swiftlint:disable:next line_length
         typedConfig: "{\"@type\":\"type.googleapis.com/envoymobile.extensions.filters.http.test_event_tracker.TestEventTracker\",\"attributes\":{\"foo\":\"bar\"}}")
       .build()
-      .streamClient()
+
+    let client = engine.streamClient()
 
     let requestHeaders = RequestHeadersBuilder(method: .get, scheme: "https",
                                                authority: "example.com", path: "/test")
@@ -34,5 +34,7 @@ final class SetEventTrackerTest: XCTestCase {
       .sendHeaders(requestHeaders, endStream: true)
 
     XCTAssertEqual(XCTWaiter.wait(for: [eventExpectation], timeout: 10), .completed)
+
+    engine.terminate()
   }
 }

--- a/test/swift/integration/SetEventTrackerTestNoTracker.swift
+++ b/test/swift/integration/SetEventTrackerTestNoTracker.swift
@@ -8,14 +8,15 @@ final class SetEventTrackerTestNoTracker: XCTestCase {
   func skipped_testSetEventTracker() throws {
     let expectation = self.expectation(description: "Response headers received")
 
-    let client = EngineBuilder()
+    let engine = EngineBuilder()
       .addLogLevel(.trace)
       .addNativeFilter(
         name: "envoy.filters.http.test_event_tracker",
         // swiftlint:disable:next line_length
         typedConfig: "{\"@type\":\"type.googleapis.com/envoymobile.extensions.filters.http.test_event_tracker.TestEventTracker\",\"attributes\":{\"foo\":\"bar\"}}")
       .build()
-      .streamClient()
+
+    let client = engine.streamClient()
 
     let requestHeaders = RequestHeadersBuilder(method: .get, scheme: "https",
                                                authority: "example.com", path: "/test")
@@ -30,5 +31,7 @@ final class SetEventTrackerTestNoTracker: XCTestCase {
       .sendHeaders(requestHeaders, endStream: true)
 
     XCTAssertEqual(XCTWaiter.wait(for: [expectation], timeout: 10), .completed)
+
+    engine.terminate()
   }
 }


### PR DESCRIPTION
Description: Explicitly terminates the engine at the conclusion of each test and randomizes the port to avoid flakiness from overlapping socket bind attempts.
Risk Level: Low
Testing: Local & CI

Signed-off-by: Mike Schore <mike.schore@gmail.com>