### PR TITLE
Fix getifaddrs to return all addresses

### DIFF
--- a/library/common/engine.cc
+++ b/library/common/engine.cc
@@ -302,13 +302,15 @@ void Engine::drainConnections() {
 
 void Engine::logInterfaces() {
   auto v4_vec = network_configurator_->enumerateV4Interfaces();
-  std::string v4_names = std::accumulate(v4_vec.begin(), v4_vec.end(), std::string{},
+  auto v4_vec_unique_end = std::unique(v4_vec.begin(), v4_vec.end());
+  std::string v4_names = std::accumulate(v4_vec.begin(), v4_vec_unique_end, std::string{},
                                          [](std::string acc, std::string next) {
                                            return acc.empty() ? next : std::move(acc) + "," + next;
                                          });
 
   auto v6_vec = network_configurator_->enumerateV6Interfaces();
-  std::string v6_names = std::accumulate(v6_vec.begin(), v6_vec.end(), std::string{},
+  auto v6_vec_unique_end = std::unique(v6_vec.begin(), v6_vec.end());
+  std::string v6_names = std::accumulate(v6_vec.begin(), v6_vec_unique_end, std::string{},
                                          [](std::string acc, std::string next) {
                                            return acc.empty() ? next : std::move(acc) + "," + next;
                                          });

--- a/third_party/android/ifaddrs-android.h
+++ b/third_party/android/ifaddrs-android.h
@@ -198,7 +198,7 @@ inline int getifaddrs(ifaddrs** result) {
                     rtattr* rta = IFA_RTA(address);
                     size_t ifaPayloadLength = IFA_PAYLOAD(hdr);
                     while (RTA_OK(rta, ifaPayloadLength)) {
-                        if (rta->rta_type == IFA_LOCAL) {
+                        if (rta->rta_type == IFA_ADDRESS) {
                             int family = address->ifa_family;
                             if (family == AF_INET || family == AF_INET6) {
                                 *result = new ifaddrs(*result);


### PR DESCRIPTION
Description:

As of today the third party implementation of `getifaddrs` we are using
returns interfaces but doesn't iterate over all addresses so the v6_vec
is always empty given that the kernel always returns v4 first.

Risk Level: Low
Docs Changes: No
