### PR TITLE
bazel: Fix absolute Swift paths

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -7,8 +7,7 @@ build --define=hot_restart=disabled
 build --define=tcmalloc=disabled
 build --features=debug_prefix_map_pwd_is_dot
 build --features=swift.cacheable_swiftmodules
-# Remove once https://github.com/bazelbuild/rules_swift/pull/427 is merged
-build --swiftcopt=-Xfrontend --swiftcopt=-no-serialize-debugging-options
+build --features=swift.debug_prefix_map
 build --host_force_python=PY3
 build --ios_minimum_os=11.0
 build --ios_simulator_device="iPhone 12"


### PR DESCRIPTION
This enables -debug-prefix-map to rewrite Swift compile's pwd to .,
similar to what we were already doing for C++ with
debug_prefix_map_pwd_is_dot

Signed-off-by: Keith Smiley <keithbsmiley@gmail.com>