### PR TITLE
network: wire interface binding config through core filter

### DIFF
--- a/library/common/config/config.cc
+++ b/library/common/config/config.cc
@@ -39,6 +39,7 @@ const std::string config_header = R"(
 - &dns_fail_max_interval 10s
 - &dns_query_timeout 25s
 - &dns_preresolve_hostnames []
+- &enable_interface_binding false
 - &h2_connection_keepalive_idle_interval 100000s
 - &h2_connection_keepalive_timeout 10s
 - &metadata {}
@@ -238,6 +239,7 @@ static_resources:
           - name: envoy.filters.http.network_configuration
             typed_config:
               "@type": type.googleapis.com/envoymobile.extensions.filters.http.network_configuration.NetworkConfiguration
+              enable_interface_binding: *enable_interface_binding
           - name: envoy.filters.http.local_error
             typed_config:
               "@type": type.googleapis.com/envoymobile.extensions.filters.http.local_error.LocalError

--- a/library/common/extensions/filters/http/network_configuration/config.cc
+++ b/library/common/extensions/filters/http/network_configuration/config.cc
@@ -8,14 +8,17 @@ namespace HttpFilters {
 namespace NetworkConfiguration {
 
 Http::FilterFactoryCb NetworkConfigurationFilterFactory::createFilterFactoryFromProtoTyped(
-    const envoymobile::extensions::filters::http::network_configuration::NetworkConfiguration& proto_config,
+    const envoymobile::extensions::filters::http::network_configuration::NetworkConfiguration&
+        proto_config,
     const std::string&, Server::Configuration::FactoryContext& context) {
 
   auto network_configurator = Network::ConfiguratorHandle{context}.get();
   bool enable_interface_binding = proto_config.enable_interface_binding();
 
-  return [network_configurator, enable_interface_binding](Http::FilterChainFactoryCallbacks& callbacks) -> void {
-    callbacks.addStreamFilter(std::make_shared<NetworkConfigurationFilter>(network_configurator, enable_interface_binding));
+  return [network_configurator,
+          enable_interface_binding](Http::FilterChainFactoryCallbacks& callbacks) -> void {
+    callbacks.addStreamFilter(std::make_shared<NetworkConfigurationFilter>(
+        network_configurator, enable_interface_binding));
   };
 }
 

--- a/library/common/extensions/filters/http/network_configuration/config.cc
+++ b/library/common/extensions/filters/http/network_configuration/config.cc
@@ -8,13 +8,14 @@ namespace HttpFilters {
 namespace NetworkConfiguration {
 
 Http::FilterFactoryCb NetworkConfigurationFilterFactory::createFilterFactoryFromProtoTyped(
-    const envoymobile::extensions::filters::http::network_configuration::NetworkConfiguration&,
+    const envoymobile::extensions::filters::http::network_configuration::NetworkConfiguration& proto_config,
     const std::string&, Server::Configuration::FactoryContext& context) {
 
   auto network_configurator = Network::ConfiguratorHandle{context}.get();
+  bool enable_interface_binding = proto_config.enable_interface_binding();
 
-  return [network_configurator](Http::FilterChainFactoryCallbacks& callbacks) -> void {
-    callbacks.addStreamFilter(std::make_shared<NetworkConfigurationFilter>(network_configurator));
+  return [network_configurator, enable_interface_binding](Http::FilterChainFactoryCallbacks& callbacks) -> void {
+    callbacks.addStreamFilter(std::make_shared<NetworkConfigurationFilter>(network_configurator, enable_interface_binding));
   };
 }
 

--- a/library/common/extensions/filters/http/network_configuration/filter.cc
+++ b/library/common/extensions/filters/http/network_configuration/filter.cc
@@ -18,7 +18,8 @@ Http::FilterHeadersStatus NetworkConfigurationFilter::decodeHeaders(Http::Reques
   }
   ENVOY_LOG(debug, "will override interface: {}", override_interface_);
 
-  auto connection_options = network_configurator_->getUpstreamSocketOptions(network, override_interface_);
+  auto connection_options =
+      network_configurator_->getUpstreamSocketOptions(network, override_interface_);
   decoder_callbacks_->addUpstreamSocketOptions(connection_options);
 
   return Http::FilterHeadersStatus::Continue;

--- a/library/common/extensions/filters/http/network_configuration/filter.cc
+++ b/library/common/extensions/filters/http/network_configuration/filter.cc
@@ -13,7 +13,12 @@ Http::FilterHeadersStatus NetworkConfigurationFilter::decodeHeaders(Http::Reques
   envoy_network_t network = network_configurator_->getPreferredNetwork();
   ENVOY_LOG(debug, "current preferred network: {}", network);
 
-  auto connection_options = network_configurator_->getUpstreamSocketOptions(network);
+  if (enable_interface_binding_) {
+    override_interface_ = network_configurator_->overrideInterface(network);
+  }
+  ENVOY_LOG(debug, "will override interface: {}", override_interface_);
+
+  auto connection_options = network_configurator_->getUpstreamSocketOptions(network, override_interface_);
   decoder_callbacks_->addUpstreamSocketOptions(connection_options);
 
   return Http::FilterHeadersStatus::Continue;

--- a/library/common/extensions/filters/http/network_configuration/filter.h
+++ b/library/common/extensions/filters/http/network_configuration/filter.h
@@ -20,8 +20,10 @@ namespace NetworkConfiguration {
 class NetworkConfigurationFilter final : public Http::PassThroughFilter,
                                          public Logger::Loggable<Logger::Id::filter> {
 public:
-  NetworkConfigurationFilter(Network::ConfiguratorSharedPtr network_configurator, bool enable_interface_binding)
-      : network_configurator_(network_configurator), enable_interface_binding_(enable_interface_binding), override_interface_(false) {}
+  NetworkConfigurationFilter(Network::ConfiguratorSharedPtr network_configurator,
+                             bool enable_interface_binding)
+      : network_configurator_(network_configurator),
+        enable_interface_binding_(enable_interface_binding), override_interface_(false) {}
 
   // Http::StreamDecoderFilter
   Http::FilterHeadersStatus decodeHeaders(Http::RequestHeaderMap& headers,

--- a/library/common/extensions/filters/http/network_configuration/filter.h
+++ b/library/common/extensions/filters/http/network_configuration/filter.h
@@ -20,8 +20,8 @@ namespace NetworkConfiguration {
 class NetworkConfigurationFilter final : public Http::PassThroughFilter,
                                          public Logger::Loggable<Logger::Id::filter> {
 public:
-  NetworkConfigurationFilter(Network::ConfiguratorSharedPtr network_configurator)
-      : network_configurator_(network_configurator) {}
+  NetworkConfigurationFilter(Network::ConfiguratorSharedPtr network_configurator, bool enable_interface_binding)
+      : network_configurator_(network_configurator), enable_interface_binding_(enable_interface_binding), override_interface_(false) {}
 
   // Http::StreamDecoderFilter
   Http::FilterHeadersStatus decodeHeaders(Http::RequestHeaderMap& headers,
@@ -29,6 +29,8 @@ public:
 
 private:
   Network::ConfiguratorSharedPtr network_configurator_;
+  bool enable_interface_binding_;
+  bool override_interface_;
 };
 
 } // namespace NetworkConfiguration

--- a/library/common/extensions/filters/http/network_configuration/filter.proto
+++ b/library/common/extensions/filters/http/network_configuration/filter.proto
@@ -3,4 +3,7 @@ syntax = "proto3";
 package envoymobile.extensions.filters.http.network_configuration;
 
 message NetworkConfiguration {
+  // If set to true, the filter will permit the NetworkConfigurator to provide upstream
+  // socket option that MAY bind a connection to a specific network interface.
+  bool enable_interface_binding = 1;
 }

--- a/library/common/network/configurator.cc
+++ b/library/common/network/configurator.cc
@@ -74,6 +74,8 @@ envoy_network_t Configurator::setPreferredNetwork(envoy_network_t network) {
 
 envoy_network_t Configurator::getPreferredNetwork() { return preferred_network_.load(); }
 
+bool Configurator::overrideInterface(envoy_network_t) { return false; }
+
 void Configurator::refreshDns(envoy_network_t network) {
   // refreshDns is intended to be queued on Envoy's event loop, whereas preferred_network_ is
   // updated synchronously. In the event that multiple refreshes become queued on the event loop,
@@ -100,7 +102,7 @@ std::vector<std::string> Configurator::enumerateV6Interfaces() {
   return enumerateInterfaces(AF_INET6);
 }
 
-Socket::OptionsSharedPtr Configurator::getUpstreamSocketOptions(envoy_network_t network) {
+Socket::OptionsSharedPtr Configurator::getUpstreamSocketOptions(envoy_network_t network, bool) {
   // Envoy uses the hash signature of overridden socket options to choose a connection pool.
   // Setting a dummy socket option is a hack that allows us to select a different
   // connection pool without materially changing the socket configuration.

--- a/library/common/network/configurator.h
+++ b/library/common/network/configurator.h
@@ -58,7 +58,8 @@ public:
   /**
    * @returns the current socket options that should be used for connections.
    */
-  Socket::OptionsSharedPtr getUpstreamSocketOptions(envoy_network_t network, bool override_interface);
+  Socket::OptionsSharedPtr getUpstreamSocketOptions(envoy_network_t network,
+                                                    bool override_interface);
 
 private:
   std::vector<std::string> enumerateInterfaces(unsigned short family);

--- a/library/common/network/configurator.h
+++ b/library/common/network/configurator.h
@@ -39,6 +39,11 @@ public:
   envoy_network_t getPreferredNetwork();
 
   /**
+   * @returns whether to override the specified network interface based on internal heuristics.
+   */
+  bool overrideInterface(envoy_network_t network);
+
+  /**
    * Sets the current OS default/preferred network class.
    * @param network, the network preference.
    */
@@ -53,7 +58,7 @@ public:
   /**
    * @returns the current socket options that should be used for connections.
    */
-  Socket::OptionsSharedPtr getUpstreamSocketOptions(envoy_network_t network);
+  Socket::OptionsSharedPtr getUpstreamSocketOptions(envoy_network_t network, bool override_interface);
 
 private:
   std::vector<std::string> enumerateInterfaces(unsigned short family);


### PR DESCRIPTION
Description: Pass interface binding configuration and state through the NetworkConfiguration filter to the NetworkConfigurator. Down the road, we may want to have a dedicated extension for configuring this sort of thing.
Risk Level: Low
Testing: Existing integration.

Signed-off-by: Mike Schore <mike.schore@gmail.com>