### PR TITLE
Save latest StreamIntel as StreamInfo may become unavailable when accessed.

### DIFF
--- a/library/common/http/client.cc
+++ b/library/common/http/client.cc
@@ -117,7 +117,7 @@ void Client::DirectStreamCallbacks::sendDataToBridge(Buffer::Instance& data, boo
             "[S{}] dispatching to platform response data for stream (length={} end_stream={})",
             direct_stream_.stream_handle_, bytes_to_send, send_end_stream);
 
-  bridge_callbacks_.on_data(Data::Utility::toBridgeData(data, bytes_to_send), end_stream,
+  bridge_callbacks_.on_data(Data::Utility::toBridgeData(data, bytes_to_send), send_end_stream,
                             streamIntel(), bridge_callbacks_.context);
   if (send_end_stream) {
     onComplete();

--- a/library/common/http/client.cc
+++ b/library/common/http/client.cc
@@ -251,7 +251,7 @@ envoy_stream_intel Client::DirectStreamCallbacks::streamIntel() {
   return direct_stream_.stream_intel_;
 }
 
-void Client::DirectStream::saveStreamIntel() {
+void Client::DirectStream::saveLatestStreamIntel() {
   const auto& info = request_decoder_->streamInfo();
   stream_intel_.connection_id = info.upstreamConnectionId().value_or(0);
   stream_intel_.stream_id = static_cast<uint64_t>(stream_handle_);

--- a/library/common/http/client.cc
+++ b/library/common/http/client.cc
@@ -40,6 +40,7 @@ void Client::DirectStreamCallbacks::encodeHeaders(const ResponseHeaderMap& heade
 
   ASSERT(http_client_.getStream(direct_stream_.stream_handle_,
                                 GetStreamFilters::ALLOW_FOR_ALL_STREAMS));
+  direct_stream_.saveLatestStreamIntel();
   if (end_stream) {
     closeStream();
   }
@@ -73,6 +74,7 @@ void Client::DirectStreamCallbacks::encodeData(Buffer::Instance& data, bool end_
 
   ASSERT(http_client_.getStream(direct_stream_.stream_handle_,
                                 GetStreamFilters::ALLOW_FOR_ALL_STREAMS));
+  direct_stream_.saveLatestStreamIntel();
   if (end_stream) {
     closeStream();
   }
@@ -132,6 +134,7 @@ void Client::DirectStreamCallbacks::encodeTrailers(const ResponseTrailerMap& tra
 
   ASSERT(http_client_.getStream(direct_stream_.stream_handle_,
                                 GetStreamFilters::ALLOW_FOR_ALL_STREAMS));
+  direct_stream_.saveLatestStreamIntel();
   closeStream(); // Trailers always indicate the end of the stream.
 
   // For explicit flow control, don't send data unless prompted.
@@ -245,12 +248,14 @@ void Client::DirectStreamCallbacks::onCancel() {
 }
 
 envoy_stream_intel Client::DirectStreamCallbacks::streamIntel() {
-  const auto& info = direct_stream_.request_decoder_->streamInfo();
-  envoy_stream_intel stream_intel{};
-  stream_intel.connection_id = info.upstreamConnectionId().value_or(0);
-  stream_intel.stream_id = static_cast<uint64_t>(direct_stream_.stream_handle_);
-  stream_intel.attempt_count = info.attemptCount().value_or(0);
-  return stream_intel;
+  return direct_stream_.stream_intel_;
+}
+
+void Client::DirectStream::saveStreamIntel() {
+  const auto& info = request_decoder_->streamInfo();
+  stream_intel_.connection_id = info.upstreamConnectionId().value_or(0);
+  stream_intel_.stream_id = static_cast<uint64_t>(stream_handle_);
+  stream_intel_.attempt_count = info.attemptCount().value_or(0);
 }
 
 envoy_error Client::DirectStreamCallbacks::streamError() {

--- a/library/common/http/client.h
+++ b/library/common/http/client.h
@@ -239,6 +239,9 @@ private:
       response_details_ = response_details;
     }
 
+    // Saves latest "Intel" data as it may not be available when accessed.
+    void saveLatestStreamIntel();
+
     const envoy_stream_t stream_handle_;
 
     // Used to issue outgoing HTTP stream operations.
@@ -264,6 +267,8 @@ private:
     // back, avoids excessive buffering of response bodies if the response body is
     // read faster than the mobile caller can process it.
     bool explicit_flow_control_ = false;
+    // Latest intel data retrieved from the InfoStream.
+    envoy_stream_intel stream_intel_;
   };
 
   using DirectStreamSharedPtr = std::shared_ptr<DirectStream>;

--- a/library/common/http/client.h
+++ b/library/common/http/client.h
@@ -267,7 +267,7 @@ private:
     // back, avoids excessive buffering of response bodies if the response body is
     // read faster than the mobile caller can process it.
     bool explicit_flow_control_ = false;
-    // Latest intel data retrieved from the InfoStream.
+    // Latest intel data retrieved from the StreamInfo.
     envoy_stream_intel stream_intel_;
   };
 

--- a/test/java/integration/AndroidEnvoyExplicitFlowTest.java
+++ b/test/java/integration/AndroidEnvoyExplicitFlowTest.java
@@ -68,11 +68,11 @@ public class AndroidEnvoyExplicitFlowTest {
       CountDownLatch latch = new CountDownLatch(1);
       Context appContext = ApplicationProvider.getApplicationContext();
       engine = new AndroidEngineBuilder(appContext)
-          .setOnEngineRunning(() -> {
-            latch.countDown();
-            return null;
-          })
-          .build();
+                   .setOnEngineRunning(() -> {
+                     latch.countDown();
+                     return null;
+                   })
+                   .build();
       latch.await(); // Don't launch a request before initialization has completed.
     }
   }
@@ -86,10 +86,11 @@ public class AndroidEnvoyExplicitFlowTest {
   public void get_simple_bufferLargerThanResponseBody() throws Exception {
     mockWebServer.enqueue(new MockResponse().setBody("hello, world"));
     mockWebServer.start();
-    RequestScenario requestScenario = new RequestScenario()
-        .setHttpMethod(RequestMethod.GET)
-        .setUrl(mockWebServer.url("get/flowers").toString())
-        .setResponseBufferSize(20); // Larger than the response body size
+    RequestScenario requestScenario =
+        new RequestScenario()
+            .setHttpMethod(RequestMethod.GET)
+            .setUrl(mockWebServer.url("get/flowers").toString())
+            .setResponseBufferSize(20); // Larger than the response body size
 
     Response response = sendRequest(requestScenario);
 
@@ -102,10 +103,11 @@ public class AndroidEnvoyExplicitFlowTest {
   public void get_simple_bufferSmallerThanResponseBody() throws Exception {
     mockWebServer.enqueue(new MockResponse().setBody("hello, world"));
     mockWebServer.start();
-    RequestScenario requestScenario = new RequestScenario()
-        .setHttpMethod(RequestMethod.GET)
-        .setUrl(mockWebServer.url("get/flowers").toString())
-        .setResponseBufferSize(4); // Smaller than the response body size
+    RequestScenario requestScenario =
+        new RequestScenario()
+            .setHttpMethod(RequestMethod.GET)
+            .setUrl(mockWebServer.url("get/flowers").toString())
+            .setResponseBufferSize(4); // Smaller than the response body size
 
     Response response = sendRequest(requestScenario);
 
@@ -119,8 +121,8 @@ public class AndroidEnvoyExplicitFlowTest {
     mockWebServer.enqueue(new MockResponse().setResponseCode(200));
     mockWebServer.start();
     RequestScenario requestScenario = new RequestScenario()
-        .setHttpMethod(RequestMethod.GET)
-        .setUrl(mockWebServer.url("get/flowers").toString());
+                                          .setHttpMethod(RequestMethod.GET)
+                                          .setUrl(mockWebServer.url("get/flowers").toString());
 
     Response response = sendRequest(requestScenario);
 
@@ -136,10 +138,11 @@ public class AndroidEnvoyExplicitFlowTest {
     mockWebServer.enqueue(
         new MockResponse().throttleBody(5, 1, TimeUnit.SECONDS).setBody("hello, world"));
     mockWebServer.start();
-    RequestScenario requestScenario = new RequestScenario()
-        .setHttpMethod(RequestMethod.GET)
-        .setUrl(mockWebServer.url("get/flowers").toString())
-        .setResponseBufferSize(6); // Larger than one chunk of the response body size
+    RequestScenario requestScenario =
+        new RequestScenario()
+            .setHttpMethod(RequestMethod.GET)
+            .setUrl(mockWebServer.url("get/flowers").toString())
+            .setResponseBufferSize(6); // Larger than one chunk of the response body size
 
     Response response = sendRequest(requestScenario);
 
@@ -157,10 +160,11 @@ public class AndroidEnvoyExplicitFlowTest {
     mockWebServer.enqueue(
         new MockResponse().throttleBody(5, 1, TimeUnit.SECONDS).setBody("hello, world"));
     mockWebServer.start();
-    RequestScenario requestScenario = new RequestScenario()
-        .setHttpMethod(RequestMethod.GET)
-        .setUrl(mockWebServer.url("get/flowers").toString())
-        .setResponseBufferSize(3); // Smaller than some chunk of the response body size
+    RequestScenario requestScenario =
+        new RequestScenario()
+            .setHttpMethod(RequestMethod.GET)
+            .setUrl(mockWebServer.url("get/flowers").toString())
+            .setResponseBufferSize(3); // Smaller than some chunk of the response body size
 
     Response response = sendRequest(requestScenario);
 
@@ -172,7 +176,7 @@ public class AndroidEnvoyExplicitFlowTest {
     assertThat(response.getNbResponseChunks()).isEqualTo(6); // 3&2 bytes, 3&2 bytes, 2, and 0 bytes
   }
 
-  // TODO(carloseltuerto) Add tests for POST once the Explicit Flow Control gets surfaced.
+  // TODO(carloseltuerto) Add tests for POST once the Explicit Flow Control surfaces.
 
   private Response sendRequest(RequestScenario requestScenario) throws Exception {
     final CountDownLatch latch = new CountDownLatch(1);
@@ -180,41 +184,41 @@ public class AndroidEnvoyExplicitFlowTest {
     final AtomicReference<Stream> streamRef = new AtomicReference<>();
 
     Stream stream = engine.streamClient()
-        .newStreamPrototype()
-        .setOnResponseHeaders((responseHeaders, endStream, ignored) -> {
-          response.get().setHeaders(responseHeaders);
-          if (endStream) {
-            latch.countDown();
-          }
-          streamRef.get().readData(requestScenario.responseBufferSize);
-          return null;
-        })
-        .setOnResponseData((data, endStream, ignored) -> {
-          response.get().addBody(data);
-          if (endStream) {
-            latch.countDown();
-          } else {
-            streamRef.get().readData(requestScenario.responseBufferSize);
-          }
-          return null;
-        })
-        .setOnResponseTrailers((trailers, ignored) -> {
-          response.get().setTrailers(trailers);
-          latch.countDown();
-          return null;
-        })
-        .setOnError((error, ignored) -> {
-          response.get().setEnvoyError(error);
-          latch.countDown();
-          return null;
-        })
-        .setOnCancel((ignored) -> {
-          response.get().setCancelled();
-          latch.countDown();
-          return null;
-        })
-        .setExplicitFlowControl(true)
-        .start(Executors.newSingleThreadExecutor());
+                        .newStreamPrototype()
+                        .setOnResponseHeaders((responseHeaders, endStream, ignored) -> {
+                          response.get().setHeaders(responseHeaders);
+                          if (endStream) {
+                            latch.countDown();
+                          }
+                          streamRef.get().readData(requestScenario.responseBufferSize);
+                          return null;
+                        })
+                        .setOnResponseData((data, endStream, ignored) -> {
+                          response.get().addBody(data);
+                          if (endStream) {
+                            latch.countDown();
+                          } else {
+                            streamRef.get().readData(requestScenario.responseBufferSize);
+                          }
+                          return null;
+                        })
+                        .setOnResponseTrailers((trailers, ignored) -> {
+                          response.get().setTrailers(trailers);
+                          latch.countDown();
+                          return null;
+                        })
+                        .setOnError((error, ignored) -> {
+                          response.get().setEnvoyError(error);
+                          latch.countDown();
+                          return null;
+                        })
+                        .setOnCancel((ignored) -> {
+                          response.get().setCancelled();
+                          latch.countDown();
+                          return null;
+                        })
+                        .setExplicitFlowControl(true)
+                        .start(Executors.newSingleThreadExecutor());
     streamRef.set(stream); // Set before sending headers to avoid race conditions.
     stream.sendHeaders(requestScenario.getHeaders(), !requestScenario.hasBody());
     requestScenario.getBodyChunks().forEach(stream::sendData);
@@ -249,7 +253,7 @@ public class AndroidEnvoyExplicitFlowTest {
 
     Optional<ByteBuffer> getClosingBodyChunk() {
       return closeBodyStream ? Optional.of(bodyChunks.get(bodyChunks.size() - 1))
-          : Optional.empty();
+                             : Optional.empty();
     }
 
     boolean hasBody() { return !bodyChunks.isEmpty(); }
@@ -324,7 +328,7 @@ public class AndroidEnvoyExplicitFlowTest {
     void setCancelled() {
       if (!cancelled.compareAndSet(false, true)) {
         assertionError.compareAndSet(null,
-            new AssertionError("setOnCancel called more than once."));
+                                     new AssertionError("setOnCancel called more than once."));
       }
     }
 

--- a/test/java/integration/AndroidEnvoyExplicitFlowTest.java
+++ b/test/java/integration/AndroidEnvoyExplicitFlowTest.java
@@ -1,0 +1,359 @@
+package integration;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import android.content.Context;
+import androidx.test.core.app.ApplicationProvider;
+import io.envoyproxy.envoymobile.AndroidEngineBuilder;
+import io.envoyproxy.envoymobile.Engine;
+import io.envoyproxy.envoymobile.EnvoyError;
+import io.envoyproxy.envoymobile.RequestHeaders;
+import io.envoyproxy.envoymobile.RequestHeadersBuilder;
+import io.envoyproxy.envoymobile.RequestMethod;
+import io.envoyproxy.envoymobile.ResponseHeaders;
+import io.envoyproxy.envoymobile.ResponseTrailers;
+import io.envoyproxy.envoymobile.Stream;
+import io.envoyproxy.envoymobile.UpstreamHttpProtocol;
+import io.envoyproxy.envoymobile.engine.AndroidJniLibrary;
+import java.io.IOException;
+import java.net.MalformedURLException;
+import java.net.URL;
+import java.nio.ByteBuffer;
+import java.util.AbstractMap.SimpleImmutableEntry;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicReference;
+import okhttp3.mockwebserver.Dispatcher;
+import okhttp3.mockwebserver.MockResponse;
+import okhttp3.mockwebserver.MockWebServer;
+import okhttp3.mockwebserver.RecordedRequest;
+import org.junit.After;
+import org.junit.AfterClass;
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.Ignore;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.robolectric.RobolectricTestRunner;
+
+@RunWith(RobolectricTestRunner.class)
+public class AndroidEnvoyExplicitFlowTest {
+
+  private static Engine engine;
+
+  private final MockWebServer mockWebServer = new MockWebServer();
+
+  @BeforeClass
+  public static void loadJniLibrary() {
+    AndroidJniLibrary.loadTestLibrary();
+  }
+
+  @AfterClass
+  public static void shutdownEngine() {
+    if (engine != null) {
+      engine.terminate();
+    }
+  }
+
+  @Before
+  public void setUpEngine() throws Exception {
+    if (engine == null) {
+      CountDownLatch latch = new CountDownLatch(1);
+      Context appContext = ApplicationProvider.getApplicationContext();
+      engine = new AndroidEngineBuilder(appContext)
+          .setOnEngineRunning(() -> {
+            latch.countDown();
+            return null;
+          })
+          .build();
+      latch.await(); // Don't launch a request before initialization has completed.
+    }
+  }
+
+  @After
+  public void shutdownMockWebServer() throws IOException {
+    mockWebServer.shutdown();
+  }
+
+  @Test
+  public void get_simple_bufferLargerThanResponseBody() throws Exception {
+    mockWebServer.enqueue(new MockResponse().setBody("hello, world"));
+    mockWebServer.start();
+    RequestScenario requestScenario = new RequestScenario()
+        .setHttpMethod(RequestMethod.GET)
+        .setUrl(mockWebServer.url("get/flowers").toString())
+        .setResponseBufferSize(20); // Larger than the response body size
+
+    Response response = sendRequest(requestScenario);
+
+    assertThat(response.getHeaders().getHttpStatus()).isEqualTo(200);
+    assertThat(response.getBodyAsString()).isEqualTo("hello, world");
+    assertThat(response.getEnvoyError()).isNull();
+  }
+
+  @Test
+  public void get_simple_bufferSmallerThanResponseBody() throws Exception {
+    mockWebServer.enqueue(new MockResponse().setBody("hello, world"));
+    mockWebServer.start();
+    RequestScenario requestScenario = new RequestScenario()
+        .setHttpMethod(RequestMethod.GET)
+        .setUrl(mockWebServer.url("get/flowers").toString())
+        .setResponseBufferSize(4); // Smaller than the response body size
+
+    Response response = sendRequest(requestScenario);
+
+    assertThat(response.getHeaders().getHttpStatus()).isEqualTo(200);
+    assertThat(response.getBodyAsString()).isEqualTo("hello, world");
+    assertThat(response.getEnvoyError()).isNull();
+  }
+
+  @Test
+  public void get_noBody() throws Exception {
+    mockWebServer.enqueue(new MockResponse().setResponseCode(200));
+    mockWebServer.start();
+    RequestScenario requestScenario = new RequestScenario()
+        .setHttpMethod(RequestMethod.GET)
+        .setUrl(mockWebServer.url("get/flowers").toString());
+
+    Response response = sendRequest(requestScenario);
+
+    assertThat(response.getHeaders().getHttpStatus()).isEqualTo(200);
+    assertThat(response.getBodyAsString()).isEmpty();
+    assertThat(response.getEnvoyError()).isNull();
+    assertThat(response.getNbResponseChunks()).isZero();
+  }
+
+  @Test
+  public void get_withThrottledBodyResponse_bufferLargerThanResponseBody() throws Exception {
+    // Note: throttle must be long enough to trickle the chunking. Chunk size is 5 bytes.
+    mockWebServer.enqueue(
+        new MockResponse().throttleBody(5, 1, TimeUnit.SECONDS).setBody("hello, world"));
+    mockWebServer.start();
+    RequestScenario requestScenario = new RequestScenario()
+        .setHttpMethod(RequestMethod.GET)
+        .setUrl(mockWebServer.url("get/flowers").toString())
+        .setResponseBufferSize(6); // Larger than one chunk of the response body size
+
+    Response response = sendRequest(requestScenario);
+
+    assertThat(response.getHeaders().getHttpStatus()).isEqualTo(200);
+    assertThat(response.getBodyAsString()).isEqualTo("hello, world");
+    assertThat(response.getEnvoyError()).isNull();
+    // A "terminating" empty buffer is systematically sent through the setOnResponseData callback.
+    // See: https://github.com/envoyproxy/envoy-mobile/issues/1393
+    assertThat(response.getNbResponseChunks()).isEqualTo(4); // 5 bytes, 5 bytes, 2, and 0 bytes
+  }
+
+  @Test
+  public void get_withThrottledBodyResponse_bufferSmallerThanResponseBody() throws Exception {
+    // Note: throttle must be long enough to trickle the chunking.
+    mockWebServer.enqueue(
+        new MockResponse().throttleBody(5, 1, TimeUnit.SECONDS).setBody("hello, world"));
+    mockWebServer.start();
+    RequestScenario requestScenario = new RequestScenario()
+        .setHttpMethod(RequestMethod.GET)
+        .setUrl(mockWebServer.url("get/flowers").toString())
+        .setResponseBufferSize(3); // Smaller than some chunk of the response body size
+
+    Response response = sendRequest(requestScenario);
+
+    assertThat(response.getHeaders().getHttpStatus()).isEqualTo(200);
+    assertThat(response.getBodyAsString()).isEqualTo("hello, world");
+    assertThat(response.getEnvoyError()).isNull();
+    // A "terminating" empty buffer is systematically sent through the setOnResponseData callback.
+    // See: https://github.com/envoyproxy/envoy-mobile/issues/1393
+    assertThat(response.getNbResponseChunks()).isEqualTo(6); // 3&2 bytes, 3&2 bytes, 2, and 0 bytes
+  }
+
+  // TODO(carloseltuerto) Add tests for POST once the Explicit Flow Control gets surfaced.
+
+  private Response sendRequest(RequestScenario requestScenario) throws Exception {
+    final CountDownLatch latch = new CountDownLatch(1);
+    final AtomicReference<Response> response = new AtomicReference<>(new Response());
+    final AtomicReference<Stream> streamRef = new AtomicReference<>();
+
+    Stream stream = engine.streamClient()
+        .newStreamPrototype()
+        .setOnResponseHeaders((responseHeaders, endStream, ignored) -> {
+          response.get().setHeaders(responseHeaders);
+          if (endStream) {
+            latch.countDown();
+          }
+          streamRef.get().readData(requestScenario.responseBufferSize);
+          return null;
+        })
+        .setOnResponseData((data, endStream, ignored) -> {
+          response.get().addBody(data);
+          if (endStream) {
+            latch.countDown();
+          } else {
+            streamRef.get().readData(requestScenario.responseBufferSize);
+          }
+          return null;
+        })
+        .setOnResponseTrailers((trailers, ignored) -> {
+          response.get().setTrailers(trailers);
+          latch.countDown();
+          return null;
+        })
+        .setOnError((error, ignored) -> {
+          response.get().setEnvoyError(error);
+          latch.countDown();
+          return null;
+        })
+        .setOnCancel((ignored) -> {
+          response.get().setCancelled();
+          latch.countDown();
+          return null;
+        })
+        .setExplicitFlowControl(true)
+        .start(Executors.newSingleThreadExecutor());
+    streamRef.set(stream); // Set before sending headers to avoid race conditions.
+    stream.sendHeaders(requestScenario.getHeaders(), !requestScenario.hasBody());
+    requestScenario.getBodyChunks().forEach(stream::sendData);
+    requestScenario.getClosingBodyChunk().ifPresent(stream::close);
+
+    latch.await();
+    response.get().throwAssertionErrorIfAny();
+    return response.get();
+  }
+
+  private static class RequestScenario {
+    private URL url;
+    private RequestMethod method = null;
+    private final List<ByteBuffer> bodyChunks = new ArrayList<>();
+    private final List<Map.Entry<String, String>> headers = new ArrayList<>();
+    private boolean closeBodyStream = false;
+    private int responseBufferSize = 1000;
+
+    RequestHeaders getHeaders() {
+      RequestHeadersBuilder requestHeadersBuilder =
+          new RequestHeadersBuilder(method, url.getProtocol(), url.getAuthority(), url.getPath());
+      headers.forEach(entry -> requestHeadersBuilder.add(entry.getKey(), entry.getValue()));
+      // HTTP1 is the only way to send HTTP requests (not HTTPS)
+      return requestHeadersBuilder.addUpstreamHttpProtocol(UpstreamHttpProtocol.HTTP1).build();
+    }
+
+    List<ByteBuffer> getBodyChunks() {
+      return closeBodyStream
+          ? Collections.unmodifiableList(bodyChunks.subList(0, bodyChunks.size() - 1))
+          : Collections.unmodifiableList(bodyChunks);
+    }
+
+    Optional<ByteBuffer> getClosingBodyChunk() {
+      return closeBodyStream ? Optional.of(bodyChunks.get(bodyChunks.size() - 1))
+          : Optional.empty();
+    }
+
+    boolean hasBody() { return !bodyChunks.isEmpty(); }
+
+    RequestScenario setHttpMethod(RequestMethod requestMethod) {
+      this.method = requestMethod;
+      return this;
+    }
+
+    RequestScenario setUrl(String url) throws MalformedURLException {
+      this.url = new URL(url);
+      return this;
+    }
+
+    RequestScenario addBody(byte[] requestBodyChunk) {
+      ByteBuffer byteBuffer = ByteBuffer.allocateDirect(requestBodyChunk.length);
+      byteBuffer.put(requestBodyChunk);
+      bodyChunks.add(byteBuffer);
+      return this;
+    }
+
+    RequestScenario addBody(String requestBodyChunk) {
+      return addBody(requestBodyChunk.getBytes());
+    }
+
+    RequestScenario addHeader(String key, String value) {
+      headers.add(new SimpleImmutableEntry<>(key, value));
+      return this;
+    }
+
+    RequestScenario setResponseBufferSize(int responseBufferSize) {
+      this.responseBufferSize = responseBufferSize;
+      return this;
+    }
+
+    RequestScenario closeBodyStream() {
+      closeBodyStream = true;
+      return this;
+    }
+  }
+
+  private static class Response {
+    private final AtomicReference<ResponseHeaders> headers = new AtomicReference<>();
+    private final AtomicReference<ResponseTrailers> trailers = new AtomicReference<>();
+    private final AtomicReference<EnvoyError> envoyError = new AtomicReference<>();
+    private final List<ByteBuffer> bodies = new ArrayList<>();
+    private final AtomicBoolean cancelled = new AtomicBoolean(false);
+    private final AtomicReference<AssertionError> assertionError = new AtomicReference<>();
+
+    void setHeaders(ResponseHeaders headers) {
+      if (!this.headers.compareAndSet(null, headers)) {
+        assertionError.compareAndSet(
+            null, new AssertionError("setOnResponseHeaders called more than once."));
+      }
+    }
+
+    void addBody(ByteBuffer body) { bodies.add(body); }
+
+    void setTrailers(ResponseTrailers trailers) {
+      if (!this.trailers.compareAndSet(null, trailers)) {
+        assertionError.compareAndSet(
+            null, new AssertionError("setOnResponseTrailers called more than once."));
+      }
+    }
+
+    void setEnvoyError(EnvoyError envoyError) {
+      if (!this.envoyError.compareAndSet(null, envoyError)) {
+        assertionError.compareAndSet(null, new AssertionError("setOnError called more than once."));
+      }
+    }
+
+    void setCancelled() {
+      if (!cancelled.compareAndSet(false, true)) {
+        assertionError.compareAndSet(null,
+            new AssertionError("setOnCancel called more than once."));
+      }
+    }
+
+    EnvoyError getEnvoyError() { return envoyError.get(); }
+
+    ResponseHeaders getHeaders() { return headers.get(); }
+
+    ResponseTrailers getTrailers() { return trailers.get(); }
+
+    boolean isCancelled() { return cancelled.get(); }
+
+    String getBodyAsString() {
+      int totalSize = bodies.stream().mapToInt(ByteBuffer::limit).sum();
+      byte[] body = new byte[totalSize];
+      int pos = 0;
+      for (ByteBuffer buffer : bodies) {
+        int bytesToRead = buffer.limit();
+        buffer.get(body, pos, bytesToRead);
+        pos += bytesToRead;
+      }
+      return new String(body);
+    }
+
+    int getNbResponseChunks() { return bodies.size(); }
+
+    void throwAssertionErrorIfAny() {
+      if (assertionError.get() != null) {
+        throw assertionError.get();
+      }
+    }
+  }
+}

--- a/test/java/integration/BUILD
+++ b/test/java/integration/BUILD
@@ -32,3 +32,17 @@ envoy_mobile_android_test(
         "//library/kotlin/io/envoyproxy/envoymobile:envoy_lib",
     ],
 )
+
+envoy_mobile_android_test(
+    name = "android_engine_explicit_flow_test",
+    srcs = [
+        "AndroidEnvoyExplicitFlowTest.java",
+    ],
+    native_deps = [
+        "//library/common/jni:libndk_envoy_jni.so",
+        "//library/common/jni:libndk_envoy_jni.jnilib",
+    ],
+    deps = [
+        "//library/kotlin/io/envoyproxy/envoymobile:envoy_lib",
+    ],
+)


### PR DESCRIPTION
- Comes with a specific Envoy Mobile test for Explicit Flow Control.
- bonus: fixes a bug: the wrong `end_stream` boolean was sent to the callback.

Description: Solve crashes for explicit flow control 
Risk Level: small - better than crashes for sure.
Testing: CI
Docs Changes: N/A
Release Notes: N/A
Signed-off-by: Charles Le Borgne <cleborgne@google.com>