### PR TITLE
Remove remaining test crutch for HTTP/1 capitalization

### DIFF
--- a/test/java/org/chromium/net/CronetUrlRequestTest.java
+++ b/test/java/org/chromium/net/CronetUrlRequestTest.java
@@ -161,7 +161,7 @@ public class CronetUrlRequestTest {
     assertEquals(0, callback.mRedirectCount);
     assertEquals(callback.mResponseStep, ResponseStep.ON_SUCCEEDED);
     UrlResponseInfo urlResponseInfo =
-        createUrlResponseInfo(new String[] {url}, "OK", 200, 86, "connection", "close",
+        createUrlResponseInfo(new String[] {url}, "OK", 200, 86, "Connection", "close",
                               "Content-Length", "3", "Content-Type", "text/plain");
     mTestRule.assertResponseEquals(urlResponseInfo, callback.mResponseInfo);
     checkResponseInfo(callback.mResponseInfo, NativeTestServer.getEchoMethodURL(), 200, "OK");
@@ -268,8 +268,8 @@ public class CronetUrlRequestTest {
 
     UrlResponseInfo urlResponseInfo = createUrlResponseInfo(
         new String[] {NativeTestServer.getRedirectURL(), NativeTestServer.getSuccessURL()}, "OK",
-        200, 258, "content-length", "20", "content-type", "text/plain",
-        "access-control-allow-origin", "*", "header-name", "header-value", "multi-header-name",
+        200, 258, "Content-Length", "20", "Content-Type", "text/plain",
+        "Access-Control-Allow-Origin", "*", "header-name", "header-value", "multi-header-name",
         "header-value1", "multi-header-name", "header-value2");
 
     mTestRule.assertResponseEquals(urlResponseInfo, callback.mResponseInfo);

--- a/test/java/org/chromium/net/CronetUrlRequestTest.java
+++ b/test/java/org/chromium/net/CronetUrlRequestTest.java
@@ -274,7 +274,7 @@ public class CronetUrlRequestTest {
 
     mTestRule.assertResponseEquals(urlResponseInfo, callback.mResponseInfo);
     // Make sure there are no other pending messages, which would trigger
-    // asserts in TestUrlRequestCallback.
+    // asserts in TestUrlRequestCallback
     testSimpleGet();
   }
 

--- a/test/java/org/chromium/net/CronetUrlRequestTest.java
+++ b/test/java/org/chromium/net/CronetUrlRequestTest.java
@@ -274,7 +274,7 @@ public class CronetUrlRequestTest {
 
     mTestRule.assertResponseEquals(urlResponseInfo, callback.mResponseInfo);
     // Make sure there are no other pending messages, which would trigger
-    // asserts in TestUrlRequestCallback
+    // asserts in TestUrlRequestCallback.
     testSimpleGet();
   }
 

--- a/test/java/org/chromium/net/testing/CronetTestRule.java
+++ b/test/java/org/chromium/net/testing/CronetTestRule.java
@@ -18,10 +18,6 @@ import java.lang.annotation.Target;
 import java.lang.reflect.Field;
 import java.net.URL;
 import java.net.URLStreamHandlerFactory;
-import java.util.AbstractMap.SimpleEntry;
-import java.util.List;
-import java.util.Map;
-import java.util.stream.Collectors;
 import org.chromium.net.ApiVersion;
 import org.chromium.net.CronetEngine;
 import org.chromium.net.ExperimentalCronetEngine;
@@ -249,29 +245,8 @@ public final class CronetTestRule implements TestRule {
   }
 
   public void assertResponseEquals(UrlResponseInfo expected, UrlResponseInfo actual) {
-    // TODO(carloseltuerto): https://github.com/envoyproxy/envoy-mobile/issues/1558
-    // Revert to original code, the two commented lines below, once capitalization issue is solved.
-    // assertEquals(expected.getAllHeaders(), actual.getAllHeaders());
-    // assertEquals(expected.getAllHeadersAsList(), actual.getAllHeadersAsList());
-    Map<String, List<String>> hackedExpectedHeaders =
-        expected.getAllHeaders().entrySet().stream().collect(
-            Collectors.toMap(e -> e.getKey().toLowerCase(), Map.Entry::getValue));
-    Map<String, List<String>> hackedActualHeaders =
-        actual.getAllHeaders().entrySet().stream().collect(
-            Collectors.toMap(e -> e.getKey().toLowerCase(), Map.Entry::getValue));
-    assertEquals(hackedExpectedHeaders, hackedActualHeaders);
-    List<Map.Entry<String, String>> hackedExpectedHeadersAsList =
-        expected.getAllHeadersAsList()
-            .stream()
-            .map(e -> new SimpleEntry<>(e.getKey().toLowerCase(), e.getValue()))
-            .collect(Collectors.toList());
-    List<Map.Entry<String, String>> hackedActualHeadersAsList =
-        actual.getAllHeadersAsList()
-            .stream()
-            .map(e -> new SimpleEntry<>(e.getKey().toLowerCase(), e.getValue()))
-            .collect(Collectors.toList());
-    assertEquals(hackedExpectedHeadersAsList, hackedActualHeadersAsList);
-    // End of hack.
+    assertEquals(expected.getAllHeaders(), actual.getAllHeaders());
+    assertEquals(expected.getAllHeadersAsList(), actual.getAllHeadersAsList());
     assertEquals(expected.getHttpStatusCode(), actual.getHttpStatusCode());
     assertEquals(expected.getHttpStatusText(), actual.getHttpStatusText());
     assertEquals(expected.getUrlChain(), actual.getUrlChain());


### PR DESCRIPTION
Remove last remnant associated with Issue [1558](https://github.com/envoyproxy/envoy-mobile/issues/1558)

Description: Fully test capitalization with HTTP/1
Risk Level: None
Testing: testing only PR
Docs Changes: N/A
Release Notes: N/A
Signed-off-by: Charles Le Borgne <cleborgne@google.com>