### PR TITLE
core: emit envoy event every time envoy bug macro is called

### DIFF
--- a/library/common/engine.cc
+++ b/library/common/engine.cc
@@ -134,6 +134,7 @@ envoy_status_t Engine::main(const std::string config, const std::string log_leve
   stat_name_set_.reset();
   log_delegate_ptr_.reset(nullptr);
   main_common.reset(nullptr);
+  bug_handler_registration_.reset(nullptr);
   assert_handler_registration_.reset(nullptr);
 
   callbacks_.on_exit(callbacks_.context);

--- a/library/common/engine.cc
+++ b/library/common/engine.cc
@@ -65,6 +65,12 @@ envoy_status_t Engine::main(const std::string config, const std::string log_leve
                   {{"name", "assertion"}, {"location", std::string(location)}});
               event_tracker_.track(event, event_tracker_.context);
             });
+        bug_handler_registration_ =
+            Assert::addEnvoyBugFailureRecordAction([this](const char* location) {
+              const auto event = Bridge::Utility::makeEnvoyMap(
+                  {{"name", "bug"}, {"location", std::string(location)}});
+              event_tracker_.track(event, event_tracker_.context);
+            });
       }
 
       if (logger_.log) {

--- a/library/common/engine.h
+++ b/library/common/engine.h
@@ -133,6 +133,7 @@ private:
   envoy_logger logger_;
   envoy_event_tracker event_tracker_;
   Assert::ActionRegistrationPtr assert_handler_registration_;
+  Assert::ActionRegistrationPtr bug_handler_registration_;
   Thread::MutexBasicLockable mutex_;
   Thread::CondVar cv_;
   Http::ClientPtr http_client_;

--- a/test/common/main_interface_test.cc
+++ b/test/common/main_interface_test.cc
@@ -627,6 +627,47 @@ TEST(EngineTest, EventTrackerRegistersDefaultAPI) {
 //  ASSERT_TRUE(test_context.on_exit.WaitForNotificationWithTimeout(absl::Seconds(3)));
 //}
 
+TEST(EngineTest, EventTrackerRegistersEnvoyBugRecordAction) {
+  engine_test_context test_context{};
+  envoy_engine_callbacks engine_cbs{[](void* context) -> void {
+                                      auto* test_context =
+                                          static_cast<engine_test_context*>(context);
+                                      test_context->on_engine_running.Notify();
+                                    } /*on_engine_running*/,
+                                    [](void* context) -> void {
+                                      auto* test_context =
+                                          static_cast<engine_test_context*>(context);
+                                      test_context->on_exit.Notify();
+                                    } /*on_exit*/,
+                                    &test_context /*context*/};
+
+  envoy_event_tracker event_tracker{[](envoy_map map, const void* context) -> void {
+                                      const auto new_map = toMap(map);
+                                      if (new_map.count("name") && new_map.at("name") == "bug") {
+                                          EXPECT_EQ(new_map.at("name"), "bug");
+                                          EXPECT_EQ(new_map.at("location"), "foo_location");
+                                          auto* test_context = static_cast<engine_test_context*>(
+                                              const_cast<void*>(context));
+                                          test_context->on_event.Notify();
+                                        }
+                                    } /*track*/,
+                                    &test_context /*context*/};
+
+  init_engine(engine_cbs, {}, event_tracker);
+  run_engine(0, MINIMAL_TEST_CONFIG.c_str(), LEVEL_DEBUG.c_str());
+
+  ASSERT_TRUE(test_context.on_engine_running.WaitForNotificationWithTimeout(absl::Seconds(3)));
+  // Simulate an envoy bug by invoking an Envoy bug failure
+  // record action.
+  // Verify that an envoy event is emitted when an event tracker is passed
+  // at engine's initialization time.
+  Assert::invokeEnvoyBugFailureRecordActionForEnvoyBugMacroUseOnly("foo_location");
+
+  ASSERT_TRUE(test_context.on_event.WaitForNotificationWithTimeout(absl::Seconds(3)));
+  terminate_engine(0);
+  ASSERT_TRUE(test_context.on_exit.WaitForNotificationWithTimeout(absl::Seconds(3)));
+}
+
 TEST(MainInterfaceTest, DrainConnections) {
   engine_test_context test_context{};
   envoy_engine_callbacks engine_cbs{[](void* context) -> void {

--- a/test/common/main_interface_test.cc
+++ b/test/common/main_interface_test.cc
@@ -644,12 +644,12 @@ TEST(EngineTest, EventTrackerRegistersEnvoyBugRecordAction) {
   envoy_event_tracker event_tracker{[](envoy_map map, const void* context) -> void {
                                       const auto new_map = toMap(map);
                                       if (new_map.count("name") && new_map.at("name") == "bug") {
-                                          EXPECT_EQ(new_map.at("name"), "bug");
-                                          EXPECT_EQ(new_map.at("location"), "foo_location");
-                                          auto* test_context = static_cast<engine_test_context*>(
-                                              const_cast<void*>(context));
-                                          test_context->on_event.Notify();
-                                        }
+                                        EXPECT_EQ(new_map.at("name"), "bug");
+                                        EXPECT_EQ(new_map.at("location"), "foo_location");
+                                        auto* test_context = static_cast<engine_test_context*>(
+                                            const_cast<void*>(context));
+                                        test_context->on_event.Notify();
+                                      }
                                     } /*track*/,
                                     &test_context /*context*/};
 


### PR DESCRIPTION
Description: Emit Envoy event every time an Envoy bug is detected. Envoy bug is similar to Envoy assert.
Risk Level: Low, new functionality
Testing: Unit

Signed-off-by: Rafal Augustyniak <raugustyniak@lyft.com>