### PR TITLE
common: register logger before engine start

### DIFF
--- a/library/common/engine.cc
+++ b/library/common/engine.cc
@@ -65,10 +65,6 @@ envoy_status_t Engine::main(const std::string config, const std::string log_leve
             });
       }
 
-      main_common = std::make_unique<EngineCommon>(envoy_argv.size() - 1, envoy_argv.data());
-      server_ = main_common->server();
-      event_dispatcher_ = &server_->dispatcher();
-
       if (logger_.log) {
         log_delegate_ptr_ =
             std::make_unique<Logger::LambdaDelegate>(logger_, Logger::Registry::getSink());
@@ -76,6 +72,10 @@ envoy_status_t Engine::main(const std::string config, const std::string log_leve
         log_delegate_ptr_ =
             std::make_unique<Logger::DefaultDelegate>(log_mutex_, Logger::Registry::getSink());
       }
+
+      main_common = std::make_unique<EngineCommon>(envoy_argv.size() - 1, envoy_argv.data());
+      server_ = main_common->server();
+      event_dispatcher_ = &server_->dispatcher();
 
       cv_.notifyAll();
     } catch (const Envoy::NoServingException& e) {


### PR DESCRIPTION
This ensures that logs and log events emitted early on in engine startup makes it through the attached logger.

Signed-off-by: Snow Pettersen <snowp@lyft.com>

Risk Level: Medium
Testing: Existing tests
Docs Changes: n/a
Release Notes: n/a
