### PR TITLE
ci: use $ANDROID_HOME relative sdkmanager

### DIFF
--- a/ci/mac_start_emulator.sh
+++ b/ci/mac_start_emulator.sh
@@ -2,7 +2,7 @@
 
 set -e
 
-echo "y" | $ANDROID_SDK_ROOT/cmdline-tools/latest/bin/sdkmanager --install 'system-images;android-29;google_apis;x86' --channel=3
+echo "y" | $ANDROID_HOME/tools/bin/sdkmanager --install 'system-images;android-29;google_apis;x86' --channel=3
 echo "no" | $ANDROID_HOME/tools/bin/avdmanager create avd -n test_android_emulator -k 'system-images;android-29;google_apis;x86' --force
 ls $ANDROID_HOME/tools/bin/
 nohup $ANDROID_HOME/emulator/emulator -partition-size 1024 -avd test_android_emulator -no-snapshot > /dev/null 2>&1 & $ANDROID_HOME/platform-tools/adb wait-for-device shell 'while [[ -z $(getprop sys.boot_completed | tr -d '\r') ]]; do sleep 1; done; input keyevent 82'


### PR DESCRIPTION
These should be the same, but this one is installed by default