### PR TITLE
bazel: unify envoy_mobile_swift_test targets

### DIFF
--- a/test/swift/BUILD
+++ b/test/swift/BUILD
@@ -3,70 +3,19 @@ load("@envoy_mobile//bazel:apple_test.bzl", "envoy_mobile_swift_test")
 licenses(["notice"])  # Apache 2
 
 envoy_mobile_swift_test(
-    name = "engine_builder_tests",
+    name = "test",
     srcs = [
         "EngineBuilderTests.swift",
-    ],
-    deps = [
-        "//library/objective-c:envoy_engine_objc_lib",
-    ],
-)
-
-envoy_mobile_swift_test(
-    name = "grpc_request_headers_builder_tests",
-    srcs = [
         "GRPCRequestHeadersBuilderTests.swift",
-    ],
-)
-
-envoy_mobile_swift_test(
-    name = "grpc_stream_tests",
-    srcs = [
         "GRPCStreamTests.swift",
-    ],
-)
-
-envoy_mobile_swift_test(
-    name = "headers_builder_tests",
-    srcs = [
         "HeadersBuilderTests.swift",
-    ],
-)
-
-envoy_mobile_swift_test(
-    name = "pulse_client_impl_tests",
-    srcs = [
         "PulseClientImplTests.swift",
-    ],
-    deps = [
-        "//library/objective-c:envoy_engine_objc_lib",
-    ],
-)
-
-envoy_mobile_swift_test(
-    name = "request_headers_builder_tests",
-    srcs = [
         "RequestHeadersBuilderTests.swift",
-    ],
-)
-
-envoy_mobile_swift_test(
-    name = "response_headers_tests",
-    srcs = [
         "ResponseHeadersTests.swift",
-    ],
-)
-
-envoy_mobile_swift_test(
-    name = "retry_policy_tests",
-    srcs = [
+        "RetryPolicyMapperTests.swift",
         "RetryPolicyTests.swift",
     ],
-)
-
-envoy_mobile_swift_test(
-    name = "retry_policy_mapper_tests",
-    srcs = [
-        "RetryPolicyMapperTests.swift",
+    deps = [
+        "//library/objective-c:envoy_engine_objc_lib",
     ],
 )

--- a/test/swift/integration/BUILD
+++ b/test/swift/integration/BUILD
@@ -5,175 +5,30 @@ load("@envoy//bazel:envoy_build_system.bzl", "envoy_cc_library")
 licenses(["notice"])  # Apache 2
 
 envoy_mobile_swift_test(
-    name = "cancel_stream_test",
+    name = "test",
     srcs = [
         "CancelStreamTest.swift",
-    ],
-    deps = [
-        "//library/objective-c:envoy_engine_objc_lib",
-    ],
-)
-
-envoy_mobile_swift_test(
-    name = "drain_connections_test",
-    srcs = [
-        "DrainConnectionsTest.swift",
-    ],
-    deps = [
-        "//library/objective-c:envoy_engine_objc_lib",
-    ],
-)
-
-envoy_mobile_swift_test(
-    name = "direct_response_contains_headers_integration_test",
-    srcs = [
         "DirectResponseContainsHeadersMatchIntegrationTest.swift",
-    ],
-)
-
-envoy_mobile_swift_test(
-    name = "direct_response_exact_headers_match_integration_test",
-    srcs = [
         "DirectResponseExactHeadersMatchIntegrationTest.swift",
-    ],
-)
-
-envoy_mobile_swift_test(
-    name = "engine_api_test",
-    srcs = [
-        "EngineApiTest.swift",
-    ],
-)
-
-envoy_mobile_swift_test(
-    name = "direct_response_exact_path_match_integration_test",
-    srcs = [
         "DirectResponseExactPathMatchIntegrationTest.swift",
-    ],
-)
-
-envoy_mobile_swift_test(
-    name = "stat_flush_integration_test",
-    srcs = [
-        "StatFlushIntegrationTest.swift",
-    ],
-    deps = [
-        "//library/objective-c:envoy_engine_objc_lib",
-    ],
-)
-
-envoy_mobile_swift_test(
-    name = "direct_response_filter_mutation_integration_test",
-    srcs = [
         "DirectResponseFilterMutationIntegrationTest.swift",
-    ],
-)
-
-envoy_mobile_swift_test(
-    name = "direct_response_prefix_headers_match_integration_test",
-    srcs = [
         "DirectResponsePrefixHeadersMatchIntegrationTest.swift",
-    ],
-)
-
-envoy_mobile_swift_test(
-    name = "direct_response_prefix_path_match_integration_test",
-    srcs = [
         "DirectResponsePrefixPathMatchIntegrationTest.swift",
-    ],
-)
-
-envoy_mobile_swift_test(
-    name = "direct_response_suffix_path_match_integration_test",
-    srcs = [
         "DirectResponseSuffixHeadersMatchIntegrationTest.swift",
-    ],
-)
-
-envoy_mobile_swift_test(
-    name = "filter_reset_idle_test",
-    srcs = [
+        "DrainConnectionsTest.swift",
+        "EngineApiTest.swift",
         "FilterResetIdleTest.swift",
-    ],
-    deps = [
-        "//library/objective-c:envoy_engine_objc_lib",
-    ],
-)
-
-envoy_mobile_swift_test(
-    name = "idle_timeout_test",
-    srcs = [
-        "IdleTimeoutTest.swift",
-    ],
-    deps = [
-        "//library/objective-c:envoy_engine_objc_lib",
-    ],
-)
-
-envoy_mobile_swift_test(
-    name = "receive_data_test",
-    srcs = [
-        "ReceiveDataTest.swift",
-    ],
-    deps = [
-        "//library/objective-c:envoy_engine_objc_lib",
-    ],
-)
-
-envoy_mobile_swift_test(
-    name = "receive_error_test",
-    srcs = [
-        "ReceiveErrorTest.swift",
-    ],
-    deps = [
-        "//library/objective-c:envoy_engine_objc_lib",
-    ],
-)
-
-envoy_mobile_swift_test(
-    name = "grpc_receive_error_test",
-    srcs = [
         "GRPCReceiveErrorTest.swift",
-    ],
-    deps = [
-        "//library/objective-c:envoy_engine_objc_lib",
-    ],
-)
-
-envoy_mobile_swift_test(
-    name = "send_data_test",
-    srcs = [
+        "IdleTimeoutTest.swift",
+        "ReceiveDataTest.swift",
+        "ReceiveErrorTest.swift",
         "SendDataTest.swift",
-    ],
-    deps = [
-        "//library/objective-c:envoy_engine_objc_lib",
-    ],
-)
-
-envoy_mobile_swift_test(
-    name = "send_headers_test",
-    srcs = [
         "SendHeadersTest.swift",
-    ],
-    deps = [
-        "//library/objective-c:envoy_engine_objc_lib",
-    ],
-)
-
-envoy_mobile_swift_test(
-    name = "send_trailers_test",
-    srcs = [
         "SendTrailersTest.swift",
-    ],
-    deps = [
-        "//library/objective-c:envoy_engine_objc_lib",
-    ],
-)
-
-envoy_mobile_swift_test(
-    name = "set_logger_test",
-    srcs = [
+        "SetEventTrackerTest.swift",
+        "SetEventTrackerTestNoTracker.swift",
         "SetLoggerTest.swift",
+        "StatFlushIntegrationTest.swift",
     ],
     deps = [
         ":test_extensions",
@@ -201,26 +56,5 @@ objc_library(
     module_name = "TestExtensions",
     deps = [
         ":test_extensions_cc",
-    ],
-)
-
-envoy_mobile_swift_test(
-    name = "set_event_tracker_test",
-    srcs = [
-        "SetEventTrackerTest.swift",
-    ],
-    deps = [
-        ":test_extensions",
-        "//library/objective-c:envoy_engine_objc_lib",
-    ],
-)
-
-envoy_mobile_swift_test(
-    name = "set_event_tracker_test_no_tracker",
-    srcs = [
-        "SetEventTrackerTestNoTracker.swift",
-    ],
-    deps = [
-        "//library/objective-c:envoy_engine_objc_lib",
     ],
 )

--- a/test/swift/integration/GRPCReceiveErrorTest.swift
+++ b/test/swift/integration/GRPCReceiveErrorTest.swift
@@ -3,7 +3,7 @@ import EnvoyEngine
 import Foundation
 import XCTest
 
-final class ReceiveErrorTests: XCTestCase {
+final class GRPCReceiveErrorTests: XCTestCase {
   func testReceiveError() {
     // swiftlint:disable:next line_length
     let emhcmType = "type.googleapis.com/envoy.extensions.filters.network.http_connection_manager.v3.EnvoyMobileHttpConnectionManager"

--- a/test/swift/stats/BUILD
+++ b/test/swift/stats/BUILD
@@ -3,25 +3,13 @@ load("@envoy_mobile//bazel:apple_test.bzl", "envoy_mobile_swift_test")
 licenses(["notice"])  # Apache 2
 
 envoy_mobile_swift_test(
-    name = "counter_impl_tests",
+    name = "test",
     srcs = [
         "CounterImplTests.swift",
+        "ElementTests.swift",
+        "TagsBuilderTests.swift",
     ],
     deps = [
         "//library/objective-c:envoy_engine_objc_lib",
-    ],
-)
-
-envoy_mobile_swift_test(
-    name = "element_tests",
-    srcs = [
-        "ElementTests.swift",
-    ],
-)
-
-envoy_mobile_swift_test(
-    name = "tags_builder_tests",
-    srcs = [
-        "TagsBuilderTests.swift",
     ],
 )


### PR DESCRIPTION
Ideally, similar to cc_test targets, these would all be separate. But
with iOS tests this has a bunch of downsides:

1. You have to re-link every test bundle (same as cc_tests) which takes
   a huge amount of time for these tests (on the order of minutes per
   target)
2. You have to re-create and launch a fresh simulator for every test
   target which is a huge amount of overhead
3. You have to separately maintain a duplicative list of deps

Combining these does have some small downsides

1. You link a bit more when iterating on a test, this is nothing
   compared to the overall deps you end up linking from envoy, so it
   shouldn't meaningfully impact performance
2. You over-specify deps for some test cases, considering how few deps
   tests have today this shouldn't be an issue

Overall I think this is worth it for the time savings above. This should
meaningfully improve CI times.