### PR TITLE
tools: add kotlin format script

### DIFF
--- a/.github/workflows/format.yml
+++ b/.github/workflows/format.yml
@@ -63,10 +63,5 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          bazel build \
-            --config=remote-ci-macos --remote_header="Authorization=Bearer $GITHUB_TOKEN" \
-            //library/kotlin/io/envoyproxy/envoymobile:envoy_lib_lint \
-            //examples/kotlin/hello_world:hello_envoy_kt_lint
-      - name: 'Run Kotlin Formatter (ktlint)'
-        run: |
-          bazel build kotlin_format
+          REMOTE_BUILD_OPTIONS=--config=remote-ci-macos --remote_header="Authorization=Bearer $GITHUB_TOKEN" \
+            ./tools/kotlin_format.sh

--- a/.github/workflows/format.yml
+++ b/.github/workflows/format.yml
@@ -63,5 +63,5 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          REMOTE_BUILD_OPTIONS=--config=remote-ci-macos --remote_header="Authorization=Bearer $GITHUB_TOKEN" \
+          REMOTE_BUILD_OPTIONS="--config=remote-ci-macos --remote_header=\"Authorization=Bearer $GITHUB_TOKEN\"" \
             ./tools/kotlin_format.sh

--- a/.github/workflows/format.yml
+++ b/.github/workflows/format.yml
@@ -63,5 +63,4 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          REMOTE_BUILD_OPTIONS="--config=remote-ci-macos --remote_header=\"Authorization=Bearer $GITHUB_TOKEN\"" \
-            ./tools/kotlin_format.sh
+	  ./tools/kotlin_format.sh --config=remote-ci-macos --remote_header="Authorization=Bearer $GITHUB_TOKEN"

--- a/tools/kotlin_format.sh
+++ b/tools/kotlin_format.sh
@@ -2,7 +2,7 @@
 
 set -e
 
-bazel build $REMOTE_BUILD_OPTIONS \
+bazel build $@ \
       //library/kotlin/io/envoyproxy/envoymobile:envoy_lib_lint \
       //examples/kotlin/hello_world:hello_envoy_kt_lint
 bazel build kotlin_format

--- a/tools/kotlin_format.sh
+++ b/tools/kotlin_format.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+
+set -e
+
+bazel build $REMOTE_BUILD_OPTIONS \
+      //library/kotlin/io/envoyproxy/envoymobile:envoy_lib_lint \
+      //examples/kotlin/hello_world:hello_envoy_kt_lint
+bazel build kotlin_format


### PR DESCRIPTION
Adds a script for running the Kotlin format process as used by CI.

Signed-off-by: Snow Pettersen <snowp@lyft.com>

Risk Level: Low
Testing: Existing CI
Docs Changes: n/a 
Release Notes: n/a
