### PR TITLE
tests: use random remote port in kotlin integration tests

### DIFF
--- a/test/kotlin/integration/CancelStreamTest.kt
+++ b/test/kotlin/integration/CancelStreamTest.kt
@@ -27,7 +27,8 @@ private const val lefType =
   "type.googleapis.com/envoymobile.extensions.filters.http.local_error.LocalError"
 private const val pbfType = "type.googleapis.com/envoymobile.extensions.filters.http.platform_bridge.PlatformBridge"
 private const val filterName = "cancel_validation_filter"
-private const val config =
+private val remotePort = (10001..11000).random()
+private val config =
 """
 static_resources:
   listeners:
@@ -69,7 +70,7 @@ static_resources:
       - lb_endpoints:
         - endpoint:
             address:
-              socket_address: { address: 127.0.0.1, port_value: 10101 }
+              socket_address: { address: 127.0.0.1, port_value: $remotePort }
 """
 
 class CancelStreamTest {

--- a/test/kotlin/integration/StreamIdleTimeoutTest.kt
+++ b/test/kotlin/integration/StreamIdleTimeoutTest.kt
@@ -29,14 +29,14 @@ private const val lefType =
   "type.googleapis.com/envoymobile.extensions.filters.http.local_error.LocalError"
 private const val pbfType = "type.googleapis.com/envoymobile.extensions.filters.http.platform_bridge.PlatformBridge"
 private const val filterName = "idle_timeout_validation_filter"
-private const val config =
-
+private val remotePort = (10001..11000).random()
+private val config =
 """
 static_resources:
   listeners:
   - name: fake_remote_listener
     address:
-      socket_address: { protocol: TCP, address: 127.0.0.1, port_value: 10101 }
+      socket_address: { protocol: TCP, address: 127.0.0.1, port_value: $remotePort }
     filter_chains:
     - filters:
       - name: envoy.filters.network.http_connection_manager
@@ -93,7 +93,7 @@ static_resources:
       - lb_endpoints:
         - endpoint:
             address:
-              socket_address: { address: 127.0.0.1, port_value: 10101 }
+              socket_address: { address: 127.0.0.1, port_value: $remotePort }
 """
 
 class CancelStreamTest {


### PR DESCRIPTION
Description: Similar to #1764, this will help prevent port reuse from concurrently running tests.
Risk Level: Low
Testing: Local & CI

Signed-off-by: Mike Schore <mike.schore@gmail.com>
