### PR TITLE
android: release builds avoids defining logger

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -79,7 +79,8 @@ build:release-ios --copt=-fembed-bitcode
 build:release-ios --compilation_mode=opt
 
 # Flags for release builds targeting Android or the JVM
-build:release-android --config=android
+# Release does not use the option --define=logger=android
+build:release-android --define=include_ifaddrs=true
 build:release-android --config=release-common
 build:release-android --compilation_mode=opt
 


### PR DESCRIPTION
The android define logger conflicts with the logger lambda API such that the logger lambda would not be called if Envoy Mobile is built with the flag.

Signed-off-by: Alan Chiu <achiu@lyft.com>

For an explanation of how to fill out the fields, please see the relevant section
in [PULL_REQUESTS.md](https://github.com/envoyproxy/envoy/blob/master/PULL_REQUESTS.md)

Description: android: release builds avoids defining logger
Risk Level: low
Testing: local
Docs Changes: n/a
Release Notes: n/a
[Optional Fixes #Issue]
[Optional Deprecated:]
