### PR TITLE
engine: add H2 ping config API

### DIFF
--- a/library/cc/engine_builder.cc
+++ b/library/cc/engine_builder.cc
@@ -109,7 +109,7 @@ std::string EngineBuilder::generateConfigStr() {
       {"h2_connection_keepalive_interval",
        fmt::format("{}s", this->h2_connection_keepalive_interval_seconds_)},
       {"h2_connection_keepalive_idle_interval",
-       fmt::format("{}s", this->h2_connection_keepalive_idle_interval_milliseconds_)},
+       fmt::format("{}s", this->h2_connection_keepalive_idle_interval_milliseconds_ / 1000.0)},
       {"h2_connection_keepalive_timeout",
        fmt::format("{}s", this->h2_connection_keepalive_timeout_seconds_)},
       {

--- a/library/cc/engine_builder.cc
+++ b/library/cc/engine_builder.cc
@@ -54,17 +54,21 @@ EngineBuilder::addDnsPreresolveHostnames(const std::string& dns_preresolve_hostn
   return *this;
 }
 
-EngineBuilder& EngineBuilder::addH2ConnectionKeepaliveIntervalSeconds(int h2_connection_keepalive_interval_seconds) {
+EngineBuilder& EngineBuilder::addH2ConnectionKeepaliveIntervalSeconds(
+    int h2_connection_keepalive_interval_seconds) {
   this->h2_connection_keepalive_interval_seconds_ = h2_connection_keepalive_interval_seconds;
   return *this;
 }
 
-EngineBuilder& EngineBuilder::addH2ConnectionKeepaliveIdleIntervalMilliseconds(int h2_connection_keepalive_idle_interval_milliseconds) {
-  this->h2_connection_keepalive_idle_interval_milliseconds_ = h2_connection_keepalive_idle_interval_milliseconds;
+EngineBuilder& EngineBuilder::addH2ConnectionKeepaliveIdleIntervalMilliseconds(
+    int h2_connection_keepalive_idle_interval_milliseconds) {
+  this->h2_connection_keepalive_idle_interval_milliseconds_ =
+      h2_connection_keepalive_idle_interval_milliseconds;
   return *this;
 }
 
-EngineBuilder& EngineBuilder::addH2ConnectionKeepaliveTimeoutSeconds(int h2_connection_keepalive_timeout_seconds) {
+EngineBuilder&
+EngineBuilder::addH2ConnectionKeepaliveTimeoutSeconds(int h2_connection_keepalive_timeout_seconds) {
   this->h2_connection_keepalive_timeout_seconds_ = h2_connection_keepalive_timeout_seconds;
   return *this;
 }
@@ -102,9 +106,12 @@ std::string EngineBuilder::generateConfigStr() {
       {"dns_preresolve_hostnames", this->dns_preresolve_hostnames_},
       {"dns_refresh_rate", fmt::format("{}s", this->dns_refresh_seconds_)},
       {"dns_query_timeout", fmt::format("{}s", this->dns_query_timeout_seconds_)},
-      {"h2_connection_keepalive_interval", fmt::format("{}s", this->h2_connection_keepalive_interval_seconds_)},
-      {"h2_connection_keepalive_idle_interval", fmt::format("{}s", this->h2_connection_keepalive_idle_interval_milliseconds_)},
-      {"h2_connection_keepalive_timeout", fmt::format("{}s", this->h2_connection_keepalive_timeout_seconds_)},
+      {"h2_connection_keepalive_interval",
+       fmt::format("{}s", this->h2_connection_keepalive_interval_seconds_)},
+      {"h2_connection_keepalive_idle_interval",
+       fmt::format("{}s", this->h2_connection_keepalive_idle_interval_milliseconds_)},
+      {"h2_connection_keepalive_timeout",
+       fmt::format("{}s", this->h2_connection_keepalive_timeout_seconds_)},
       {
           "metadata",
           fmt::format("{{ device_os: {}, app_version: {}, app_id: {} }}", this->device_os_,

--- a/library/cc/engine_builder.cc
+++ b/library/cc/engine_builder.cc
@@ -54,6 +54,21 @@ EngineBuilder::addDnsPreresolveHostnames(const std::string& dns_preresolve_hostn
   return *this;
 }
 
+EngineBuilder& EngineBuilder::addH2ConnectionKeepaliveIntervalSeconds(int h2_connection_keepalive_interval_seconds) {
+  this->h2_connection_keepalive_interval_seconds_ = h2_connection_keepalive_interval_seconds;
+  return *this;
+}
+
+EngineBuilder& EngineBuilder::addH2ConnectionKeepaliveIdleIntervalMilliseconds(int h2_connection_keepalive_idle_interval_milliseconds) {
+  this->h2_connection_keepalive_idle_interval_milliseconds_ = h2_connection_keepalive_idle_interval_milliseconds;
+  return *this;
+}
+
+EngineBuilder& EngineBuilder::addH2ConnectionKeepaliveTimeoutSeconds(int h2_connection_keepalive_timeout_seconds) {
+  this->h2_connection_keepalive_timeout_seconds_ = h2_connection_keepalive_timeout_seconds;
+  return *this;
+}
+
 EngineBuilder& EngineBuilder::addStatsFlushSeconds(int stats_flush_seconds) {
   this->stats_flush_seconds_ = stats_flush_seconds;
   return *this;
@@ -87,6 +102,9 @@ std::string EngineBuilder::generateConfigStr() {
       {"dns_preresolve_hostnames", this->dns_preresolve_hostnames_},
       {"dns_refresh_rate", fmt::format("{}s", this->dns_refresh_seconds_)},
       {"dns_query_timeout", fmt::format("{}s", this->dns_query_timeout_seconds_)},
+      {"h2_connection_keepalive_interval", fmt::format("{}s", this->h2_connection_keepalive_interval_seconds_)},
+      {"h2_connection_keepalive_idle_interval", fmt::format("{}s", this->h2_connection_keepalive_idle_interval_milliseconds_)},
+      {"h2_connection_keepalive_timeout", fmt::format("{}s", this->h2_connection_keepalive_timeout_seconds_)},
       {
           "metadata",
           fmt::format("{{ device_os: {}, app_version: {}, app_id: {} }}", this->device_os_,

--- a/library/cc/engine_builder.cc
+++ b/library/cc/engine_builder.cc
@@ -54,12 +54,6 @@ EngineBuilder::addDnsPreresolveHostnames(const std::string& dns_preresolve_hostn
   return *this;
 }
 
-EngineBuilder& EngineBuilder::addH2ConnectionKeepaliveIntervalSeconds(
-    int h2_connection_keepalive_interval_seconds) {
-  this->h2_connection_keepalive_interval_seconds_ = h2_connection_keepalive_interval_seconds;
-  return *this;
-}
-
 EngineBuilder& EngineBuilder::addH2ConnectionKeepaliveIdleIntervalMilliseconds(
     int h2_connection_keepalive_idle_interval_milliseconds) {
   this->h2_connection_keepalive_idle_interval_milliseconds_ =
@@ -106,8 +100,6 @@ std::string EngineBuilder::generateConfigStr() {
       {"dns_preresolve_hostnames", this->dns_preresolve_hostnames_},
       {"dns_refresh_rate", fmt::format("{}s", this->dns_refresh_seconds_)},
       {"dns_query_timeout", fmt::format("{}s", this->dns_query_timeout_seconds_)},
-      {"h2_connection_keepalive_interval",
-       fmt::format("{}s", this->h2_connection_keepalive_interval_seconds_)},
       {"h2_connection_keepalive_idle_interval",
        fmt::format("{}s", this->h2_connection_keepalive_idle_interval_milliseconds_ / 1000.0)},
       {"h2_connection_keepalive_timeout",

--- a/library/cc/engine_builder.h
+++ b/library/cc/engine_builder.h
@@ -59,8 +59,8 @@ private:
   int dns_failure_refresh_seconds_max_ = 10;
   int dns_query_timeout_seconds_ = 25;
   std::string dns_preresolve_hostnames_ = "[]";
-  int h2_connection_keepalive_interval_seconds_ = 2;
-  int h2_connection_keepalive_idle_interval_milliseconds_ = 1;
+  int h2_connection_keepalive_interval_seconds_ = 0;
+  int h2_connection_keepalive_idle_interval_milliseconds_ = 0;
   int h2_connection_keepalive_timeout_seconds_ = 5;
   int stats_flush_seconds_ = 60;
   std::string app_version_ = "unspecified";

--- a/library/cc/engine_builder.h
+++ b/library/cc/engine_builder.h
@@ -57,8 +57,8 @@ private:
   int dns_failure_refresh_seconds_max_ = 10;
   int dns_query_timeout_seconds_ = 25;
   std::string dns_preresolve_hostnames_ = "[]";
-  int h2_connection_keepalive_idle_interval_milliseconds_ = 0;
-  int h2_connection_keepalive_timeout_seconds_ = 5;
+  int h2_connection_keepalive_idle_interval_milliseconds_ = 100000000;
+  int h2_connection_keepalive_timeout_seconds_ = 10;
   int stats_flush_seconds_ = 60;
   std::string app_version_ = "unspecified";
   std::string app_id_ = "unspecified";

--- a/library/cc/engine_builder.h
+++ b/library/cc/engine_builder.h
@@ -27,7 +27,7 @@ public:
   EngineBuilder& addH2ConnectionKeepaliveIdleIntervalMilliseconds(
       int h2_connection_keepalive_idle_interval_milliseconds);
   EngineBuilder&
-  addh2ConnectionKeepaliveTimeoutSeconds(int h2_connection_keepalive_timeout_seconds);
+  addH2ConnectionKeepaliveTimeoutSeconds(int h2_connection_keepalive_timeout_seconds);
   EngineBuilder& addStatsFlushSeconds(int stats_flush_seconds);
   EngineBuilder& addVirtualClusters(const std::string& virtual_clusters);
   EngineBuilder& setAppVersion(const std::string& app_version);

--- a/library/cc/engine_builder.h
+++ b/library/cc/engine_builder.h
@@ -24,9 +24,12 @@ public:
   EngineBuilder& addDnsFailureRefreshSeconds(int base, int max);
   EngineBuilder& addDnsQueryTimeoutSeconds(int dns_query_timeout_seconds);
   EngineBuilder& addDnsPreresolveHostnames(const std::string& dns_preresolve_hostnames);
-  EngineBuilder& addH2ConnectionKeepaliveIntervalSeconds(int h2_connection_keepalive_interval_seconds);
-  EngineBuilder& addH2ConnectionKeepaliveIdleIntervalMilliseconds(int h2_connection_keepalive_idle_interval_milliseconds);
-  EngineBuilder& addh2ConnectionKeepaliveTimeoutSeconds(int h2_connection_keepalive_timeout_seconds);
+  EngineBuilder&
+  addH2ConnectionKeepaliveIntervalSeconds(int h2_connection_keepalive_interval_seconds);
+  EngineBuilder& addH2ConnectionKeepaliveIdleIntervalMilliseconds(
+      int h2_connection_keepalive_idle_interval_milliseconds);
+  EngineBuilder&
+  addh2ConnectionKeepaliveTimeoutSeconds(int h2_connection_keepalive_timeout_seconds);
   EngineBuilder& addStatsFlushSeconds(int stats_flush_seconds);
   EngineBuilder& addVirtualClusters(const std::string& virtual_clusters);
   EngineBuilder& setAppVersion(const std::string& app_version);
@@ -56,10 +59,9 @@ private:
   int dns_failure_refresh_seconds_max_ = 10;
   int dns_query_timeout_seconds_ = 25;
   std::string dns_preresolve_hostnames_ = "[]";
-  int h2_connection_keepalive_interval_seconds = 2
-  int h2_connection_keepalive_idle_interval_milliseconds = 1
-  int h2_connection_keepalive_timeout_seconds = 5
-  int stats_flush_seconds_ = 60;
+  int h2_connection_keepalive_interval_seconds =
+      2 int h2_connection_keepalive_idle_interval_milliseconds =
+          1 int h2_connection_keepalive_timeout_seconds = 5 int stats_flush_seconds_ = 60;
   std::string app_version_ = "unspecified";
   std::string app_id_ = "unspecified";
   std::string device_os_ = "unspecified";

--- a/library/cc/engine_builder.h
+++ b/library/cc/engine_builder.h
@@ -59,9 +59,10 @@ private:
   int dns_failure_refresh_seconds_max_ = 10;
   int dns_query_timeout_seconds_ = 25;
   std::string dns_preresolve_hostnames_ = "[]";
-  int h2_connection_keepalive_interval_seconds =
-      2 int h2_connection_keepalive_idle_interval_milliseconds =
-          1 int h2_connection_keepalive_timeout_seconds = 5 int stats_flush_seconds_ = 60;
+  int h2_connection_keepalive_interval_seconds_ = 2;
+  int h2_connection_keepalive_idle_interval_milliseconds_ = 1;
+  int h2_connection_keepalive_timeout_seconds_ = 5;
+  int stats_flush_seconds_ = 60;
   std::string app_version_ = "unspecified";
   std::string app_id_ = "unspecified";
   std::string device_os_ = "unspecified";

--- a/library/cc/engine_builder.h
+++ b/library/cc/engine_builder.h
@@ -24,6 +24,9 @@ public:
   EngineBuilder& addDnsFailureRefreshSeconds(int base, int max);
   EngineBuilder& addDnsQueryTimeoutSeconds(int dns_query_timeout_seconds);
   EngineBuilder& addDnsPreresolveHostnames(const std::string& dns_preresolve_hostnames);
+  EngineBuilder& addH2ConnectionKeepaliveIntervalSeconds(int h2_connection_keepalive_interval_seconds);
+  EngineBuilder& addH2ConnectionKeepaliveIdleIntervalMilliseconds(int h2_connection_keepalive_idle_interval_milliseconds);
+  EngineBuilder& addh2ConnectionKeepaliveTimeoutSeconds(int h2_connection_keepalive_timeout_seconds);
   EngineBuilder& addStatsFlushSeconds(int stats_flush_seconds);
   EngineBuilder& addVirtualClusters(const std::string& virtual_clusters);
   EngineBuilder& setAppVersion(const std::string& app_version);
@@ -53,6 +56,9 @@ private:
   int dns_failure_refresh_seconds_max_ = 10;
   int dns_query_timeout_seconds_ = 25;
   std::string dns_preresolve_hostnames_ = "[]";
+  int h2_connection_keepalive_interval_seconds = 2
+  int h2_connection_keepalive_idle_interval_milliseconds = 1
+  int h2_connection_keepalive_timeout_seconds = 5
   int stats_flush_seconds_ = 60;
   std::string app_version_ = "unspecified";
   std::string app_id_ = "unspecified";

--- a/library/cc/engine_builder.h
+++ b/library/cc/engine_builder.h
@@ -24,8 +24,6 @@ public:
   EngineBuilder& addDnsFailureRefreshSeconds(int base, int max);
   EngineBuilder& addDnsQueryTimeoutSeconds(int dns_query_timeout_seconds);
   EngineBuilder& addDnsPreresolveHostnames(const std::string& dns_preresolve_hostnames);
-  EngineBuilder&
-  addH2ConnectionKeepaliveIntervalSeconds(int h2_connection_keepalive_interval_seconds);
   EngineBuilder& addH2ConnectionKeepaliveIdleIntervalMilliseconds(
       int h2_connection_keepalive_idle_interval_milliseconds);
   EngineBuilder&
@@ -59,7 +57,6 @@ private:
   int dns_failure_refresh_seconds_max_ = 10;
   int dns_query_timeout_seconds_ = 25;
   std::string dns_preresolve_hostnames_ = "[]";
-  int h2_connection_keepalive_interval_seconds_ = 0;
   int h2_connection_keepalive_idle_interval_milliseconds_ = 0;
   int h2_connection_keepalive_timeout_seconds_ = 5;
   int stats_flush_seconds_ = 60;

--- a/library/common/config/config.cc
+++ b/library/common/config/config.cc
@@ -73,7 +73,11 @@ const std::string config_header = R"(
     envoy.extensions.upstreams.http.v3.HttpProtocolOptions:
       "@type": type.googleapis.com/envoy.extensions.upstreams.http.v3.HttpProtocolOptions
       auto_config:
-        http2_protocol_options: {}
+        http2_protocol_options:
+          connection_keepalive:
+            interval: *h2_connection_keepalive_interval
+            connection_idle_interval: *h2_connection_keepalive_idle_interval
+            timeout: *h2_connection_keepalive_timeout
         http_protocol_options:
           header_key_format:
             stateful_formatter:

--- a/library/common/config/config.cc
+++ b/library/common/config/config.cc
@@ -39,8 +39,7 @@ const std::string config_header = R"(
 - &dns_fail_max_interval 10s
 - &dns_query_timeout 25s
 - &dns_preresolve_hostnames []
-- &h2_connection_keepalive_interval 0s
-- &h2_connection_keepalive_idle_interval 0s
+- &h2_connection_keepalive_idle_interval 100000s
 - &h2_connection_keepalive_timeout 5s
 - &metadata {}
 - &stats_domain 127.0.0.1
@@ -75,7 +74,6 @@ const std::string config_header = R"(
       auto_config:
         http2_protocol_options:
           connection_keepalive:
-            interval: *h2_connection_keepalive_interval
             connection_idle_interval: *h2_connection_keepalive_idle_interval
             timeout: *h2_connection_keepalive_timeout
         http_protocol_options:

--- a/library/common/config/config.cc
+++ b/library/common/config/config.cc
@@ -39,6 +39,9 @@ const std::string config_header = R"(
 - &dns_fail_max_interval 10s
 - &dns_query_timeout 25s
 - &dns_preresolve_hostnames []
+- &h2_connection_keepalive_interval 0s
+- &h2_connection_keepalive_idle_interval 0s
+- &h2_connection_keepalive_timeout 5s
 - &metadata {}
 - &stats_domain 127.0.0.1
 - &stats_flush_interval 60s

--- a/library/common/config/config.cc
+++ b/library/common/config/config.cc
@@ -40,7 +40,7 @@ const std::string config_header = R"(
 - &dns_query_timeout 25s
 - &dns_preresolve_hostnames []
 - &h2_connection_keepalive_idle_interval 100000s
-- &h2_connection_keepalive_timeout 5s
+- &h2_connection_keepalive_timeout 10s
 - &metadata {}
 - &stats_domain 127.0.0.1
 - &stats_flush_interval 60s

--- a/library/java/io/envoyproxy/envoymobile/engine/EnvoyConfiguration.java
+++ b/library/java/io/envoyproxy/envoymobile/engine/EnvoyConfiguration.java
@@ -20,7 +20,6 @@ public class EnvoyConfiguration {
   public final Integer dnsFailureRefreshSecondsMax;
   public final Integer dnsQueryTimeoutSeconds;
   public final String dnsPreresolveHostnames;
-  public final Integer h2ConnectionKeepaliveIntervalSeconds;
   public final Integer h2ConnectionKeepaliveIdleIntervalMilliseconds;
   public final Integer h2ConnectionKeepaliveTimeoutSeconds;
   public final List<EnvoyHTTPFilterFactory> httpPlatformFilterFactories;
@@ -46,7 +45,6 @@ public class EnvoyConfiguration {
    * @param dnsFailureRefreshSecondsMax  max rate in seconds to refresh DNS on failure.
    * @param dnsQueryTimeoutSeconds       rate in seconds to timeout DNS queries.
    * @param dnsPreresolveHostnames       hostnames to preresolve on Envoy Client construction.
-   * @param h2ConnectionKeepaliveIntervalSeconds rate in seconds to send h2 pings.
    * @param h2ConnectionKeepaliveIdleIntervalMilliseconds rate in milliseconds seconds to send h2
    *     pings on stream creation.
    * @param h2ConnectionKeepaliveTimeoutSeconds rate in seconds to timeout h2 pings.
@@ -63,7 +61,7 @@ public class EnvoyConfiguration {
                             @Nullable Integer statsdPort, int connectTimeoutSeconds,
                             int dnsRefreshSeconds, int dnsFailureRefreshSecondsBase,
                             int dnsFailureRefreshSecondsMax, int dnsQueryTimeoutSeconds,
-                            String dnsPreresolveHostnames, int h2ConnectionKeepaliveIntervalSeconds,
+                            String dnsPreresolveHostnames,
                             int h2ConnectionKeepaliveIdleIntervalMilliseconds,
                             int h2ConnectionKeepaliveTimeoutSeconds, int statsFlushSeconds,
                             int streamIdleTimeoutSeconds, String appVersion, String appId,
@@ -79,7 +77,6 @@ public class EnvoyConfiguration {
     this.dnsFailureRefreshSecondsMax = dnsFailureRefreshSecondsMax;
     this.dnsQueryTimeoutSeconds = dnsQueryTimeoutSeconds;
     this.dnsPreresolveHostnames = dnsPreresolveHostnames;
-    this.h2ConnectionKeepaliveIntervalSeconds = h2ConnectionKeepaliveIntervalSeconds;
     this.h2ConnectionKeepaliveIdleIntervalMilliseconds =
         h2ConnectionKeepaliveIdleIntervalMilliseconds;
     this.h2ConnectionKeepaliveTimeoutSeconds = h2ConnectionKeepaliveTimeoutSeconds;
@@ -131,8 +128,6 @@ public class EnvoyConfiguration {
         .append(String.format("- &dns_fail_max_interval %ss\n", dnsFailureRefreshSecondsMax))
         .append(String.format("- &dns_query_timeout %ss\n", dnsQueryTimeoutSeconds))
         .append(String.format("- &dns_preresolve_hostnames %s\n", dnsPreresolveHostnames))
-        .append(String.format("- &h2_connection_keepalive_interval %ss\n",
-                              h2ConnectionKeepaliveIntervalSeconds))
         .append(String.format("- &h2_connection_keepalive_idle_interval %ss\n",
                               h2ConnectionKeepaliveIdleIntervalMilliseconds / 1000.0))
         .append(String.format("- &h2_connection_keepalive_timeout %ss\n",

--- a/library/java/io/envoyproxy/envoymobile/engine/EnvoyConfiguration.java
+++ b/library/java/io/envoyproxy/envoymobile/engine/EnvoyConfiguration.java
@@ -133,8 +133,8 @@ public class EnvoyConfiguration {
         .append(String.format("- &dns_preresolve_hostnames %s\n", dnsPreresolveHostnames))
         .append(String.format("- &h2_connection_keepalive_interval %ss\n",
                               h2ConnectionKeepaliveIntervalSeconds))
-        .append(String.format("- &h2_connection_keepalive_idle_interval %sms\n",
-                              h2ConnectionKeepaliveIdleIntervalMilliseconds))
+        .append(String.format("- &h2_connection_keepalive_idle_interval %ss\n",
+                              h2ConnectionKeepaliveIdleIntervalMilliseconds / 1000.0))
         .append(String.format("- &h2_connection_keepalive_timeout %ss\n",
                               h2ConnectionKeepaliveTimeoutSeconds))
         .append(String.format("- &stream_idle_timeout %ss\n", streamIdleTimeoutSeconds))

--- a/library/java/io/envoyproxy/envoymobile/engine/EnvoyConfiguration.java
+++ b/library/java/io/envoyproxy/envoymobile/engine/EnvoyConfiguration.java
@@ -20,6 +20,9 @@ public class EnvoyConfiguration {
   public final Integer dnsFailureRefreshSecondsMax;
   public final Integer dnsQueryTimeoutSeconds;
   public final String dnsPreresolveHostnames;
+  public final Integer h2ConnectionKeepaliveIntervalSeconds;
+  public final Integer h2ConnectionKeepaliveIdleIntervalMilliseconds;
+  public final Integer h2ConnectionKeepaliveTimeoutSeconds;
   public final List<EnvoyHTTPFilterFactory> httpPlatformFilterFactories;
   public final Integer statsFlushSeconds;
   public final Integer streamIdleTimeoutSeconds;
@@ -43,6 +46,9 @@ public class EnvoyConfiguration {
    * @param dnsFailureRefreshSecondsMax  max rate in seconds to refresh DNS on failure.
    * @param dnsQueryTimeoutSeconds       rate in seconds to timeout DNS queries.
    * @param dnsPreresolveHostnames       hostnames to preresolve on Envoy Client construction.
+   * @param h2ConnectionKeepaliveIntervalSeconds rate in seconds to send h2 pings.
+   * @param h2ConnectionKeepaliveIdleIntervalMilliseconds rate in milliseconds seconds to send h2 pings on stream creation.
+   * @param h2ConnectionKeepaliveTimeoutSeconds rate in seconds to timeout h2 pings.
    * @param statsFlushSeconds            interval at which to flush Envoy stats.
    * @param streamIdleTimeoutSeconds     idle timeout for HTTP streams.
    * @param appVersion                   the App Version of the App using this Envoy Client.
@@ -56,7 +62,9 @@ public class EnvoyConfiguration {
                             @Nullable Integer statsdPort, int connectTimeoutSeconds,
                             int dnsRefreshSeconds, int dnsFailureRefreshSecondsBase,
                             int dnsFailureRefreshSecondsMax, int dnsQueryTimeoutSeconds,
-                            String dnsPreresolveHostnames, int statsFlushSeconds,
+                            String dnsPreresolveHostnames, int h2ConnectionKeepaliveIntervalSeconds,
+int h2ConnectionKeepaliveIdleIntervalMilliseconds,
+int h2ConnectionKeepaliveTimeoutSeconds, int statsFlushSeconds,
                             int streamIdleTimeoutSeconds, String appVersion, String appId,
                             String virtualClusters, List<EnvoyNativeFilterConfig> nativeFilterChain,
                             List<EnvoyHTTPFilterFactory> httpPlatformFilterFactories,
@@ -70,6 +78,9 @@ public class EnvoyConfiguration {
     this.dnsFailureRefreshSecondsMax = dnsFailureRefreshSecondsMax;
     this.dnsQueryTimeoutSeconds = dnsQueryTimeoutSeconds;
     this.dnsPreresolveHostnames = dnsPreresolveHostnames;
+    this.h2ConnectionKeepaliveIntervalSeconds = h2ConnectionKeepaliveIntervalSeconds;
+this.h2ConnectionKeepaliveIdleIntervalMilliseconds = h2ConnectionKeepaliveIdleIntervalMilliseconds;
+this.h2ConnectionKeepaliveTimeoutSeconds = h2ConnectionKeepaliveTimeoutSeconds;
     this.statsFlushSeconds = statsFlushSeconds;
     this.streamIdleTimeoutSeconds = streamIdleTimeoutSeconds;
     this.appVersion = appVersion;
@@ -118,6 +129,9 @@ public class EnvoyConfiguration {
         .append(String.format("- &dns_fail_max_interval %ss\n", dnsFailureRefreshSecondsMax))
         .append(String.format("- &dns_query_timeout %ss\n", dnsQueryTimeoutSeconds))
         .append(String.format("- &dns_preresolve_hostnames %s\n", dnsPreresolveHostnames))
+        .append(String.format("- &h2_connection_keepalive_interval %ss\n", h2ConnectionKeepaliveIntervalSeconds))
+        .append(String.format("- &h2_connection_keepalive_idle_interval %sms\n", h2ConnectionKeepaliveIdleIntervalMilliseconds))
+        .append(String.format("- &h2_connection_keepalive_timeout %ss\n", h2ConnectionKeepaliveTimeoutSeconds))
         .append(String.format("- &stream_idle_timeout %ss\n", streamIdleTimeoutSeconds))
         .append(String.format("- &metadata { device_os: %s, app_version: %s, app_id: %s }\n",
                               "Android", appVersion, appId))

--- a/library/java/io/envoyproxy/envoymobile/engine/EnvoyConfiguration.java
+++ b/library/java/io/envoyproxy/envoymobile/engine/EnvoyConfiguration.java
@@ -47,7 +47,8 @@ public class EnvoyConfiguration {
    * @param dnsQueryTimeoutSeconds       rate in seconds to timeout DNS queries.
    * @param dnsPreresolveHostnames       hostnames to preresolve on Envoy Client construction.
    * @param h2ConnectionKeepaliveIntervalSeconds rate in seconds to send h2 pings.
-   * @param h2ConnectionKeepaliveIdleIntervalMilliseconds rate in milliseconds seconds to send h2 pings on stream creation.
+   * @param h2ConnectionKeepaliveIdleIntervalMilliseconds rate in milliseconds seconds to send h2
+   *     pings on stream creation.
    * @param h2ConnectionKeepaliveTimeoutSeconds rate in seconds to timeout h2 pings.
    * @param statsFlushSeconds            interval at which to flush Envoy stats.
    * @param streamIdleTimeoutSeconds     idle timeout for HTTP streams.
@@ -63,8 +64,8 @@ public class EnvoyConfiguration {
                             int dnsRefreshSeconds, int dnsFailureRefreshSecondsBase,
                             int dnsFailureRefreshSecondsMax, int dnsQueryTimeoutSeconds,
                             String dnsPreresolveHostnames, int h2ConnectionKeepaliveIntervalSeconds,
-int h2ConnectionKeepaliveIdleIntervalMilliseconds,
-int h2ConnectionKeepaliveTimeoutSeconds, int statsFlushSeconds,
+                            int h2ConnectionKeepaliveIdleIntervalMilliseconds,
+                            int h2ConnectionKeepaliveTimeoutSeconds, int statsFlushSeconds,
                             int streamIdleTimeoutSeconds, String appVersion, String appId,
                             String virtualClusters, List<EnvoyNativeFilterConfig> nativeFilterChain,
                             List<EnvoyHTTPFilterFactory> httpPlatformFilterFactories,
@@ -79,8 +80,9 @@ int h2ConnectionKeepaliveTimeoutSeconds, int statsFlushSeconds,
     this.dnsQueryTimeoutSeconds = dnsQueryTimeoutSeconds;
     this.dnsPreresolveHostnames = dnsPreresolveHostnames;
     this.h2ConnectionKeepaliveIntervalSeconds = h2ConnectionKeepaliveIntervalSeconds;
-this.h2ConnectionKeepaliveIdleIntervalMilliseconds = h2ConnectionKeepaliveIdleIntervalMilliseconds;
-this.h2ConnectionKeepaliveTimeoutSeconds = h2ConnectionKeepaliveTimeoutSeconds;
+    this.h2ConnectionKeepaliveIdleIntervalMilliseconds =
+        h2ConnectionKeepaliveIdleIntervalMilliseconds;
+    this.h2ConnectionKeepaliveTimeoutSeconds = h2ConnectionKeepaliveTimeoutSeconds;
     this.statsFlushSeconds = statsFlushSeconds;
     this.streamIdleTimeoutSeconds = streamIdleTimeoutSeconds;
     this.appVersion = appVersion;
@@ -129,9 +131,12 @@ this.h2ConnectionKeepaliveTimeoutSeconds = h2ConnectionKeepaliveTimeoutSeconds;
         .append(String.format("- &dns_fail_max_interval %ss\n", dnsFailureRefreshSecondsMax))
         .append(String.format("- &dns_query_timeout %ss\n", dnsQueryTimeoutSeconds))
         .append(String.format("- &dns_preresolve_hostnames %s\n", dnsPreresolveHostnames))
-        .append(String.format("- &h2_connection_keepalive_interval %ss\n", h2ConnectionKeepaliveIntervalSeconds))
-        .append(String.format("- &h2_connection_keepalive_idle_interval %sms\n", h2ConnectionKeepaliveIdleIntervalMilliseconds))
-        .append(String.format("- &h2_connection_keepalive_timeout %ss\n", h2ConnectionKeepaliveTimeoutSeconds))
+        .append(String.format("- &h2_connection_keepalive_interval %ss\n",
+                              h2ConnectionKeepaliveIntervalSeconds))
+        .append(String.format("- &h2_connection_keepalive_idle_interval %sms\n",
+                              h2ConnectionKeepaliveIdleIntervalMilliseconds))
+        .append(String.format("- &h2_connection_keepalive_timeout %ss\n",
+                              h2ConnectionKeepaliveTimeoutSeconds))
         .append(String.format("- &stream_idle_timeout %ss\n", streamIdleTimeoutSeconds))
         .append(String.format("- &metadata { device_os: %s, app_version: %s, app_id: %s }\n",
                               "Android", appVersion, appId))

--- a/library/kotlin/io/envoyproxy/envoymobile/EngineBuilder.kt
+++ b/library/kotlin/io/envoyproxy/envoymobile/EngineBuilder.kt
@@ -35,6 +35,9 @@ open class EngineBuilder(
   private var dnsFailureRefreshSecondsMax = 10
   private var dnsQueryTimeoutSeconds = 25
   private var dnsPreresolveHostnames = "[]"
+  private var h2ConnectionKeepaliveIntervalSeconds = 2
+  private var h2ConnectionKeepaliveIdleIntervalMilliseconds = 1
+  private var h2ConnectionKeepaliveTimeoutSeconds = 5
   private var statsFlushSeconds = 60
   private var streamIdleTimeoutSeconds = 15
   private var appVersion = "unspecified"
@@ -145,6 +148,42 @@ open class EngineBuilder(
    */
   fun addDNSPreresolveHostnames(dnsPreresolveHostnames: String): EngineBuilder {
     this.dnsPreresolveHostnames = dnsPreresolveHostnames
+    return this
+  }
+
+  /**
+   * Add a rate at which to ping h2 connections.
+   *
+   * @param h2ConnectionKeepaliveIntervalSeconds rate in seconds to ping h2 connections.
+   *
+   * @return this builder.
+   */
+  fun addH2ConnectionKeepaliveIntervalSeconds(h2ConnectionKeepaliveIntervalSeconds: Int): EngineBuilder {
+    this.h2ConnectionKeepaliveIntervalSeconds = h2ConnectionKeepaliveIntervalSeconds
+    return this
+  }
+
+  /**
+   * Add a rate at which to ping h2 connections on new stream creation if the connection has sat idle.
+   *
+   * @param h2ConnectionKeepaliveIdleIntervalMilliseconds rate in milliseconds.
+   *
+   * @return this builder.
+   */
+  fun addH2ConnectionKeepaliveIdleIntervalMilliseconds(h2ConnectionKeepaliveIdleIntervalMilliseconds: Int): EngineBuilder {
+    this.h2ConnectionKeepaliveIdleIntervalMilliseconds = h2ConnectionKeepaliveIdleIntervalMilliseconds
+    return this
+  }
+
+  /**
+   * Add a rate at which to timeout h2 pings.
+   *
+   * @param h2ConnectionKeepaliveTimeoutSeconds rate in seconds to timeout h2 pings.
+   *
+   * @return this builder.
+   */
+  fun addH2ConnectionKeepaliveTimeoutSeconds(h2ConnectionKeepaliveTimeoutSeconds: Int): EngineBuilder {
+    this.h2ConnectionKeepaliveTimeoutSeconds = h2ConnectionKeepaliveTimeoutSeconds
     return this
   }
 
@@ -321,8 +360,9 @@ open class EngineBuilder(
           EnvoyConfiguration(
             adminInterfaceEnabled, grpcStatsDomain, statsDPort, connectTimeoutSeconds,
             dnsRefreshSeconds, dnsFailureRefreshSecondsBase, dnsFailureRefreshSecondsMax,
-            dnsQueryTimeoutSeconds,
-            dnsPreresolveHostnames, statsFlushSeconds, streamIdleTimeoutSeconds, appVersion, appId,
+            dnsQueryTimeoutSeconds, dnsPreresolveHostnames, h2ConnectionKeepaliveIntervalSeconds,
+            h2ConnectionKeepaliveIdleIntervalMilliseconds, h2ConnectionKeepaliveTimeoutSeconds,
+            statsFlushSeconds, streamIdleTimeoutSeconds, appVersion, appId,
             virtualClusters, nativeFilterChain, platformFilterChain, stringAccessors
           ),
           configuration.yaml,
@@ -335,8 +375,9 @@ open class EngineBuilder(
           EnvoyConfiguration(
             adminInterfaceEnabled, grpcStatsDomain, statsDPort, connectTimeoutSeconds,
             dnsRefreshSeconds, dnsFailureRefreshSecondsBase, dnsFailureRefreshSecondsMax,
-            dnsQueryTimeoutSeconds,
-            dnsPreresolveHostnames, statsFlushSeconds, streamIdleTimeoutSeconds, appVersion, appId,
+            dnsQueryTimeoutSeconds, dnsPreresolveHostnames, h2ConnectionKeepaliveIntervalSeconds,
+            h2ConnectionKeepaliveIdleIntervalMilliseconds, h2ConnectionKeepaliveTimeoutSeconds,
+            statsFlushSeconds, streamIdleTimeoutSeconds, appVersion, appId,
             virtualClusters, nativeFilterChain, platformFilterChain, stringAccessors
           ),
           logLevel

--- a/library/kotlin/io/envoyproxy/envoymobile/EngineBuilder.kt
+++ b/library/kotlin/io/envoyproxy/envoymobile/EngineBuilder.kt
@@ -158,10 +158,8 @@ open class EngineBuilder(
    *
    * @return this builder.
    */
-  fun addH2ConnectionKeepaliveIdleIntervalMilliseconds(
-    h2ConnectionKeepaliveIdleIntervalMilliseconds: Int): EngineBuilder {
-    this.h2ConnectionKeepaliveIdleIntervalMilliseconds =
-      h2ConnectionKeepaliveIdleIntervalMilliseconds
+  fun addH2ConnectionKeepaliveIdleIntervalMilliseconds(idleIntervalMs: Int): EngineBuilder {
+    this.h2ConnectionKeepaliveIdleIntervalMilliseconds = idleIntervalMs
     return this
   }
 
@@ -172,9 +170,8 @@ open class EngineBuilder(
    *
    * @return this builder.
    */
-  fun addH2ConnectionKeepaliveTimeoutSeconds(
-    h2ConnectionKeepaliveTimeoutSeconds: Int): EngineBuilder {
-    this.h2ConnectionKeepaliveTimeoutSeconds = h2ConnectionKeepaliveTimeoutSeconds
+  fun addH2ConnectionKeepaliveTimeoutSeconds(timeoutSeconds: Int): EngineBuilder {
+    this.h2ConnectionKeepaliveTimeoutSeconds = timeoutSeconds
     return this
   }
 

--- a/library/kotlin/io/envoyproxy/envoymobile/EngineBuilder.kt
+++ b/library/kotlin/io/envoyproxy/envoymobile/EngineBuilder.kt
@@ -35,8 +35,8 @@ open class EngineBuilder(
   private var dnsFailureRefreshSecondsMax = 10
   private var dnsQueryTimeoutSeconds = 25
   private var dnsPreresolveHostnames = "[]"
-  private var h2ConnectionKeepaliveIdleIntervalMilliseconds = 0
-  private var h2ConnectionKeepaliveTimeoutSeconds = 5
+  private var h2ConnectionKeepaliveIdleIntervalMilliseconds = 100000000
+  private var h2ConnectionKeepaliveTimeoutSeconds = 10
   private var statsFlushSeconds = 60
   private var streamIdleTimeoutSeconds = 15
   private var appVersion = "unspecified"

--- a/library/kotlin/io/envoyproxy/envoymobile/EngineBuilder.kt
+++ b/library/kotlin/io/envoyproxy/envoymobile/EngineBuilder.kt
@@ -35,8 +35,8 @@ open class EngineBuilder(
   private var dnsFailureRefreshSecondsMax = 10
   private var dnsQueryTimeoutSeconds = 25
   private var dnsPreresolveHostnames = "[]"
-  private var h2ConnectionKeepaliveIntervalSeconds = 2
-  private var h2ConnectionKeepaliveIdleIntervalMilliseconds = 1
+  private var h2ConnectionKeepaliveIntervalSeconds = 0
+  private var h2ConnectionKeepaliveIdleIntervalMilliseconds = 0
   private var h2ConnectionKeepaliveTimeoutSeconds = 5
   private var statsFlushSeconds = 60
   private var streamIdleTimeoutSeconds = 15

--- a/library/kotlin/io/envoyproxy/envoymobile/EngineBuilder.kt
+++ b/library/kotlin/io/envoyproxy/envoymobile/EngineBuilder.kt
@@ -35,7 +35,6 @@ open class EngineBuilder(
   private var dnsFailureRefreshSecondsMax = 10
   private var dnsQueryTimeoutSeconds = 25
   private var dnsPreresolveHostnames = "[]"
-  private var h2ConnectionKeepaliveIntervalSeconds = 0
   private var h2ConnectionKeepaliveIdleIntervalMilliseconds = 0
   private var h2ConnectionKeepaliveTimeoutSeconds = 5
   private var statsFlushSeconds = 60
@@ -152,26 +151,17 @@ open class EngineBuilder(
   }
 
   /**
-   * Add a rate at which to ping h2 connections.
-   *
-   * @param h2ConnectionKeepaliveIntervalSeconds rate in seconds to ping h2 connections.
-   *
-   * @return this builder.
-   */
-  fun addH2ConnectionKeepaliveIntervalSeconds(h2ConnectionKeepaliveIntervalSeconds: Int): EngineBuilder {
-    this.h2ConnectionKeepaliveIntervalSeconds = h2ConnectionKeepaliveIntervalSeconds
-    return this
-  }
-
-  /**
-   * Add a rate at which to ping h2 connections on new stream creation if the connection has sat idle.
+   * Add a rate at which to ping h2 connections on new stream creation if the connection has
+   * sat idle.
    *
    * @param h2ConnectionKeepaliveIdleIntervalMilliseconds rate in milliseconds.
    *
    * @return this builder.
    */
-  fun addH2ConnectionKeepaliveIdleIntervalMilliseconds(h2ConnectionKeepaliveIdleIntervalMilliseconds: Int): EngineBuilder {
-    this.h2ConnectionKeepaliveIdleIntervalMilliseconds = h2ConnectionKeepaliveIdleIntervalMilliseconds
+  fun addH2ConnectionKeepaliveIdleIntervalMilliseconds(
+    h2ConnectionKeepaliveIdleIntervalMilliseconds: Int): EngineBuilder {
+    this.h2ConnectionKeepaliveIdleIntervalMilliseconds =
+      h2ConnectionKeepaliveIdleIntervalMilliseconds
     return this
   }
 
@@ -182,7 +172,8 @@ open class EngineBuilder(
    *
    * @return this builder.
    */
-  fun addH2ConnectionKeepaliveTimeoutSeconds(h2ConnectionKeepaliveTimeoutSeconds: Int): EngineBuilder {
+  fun addH2ConnectionKeepaliveTimeoutSeconds(
+    h2ConnectionKeepaliveTimeoutSeconds: Int): EngineBuilder {
     this.h2ConnectionKeepaliveTimeoutSeconds = h2ConnectionKeepaliveTimeoutSeconds
     return this
   }
@@ -360,7 +351,7 @@ open class EngineBuilder(
           EnvoyConfiguration(
             adminInterfaceEnabled, grpcStatsDomain, statsDPort, connectTimeoutSeconds,
             dnsRefreshSeconds, dnsFailureRefreshSecondsBase, dnsFailureRefreshSecondsMax,
-            dnsQueryTimeoutSeconds, dnsPreresolveHostnames, h2ConnectionKeepaliveIntervalSeconds,
+            dnsQueryTimeoutSeconds, dnsPreresolveHostnames,
             h2ConnectionKeepaliveIdleIntervalMilliseconds, h2ConnectionKeepaliveTimeoutSeconds,
             statsFlushSeconds, streamIdleTimeoutSeconds, appVersion, appId,
             virtualClusters, nativeFilterChain, platformFilterChain, stringAccessors
@@ -375,7 +366,7 @@ open class EngineBuilder(
           EnvoyConfiguration(
             adminInterfaceEnabled, grpcStatsDomain, statsDPort, connectTimeoutSeconds,
             dnsRefreshSeconds, dnsFailureRefreshSecondsBase, dnsFailureRefreshSecondsMax,
-            dnsQueryTimeoutSeconds, dnsPreresolveHostnames, h2ConnectionKeepaliveIntervalSeconds,
+            dnsQueryTimeoutSeconds, dnsPreresolveHostnames,
             h2ConnectionKeepaliveIdleIntervalMilliseconds, h2ConnectionKeepaliveTimeoutSeconds,
             statsFlushSeconds, streamIdleTimeoutSeconds, appVersion, appId,
             virtualClusters, nativeFilterChain, platformFilterChain, stringAccessors

--- a/library/objective-c/EnvoyConfiguration.m
+++ b/library/objective-c/EnvoyConfiguration.m
@@ -12,7 +12,6 @@
                       dnsFailureRefreshSecondsMax:(UInt32)dnsFailureRefreshSecondsMax
                            dnsQueryTimeoutSeconds:(UInt32)dnsQueryTimeoutSeconds
                            dnsPreresolveHostnames:(NSString *)dnsPreresolveHostnames
-             h2ConnectionKeepaliveIntervalSeconds:(UInt32)h2ConnectionKeepaliveIntervalSeconds
     h2ConnectionKeepaliveIdleIntervalMilliseconds:
         (UInt32)h2ConnectionKeepaliveIdleIntervalMilliseconds
               h2ConnectionKeepaliveTimeoutSeconds:(UInt32)h2ConnectionKeepaliveTimeoutSeconds
@@ -43,7 +42,6 @@
   self.dnsFailureRefreshSecondsMax = dnsFailureRefreshSecondsMax;
   self.dnsQueryTimeoutSeconds = dnsQueryTimeoutSeconds;
   self.dnsPreresolveHostnames = dnsPreresolveHostnames;
-  self.h2ConnectionKeepaliveIntervalSeconds = h2ConnectionKeepaliveIntervalSeconds;
   self.h2ConnectionKeepaliveIdleIntervalMilliseconds =
       h2ConnectionKeepaliveIdleIntervalMilliseconds;
   self.h2ConnectionKeepaliveTimeoutSeconds = h2ConnectionKeepaliveTimeoutSeconds;
@@ -118,10 +116,8 @@
   [definitions
       appendFormat:@"- &dns_query_timeout %lus\n", (unsigned long)self.dnsQueryTimeoutSeconds];
   [definitions appendFormat:@"- &dns_preresolve_hostnames %@\n", self.dnsPreresolveHostnames];
-  [definitions appendFormat:@"- &h2_connection_keepalive_interval %lus\n",
-                            (unsigned long)self.h2ConnectionKeepaliveIntervalSeconds];
-  [definitions appendFormat:@"- &h2_connection_keepalive_idle_interval %lus\n",
-                            (unsigned long)self.h2ConnectionKeepaliveIdleIntervalMilliseconds / 1000.0];
+  [definitions appendFormat:@"- &h2_connection_keepalive_idle_interval %.*fs\n", 3,
+                            (double)self.h2ConnectionKeepaliveIdleIntervalMilliseconds / 1000.0];
   [definitions appendFormat:@"- &h2_connection_keepalive_timeout %lus\n",
                             (unsigned long)self.h2ConnectionKeepaliveTimeoutSeconds];
   [definitions

--- a/library/objective-c/EnvoyConfiguration.m
+++ b/library/objective-c/EnvoyConfiguration.m
@@ -120,8 +120,8 @@
   [definitions appendFormat:@"- &dns_preresolve_hostnames %@\n", self.dnsPreresolveHostnames];
   [definitions appendFormat:@"- &h2_connection_keepalive_interval %lus\n",
                             (unsigned long)self.h2ConnectionKeepaliveIntervalSeconds];
-  [definitions appendFormat:@"- &h2_connection_keepalive_idle_interval %lums\n",
-                            (unsigned long)self.h2ConnectionKeepaliveIdleIntervalMilliseconds];
+  [definitions appendFormat:@"- &h2_connection_keepalive_idle_interval %lus\n",
+                            (unsigned long)self.h2ConnectionKeepaliveIdleIntervalMilliseconds / 1000.0];
   [definitions appendFormat:@"- &h2_connection_keepalive_timeout %lus\n",
                             (unsigned long)self.h2ConnectionKeepaliveTimeoutSeconds];
   [definitions

--- a/library/objective-c/EnvoyConfiguration.m
+++ b/library/objective-c/EnvoyConfiguration.m
@@ -4,29 +4,32 @@
 
 @implementation EnvoyConfiguration
 
-- (instancetype)
-    initWithAdminInterfaceEnabled:(BOOL)adminInterfaceEnabled
-                  GrpcStatsDomain:(nullable NSString *)grpcStatsDomain
-            connectTimeoutSeconds:(UInt32)connectTimeoutSeconds
-                dnsRefreshSeconds:(UInt32)dnsRefreshSeconds
-     dnsFailureRefreshSecondsBase:(UInt32)dnsFailureRefreshSecondsBase
-      dnsFailureRefreshSecondsMax:(UInt32)dnsFailureRefreshSecondsMax
-           dnsQueryTimeoutSeconds:(UInt32)dnsQueryTimeoutSeconds
-           dnsPreresolveHostnames:(NSString *)dnsPreresolveHostnames
-           h2ConnectionKeepaliveIntervalSeconds:(UInt32)h2ConnectionKeepaliveIntervalSeconds
-           h2ConnectionKeepaliveIdleIntervalMilliseconds:(UInt32)h2ConnectionKeepaliveIdleIntervalMilliseconds
-           h2ConnectionKeepaliveTimeoutSeconds:(UInt32)h2ConnectionKeepaliveTimeoutSeconds
-                statsFlushSeconds:(UInt32)statsFlushSeconds
-         streamIdleTimeoutSeconds:(UInt32)streamIdleTimeoutSeconds
-                       appVersion:(NSString *)appVersion
-                            appId:(NSString *)appId
-                  virtualClusters:(NSString *)virtualClusters
-           directResponseMatchers:(NSString *)directResponseMatchers
-                  directResponses:(NSString *)directResponses
-                nativeFilterChain:(NSArray<EnvoyNativeFilterConfig *> *)nativeFilterChain
-              platformFilterChain:(NSArray<EnvoyHTTPFilterFactory *> *)httpPlatformFilterFactories
-                  stringAccessors:
-                      (NSDictionary<NSString *, EnvoyStringAccessor *> *)stringAccessors {
+- (instancetype)initWithAdminInterfaceEnabled:(BOOL)adminInterfaceEnabled
+                                  GrpcStatsDomain:(nullable NSString *)grpcStatsDomain
+                            connectTimeoutSeconds:(UInt32)connectTimeoutSeconds
+                                dnsRefreshSeconds:(UInt32)dnsRefreshSeconds
+                     dnsFailureRefreshSecondsBase:(UInt32)dnsFailureRefreshSecondsBase
+                      dnsFailureRefreshSecondsMax:(UInt32)dnsFailureRefreshSecondsMax
+                           dnsQueryTimeoutSeconds:(UInt32)dnsQueryTimeoutSeconds
+                           dnsPreresolveHostnames:(NSString *)dnsPreresolveHostnames
+             h2ConnectionKeepaliveIntervalSeconds:(UInt32)h2ConnectionKeepaliveIntervalSeconds
+    h2ConnectionKeepaliveIdleIntervalMilliseconds:
+        (UInt32)h2ConnectionKeepaliveIdleIntervalMilliseconds
+              h2ConnectionKeepaliveTimeoutSeconds:(UInt32)h2ConnectionKeepaliveTimeoutSeconds
+                                statsFlushSeconds:(UInt32)statsFlushSeconds
+                         streamIdleTimeoutSeconds:(UInt32)streamIdleTimeoutSeconds
+                                       appVersion:(NSString *)appVersion
+                                            appId:(NSString *)appId
+                                  virtualClusters:(NSString *)virtualClusters
+                           directResponseMatchers:(NSString *)directResponseMatchers
+                                  directResponses:(NSString *)directResponses
+                                nativeFilterChain:
+                                    (NSArray<EnvoyNativeFilterConfig *> *)nativeFilterChain
+                              platformFilterChain:
+                                  (NSArray<EnvoyHTTPFilterFactory *> *)httpPlatformFilterFactories
+                                  stringAccessors:
+                                      (NSDictionary<NSString *, EnvoyStringAccessor *> *)
+                                          stringAccessors {
   self = [super init];
   if (!self) {
     return nil;
@@ -41,7 +44,8 @@
   self.dnsQueryTimeoutSeconds = dnsQueryTimeoutSeconds;
   self.dnsPreresolveHostnames = dnsPreresolveHostnames;
   self.h2ConnectionKeepaliveIntervalSeconds = h2ConnectionKeepaliveIntervalSeconds;
-  self.h2ConnectionKeepaliveIdleIntervalMilliseconds = h2ConnectionKeepaliveIdleIntervalMilliseconds;
+  self.h2ConnectionKeepaliveIdleIntervalMilliseconds =
+      h2ConnectionKeepaliveIdleIntervalMilliseconds;
   self.h2ConnectionKeepaliveTimeoutSeconds = h2ConnectionKeepaliveTimeoutSeconds;
   self.statsFlushSeconds = statsFlushSeconds;
   self.streamIdleTimeoutSeconds = streamIdleTimeoutSeconds;
@@ -114,9 +118,12 @@
   [definitions
       appendFormat:@"- &dns_query_timeout %lus\n", (unsigned long)self.dnsQueryTimeoutSeconds];
   [definitions appendFormat:@"- &dns_preresolve_hostnames %@\n", self.dnsPreresolveHostnames];
-  [definitions appendFormat:@"- &h2_connection_keepalive_interval %lus\n", (unsigned long)self.h2ConnectionKeepaliveIntervalSeconds];
-  [definitions appendFormat:@"- &h2_connection_keepalive_idle_interval %lums\n", (unsigned long)self.h2ConnectionKeepaliveIdleIntervalMilliseconds];
-  [definitions appendFormat:@"- &h2_connection_keepalive_timeout %lus\n", (unsigned long)self.h2ConnectionKeepaliveTimeoutSeconds];
+  [definitions appendFormat:@"- &h2_connection_keepalive_interval %lus\n",
+                            (unsigned long)self.h2ConnectionKeepaliveIntervalSeconds];
+  [definitions appendFormat:@"- &h2_connection_keepalive_idle_interval %lums\n",
+                            (unsigned long)self.h2ConnectionKeepaliveIdleIntervalMilliseconds];
+  [definitions appendFormat:@"- &h2_connection_keepalive_timeout %lus\n",
+                            (unsigned long)self.h2ConnectionKeepaliveTimeoutSeconds];
   [definitions
       appendFormat:@"- &stream_idle_timeout %lus\n", (unsigned long)self.streamIdleTimeoutSeconds];
   [definitions appendFormat:@"- &metadata { device_os: %@, app_version: %@, app_id: %@ }\n", @"iOS",

--- a/library/objective-c/EnvoyConfiguration.m
+++ b/library/objective-c/EnvoyConfiguration.m
@@ -13,6 +13,9 @@
       dnsFailureRefreshSecondsMax:(UInt32)dnsFailureRefreshSecondsMax
            dnsQueryTimeoutSeconds:(UInt32)dnsQueryTimeoutSeconds
            dnsPreresolveHostnames:(NSString *)dnsPreresolveHostnames
+           h2ConnectionKeepaliveIntervalSeconds:(UInt32)h2ConnectionKeepaliveIntervalSeconds
+           h2ConnectionKeepaliveIdleIntervalMilliseconds:(UInt32)h2ConnectionKeepaliveIdleIntervalMilliseconds
+           h2ConnectionKeepaliveTimeoutSeconds:(UInt32)h2ConnectionKeepaliveTimeoutSeconds
                 statsFlushSeconds:(UInt32)statsFlushSeconds
          streamIdleTimeoutSeconds:(UInt32)streamIdleTimeoutSeconds
                        appVersion:(NSString *)appVersion
@@ -37,6 +40,9 @@
   self.dnsFailureRefreshSecondsMax = dnsFailureRefreshSecondsMax;
   self.dnsQueryTimeoutSeconds = dnsQueryTimeoutSeconds;
   self.dnsPreresolveHostnames = dnsPreresolveHostnames;
+  self.h2ConnectionKeepaliveIntervalSeconds = h2ConnectionKeepaliveIntervalSeconds;
+  self.h2ConnectionKeepaliveIdleIntervalMilliseconds = h2ConnectionKeepaliveIdleIntervalMilliseconds;
+  self.h2ConnectionKeepaliveTimeoutSeconds = h2ConnectionKeepaliveTimeoutSeconds;
   self.statsFlushSeconds = statsFlushSeconds;
   self.streamIdleTimeoutSeconds = streamIdleTimeoutSeconds;
   self.appVersion = appVersion;
@@ -108,6 +114,9 @@
   [definitions
       appendFormat:@"- &dns_query_timeout %lus\n", (unsigned long)self.dnsQueryTimeoutSeconds];
   [definitions appendFormat:@"- &dns_preresolve_hostnames %@\n", self.dnsPreresolveHostnames];
+  [definitions appendFormat:@"- &h2_connection_keepalive_interval %lus\n", (unsigned long)self.h2ConnectionKeepaliveIntervalSeconds];
+  [definitions appendFormat:@"- &h2_connection_keepalive_idle_interval %lums\n", (unsigned long)self.h2ConnectionKeepaliveIdleIntervalMilliseconds];
+  [definitions appendFormat:@"- &h2_connection_keepalive_timeout %lus\n", (unsigned long)self.h2ConnectionKeepaliveTimeoutSeconds];
   [definitions
       appendFormat:@"- &stream_idle_timeout %lus\n", (unsigned long)self.streamIdleTimeoutSeconds];
   [definitions appendFormat:@"- &metadata { device_os: %@, app_version: %@, app_id: %@ }\n", @"iOS",

--- a/library/objective-c/EnvoyEngine.h
+++ b/library/objective-c/EnvoyEngine.h
@@ -318,29 +318,32 @@ extern const int kEnvoyFilterResumeStatusResumeIteration;
 /**
  Create a new instance of the configuration.
  */
-- (instancetype)
-    initWithAdminInterfaceEnabled:(BOOL)adminInterfaceEnabled
-                  GrpcStatsDomain:(nullable NSString *)grpcStatsDomain
-            connectTimeoutSeconds:(UInt32)connectTimeoutSeconds
-                dnsRefreshSeconds:(UInt32)dnsRefreshSeconds
-     dnsFailureRefreshSecondsBase:(UInt32)dnsFailureRefreshSecondsBase
-      dnsFailureRefreshSecondsMax:(UInt32)dnsFailureRefreshSecondsMax
-           dnsQueryTimeoutSeconds:(UInt32)dnsQueryTimeoutSeconds
-           dnsPreresolveHostnames:(NSString *)dnsPreresolveHostnames
-           h2ConnectionKeepaliveIntervalSeconds:(UInt32)h2ConnectionKeepaliveIntervalSeconds
-           h2ConnectionKeepaliveIdleIntervalMilliseconds:(UInt32)h2ConnectionKeepaliveIdleIntervalMilliseconds
-           h2ConnectionKeepaliveTimeoutSeconds:(UInt32)h2ConnectionKeepaliveTimeoutSeconds
-                statsFlushSeconds:(UInt32)statsFlushSeconds
-         streamIdleTimeoutSeconds:(UInt32)streamIdleTimeoutSeconds
-                       appVersion:(NSString *)appVersion
-                            appId:(NSString *)appId
-                  virtualClusters:(NSString *)virtualClusters
-           directResponseMatchers:(NSString *)directResponseMatchers
-                  directResponses:(NSString *)directResponses
-                nativeFilterChain:(NSArray<EnvoyNativeFilterConfig *> *)nativeFilterChain
-              platformFilterChain:(NSArray<EnvoyHTTPFilterFactory *> *)httpPlatformFilterFactories
-                  stringAccessors:
-                      (NSDictionary<NSString *, EnvoyStringAccessor *> *)stringAccessors;
+- (instancetype)initWithAdminInterfaceEnabled:(BOOL)adminInterfaceEnabled
+                                  GrpcStatsDomain:(nullable NSString *)grpcStatsDomain
+                            connectTimeoutSeconds:(UInt32)connectTimeoutSeconds
+                                dnsRefreshSeconds:(UInt32)dnsRefreshSeconds
+                     dnsFailureRefreshSecondsBase:(UInt32)dnsFailureRefreshSecondsBase
+                      dnsFailureRefreshSecondsMax:(UInt32)dnsFailureRefreshSecondsMax
+                           dnsQueryTimeoutSeconds:(UInt32)dnsQueryTimeoutSeconds
+                           dnsPreresolveHostnames:(NSString *)dnsPreresolveHostnames
+             h2ConnectionKeepaliveIntervalSeconds:(UInt32)h2ConnectionKeepaliveIntervalSeconds
+    h2ConnectionKeepaliveIdleIntervalMilliseconds:
+        (UInt32)h2ConnectionKeepaliveIdleIntervalMilliseconds
+              h2ConnectionKeepaliveTimeoutSeconds:(UInt32)h2ConnectionKeepaliveTimeoutSeconds
+                                statsFlushSeconds:(UInt32)statsFlushSeconds
+                         streamIdleTimeoutSeconds:(UInt32)streamIdleTimeoutSeconds
+                                       appVersion:(NSString *)appVersion
+                                            appId:(NSString *)appId
+                                  virtualClusters:(NSString *)virtualClusters
+                           directResponseMatchers:(NSString *)directResponseMatchers
+                                  directResponses:(NSString *)directResponses
+                                nativeFilterChain:
+                                    (NSArray<EnvoyNativeFilterConfig *> *)nativeFilterChain
+                              platformFilterChain:
+                                  (NSArray<EnvoyHTTPFilterFactory *> *)httpPlatformFilterFactories
+                                  stringAccessors:
+                                      (NSDictionary<NSString *, EnvoyStringAccessor *> *)
+                                          stringAccessors;
 
 /**
  Resolves the provided configuration template using properties on this configuration.

--- a/library/objective-c/EnvoyEngine.h
+++ b/library/objective-c/EnvoyEngine.h
@@ -301,6 +301,9 @@ extern const int kEnvoyFilterResumeStatusResumeIteration;
 @property (nonatomic, assign) UInt32 dnsFailureRefreshSecondsMax;
 @property (nonatomic, assign) UInt32 dnsQueryTimeoutSeconds;
 @property (nonatomic, strong) NSString *dnsPreresolveHostnames;
+@property (nonatomic, assign) UInt32 h2ConnectionKeepaliveIntervalSeconds;
+@property (nonatomic, assign) UInt32 h2ConnectionKeepaliveIdleIntervalMilliseconds;
+@property (nonatomic, assign) UInt32 h2ConnectionKeepaliveTimeoutSeconds;
 @property (nonatomic, assign) UInt32 statsFlushSeconds;
 @property (nonatomic, assign) UInt32 streamIdleTimeoutSeconds;
 @property (nonatomic, strong) NSString *appVersion;
@@ -324,6 +327,9 @@ extern const int kEnvoyFilterResumeStatusResumeIteration;
       dnsFailureRefreshSecondsMax:(UInt32)dnsFailureRefreshSecondsMax
            dnsQueryTimeoutSeconds:(UInt32)dnsQueryTimeoutSeconds
            dnsPreresolveHostnames:(NSString *)dnsPreresolveHostnames
+           h2ConnectionKeepaliveIntervalSeconds:(UInt32)h2ConnectionKeepaliveIntervalSeconds
+           h2ConnectionKeepaliveIdleIntervalMilliseconds:(UInt32)h2ConnectionKeepaliveIdleIntervalMilliseconds
+           h2ConnectionKeepaliveTimeoutSeconds:(UInt32)h2ConnectionKeepaliveTimeoutSeconds
                 statsFlushSeconds:(UInt32)statsFlushSeconds
          streamIdleTimeoutSeconds:(UInt32)streamIdleTimeoutSeconds
                        appVersion:(NSString *)appVersion

--- a/library/objective-c/EnvoyEngine.h
+++ b/library/objective-c/EnvoyEngine.h
@@ -301,7 +301,6 @@ extern const int kEnvoyFilterResumeStatusResumeIteration;
 @property (nonatomic, assign) UInt32 dnsFailureRefreshSecondsMax;
 @property (nonatomic, assign) UInt32 dnsQueryTimeoutSeconds;
 @property (nonatomic, strong) NSString *dnsPreresolveHostnames;
-@property (nonatomic, assign) UInt32 h2ConnectionKeepaliveIntervalSeconds;
 @property (nonatomic, assign) UInt32 h2ConnectionKeepaliveIdleIntervalMilliseconds;
 @property (nonatomic, assign) UInt32 h2ConnectionKeepaliveTimeoutSeconds;
 @property (nonatomic, assign) UInt32 statsFlushSeconds;
@@ -326,7 +325,6 @@ extern const int kEnvoyFilterResumeStatusResumeIteration;
                       dnsFailureRefreshSecondsMax:(UInt32)dnsFailureRefreshSecondsMax
                            dnsQueryTimeoutSeconds:(UInt32)dnsQueryTimeoutSeconds
                            dnsPreresolveHostnames:(NSString *)dnsPreresolveHostnames
-             h2ConnectionKeepaliveIntervalSeconds:(UInt32)h2ConnectionKeepaliveIntervalSeconds
     h2ConnectionKeepaliveIdleIntervalMilliseconds:
         (UInt32)h2ConnectionKeepaliveIdleIntervalMilliseconds
               h2ConnectionKeepaliveTimeoutSeconds:(UInt32)h2ConnectionKeepaliveTimeoutSeconds

--- a/library/swift/EngineBuilder.swift
+++ b/library/swift/EngineBuilder.swift
@@ -21,8 +21,8 @@ open class EngineBuilder: NSObject {
   private var dnsFailureRefreshSecondsMax: UInt32 = 10
   private var dnsQueryTimeoutSeconds: UInt32 = 25
   private var dnsPreresolveHostnames: String = "[]"
-  private var h2ConnectionKeepaliveIdleIntervalMilliseconds: UInt32 = 0
-  private var h2ConnectionKeepaliveTimeoutSeconds: UInt32 = 5
+  private var h2ConnectionKeepaliveIdleIntervalMilliseconds: UInt32 = 100000000
+  private var h2ConnectionKeepaliveTimeoutSeconds: UInt32 = 10
   private var statsFlushSeconds: UInt32 = 60
   private var streamIdleTimeoutSeconds: UInt32 = 15
   private var appVersion: String = "unspecified"

--- a/library/swift/EngineBuilder.swift
+++ b/library/swift/EngineBuilder.swift
@@ -21,6 +21,9 @@ open class EngineBuilder: NSObject {
   private var dnsFailureRefreshSecondsMax: UInt32 = 10
   private var dnsQueryTimeoutSeconds: UInt32 = 25
   private var dnsPreresolveHostnames: String = "[]"
+  private var h2ConnectionKeepaliveIntervalSeconds: UInt32 = 2
+  private var h2ConnectionKeepaliveIdleIntervalMilliseconds: UInt32 = 1
+  private var h2ConnectionKeepaliveTimeoutSeconds: UInt32 = 5
   private var statsFlushSeconds: UInt32 = 60
   private var streamIdleTimeoutSeconds: UInt32 = 15
   private var appVersion: String = "unspecified"
@@ -127,6 +130,39 @@ open class EngineBuilder: NSObject {
   @discardableResult
   public func addDNSPreresolveHostnames(dnsPreresolveHostnames: String) -> Self {
     self.dnsPreresolveHostnames = dnsPreresolveHostnames
+    return self
+  }
+
+  /// Add a rate at which to ping h2 connections.
+  ///
+  /// - parameter h2ConnectionKeepaliveIntervalSeconds: Rate in seconds to ping h2 connections.
+  ///
+  /// - returns: This builder.
+  @discardableResult
+  public func addH2ConnectionKeepaliveIntervalSeconds(_ h2ConnectionKeepaliveIntervalSeconds: UInt32) -> Self {
+    self.h2ConnectionKeepaliveIntervalSeconds = h2ConnectionKeepaliveIntervalSeconds
+    return self
+  }
+
+  /// Add a rate at which to ping h2 connections on new stream creation if the connection has sat idle.
+  ///
+  /// - parameter h2ConnectionKeepaliveIdleIntervalMilliseconds: Rate in milliseconds.
+  ///
+  /// - returns: This builder.
+  @discardableResult
+  public func addH2ConnectionKeepaliveIdleIntervalMilliseconds(_ h2ConnectionKeepaliveIdleIntervalMilliseconds: UInt32) -> Self {
+    self.h2ConnectionKeepaliveIdleIntervalMilliseconds = h2ConnectionKeepaliveIdleIntervalMilliseconds
+    return self
+  }
+
+  /// Add a rate at which to timeout h2 pings.
+  ///
+  /// - parameter h2ConnectionKeepaliveTimeoutSeconds: Rate in seconds to timeout h2 pings.
+  ///
+  /// - returns: This builder.
+  @discardableResult
+  public func addH2ConnectionKeepaliveTimeoutSeconds(_ h2ConnectionKeepaliveTimeoutSeconds: UInt32) -> Self {
+    self.h2ConnectionKeepaliveTimeoutSeconds = h2ConnectionKeepaliveTimeoutSeconds
     return self
   }
 
@@ -299,6 +335,9 @@ open class EngineBuilder: NSObject {
       dnsFailureRefreshSecondsMax: self.dnsFailureRefreshSecondsMax,
       dnsQueryTimeoutSeconds: self.dnsQueryTimeoutSeconds,
       dnsPreresolveHostnames: self.dnsPreresolveHostnames,
+      h2ConnectionKeepaliveIntervalSeconds: self.h2ConnectionKeepaliveIntervalSeconds,
+      h2ConnectionKeepaliveIdleIntervalMilliseconds: self.h2ConnectionKeepaliveIdleIntervalMilliseconds,
+      h2ConnectionKeepaliveTimeoutSeconds: self.h2ConnectionKeepaliveTimeoutSeconds,
       statsFlushSeconds: self.statsFlushSeconds,
       streamIdleTimeoutSeconds: self.streamIdleTimeoutSeconds,
       appVersion: self.appVersion,

--- a/library/swift/EngineBuilder.swift
+++ b/library/swift/EngineBuilder.swift
@@ -21,7 +21,6 @@ open class EngineBuilder: NSObject {
   private var dnsFailureRefreshSecondsMax: UInt32 = 10
   private var dnsQueryTimeoutSeconds: UInt32 = 25
   private var dnsPreresolveHostnames: String = "[]"
-  private var h2ConnectionKeepaliveIntervalSeconds: UInt32 = 0
   private var h2ConnectionKeepaliveIdleIntervalMilliseconds: UInt32 = 0
   private var h2ConnectionKeepaliveTimeoutSeconds: UInt32 = 5
   private var statsFlushSeconds: UInt32 = 60
@@ -130,18 +129,6 @@ open class EngineBuilder: NSObject {
   @discardableResult
   public func addDNSPreresolveHostnames(dnsPreresolveHostnames: String) -> Self {
     self.dnsPreresolveHostnames = dnsPreresolveHostnames
-    return self
-  }
-
-  /// Add a rate at which to ping h2 connections.
-  ///
-  /// - parameter h2ConnectionKeepaliveIntervalSeconds: Rate in seconds to ping h2 connections.
-  ///
-  /// - returns: This builder.
-  @discardableResult
-  public func addH2ConnectionKeepaliveIntervalSeconds(
-    _ h2ConnectionKeepaliveIntervalSeconds: UInt32) -> Self {
-    self.h2ConnectionKeepaliveIntervalSeconds = h2ConnectionKeepaliveIntervalSeconds
     return self
   }
 
@@ -340,8 +327,6 @@ open class EngineBuilder: NSObject {
       dnsFailureRefreshSecondsMax: self.dnsFailureRefreshSecondsMax,
       dnsQueryTimeoutSeconds: self.dnsQueryTimeoutSeconds,
       dnsPreresolveHostnames: self.dnsPreresolveHostnames,
-      h2ConnectionKeepaliveIntervalSeconds:
-        self.h2ConnectionKeepaliveIntervalSeconds,
       h2ConnectionKeepaliveIdleIntervalMilliseconds:
         self.h2ConnectionKeepaliveIdleIntervalMilliseconds,
       h2ConnectionKeepaliveTimeoutSeconds: self.h2ConnectionKeepaliveTimeoutSeconds,

--- a/library/swift/EngineBuilder.swift
+++ b/library/swift/EngineBuilder.swift
@@ -21,8 +21,8 @@ open class EngineBuilder: NSObject {
   private var dnsFailureRefreshSecondsMax: UInt32 = 10
   private var dnsQueryTimeoutSeconds: UInt32 = 25
   private var dnsPreresolveHostnames: String = "[]"
-  private var h2ConnectionKeepaliveIntervalSeconds: UInt32 = 2
-  private var h2ConnectionKeepaliveIdleIntervalMilliseconds: UInt32 = 1
+  private var h2ConnectionKeepaliveIntervalSeconds: UInt32 = 0
+  private var h2ConnectionKeepaliveIdleIntervalMilliseconds: UInt32 = 0
   private var h2ConnectionKeepaliveTimeoutSeconds: UInt32 = 5
   private var statsFlushSeconds: UInt32 = 60
   private var streamIdleTimeoutSeconds: UInt32 = 15

--- a/library/swift/EngineBuilder.swift
+++ b/library/swift/EngineBuilder.swift
@@ -139,19 +139,23 @@ open class EngineBuilder: NSObject {
   ///
   /// - returns: This builder.
   @discardableResult
-  public func addH2ConnectionKeepaliveIntervalSeconds(_ h2ConnectionKeepaliveIntervalSeconds: UInt32) -> Self {
+  public func addH2ConnectionKeepaliveIntervalSeconds(
+    _ h2ConnectionKeepaliveIntervalSeconds: UInt32) -> Self {
     self.h2ConnectionKeepaliveIntervalSeconds = h2ConnectionKeepaliveIntervalSeconds
     return self
   }
 
-  /// Add a rate at which to ping h2 connections on new stream creation if the connection has sat idle.
+  /// Add a rate at which to ping h2 connections on new stream creation if the connection has
+  /// sat idle.
   ///
   /// - parameter h2ConnectionKeepaliveIdleIntervalMilliseconds: Rate in milliseconds.
   ///
   /// - returns: This builder.
   @discardableResult
-  public func addH2ConnectionKeepaliveIdleIntervalMilliseconds(_ h2ConnectionKeepaliveIdleIntervalMilliseconds: UInt32) -> Self {
-    self.h2ConnectionKeepaliveIdleIntervalMilliseconds = h2ConnectionKeepaliveIdleIntervalMilliseconds
+  public func addH2ConnectionKeepaliveIdleIntervalMilliseconds(
+    _ h2ConnectionKeepaliveIdleIntervalMilliseconds: UInt32) -> Self {
+    self.h2ConnectionKeepaliveIdleIntervalMilliseconds =
+      h2ConnectionKeepaliveIdleIntervalMilliseconds
     return self
   }
 
@@ -161,7 +165,8 @@ open class EngineBuilder: NSObject {
   ///
   /// - returns: This builder.
   @discardableResult
-  public func addH2ConnectionKeepaliveTimeoutSeconds(_ h2ConnectionKeepaliveTimeoutSeconds: UInt32) -> Self {
+  public func addH2ConnectionKeepaliveTimeoutSeconds(
+    _ h2ConnectionKeepaliveTimeoutSeconds: UInt32) -> Self {
     self.h2ConnectionKeepaliveTimeoutSeconds = h2ConnectionKeepaliveTimeoutSeconds
     return self
   }
@@ -335,8 +340,10 @@ open class EngineBuilder: NSObject {
       dnsFailureRefreshSecondsMax: self.dnsFailureRefreshSecondsMax,
       dnsQueryTimeoutSeconds: self.dnsQueryTimeoutSeconds,
       dnsPreresolveHostnames: self.dnsPreresolveHostnames,
-      h2ConnectionKeepaliveIntervalSeconds: self.h2ConnectionKeepaliveIntervalSeconds,
-      h2ConnectionKeepaliveIdleIntervalMilliseconds: self.h2ConnectionKeepaliveIdleIntervalMilliseconds,
+      h2ConnectionKeepaliveIntervalSeconds:
+        self.h2ConnectionKeepaliveIntervalSeconds,
+      h2ConnectionKeepaliveIdleIntervalMilliseconds:
+        self.h2ConnectionKeepaliveIdleIntervalMilliseconds,
       h2ConnectionKeepaliveTimeoutSeconds: self.h2ConnectionKeepaliveTimeoutSeconds,
       statsFlushSeconds: self.statsFlushSeconds,
       streamIdleTimeoutSeconds: self.streamIdleTimeoutSeconds,

--- a/test/cc/unit/envoy_config_test.cc
+++ b/test/cc/unit/envoy_config_test.cc
@@ -36,8 +36,8 @@ TEST(TestConfig, ConfigIsApplied) {
       "- &dns_fail_max_interval 987s",
       "- &dns_query_timeout 321s",
       "- &dns_preresolve_hostnames [hostname]",
-      "- &h2_connection_keepalive_idle_interval 0.222s"
-      "- &h2_connection_keepalive_timeout 333s"
+      "- &h2_connection_keepalive_idle_interval 0.222s",
+      "- &h2_connection_keepalive_timeout 333s",
       "- &stats_flush_interval 654s",
       "- &virtual_clusters [virtual-clusters]",
       ("- &metadata { device_os: probably-ubuntu-on-CI, "

--- a/test/cc/unit/envoy_config_test.cc
+++ b/test/cc/unit/envoy_config_test.cc
@@ -19,7 +19,6 @@ TEST(TestConfig, ConfigIsApplied) {
       .addDnsFailureRefreshSeconds(789, 987)
       .addDnsQueryTimeoutSeconds(321)
       .addDnsPreresolveHostnames("[hostname]")
-      .addH2ConnectionKeepaliveIntervalSeconds(111)
       .addH2ConnectionKeepaliveIdleIntervalMilliseconds(222)
       .addH2ConnectionKeepaliveTimeoutSeconds(333)
       .addStatsFlushSeconds(654)
@@ -37,7 +36,6 @@ TEST(TestConfig, ConfigIsApplied) {
       "- &dns_fail_max_interval 987s",
       "- &dns_query_timeout 321s",
       "- &dns_preresolve_hostnames [hostname]",
-      "- &h2_connection_keepalive_interval 111s"
       "- &h2_connection_keepalive_idle_interval 0.222s"
       "- &h2_connection_keepalive_timeout 333s"
       "- &stats_flush_interval 654s",

--- a/test/cc/unit/envoy_config_test.cc
+++ b/test/cc/unit/envoy_config_test.cc
@@ -19,6 +19,9 @@ TEST(TestConfig, ConfigIsApplied) {
       .addDnsFailureRefreshSeconds(789, 987)
       .addDnsQueryTimeoutSeconds(321)
       .addDnsPreresolveHostnames("[hostname]")
+      .addH2ConnectionKeepaliveIntervalSeconds(111)
+      .addH2ConnectionKeepaliveIdleIntervalMilliseconds(222)
+      .addH2ConnectionKeepaliveTimeoutSeconds(333)
       .addStatsFlushSeconds(654)
       .addVirtualClusters("[virtual-clusters]")
       .setAppVersion("1.2.3")
@@ -34,6 +37,9 @@ TEST(TestConfig, ConfigIsApplied) {
       "- &dns_fail_max_interval 987s",
       "- &dns_query_timeout 321s",
       "- &dns_preresolve_hostnames [hostname]",
+      "- &h2_connection_keepalive_interval 111s"
+      "- &h2_connection_keepalive_idle_interval 222ms"
+      "- &h2_connection_keepalive_timeout 333s"
       "- &stats_flush_interval 654s",
       "- &virtual_clusters [virtual-clusters]",
       ("- &metadata { device_os: probably-ubuntu-on-CI, "

--- a/test/cc/unit/envoy_config_test.cc
+++ b/test/cc/unit/envoy_config_test.cc
@@ -38,7 +38,7 @@ TEST(TestConfig, ConfigIsApplied) {
       "- &dns_query_timeout 321s",
       "- &dns_preresolve_hostnames [hostname]",
       "- &h2_connection_keepalive_interval 111s"
-      "- &h2_connection_keepalive_idle_interval 222ms"
+      "- &h2_connection_keepalive_idle_interval 0.222s"
       "- &h2_connection_keepalive_timeout 333s"
       "- &stats_flush_interval 654s",
       "- &virtual_clusters [virtual-clusters]",

--- a/test/java/io/envoyproxy/envoymobile/engine/EnvoyConfigurationTest.kt
+++ b/test/java/io/envoyproxy/envoymobile/engine/EnvoyConfigurationTest.kt
@@ -28,7 +28,7 @@ class EnvoyConfigurationTest {
   @Test
   fun `resolving with default configuration resolves with values`() {
     val envoyConfiguration = EnvoyConfiguration(
-      false, "stats.foo.com", null, 123, 234, 345, 456, 321, "[hostname]", 111, 222, 333, 567, 678, "v1.2.3", "com.mydomain.myapp", "[test]",
+      false, "stats.foo.com", null, 123, 234, 345, 456, 321, "[hostname]", 222, 333, 567, 678, "v1.2.3", "com.mydomain.myapp", "[test]",
       listOf<EnvoyNativeFilterConfig>(EnvoyNativeFilterConfig("filter_name", "test_config")),
       emptyList(), emptyMap()
     )
@@ -48,7 +48,6 @@ class EnvoyConfigurationTest {
     assertThat(resolvedTemplate).contains("&dns_preresolve_hostnames [hostname]")
 
     // H2 Ping
-    assertThat(resolvedTemplate).contains("&h2_connection_keepalive_interval 111s")
     assertThat(resolvedTemplate).contains("&h2_connection_keepalive_idle_interval 0.222s")
     assertThat(resolvedTemplate).contains("&h2_connection_keepalive_timeout 333s")
 
@@ -71,7 +70,7 @@ class EnvoyConfigurationTest {
   @Test
   fun `resolve templates with invalid templates will throw on build`() {
     val envoyConfiguration = EnvoyConfiguration(
-      false, "stats.foo.com", null, 123, 234, 345, 456, 321, "[hostname]", 123, 123, 123, 567, 678, "v1.2.3", "com.mydomain.myapp", "[test]",
+      false, "stats.foo.com", null, 123, 234, 345, 456, 321, "[hostname]", 123, 123, 567, 678, "v1.2.3", "com.mydomain.myapp", "[test]",
       emptyList(), emptyList(), emptyMap()
     )
 
@@ -86,7 +85,7 @@ class EnvoyConfigurationTest {
   @Test
   fun `cannot configure both statsD and gRPC stat sink`() {
     val envoyConfiguration = EnvoyConfiguration(
-      false, "stats.foo.com", 5050, 123, 234, 345, 456, 321, "[hostname]", 123, 123, 123, 567, 678, "v1.2.3", "com.mydomain.myapp", "[test]",
+      false, "stats.foo.com", 5050, 123, 234, 345, 456, 321, "[hostname]", 123, 123, 567, 678, "v1.2.3", "com.mydomain.myapp", "[test]",
       emptyList(), emptyList(), emptyMap()
     )
 

--- a/test/java/io/envoyproxy/envoymobile/engine/EnvoyConfigurationTest.kt
+++ b/test/java/io/envoyproxy/envoymobile/engine/EnvoyConfigurationTest.kt
@@ -49,7 +49,7 @@ class EnvoyConfigurationTest {
 
     // H2 Ping
     assertThat(resolvedTemplate).contains("&h2_connection_keepalive_interval 111s")
-    assertThat(resolvedTemplate).contains("&h2_connection_keepalive_idle_interval 222ms")
+    assertThat(resolvedTemplate).contains("&h2_connection_keepalive_idle_interval 0.222s")
     assertThat(resolvedTemplate).contains("&h2_connection_keepalive_timeout 333s")
 
     // Metadata

--- a/test/java/io/envoyproxy/envoymobile/engine/EnvoyConfigurationTest.kt
+++ b/test/java/io/envoyproxy/envoymobile/engine/EnvoyConfigurationTest.kt
@@ -28,7 +28,7 @@ class EnvoyConfigurationTest {
   @Test
   fun `resolving with default configuration resolves with values`() {
     val envoyConfiguration = EnvoyConfiguration(
-      false, "stats.foo.com", null, 123, 234, 345, 456, 321, "[hostname]", 567, 678, "v1.2.3", "com.mydomain.myapp", "[test]",
+      false, "stats.foo.com", null, 123, 234, 345, 456, 321, "[hostname]", 111, 222, 333, 567, 678, "v1.2.3", "com.mydomain.myapp", "[test]",
       listOf<EnvoyNativeFilterConfig>(EnvoyNativeFilterConfig("filter_name", "test_config")),
       emptyList(), emptyMap()
     )
@@ -46,6 +46,11 @@ class EnvoyConfigurationTest {
     assertThat(resolvedTemplate).contains("&dns_fail_max_interval 456s")
     assertThat(resolvedTemplate).contains("&dns_query_timeout 321s")
     assertThat(resolvedTemplate).contains("&dns_preresolve_hostnames [hostname]")
+
+    // H2 Ping
+    assertThat(resolvedTemplate).contains("&h2_connection_keepalive_interval 111s")
+    assertThat(resolvedTemplate).contains("&h2_connection_keepalive_idle_interval 222ms")
+    assertThat(resolvedTemplate).contains("&h2_connection_keepalive_timeout 333s")
 
     // Metadata
     assertThat(resolvedTemplate).contains("os: Android")
@@ -66,7 +71,7 @@ class EnvoyConfigurationTest {
   @Test
   fun `resolve templates with invalid templates will throw on build`() {
     val envoyConfiguration = EnvoyConfiguration(
-      false, "stats.foo.com", null, 123, 234, 345, 456, 321, "[hostname]", 567, 678, "v1.2.3", "com.mydomain.myapp", "[test]",
+      false, "stats.foo.com", null, 123, 234, 345, 456, 321, "[hostname]", 123, 123, 123, 567, 678, "v1.2.3", "com.mydomain.myapp", "[test]",
       emptyList(), emptyList(), emptyMap()
     )
 
@@ -81,7 +86,7 @@ class EnvoyConfigurationTest {
   @Test
   fun `cannot configure both statsD and gRPC stat sink`() {
     val envoyConfiguration = EnvoyConfiguration(
-      false, "stats.foo.com", 5050, 123, 234, 345, 456, 321, "[hostname]", 567, 678, "v1.2.3", "com.mydomain.myapp", "[test]",
+      false, "stats.foo.com", 5050, 123, 234, 345, 456, 321, "[hostname]", 123, 123, 123, 567, 678, "v1.2.3", "com.mydomain.myapp", "[test]",
       emptyList(), emptyList(), emptyMap()
     )
 

--- a/test/kotlin/io/envoyproxy/envoymobile/EngineBuilderTest.kt
+++ b/test/kotlin/io/envoyproxy/envoymobile/EngineBuilderTest.kt
@@ -81,6 +81,36 @@ class EngineBuilderTest {
   }
 
   @Test
+  fun `specifying H2 Ping interval overrides default`() {
+    engineBuilder = EngineBuilder(Standard())
+    engineBuilder.addEngineType { envoyEngine }
+    engineBuilder.addH2ConnectionKeepaliveIntervalSeconds(111)
+
+    val engine = engineBuilder.build() as EngineImpl
+    assertThat(engine.envoyConfiguration!!.h2ConnectionKeepaliveIntervalSeconds).isEqualTo(111)
+  }
+
+  @Test
+  fun `specifying H2 Ping idle interval overrides default`() {
+    engineBuilder = EngineBuilder(Standard())
+    engineBuilder.addEngineType { envoyEngine }
+    engineBuilder.addH2ConnectionKeepaliveIdleIntervalMilliseconds(1234)
+
+    val engine = engineBuilder.build() as EngineImpl
+    assertThat(engine.envoyConfiguration!!.h2ConnectionKeepaliveIdleIntervalMilliseconds).isEqualTo(1234)
+  }
+
+  @Test
+  fun `specifying H2 Ping timeout overrides default`() {
+    engineBuilder = EngineBuilder(Standard())
+    engineBuilder.addEngineType { envoyEngine }
+    engineBuilder.addH2ConnectionKeepaliveTimeoutSeconds(1234)
+
+    val engine = engineBuilder.build() as EngineImpl
+    assertThat(engine.envoyConfiguration!!.h2ConnectionKeepaliveTimeoutSeconds).isEqualTo(1234)
+  }
+
+  @Test
   fun `specifying stats flush overrides default`() {
     engineBuilder = EngineBuilder(Standard())
     engineBuilder.addEngineType { envoyEngine }

--- a/test/kotlin/io/envoyproxy/envoymobile/EngineBuilderTest.kt
+++ b/test/kotlin/io/envoyproxy/envoymobile/EngineBuilderTest.kt
@@ -81,16 +81,6 @@ class EngineBuilderTest {
   }
 
   @Test
-  fun `specifying H2 Ping interval overrides default`() {
-    engineBuilder = EngineBuilder(Standard())
-    engineBuilder.addEngineType { envoyEngine }
-    engineBuilder.addH2ConnectionKeepaliveIntervalSeconds(111)
-
-    val engine = engineBuilder.build() as EngineImpl
-    assertThat(engine.envoyConfiguration!!.h2ConnectionKeepaliveIntervalSeconds).isEqualTo(111)
-  }
-
-  @Test
   fun `specifying H2 Ping idle interval overrides default`() {
     engineBuilder = EngineBuilder(Standard())
     engineBuilder.addEngineType { envoyEngine }

--- a/test/swift/EngineBuilderTests.swift
+++ b/test/swift/EngineBuilderTests.swift
@@ -137,20 +137,6 @@ final class EngineBuilderTests: XCTestCase {
     self.waitForExpectations(timeout: 0.01)
   }
 
-  func testAddingPlatformFiltersToConfigurationWhenRunningEnvoy() {
-    let expectation = self.expectation(description: "Run called with expected data")
-    MockEnvoyEngine.onRunWithConfig = { config, _ in
-      XCTAssertEqual(1, config.httpPlatformFilterFactories.count)
-      expectation.fulfill()
-    }
-
-    _ = EngineBuilder()
-      .addEngineType(MockEnvoyEngine.self)
-      .addPlatformFilter(TestFilter.init)
-      .build()
-    self.waitForExpectations(timeout: 0.01)
-  }
-
   func testAddingDNSFailureRefreshSecondsAddsToConfigurationWhenRunningEnvoy() {
     let expectation = self.expectation(description: "Run called with expected data")
     MockEnvoyEngine.onRunWithConfig = { config, _ in
@@ -162,6 +148,62 @@ final class EngineBuilderTests: XCTestCase {
     _ = EngineBuilder()
       .addEngineType(MockEnvoyEngine.self)
       .addDNSFailureRefreshSeconds(base: 1234, max: 5678)
+      .build()
+    self.waitForExpectations(timeout: 0.01)
+  }
+
+  func testAddingH2ConnectionKeepaliveIntervalSecondsAddsToConfigurationWhenRunningEnvoy() {
+    let expectation = self.expectation(description: "Run called with expected data")
+    MockEnvoyEngine.onRunWithConfig = { config, _ in
+      XCTAssertEqual(234, config.h2ConnectionKeepaliveIntervalSeconds)
+      expectation.fulfill()
+    }
+
+    _ = EngineBuilder()
+      .addEngineType(MockEnvoyEngine.self)
+      .addH2ConnectionKeepaliveIntervalSeconds(234)
+      .build()
+    self.waitForExpectations(timeout: 0.01)
+  }
+
+  func testAddingH2ConnectionKeepaliveIdleIntervalMillisecondsAddsToConfigurationWhenRunningEnvoy() {
+    let expectation = self.expectation(description: "Run called with expected data")
+    MockEnvoyEngine.onRunWithConfig = { config, _ in
+      XCTAssertEqual(234, config.h2ConnectionKeepaliveIdleIntervalMilliseconds)
+      expectation.fulfill()
+    }
+
+    _ = EngineBuilder()
+      .addEngineType(MockEnvoyEngine.self)
+      .addH2ConnectionKeepaliveIdleIntervalMilliseconds(234)
+      .build()
+    self.waitForExpectations(timeout: 0.01)
+  }
+
+  func testAddingH2ConnectionKeepaliveTimeoutSecondsAddsToConfigurationWhenRunningEnvoy() {
+    let expectation = self.expectation(description: "Run called with expected data")
+    MockEnvoyEngine.onRunWithConfig = { config, _ in
+      XCTAssertEqual(234, config.h2ConnectionKeepaliveTimeoutSeconds)
+      expectation.fulfill()
+    }
+
+    _ = EngineBuilder()
+      .addEngineType(MockEnvoyEngine.self)
+      .addH2ConnectionKeepaliveTimeoutSeconds(234)
+      .build()
+    self.waitForExpectations(timeout: 0.01)
+  }
+
+  func testAddingPlatformFiltersToConfigurationWhenRunningEnvoy() {
+    let expectation = self.expectation(description: "Run called with expected data")
+    MockEnvoyEngine.onRunWithConfig = { config, _ in
+      XCTAssertEqual(1, config.httpPlatformFilterFactories.count)
+      expectation.fulfill()
+    }
+
+    _ = EngineBuilder()
+      .addEngineType(MockEnvoyEngine.self)
+      .addPlatformFilter(TestFilter.init)
       .build()
     self.waitForExpectations(timeout: 0.01)
   }
@@ -274,6 +316,9 @@ final class EngineBuilderTests: XCTestCase {
       dnsFailureRefreshSecondsMax: 500,
       dnsQueryTimeoutSeconds: 800,
       dnsPreresolveHostnames: "[test]",
+      h2ConnectionKeepaliveIntervalSeconds: 111,
+      h2ConnectionKeepaliveIdleIntervalMilliseconds: 222,
+      h2ConnectionKeepaliveTimeoutSeconds: 333,
       statsFlushSeconds: 600,
       streamIdleTimeoutSeconds: 700,
       appVersion: "v1.2.3",
@@ -296,6 +341,10 @@ final class EngineBuilderTests: XCTestCase {
     XCTAssertTrue(resolvedYAML.contains("&dns_fail_max_interval 500s"))
     XCTAssertTrue(resolvedYAML.contains("&dns_query_timeout 800s"))
     XCTAssertTrue(resolvedYAML.contains("&dns_preresolve_hostnames [test]"))
+
+    XCTAssertTrue(resolvedYAML.contains("&h2_connection_keepalive_interval 111s"))
+    XCTAssertTrue(resolvedYAML.contains("&h2_connection_keepalive_idle_interval 222ms"))
+    XCTAssertTrue(resolvedYAML.contains("&h2_connection_keepalive_timeout 333s"))
 
     XCTAssertTrue(resolvedYAML.contains("&stream_idle_timeout 700s"))
 
@@ -328,6 +377,9 @@ final class EngineBuilderTests: XCTestCase {
       dnsFailureRefreshSecondsMax: 500,
       dnsQueryTimeoutSeconds: 800,
       dnsPreresolveHostnames: "[test]",
+      h2ConnectionKeepaliveIntervalSeconds: 111,
+      h2ConnectionKeepaliveIdleIntervalMilliseconds: 222,
+      h2ConnectionKeepaliveTimeoutSeconds: 333,
       statsFlushSeconds: 600,
       streamIdleTimeoutSeconds: 700,
       appVersion: "v1.2.3",

--- a/test/swift/EngineBuilderTests.swift
+++ b/test/swift/EngineBuilderTests.swift
@@ -343,7 +343,7 @@ final class EngineBuilderTests: XCTestCase {
     XCTAssertTrue(resolvedYAML.contains("&dns_preresolve_hostnames [test]"))
 
     XCTAssertTrue(resolvedYAML.contains("&h2_connection_keepalive_interval 111s"))
-    XCTAssertTrue(resolvedYAML.contains("&h2_connection_keepalive_idle_interval 222ms"))
+    XCTAssertTrue(resolvedYAML.contains("&h2_connection_keepalive_idle_interval 0.222s"))
     XCTAssertTrue(resolvedYAML.contains("&h2_connection_keepalive_timeout 333s"))
 
     XCTAssertTrue(resolvedYAML.contains("&stream_idle_timeout 700s"))

--- a/test/swift/EngineBuilderTests.swift
+++ b/test/swift/EngineBuilderTests.swift
@@ -152,20 +152,6 @@ final class EngineBuilderTests: XCTestCase {
     self.waitForExpectations(timeout: 0.01)
   }
 
-  func testAddingH2ConnectionKeepaliveIntervalSecondsAddsToConfigurationWhenRunningEnvoy() {
-    let expectation = self.expectation(description: "Run called with expected data")
-    MockEnvoyEngine.onRunWithConfig = { config, _ in
-      XCTAssertEqual(234, config.h2ConnectionKeepaliveIntervalSeconds)
-      expectation.fulfill()
-    }
-
-    _ = EngineBuilder()
-      .addEngineType(MockEnvoyEngine.self)
-      .addH2ConnectionKeepaliveIntervalSeconds(234)
-      .build()
-    self.waitForExpectations(timeout: 0.01)
-  }
-
   func testAddingH2ConnectionKeepaliveIdleIntervalMSAddsToConfigurationWhenRunningEnvoy() {
     let expectation = self.expectation(description: "Run called with expected data")
     MockEnvoyEngine.onRunWithConfig = { config, _ in
@@ -316,8 +302,7 @@ final class EngineBuilderTests: XCTestCase {
       dnsFailureRefreshSecondsMax: 500,
       dnsQueryTimeoutSeconds: 800,
       dnsPreresolveHostnames: "[test]",
-      h2ConnectionKeepaliveIntervalSeconds: 111,
-      h2ConnectionKeepaliveIdleIntervalMilliseconds: 222,
+      h2ConnectionKeepaliveIdleIntervalMilliseconds: 1,
       h2ConnectionKeepaliveTimeoutSeconds: 333,
       statsFlushSeconds: 600,
       streamIdleTimeoutSeconds: 700,
@@ -342,8 +327,7 @@ final class EngineBuilderTests: XCTestCase {
     XCTAssertTrue(resolvedYAML.contains("&dns_query_timeout 800s"))
     XCTAssertTrue(resolvedYAML.contains("&dns_preresolve_hostnames [test]"))
 
-    XCTAssertTrue(resolvedYAML.contains("&h2_connection_keepalive_interval 111s"))
-    XCTAssertTrue(resolvedYAML.contains("&h2_connection_keepalive_idle_interval 0.222s"))
+    XCTAssertTrue(resolvedYAML.contains("&h2_connection_keepalive_idle_interval 0.001s"))
     XCTAssertTrue(resolvedYAML.contains("&h2_connection_keepalive_timeout 333s"))
 
     XCTAssertTrue(resolvedYAML.contains("&stream_idle_timeout 700s"))
@@ -377,7 +361,6 @@ final class EngineBuilderTests: XCTestCase {
       dnsFailureRefreshSecondsMax: 500,
       dnsQueryTimeoutSeconds: 800,
       dnsPreresolveHostnames: "[test]",
-      h2ConnectionKeepaliveIntervalSeconds: 111,
       h2ConnectionKeepaliveIdleIntervalMilliseconds: 222,
       h2ConnectionKeepaliveTimeoutSeconds: 333,
       statsFlushSeconds: 600,

--- a/test/swift/EngineBuilderTests.swift
+++ b/test/swift/EngineBuilderTests.swift
@@ -166,7 +166,7 @@ final class EngineBuilderTests: XCTestCase {
     self.waitForExpectations(timeout: 0.01)
   }
 
-  func testAddingH2ConnectionKeepaliveIdleIntervalMillisecondsAddsToConfigurationWhenRunningEnvoy() {
+  func testAddingH2ConnectionKeepaliveIdleIntervalMSAddsToConfigurationWhenRunningEnvoy() {
     let expectation = self.expectation(description: "Run called with expected data")
     MockEnvoyEngine.onRunWithConfig = { config, _ in
       XCTAssertEqual(234, config.h2ConnectionKeepaliveIdleIntervalMilliseconds)


### PR DESCRIPTION
Description: adds engine builder and config plumbing to setup h2 ping support
Risk Level: low - exposed API. Default config is no-op in Envoy
Testing: added tests
Docs Changes: pending if reviewers agree with API


