### PR TITLE
bazel: remove unnecessary rules_foreign_cc load

### DIFF
--- a/bazel/envoy_mobile_swift_bazel_support.bzl
+++ b/bazel/envoy_mobile_swift_bazel_support.bzl
@@ -1,9 +1,6 @@
-load("@rules_foreign_cc//:workspace_definitions.bzl", "rules_foreign_cc_dependencies")
 load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
 
 def swift_support():
-    rules_foreign_cc_dependencies()
-
     http_archive(
         name = "build_bazel_apple_support",
         sha256 = "595a6652d8d65380a3d764826bf1a856a8cc52371bbd961dfcd942fdb14bc133",


### PR DESCRIPTION
This is covered by envoy's dependencies. I don't see any reason why we
need to force it to load earlier or differently from when envoy would do
it.

Signed-off-by: Keith Smiley <keithbsmiley@gmail.com>