### PR TITLE
header handling: prevent nil header value crashes in obj-c

### DIFF
--- a/library/objective-c/EnvoyBridgeUtility.h
+++ b/library/objective-c/EnvoyBridgeUtility.h
@@ -127,13 +127,17 @@ static inline EnvoyHeaders *to_ios_headers(envoy_headers headers) {
     NSString *headerValue = [[NSString alloc] initWithBytes:header.value.bytes
                                                      length:header.value.length
                                                    encoding:NSUTF8StringEncoding];
-    // Ensure list is present in dictionary value
-    NSMutableArray *headerValueList = headerDict[headerKey];
-    if (headerValueList == nil) {
-      headerValueList = [NSMutableArray new];
-      headerDict[headerKey] = headerValueList;
+    // TODO: https://github.com/envoyproxy/envoy-mobile/issues/1825. All header values passed in
+    // here should be valid.
+    if (headerKey != nil && headerValue != nil) {
+      // Ensure list is present in dictionary value
+      NSMutableArray *headerValueList = headerDict[headerKey];
+      if (headerValueList == nil) {
+        headerValueList = [NSMutableArray new];
+        headerDict[headerKey] = headerValueList;
+      }
+      [headerValueList addObject:headerValue];
     }
-    [headerValueList addObject:headerValue];
   }
   // The C envoy_headers struct can be released now because the headers have been copied.
   release_envoy_headers(headers);


### PR DESCRIPTION
Signed-off-by: Jose Nino <jnino@lyft.com>