### PR TITLE
network: create SocketSelectionFilter 

### DIFF
--- a/envoy_build_config/BUILD
+++ b/envoy_build_config/BUILD
@@ -31,5 +31,6 @@ envoy_cc_library(
         "@envoy_mobile//library/common/extensions/filters/http/local_error:config",
         "@envoy_mobile//library/common/extensions/filters/http/platform_bridge:config",
         "@envoy_mobile//library/common/extensions/filters/http/route_cache_reset:config",
+        "@envoy_mobile//library/common/extensions/filters/http/socket_selection:config",
     ],
 )

--- a/envoy_build_config/extension_registry.cc
+++ b/envoy_build_config/extension_registry.cc
@@ -34,6 +34,7 @@ void ExtensionRegistry::registerFactories() {
   Envoy::Extensions::HttpFilters::PlatformBridge::forceRegisterPlatformBridgeFilterFactory();
   Envoy::Extensions::HttpFilters::RouteCacheReset::forceRegisterRouteCacheResetFilterFactory();
   Envoy::Extensions::HttpFilters::RouterFilter::forceRegisterRouterFilterConfig();
+  Envoy::Extensions::HttpFilters::SocketSelection::forceRegisterSocketSelectionFilterFactory();
   Envoy::Extensions::NetworkFilters::HttpConnectionManager::
       forceRegisterHttpConnectionManagerFilterConfigFactory();
   Envoy::Extensions::StatSinks::MetricsService::forceRegisterMetricsServiceSinkFactory();

--- a/envoy_build_config/extension_registry.h
+++ b/envoy_build_config/extension_registry.h
@@ -20,6 +20,7 @@
 #include "library/common/extensions/filters/http/local_error/config.h"
 #include "library/common/extensions/filters/http/platform_bridge/config.h"
 #include "library/common/extensions/filters/http/route_cache_reset/config.h"
+#include "library/common/extensions/filters/http/socket_selection/config.h"
 
 namespace Envoy {
 class ExtensionRegistry {

--- a/envoy_build_config/extensions_build_config.bzl
+++ b/envoy_build_config/extensions_build_config.bzl
@@ -8,6 +8,7 @@ EXTENSIONS = {
     "envoy.filters.http.dynamic_forward_proxy":            "//source/extensions/filters/http/dynamic_forward_proxy:config",
     "envoy.filters.http.local_error":                      "@envoy_mobile//library/common/extensions/filters/http/local_error:config",
     "envoy.filters.http.platform_bridge":                  "@envoy_mobile//library/common/extensions/filters/http/platform_bridge:config",
+    "envoy.filters.http.socket_selection":                 "@envoy_mobile//library/common/extensions/filters/http/socket_selection:config",
     "envoy.filters.http.route_cache_reset":                "@envoy_mobile//library/common/extensions/filters/http/route_cache_reset:config",
     "envoy.filters.http.router":                           "//source/extensions/filters/http/router:config",
     "envoy.filters.network.http_connection_manager":       "//source/extensions/filters/network/http_connection_manager:config",

--- a/library/common/config/config.cc
+++ b/library/common/config/config.cc
@@ -233,6 +233,9 @@ static_resources:
                       max_interval: 60s
           http_filters:
 #{custom_filters}
+          - name: envoy.filters.http.socket_selection
+            typed_config:
+              "@type": type.googleapis.com/envoymobile.extensions.filters.http.socket_selection.SocketSelection
           - name: envoy.filters.http.local_error
             typed_config:
               "@type": type.googleapis.com/envoymobile.extensions.filters.http.local_error.LocalError

--- a/library/common/config/config.cc
+++ b/library/common/config/config.cc
@@ -321,43 +321,7 @@ R"(
       max_ejection_time: 0.001s
       interval: 1s
     typed_extension_protocol_options: *http1_protocol_options_defs
-  - name: base_wlan
-    connect_timeout: *connect_timeout
-    lb_policy: CLUSTER_PROVIDED
-    cluster_type: *base_cluster_type
-    transport_socket: *base_tls_socket
-    upstream_connection_options: *upstream_opts
-    circuit_breakers: *circuit_breakers_settings
-    outlier_detection: *base_outlier_detection
-    typed_extension_protocol_options: *http1_protocol_options_defs
-  - name: base_wwan
-    connect_timeout: *connect_timeout
-    lb_policy: CLUSTER_PROVIDED
-    cluster_type: *base_cluster_type
-    transport_socket: *base_tls_socket
-    upstream_connection_options: *upstream_opts
-    circuit_breakers: *circuit_breakers_settings
-    outlier_detection: *base_outlier_detection
-    typed_extension_protocol_options: *http1_protocol_options_defs
   - name: base_clear
-    connect_timeout: *connect_timeout
-    lb_policy: CLUSTER_PROVIDED
-    cluster_type: *base_cluster_type
-    transport_socket: { name: envoy.transport_sockets.raw_buffer }
-    upstream_connection_options: *upstream_opts
-    circuit_breakers: *circuit_breakers_settings
-    outlier_detection: *base_outlier_detection
-    typed_extension_protocol_options: *http1_protocol_options_defs
-  - name: base_wlan_clear
-    connect_timeout: *connect_timeout
-    lb_policy: CLUSTER_PROVIDED
-    cluster_type: *base_cluster_type
-    transport_socket: { name: envoy.transport_sockets.raw_buffer }
-    upstream_connection_options: *upstream_opts
-    circuit_breakers: *circuit_breakers_settings
-    outlier_detection: *base_outlier_detection
-    typed_extension_protocol_options: *http1_protocol_options_defs
-  - name: base_wwan_clear
     connect_timeout: *connect_timeout
     lb_policy: CLUSTER_PROVIDED
     cluster_type: *base_cluster_type
@@ -376,47 +340,7 @@ R"(
     circuit_breakers: *circuit_breakers_settings
     outlier_detection: *base_outlier_detection
     typed_extension_protocol_options: *base_protocol_options
-  - name: base_wlan_h2
-    http2_protocol_options: {}
-    connect_timeout: *connect_timeout
-    lb_policy: CLUSTER_PROVIDED
-    cluster_type: *base_cluster_type
-    transport_socket: *base_tls_h2_socket
-    upstream_connection_options: *upstream_opts
-    circuit_breakers: *circuit_breakers_settings
-    outlier_detection: *base_outlier_detection
-    typed_extension_protocol_options: *base_protocol_options
-  - name: base_wwan_h2
-    http2_protocol_options: {}
-    connect_timeout: *connect_timeout
-    lb_policy: CLUSTER_PROVIDED
-    cluster_type: *base_cluster_type
-    transport_socket: *base_tls_h2_socket
-    upstream_connection_options: *upstream_opts
-    circuit_breakers: *circuit_breakers_settings
-    outlier_detection: *base_outlier_detection
-    typed_extension_protocol_options: *base_protocol_options
   - name: base_alpn
-    connect_timeout: *connect_timeout
-    lb_policy: CLUSTER_PROVIDED
-    cluster_type: *base_cluster_type
-    transport_socket: *base_tls_socket
-    upstream_connection_options: *upstream_opts
-    circuit_breakers: *circuit_breakers_settings
-    outlier_detection: *base_outlier_detection
-    typed_extension_protocol_options: *base_protocol_options
-  - name: base_wlan_alpn
-    http2_protocol_options: {}
-    connect_timeout: *connect_timeout
-    lb_policy: CLUSTER_PROVIDED
-    cluster_type: *base_cluster_type
-    transport_socket: *base_tls_socket
-    upstream_connection_options: *upstream_opts
-    circuit_breakers: *circuit_breakers_settings
-    outlier_detection: *base_outlier_detection
-    typed_extension_protocol_options: *base_protocol_options
-  - name: base_wwan_alpn
-    http2_protocol_options: {}
     connect_timeout: *connect_timeout
     lb_policy: CLUSTER_PROVIDED
     cluster_type: *base_cluster_type

--- a/library/common/engine.cc
+++ b/library/common/engine.cc
@@ -113,9 +113,9 @@ envoy_status_t Engine::main(const std::string config, const std::string log_leve
           stat_name_set_ = client_scope_->symbolTable().makeSet("pulse");
           auto api_listener = server_->listenerManager().apiListener()->get().http();
           ASSERT(api_listener.has_value());
-          http_client_ = std::make_unique<Http::Client>(
-              api_listener.value(), *dispatcher_, server_->serverFactoryContext().scope(),
-              server_->api().randomGenerator());
+          http_client_ = std::make_unique<Http::Client>(api_listener.value(), *dispatcher_,
+                                                        server_->serverFactoryContext().scope(),
+                                                        server_->api().randomGenerator());
           dispatcher_->drain(server_->dispatcher());
           if (callbacks_.on_engine_running != nullptr) {
             callbacks_.on_engine_running(callbacks_.context);

--- a/library/common/engine.cc
+++ b/library/common/engine.cc
@@ -14,10 +14,9 @@
 namespace Envoy {
 
 Engine::Engine(envoy_engine_callbacks callbacks, envoy_logger logger,
-               envoy_event_tracker event_tracker, std::atomic<envoy_network_t>& preferred_network)
+               envoy_event_tracker event_tracker)
     : callbacks_(callbacks), logger_(logger), event_tracker_(event_tracker),
-      dispatcher_(std::make_unique<Event::ProvisionalDispatcher>()),
-      preferred_network_(preferred_network) {
+      dispatcher_(std::make_unique<Event::ProvisionalDispatcher>()) {
   // Ensure static factory registration occurs on time.
   // TODO: ensure this is only called one time once multiple Engine objects can be allocated.
   // https://github.com/lyft/envoy-mobile/issues/332
@@ -116,7 +115,7 @@ envoy_status_t Engine::main(const std::string config, const std::string log_leve
           ASSERT(api_listener.has_value());
           http_client_ = std::make_unique<Http::Client>(
               api_listener.value(), *dispatcher_, server_->serverFactoryContext().scope(),
-              preferred_network_, server_->api().randomGenerator());
+              server_->api().randomGenerator());
           dispatcher_->drain(server_->dispatcher());
           if (callbacks_.on_engine_running != nullptr) {
             callbacks_.on_engine_running(callbacks_.context);

--- a/library/common/engine.h
+++ b/library/common/engine.h
@@ -21,10 +21,8 @@ public:
    * @param callbacks, the callbacks to use for engine lifecycle monitoring.
    * @param logger, the callbacks to use for engine logging.
    * @param event_tracker, the event tracker to use for the emission of events.
-   * @param preferred_network, hook to obtain the preferred network for new streams.
    */
-  Engine(envoy_engine_callbacks callbacks, envoy_logger logger, envoy_event_tracker event_tracker,
-         std::atomic<envoy_network_t>& preferred_network);
+  Engine(envoy_engine_callbacks callbacks, envoy_logger logger, envoy_event_tracker event_tracker);
 
   /**
    * Engine destructor.
@@ -143,7 +141,6 @@ private:
   Logger::EventTrackingDelegatePtr log_delegate_ptr_{};
   Server::Instance* server_{};
   Server::ServerLifecycleNotifier::HandlePtr postinit_callback_handler_;
-  std::atomic<envoy_network_t>& preferred_network_;
   // main_thread_ should be destroyed first, hence it is the last member variable. Objects with
   // instructions scheduled on the main_thread_ need to have a longer lifetime.
   std::thread main_thread_{}; // Empty placeholder to be populated later.

--- a/library/common/extensions/filters/http/socket_selection/BUILD
+++ b/library/common/extensions/filters/http/socket_selection/BUILD
@@ -1,0 +1,47 @@
+load(
+    "@envoy//bazel:envoy_build_system.bzl",
+    "envoy_cc_extension",
+    "envoy_extension_package",
+    "envoy_proto_library",
+)
+
+licenses(["notice"])  # Apache 2
+
+envoy_extension_package()
+
+envoy_proto_library(
+    name = "filter",
+    srcs = ["filter.proto"],
+)
+
+envoy_cc_extension(
+    name = "socket_selection_filter_lib",
+    srcs = ["filter.cc"],
+    hdrs = ["filter.h"],
+    repository = "@envoy",
+    deps = [
+        ":filter_cc_proto",
+        "//library/common/http:internal_headers_lib",
+        "//library/common/types:c_types_lib",
+        "@envoy//envoy/http:codes_interface",
+        "@envoy//envoy/http:filter_interface",
+        "@envoy//source/common/grpc:common_lib",
+        "@envoy//source/common/grpc:status_lib",
+        "@envoy//source/common/http:codes_lib",
+        "@envoy//source/common/http:header_map_lib",
+        "@envoy//source/common/http:headers_lib",
+        "@envoy//source/common/http:utility_lib",
+        "@envoy//source/extensions/filters/http/common:pass_through_filter_lib",
+    ],
+)
+
+envoy_cc_extension(
+    name = "config",
+    srcs = ["config.cc"],
+    hdrs = ["config.h"],
+    repository = "@envoy",
+    deps = [
+        ":socket_selection_filter_lib",
+        "@envoy//source/extensions/filters/http/common:factory_base_lib",
+    ],
+)

--- a/library/common/extensions/filters/http/socket_selection/BUILD
+++ b/library/common/extensions/filters/http/socket_selection/BUILD
@@ -31,6 +31,7 @@ envoy_cc_extension(
         "@envoy//source/common/http:header_map_lib",
         "@envoy//source/common/http:headers_lib",
         "@envoy//source/common/http:utility_lib",
+        "@envoy//source/common/network:upstream_socket_options_filter_state_lib",
         "@envoy//source/extensions/filters/http/common:pass_through_filter_lib",
     ],
 )

--- a/library/common/extensions/filters/http/socket_selection/BUILD
+++ b/library/common/extensions/filters/http/socket_selection/BUILD
@@ -22,6 +22,7 @@ envoy_cc_extension(
     deps = [
         ":filter_cc_proto",
         "//library/common/http:internal_headers_lib",
+        "//library/common/network:mobile_utility_lib",
         "//library/common/types:c_types_lib",
         "@envoy//envoy/http:codes_interface",
         "@envoy//envoy/http:filter_interface",
@@ -31,7 +32,6 @@ envoy_cc_extension(
         "@envoy//source/common/http:header_map_lib",
         "@envoy//source/common/http:headers_lib",
         "@envoy//source/common/http:utility_lib",
-        "@envoy//source/common/network:upstream_socket_options_filter_state_lib",
         "@envoy//source/extensions/filters/http/common:pass_through_filter_lib",
     ],
 )

--- a/library/common/extensions/filters/http/socket_selection/config.cc
+++ b/library/common/extensions/filters/http/socket_selection/config.cc
@@ -1,0 +1,27 @@
+#include "library/common/extensions/filters/http/socket_selection/config.h"
+
+#include "library/common/extensions/filters/http/socket_selection/filter.h"
+
+namespace Envoy {
+namespace Extensions {
+namespace HttpFilters {
+namespace SocketSelection {
+
+Http::FilterFactoryCb SocketSelectionFilterFactory::createFilterFactoryFromProtoTyped(
+    const envoymobile::extensions::filters::http::socket_selection::SocketSelection&, const std::string&,
+    Server::Configuration::FactoryContext&) {
+
+  return [](Http::FilterChainFactoryCallbacks& callbacks) -> void {
+    callbacks.addStreamFilter(std::make_shared<SocketSelectionFilter>());
+  };
+}
+
+/**
+ * Static registration for the SocketSelection filter. @see NamedHttpFilterConfigFactory.
+ */
+REGISTER_FACTORY(SocketSelectionFilterFactory, Server::Configuration::NamedHttpFilterConfigFactory);
+
+} // namespace SocketSelection
+} // namespace HttpFilters
+} // namespace Extensions
+} // namespace Envoy

--- a/library/common/extensions/filters/http/socket_selection/config.cc
+++ b/library/common/extensions/filters/http/socket_selection/config.cc
@@ -8,8 +8,8 @@ namespace HttpFilters {
 namespace SocketSelection {
 
 Http::FilterFactoryCb SocketSelectionFilterFactory::createFilterFactoryFromProtoTyped(
-    const envoymobile::extensions::filters::http::socket_selection::SocketSelection&, const std::string&,
-    Server::Configuration::FactoryContext&) {
+    const envoymobile::extensions::filters::http::socket_selection::SocketSelection&,
+    const std::string&, Server::Configuration::FactoryContext&) {
 
   return [](Http::FilterChainFactoryCallbacks& callbacks) -> void {
     callbacks.addStreamFilter(std::make_shared<SocketSelectionFilter>());

--- a/library/common/extensions/filters/http/socket_selection/config.h
+++ b/library/common/extensions/filters/http/socket_selection/config.h
@@ -14,7 +14,8 @@ namespace SocketSelection {
  * Config registration for the socket_selection filter. @see NamedHttpFilterConfigFactory.
  */
 class SocketSelectionFilterFactory
-    : public Common::FactoryBase<envoymobile::extensions::filters::http::socket_selection::SocketSelection> {
+    : public Common::FactoryBase<
+          envoymobile::extensions::filters::http::socket_selection::SocketSelection> {
 public:
   SocketSelectionFilterFactory() : FactoryBase("socket_selection") {}
 

--- a/library/common/extensions/filters/http/socket_selection/config.h
+++ b/library/common/extensions/filters/http/socket_selection/config.h
@@ -1,0 +1,32 @@
+#include <string>
+
+#include "source/extensions/filters/http/common/factory_base.h"
+
+#include "library/common/extensions/filters/http/socket_selection/filter.pb.h"
+#include "library/common/extensions/filters/http/socket_selection/filter.pb.validate.h"
+
+namespace Envoy {
+namespace Extensions {
+namespace HttpFilters {
+namespace SocketSelection {
+
+/**
+ * Config registration for the socket_selection filter. @see NamedHttpFilterConfigFactory.
+ */
+class SocketSelectionFilterFactory
+    : public Common::FactoryBase<envoymobile::extensions::filters::http::socket_selection::SocketSelection> {
+public:
+  SocketSelectionFilterFactory() : FactoryBase("socket_selection") {}
+
+private:
+  ::Envoy::Http::FilterFactoryCb createFilterFactoryFromProtoTyped(
+      const envoymobile::extensions::filters::http::socket_selection::SocketSelection& config,
+      const std::string& stats_prefix, Server::Configuration::FactoryContext& context) override;
+};
+
+DECLARE_FACTORY(SocketSelectionFilterFactory);
+
+} // namespace SocketSelection
+} // namespace HttpFilters
+} // namespace Extensions
+} // namespace Envoy

--- a/library/common/extensions/filters/http/socket_selection/filter.cc
+++ b/library/common/extensions/filters/http/socket_selection/filter.cc
@@ -1,0 +1,39 @@
+#include "library/common/extensions/filters/http/socket_selection/filter.h"
+
+#include "envoy/server/filter_config.h"
+
+namespace Envoy {
+namespace Extensions {
+namespace HttpFilters {
+namespace SocketSelection {
+
+Http::FilterHeadersStatus SocketSelectionFilter::decodeHeaders(Http::RequestHeaderMap&, bool) {
+  ASSERT(decoder_callbacks_);
+  ENVOY_LOG(debug, "SocketSelectionFilter::decodeHeaders");
+  //auto& info = decoder_callbacks_->streamInfo();
+
+  return Http::FilterHeadersStatus::Continue;
+}
+
+Http::LocalErrorStatus SocketSelectionFilter::onLocalReply(const LocalReplyData& reply) {
+  ENVOY_LOG(debug, "SocketSelectionFilter::onLocalReply({}, {})", reply.code_, reply.details_);
+  ASSERT(decoder_callbacks_);
+  auto& info = decoder_callbacks_->streamInfo();
+  // TODO(goaway): set responseCode in upstream Envoy when responseCodDetails are set.
+  // ASSERT(static_cast<uint32_t>(reply.code_) == info.responseCode());
+  // TODO(goaway): follow up on the underscore discrepancy between these values.
+  // ASSERT(reply.details_ == info.responseCodeDetails().value());
+  info.setResponseCode(static_cast<uint32_t>(reply.code_));
+
+  // Charge failures to the upstream cluster to allow for passive healthchecking.
+  if (auto upstream = info.upstreamHost()) {
+    ENVOY_LOG(trace, "SocketSelectionFilter::onLocalReply charging failure to upstream host");
+    upstream->outlierDetector().putHttpResponseCode(static_cast<uint64_t>(reply.code_));
+  }
+  return Http::LocalErrorStatus::ContinueAndResetStream;
+}
+
+} // namespace SocketSelection
+} // namespace HttpFilters
+} // namespace Extensions
+} // namespace Envoy

--- a/library/common/extensions/filters/http/socket_selection/filter.cc
+++ b/library/common/extensions/filters/http/socket_selection/filter.cc
@@ -10,7 +10,6 @@ namespace HttpFilters {
 namespace SocketSelection {
 
 Http::FilterHeadersStatus SocketSelectionFilter::decodeHeaders(Http::RequestHeaderMap&, bool) {
-  ASSERT(decoder_callbacks_);
   ENVOY_LOG(debug, "SocketSelectionFilter::decodeHeaders");
 
   envoy_network_t network = Network::MobileUtility::getPreferredNetwork();
@@ -20,11 +19,6 @@ Http::FilterHeadersStatus SocketSelectionFilter::decodeHeaders(Http::RequestHead
   decoder_callbacks_->addUpstreamSocketOptions(connection_options);
 
   return Http::FilterHeadersStatus::Continue;
-}
-
-Http::LocalErrorStatus SocketSelectionFilter::onLocalReply(const LocalReplyData&) {
-  ASSERT(decoder_callbacks_);
-  return Http::LocalErrorStatus::ContinueAndResetStream;
 }
 
 } // namespace SocketSelection

--- a/library/common/extensions/filters/http/socket_selection/filter.cc
+++ b/library/common/extensions/filters/http/socket_selection/filter.cc
@@ -1,6 +1,7 @@
 #include "library/common/extensions/filters/http/socket_selection/filter.h"
 
 #include "envoy/server/filter_config.h"
+#include "source/common/network/upstream_socket_options_filter_state.h"
 
 namespace Envoy {
 namespace Extensions {
@@ -10,7 +11,9 @@ namespace SocketSelection {
 Http::FilterHeadersStatus SocketSelectionFilter::decodeHeaders(Http::RequestHeaderMap&, bool) {
   ASSERT(decoder_callbacks_);
   ENVOY_LOG(debug, "SocketSelectionFilter::decodeHeaders");
-  //auto& info = decoder_callbacks_->streamInfo();
+
+  auto network_selection_options = std::make_shared<Network::Socket::Options>();
+  decoder_callbacks_->addUpstreamSocketOptions(network_selection_options);
 
   return Http::FilterHeadersStatus::Continue;
 }
@@ -18,18 +21,6 @@ Http::FilterHeadersStatus SocketSelectionFilter::decodeHeaders(Http::RequestHead
 Http::LocalErrorStatus SocketSelectionFilter::onLocalReply(const LocalReplyData& reply) {
   ENVOY_LOG(debug, "SocketSelectionFilter::onLocalReply({}, {})", reply.code_, reply.details_);
   ASSERT(decoder_callbacks_);
-  auto& info = decoder_callbacks_->streamInfo();
-  // TODO(goaway): set responseCode in upstream Envoy when responseCodDetails are set.
-  // ASSERT(static_cast<uint32_t>(reply.code_) == info.responseCode());
-  // TODO(goaway): follow up on the underscore discrepancy between these values.
-  // ASSERT(reply.details_ == info.responseCodeDetails().value());
-  info.setResponseCode(static_cast<uint32_t>(reply.code_));
-
-  // Charge failures to the upstream cluster to allow for passive healthchecking.
-  if (auto upstream = info.upstreamHost()) {
-    ENVOY_LOG(trace, "SocketSelectionFilter::onLocalReply charging failure to upstream host");
-    upstream->outlierDetector().putHttpResponseCode(static_cast<uint64_t>(reply.code_));
-  }
   return Http::LocalErrorStatus::ContinueAndResetStream;
 }
 

--- a/library/common/extensions/filters/http/socket_selection/filter.cc
+++ b/library/common/extensions/filters/http/socket_selection/filter.cc
@@ -22,7 +22,7 @@ Http::FilterHeadersStatus SocketSelectionFilter::decodeHeaders(Http::RequestHead
   return Http::FilterHeadersStatus::Continue;
 }
 
-Http::LocalErrorStatus SocketSelectionFilter::onLocalReply(const LocalReplyData& reply) {
+Http::LocalErrorStatus SocketSelectionFilter::onLocalReply(const LocalReplyData&) {
   ASSERT(decoder_callbacks_);
   return Http::LocalErrorStatus::ContinueAndResetStream;
 }

--- a/library/common/extensions/filters/http/socket_selection/filter.h
+++ b/library/common/extensions/filters/http/socket_selection/filter.h
@@ -1,0 +1,44 @@
+#pragma once
+
+#include "envoy/http/filter.h"
+
+#include "source/common/common/logger.h"
+#include "source/extensions/filters/http/common/pass_through_filter.h"
+
+#include "library/common/extensions/filters/http/socket_selection/filter.pb.h"
+#include "library/common/types/c_types.h"
+
+namespace Envoy {
+namespace Extensions {
+namespace HttpFilters {
+namespace SocketSelection {
+
+/**
+ * Interface for socket selection controller. Shared by filter instances.
+ */
+class SocketSelectionController {
+public:
+  virtual ~SocketSelectionController() {}
+
+  void setPreferedNetwork(envoy_network_t interface);
+  absl::optional<envoy_network_t> getNetworkOverride();
+
+};
+
+/**
+ * Filter to set upstream socket options based on network conditions.
+ */
+class SocketSelectionFilter final : public Http::PassThroughFilter,
+                                    public Logger::Loggable<Logger::Id::filter> {
+public:
+  // Http::StreamFilterBase
+  Http::LocalErrorStatus onLocalReply(const LocalReplyData&) override;
+  // Http::StreamDecoderFilter
+  Http::FilterHeadersStatus decodeHeaders(Http::RequestHeaderMap& headers,
+                                          bool end_stream) override;
+};
+
+} // namespace SocketSelection
+} // namespace HttpFilters
+} // namespace Extensions
+} // namespace Envoy

--- a/library/common/extensions/filters/http/socket_selection/filter.h
+++ b/library/common/extensions/filters/http/socket_selection/filter.h
@@ -14,24 +14,11 @@ namespace HttpFilters {
 namespace SocketSelection {
 
 /**
- * Interface for socket selection controller. Shared by filter instances.
- */
-class SocketSelectionController {
-public:
-  virtual ~SocketSelectionController() {}
-
-  void setPreferedNetwork(envoy_network_t interface);
-  absl::optional<envoy_network_t> getNetworkOverride();
-};
-
-/**
  * Filter to set upstream socket options based on network conditions.
  */
 class SocketSelectionFilter final : public Http::PassThroughFilter,
                                     public Logger::Loggable<Logger::Id::filter> {
 public:
-  // Http::StreamFilterBase
-  Http::LocalErrorStatus onLocalReply(const LocalReplyData&) override;
   // Http::StreamDecoderFilter
   Http::FilterHeadersStatus decodeHeaders(Http::RequestHeaderMap& headers,
                                           bool end_stream) override;

--- a/library/common/extensions/filters/http/socket_selection/filter.h
+++ b/library/common/extensions/filters/http/socket_selection/filter.h
@@ -22,7 +22,6 @@ public:
 
   void setPreferedNetwork(envoy_network_t interface);
   absl::optional<envoy_network_t> getNetworkOverride();
-
 };
 
 /**

--- a/library/common/extensions/filters/http/socket_selection/filter.proto
+++ b/library/common/extensions/filters/http/socket_selection/filter.proto
@@ -1,0 +1,6 @@
+syntax = "proto3";
+
+package envoymobile.extensions.filters.http.socket_selection;
+
+message SocketSelection {
+}

--- a/library/common/http/BUILD
+++ b/library/common/http/BUILD
@@ -18,6 +18,7 @@ envoy_cc_library(
         "//library/common/extensions/filters/http/local_error:local_error_filter_lib",
         "//library/common/extensions/filters/http/socket_selection:socket_selection_filter_lib",
         "//library/common/http:header_utility_lib",
+        "//library/common/network:mobile_utility_lib",
         "//library/common/network:synthetic_address_lib",
         "//library/common/types:c_types_lib",
         "@envoy//envoy/buffer:buffer_interface",

--- a/library/common/http/BUILD
+++ b/library/common/http/BUILD
@@ -16,6 +16,7 @@ envoy_cc_library(
         "//library/common/data:utility_lib",
         "//library/common/event:provisional_dispatcher_lib",
         "//library/common/extensions/filters/http/local_error:local_error_filter_lib",
+        "//library/common/extensions/filters/http/socket_selection:socket_selection_filter_lib",
         "//library/common/http:header_utility_lib",
         "//library/common/network:synthetic_address_lib",
         "//library/common/types:c_types_lib",

--- a/library/common/http/client.cc
+++ b/library/common/http/client.cc
@@ -13,6 +13,7 @@
 #include "library/common/data/utility.h"
 #include "library/common/http/header_utility.h"
 #include "library/common/http/headers.h"
+#include "library/common/network/mobile_utility.h"
 
 namespace Envoy {
 namespace Http {
@@ -558,9 +559,9 @@ void Client::setDestinationCluster(Http::RequestHeaderMap& headers) {
   // - Force http/1.1 if request scheme is http (cleartext).
   const char* cluster{};
   auto h2_header = headers.get(H2UpstreamHeader);
-  auto network = preferred_network_.load();
+  auto network = Network::MobileUtility::getPreferredNetwork();
   ASSERT(network >= 0 && network < ClustersPerPool,
-         "preferred_network_ must be valid index into cluster array");
+         "preferred network must be valid index into cluster array");
 
   if (headers.getSchemeValue() == Headers::get().SchemeValues.Http) {
     cluster = ClearTextClusters[network];

--- a/library/common/http/client.cc
+++ b/library/common/http/client.cc
@@ -525,30 +525,10 @@ const LowerCaseString H2UpstreamHeader{"x-envoy-mobile-upstream-protocol"};
 // Long-term we will be working to generally provide more responsive connection handling within
 // Envoy itself.
 
-const size_t ClustersPerPool = 3;
-const char* BaseClusters[ClustersPerPool] = {
-    "base",
-    "base_wlan",
-    "base_wwan",
-};
-
-const char* H2Clusters[ClustersPerPool] = {
-    "base_h2",
-    "base_wlan_h2",
-    "base_wwan_h2",
-};
-
-const char* ClearTextClusters[ClustersPerPool] = {
-    "base_clear",
-    "base_wlan_clear",
-    "base_wwan_clear",
-};
-
-const char* AlpnClusters[ClustersPerPool] = {
-    "base_alpn",
-    "base_wlan_alpn",
-    "base_wwan_alpn",
-};
+const char* BaseCluster = "base";
+const char* H2Cluster = "base_h2";
+const char* ClearTextCluster = "base_clear";
+const char* AlpnCluster = "base_alpn";
 
 } // namespace
 
@@ -559,25 +539,24 @@ void Client::setDestinationCluster(Http::RequestHeaderMap& headers) {
   // - Force http/1.1 if request scheme is http (cleartext).
   const char* cluster{};
   auto h2_header = headers.get(H2UpstreamHeader);
-  auto network = Network::MobileUtility::getPreferredNetwork();
   ASSERT(network >= 0 && network < ClustersPerPool,
          "preferred network must be valid index into cluster array");
 
   if (headers.getSchemeValue() == Headers::get().SchemeValues.Http) {
-    cluster = ClearTextClusters[network];
+    cluster = ClearTextCluster;
   } else if (!h2_header.empty()) {
     ASSERT(h2_header.size() == 1);
     const auto value = h2_header[0]->value().getStringView();
     if (value == "http2") {
-      cluster = H2Clusters[network];
+      cluster = H2Cluster;
     } else if (value == "alpn") {
-      cluster = AlpnClusters[network];
+      cluster = AlpnCluster;
     } else {
       RELEASE_ASSERT(value == "http1", fmt::format("using unsupported protocol version {}", value));
-      cluster = BaseClusters[network];
+      cluster = BaseCluster;
     }
   } else {
-    cluster = BaseClusters[network];
+    cluster = BaseCluster;
   }
 
   if (!h2_header.empty()) {

--- a/library/common/http/client.cc
+++ b/library/common/http/client.cc
@@ -539,9 +539,6 @@ void Client::setDestinationCluster(Http::RequestHeaderMap& headers) {
   // - Force http/1.1 if request scheme is http (cleartext).
   const char* cluster{};
   auto h2_header = headers.get(H2UpstreamHeader);
-  ASSERT(network >= 0 && network < ClustersPerPool,
-         "preferred network must be valid index into cluster array");
-
   if (headers.getSchemeValue() == Headers::get().SchemeValues.Http) {
     cluster = ClearTextCluster;
   } else if (!h2_header.empty()) {

--- a/library/common/http/client.h
+++ b/library/common/http/client.h
@@ -43,10 +43,9 @@ struct HttpClientStats {
 class Client : public Logger::Loggable<Logger::Id::http> {
 public:
   Client(ApiListener& api_listener, Event::ProvisionalDispatcher& dispatcher, Stats::Scope& scope,
-         std::atomic<envoy_network_t>& preferred_network, Random::RandomGenerator& random)
+         Random::RandomGenerator& random)
       : api_listener_(api_listener), dispatcher_(dispatcher),
         stats_(HttpClientStats{ALL_HTTP_CLIENT_STATS(POOL_COUNTER_PREFIX(scope, "http.client."))}),
-        preferred_network_(preferred_network),
         address_(std::make_shared<Network::Address::SyntheticAddressImpl>()), random_(random) {}
 
   /**
@@ -310,7 +309,6 @@ private:
   // The set of closed streams, where end stream has been received from upstream
   // but not yet communicated to the mobile library.
   absl::flat_hash_map<envoy_stream_t, DirectStreamSharedPtr> closed_streams_;
-  std::atomic<envoy_network_t>& preferred_network_;
   // Shared synthetic address across DirectStreams.
   Network::Address::InstanceConstSharedPtr address_;
   Random::RandomGenerator& random_;

--- a/library/common/main_interface.cc
+++ b/library/common/main_interface.cc
@@ -235,8 +235,7 @@ envoy_engine_t init_engine(envoy_engine_callbacks callbacks, envoy_logger logger
                            envoy_event_tracker event_tracker) {
   // TODO(goaway): return new handle once multiple engine support is in place.
   // https://github.com/lyft/envoy-mobile/issues/332
-  strong_engine_ =
-      std::make_shared<Envoy::Engine>(callbacks, logger, event_tracker);
+  strong_engine_ = std::make_shared<Envoy::Engine>(callbacks, logger, event_tracker);
   engine_ = strong_engine_;
   return 1;
 }

--- a/library/common/main_interface.cc
+++ b/library/common/main_interface.cc
@@ -8,6 +8,7 @@
 #include "library/common/engine.h"
 #include "library/common/extensions/filters/http/platform_bridge/c_types.h"
 #include "library/common/http/client.h"
+#include "library/common/network/mobile_utility.h"
 #include "types/c_types.h"
 
 // NOLINT(namespace-envoy)
@@ -15,7 +16,6 @@
 static Envoy::EngineSharedPtr strong_engine_;
 static Envoy::EngineWeakPtr engine_;
 static std::atomic<envoy_stream_t> current_stream_handle_{0};
-static std::atomic<envoy_network_t> preferred_network_{ENVOY_NET_GENERIC};
 
 static std::shared_ptr<Envoy::Engine> engine() {
   // TODO(goaway): enable configurable heap-based allocation
@@ -89,7 +89,7 @@ envoy_status_t reset_stream(envoy_stream_t stream) {
 }
 
 envoy_status_t set_preferred_network(envoy_network_t network) {
-  preferred_network_.store(network);
+  Envoy::Network::MobileUtility::setPreferredNetwork(network);
   return ENVOY_SUCCESS;
 }
 
@@ -236,7 +236,7 @@ envoy_engine_t init_engine(envoy_engine_callbacks callbacks, envoy_logger logger
   // TODO(goaway): return new handle once multiple engine support is in place.
   // https://github.com/lyft/envoy-mobile/issues/332
   strong_engine_ =
-      std::make_shared<Envoy::Engine>(callbacks, logger, event_tracker, preferred_network_);
+      std::make_shared<Envoy::Engine>(callbacks, logger, event_tracker);
   engine_ = strong_engine_;
   return 1;
 }

--- a/library/common/network/BUILD
+++ b/library/common/network/BUILD
@@ -24,7 +24,11 @@ envoy_cc_library(
     repository = "@envoy",
     deps = [
         "//library/common/types:c_types_lib",
+        "@envoy//envoy/network:socket_interface",
         "@envoy//source/common/common:assert_lib",
+        "@envoy//source/common/common:scalar_to_byte_vector_lib",
+        "@envoy//source/common/common:utility_lib",
+        "@envoy//source/common/network:socket_option_lib",
     ],
 )
 

--- a/library/common/network/BUILD
+++ b/library/common/network/BUILD
@@ -23,6 +23,7 @@ envoy_cc_library(
     }),
     repository = "@envoy",
     deps = [
+        "//library/common/types:c_types_lib",
         "@envoy//source/common/common:assert_lib",
     ],
 )

--- a/library/common/network/mobile_utility.cc
+++ b/library/common/network/mobile_utility.cc
@@ -4,6 +4,24 @@
 
 #include "source/common/common/assert.h"
 
+#ifdef SO_BINDTODEVICE
+#define ENVOY_SOCKET_SO_BINDTODEVICE ENVOY_MAKE_SOCKET_OPTION_NAME(SOL_SOCKET, SO_BINDTODEVICE)
+#else
+#define ENVOY_SOCKET_SO_BINDTODEVICE Network::SocketOptionName()
+#endif
+
+#ifdef IP_BOUND_IF
+#define ENVOY_SOCKET_IP_BOUND_IF ENVOY_MAKE_SOCKET_OPTION_NAME(IPPROTO_IP, IP_BOUND_IF)
+#else
+#define ENVOY_SOCKET_IP_BOUND_IF Network::SocketOptionName()
+#endif
+
+#ifdef IPV6_BOUND_IF
+#define ENVOY_SOCKET_IPV6_BOUND_IF ENVOY_MAKE_SOCKET_OPTION_NAME(IPPROTO_IPV6, IPV6_BOUND_IF)
+#else
+#define ENVOY_SOCKET_IPV6_BOUND_IF Network::SocketOptionName()
+#endif
+
 #ifdef SUPPORTS_GETIFADDRS
 #include <ifaddrs.h>
 #endif
@@ -20,6 +38,16 @@ namespace {
 #pragma clang diagnostic pop
 #define SUPPORTS_GETIFADDRS
 #endif
+
+std::atomic<envoy_network_t> MobileUtility::preferred_network_{ENVOY_NET_GENERIC};
+
+void MobileUtility::setPreferredNetwork(envoy_network_t network) {
+  preferred_network_ = network;
+}
+
+envoy_network_t MobileUtility::getPreferredNetwork() {
+  return preferred_network_.load();
+}
 
 std::vector<std::string> MobileUtility::enumerateV4Interfaces() {
   return enumerateInterfaces(AF_INET);

--- a/library/common/network/mobile_utility.cc
+++ b/library/common/network/mobile_utility.cc
@@ -59,17 +59,17 @@ namespace {
 class InternalOptionImpl : public SocketOptionImpl {
 public:
   InternalOptionImpl(envoy::config::core::v3::SocketOption::SocketState in_state,
-                   Network::SocketOptionName optname, absl::string_view value)
+                     Network::SocketOptionName optname, absl::string_view value)
       : SocketOptionImpl(in_state, optname, value) {
-        name_ = optname.name();
-        value_ = value;
+    name_ = optname.name();
+    value_ = value;
   }
 
   InternalOptionImpl(envoy::config::core::v3::SocketOption::SocketState in_state,
-                   Network::SocketOptionName optname,
-                   int value) // Yup, int. See setsockopt(2).
+                     Network::SocketOptionName optname,
+                     int value) // Yup, int. See setsockopt(2).
       : InternalOptionImpl(in_state, optname,
-                         absl::string_view(reinterpret_cast<char*>(&value), sizeof(value))) {}
+                           absl::string_view(reinterpret_cast<char*>(&value), sizeof(value))) {}
 
   // The common socket options don't require a hash key.
   void hashKey(std::vector<uint8_t>& hash) const override {
@@ -86,13 +86,9 @@ private:
 
 std::atomic<envoy_network_t> MobileUtility::preferred_network_{ENVOY_NET_GENERIC};
 
-void MobileUtility::setPreferredNetwork(envoy_network_t network) {
-  preferred_network_ = network;
-}
+void MobileUtility::setPreferredNetwork(envoy_network_t network) { preferred_network_ = network; }
 
-envoy_network_t MobileUtility::getPreferredNetwork() {
-  return preferred_network_.load();
-}
+envoy_network_t MobileUtility::getPreferredNetwork() { return preferred_network_.load(); }
 
 std::vector<std::string> MobileUtility::enumerateV4Interfaces() {
   return enumerateInterfaces(AF_INET);
@@ -110,7 +106,7 @@ Socket::OptionsSharedPtr MobileUtility::getUpstreamSocketOptions(envoy_network_t
   int ttl_value = DEFAULT_IP_TTL + static_cast<int>(network);
   auto options = std::make_shared<Socket::Options>();
   options->push_back(std::make_shared<InternalOptionImpl>(
-    envoy::config::core::v3::SocketOption::STATE_PREBIND, ENVOY_SOCKET_IP_TTL, ttl_value));
+      envoy::config::core::v3::SocketOption::STATE_PREBIND, ENVOY_SOCKET_IP_TTL, ttl_value));
   return options;
 }
 

--- a/library/common/network/mobile_utility.cc
+++ b/library/common/network/mobile_utility.cc
@@ -106,7 +106,6 @@ Socket::OptionsSharedPtr MobileUtility::getUpstreamSocketOptions(envoy_network_t
   // Envoy uses the hash signature of overridden socket options to choose a connection pool.
   // Setting a dummy socket option is a hack that allows us to select a different
   // connection pool without materially changing the socket configuration.
-
   ASSERT(network >= 0 && network < 3);
   int ttl_value = DEFAULT_IP_TTL + static_cast<int>(network);
   auto options = std::make_shared<Socket::Options>();

--- a/library/common/network/mobile_utility.h
+++ b/library/common/network/mobile_utility.h
@@ -3,9 +3,9 @@
 #include <string>
 #include <vector>
 
-#include "library/common/types/c_types.h"
-
 #include "envoy/network/socket.h"
+
+#include "library/common/types/c_types.h"
 
 namespace Envoy {
 namespace Network {

--- a/library/common/network/mobile_utility.h
+++ b/library/common/network/mobile_utility.h
@@ -3,6 +3,8 @@
 #include <string>
 #include <vector>
 
+#include "library/common/types/c_types.h"
+
 namespace Envoy {
 namespace Network {
 
@@ -21,8 +23,20 @@ public:
    */
   static std::vector<std::string> enumerateV6Interfaces();
 
+  /**
+   * @returns the current OS default/preferred network class.
+   */
+  static envoy_network_t getPreferredNetwork();
+
+  /**
+   * Sets the current OS default/preferred network class.
+   * @param network, the network preference.
+   */
+  static void setPreferredNetwork(envoy_network_t network);
+
 private:
   static std::vector<std::string> enumerateInterfaces(unsigned short family);
+  static std::atomic<envoy_network_t> preferred_network_;
 };
 
 } // namespace Network

--- a/library/common/network/mobile_utility.h
+++ b/library/common/network/mobile_utility.h
@@ -5,6 +5,8 @@
 
 #include "library/common/types/c_types.h"
 
+#include "envoy/network/socket.h"
+
 namespace Envoy {
 namespace Network {
 
@@ -33,6 +35,11 @@ public:
    * @param network, the network preference.
    */
   static void setPreferredNetwork(envoy_network_t network);
+
+  /**
+   * @returns the current socket options that should be used for connections.
+   */
+  static Socket::OptionsSharedPtr getUpstreamSocketOptions(envoy_network_t network);
 
 private:
   static std::vector<std::string> enumerateInterfaces(unsigned short family);

--- a/test/common/integration/client_integration_test.cc
+++ b/test/common/integration/client_integration_test.cc
@@ -155,8 +155,7 @@ TEST_P(ClientIntegrationTest, Basic) {
   test_server_->server().dispatcher().post([this, &server_started]() -> void {
     http_client_ = std::make_unique<Http::Client>(
         test_server_->server().listenerManager().apiListener()->get().http()->get(), *dispatcher_,
-        test_server_->statStore(),
-        test_server_->server().api().randomGenerator());
+        test_server_->statStore(), test_server_->server().api().randomGenerator());
     dispatcher_->drain(test_server_->server().dispatcher());
     server_started.setReady();
   });
@@ -217,8 +216,7 @@ TEST_P(ClientIntegrationTest, BasicNon2xx) {
   test_server_->server().dispatcher().post([this, &server_started]() -> void {
     http_client_ = std::make_unique<Http::Client>(
         test_server_->server().listenerManager().apiListener()->get().http()->get(), *dispatcher_,
-        test_server_->statStore(),
-        test_server_->server().api().randomGenerator());
+        test_server_->statStore(), test_server_->server().api().randomGenerator());
     dispatcher_->drain(test_server_->server().dispatcher());
     server_started.setReady();
   });
@@ -258,8 +256,7 @@ TEST_P(ClientIntegrationTest, BasicReset) {
   test_server_->server().dispatcher().post([this, &server_started]() -> void {
     http_client_ = std::make_unique<Http::Client>(
         test_server_->server().listenerManager().apiListener()->get().http()->get(), *dispatcher_,
-        test_server_->statStore(),
-        test_server_->server().api().randomGenerator());
+        test_server_->statStore(), test_server_->server().api().randomGenerator());
     dispatcher_->drain(test_server_->server().dispatcher());
     server_started.setReady();
   });
@@ -314,8 +311,7 @@ TEST_P(ClientIntegrationTest, CaseSensitive) {
   test_server_->server().dispatcher().post([this, &server_started]() -> void {
     http_client_ = std::make_unique<Http::Client>(
         test_server_->server().listenerManager().apiListener()->get().http()->get(), *dispatcher_,
-        test_server_->statStore(),
-        test_server_->server().api().randomGenerator());
+        test_server_->statStore(), test_server_->server().api().randomGenerator());
     dispatcher_->drain(test_server_->server().dispatcher());
     server_started.setReady();
   });

--- a/test/common/integration/client_integration_test.cc
+++ b/test/common/integration/client_integration_test.cc
@@ -137,7 +137,6 @@ api_listener:
       )EOF";
   }
 
-  std::atomic<envoy_network_t> preferred_network_{ENVOY_NET_GENERIC};
   Event::ProvisionalDispatcherPtr dispatcher_ = std::make_unique<Event::ProvisionalDispatcher>();
   Http::ClientPtr http_client_{};
   envoy_http_callbacks bridge_callbacks_;
@@ -156,7 +155,7 @@ TEST_P(ClientIntegrationTest, Basic) {
   test_server_->server().dispatcher().post([this, &server_started]() -> void {
     http_client_ = std::make_unique<Http::Client>(
         test_server_->server().listenerManager().apiListener()->get().http()->get(), *dispatcher_,
-        test_server_->statStore(), preferred_network_,
+        test_server_->statStore(),
         test_server_->server().api().randomGenerator());
     dispatcher_->drain(test_server_->server().dispatcher());
     server_started.setReady();
@@ -218,7 +217,7 @@ TEST_P(ClientIntegrationTest, BasicNon2xx) {
   test_server_->server().dispatcher().post([this, &server_started]() -> void {
     http_client_ = std::make_unique<Http::Client>(
         test_server_->server().listenerManager().apiListener()->get().http()->get(), *dispatcher_,
-        test_server_->statStore(), preferred_network_,
+        test_server_->statStore(),
         test_server_->server().api().randomGenerator());
     dispatcher_->drain(test_server_->server().dispatcher());
     server_started.setReady();
@@ -259,7 +258,7 @@ TEST_P(ClientIntegrationTest, BasicReset) {
   test_server_->server().dispatcher().post([this, &server_started]() -> void {
     http_client_ = std::make_unique<Http::Client>(
         test_server_->server().listenerManager().apiListener()->get().http()->get(), *dispatcher_,
-        test_server_->statStore(), preferred_network_,
+        test_server_->statStore(),
         test_server_->server().api().randomGenerator());
     dispatcher_->drain(test_server_->server().dispatcher());
     server_started.setReady();
@@ -315,7 +314,7 @@ TEST_P(ClientIntegrationTest, CaseSensitive) {
   test_server_->server().dispatcher().post([this, &server_started]() -> void {
     http_client_ = std::make_unique<Http::Client>(
         test_server_->server().listenerManager().apiListener()->get().http()->get(), *dispatcher_,
-        test_server_->statStore(), preferred_network_,
+        test_server_->statStore(),
         test_server_->server().api().randomGenerator());
     dispatcher_->drain(test_server_->server().dispatcher());
     server_started.setReady();


### PR DESCRIPTION
TODO:
- [x] create selection filter
- [x] define (different) socket option for Android and iOS
- [x] central network preference handling
- [x] define dummy option to create non-default cluster
- [x] select default/non-default cluster based on reachability status
- [x] remove network clusters

Description: Removes network-specific clusters and replaces with a filter that sets unique socket options based on current preferred network (via Reachability) status. Envoy internally creates a different socket pool for a unique set of socket options, so the effect of this is that we still use different sets of connections per interface, but no longer rely on a large set of clusters to do so. This PR also lays the groundwork for us to experiment with interface-bound sockets.
Risk Level: High
Testing: Existing unit and integration coverage
