### PR TITLE
docs: Upgrade Dokka to 1.5.31

### DIFF
--- a/bazel/android_artifacts.bzl
+++ b/bazel/android_artifacts.bzl
@@ -1,3 +1,4 @@
+load("@envoy_mobile//bazel:dokka.bzl", "sources_javadocs")
 load("@rules_java//java:defs.bzl", "java_binary")
 load("@rules_cc//cc:defs.bzl", "cc_library")
 load("@google_bazel_common//tools/maven:pom_file.bzl", "pom_file")
@@ -242,6 +243,7 @@ def _create_classes_jar(name, manifest, android_library):
 def _create_sources_javadocs(name, android_library):
     """
     Creates the sources.jar and javadocs.jar for the provided android library.
+
     This rule generates a sources jar first using a proxy java_binary's result and then uses
     kotlin/dokka's CLI tool to generate javadocs from the sources.jar.
 
@@ -259,26 +261,9 @@ def _create_sources_javadocs(name, android_library):
     )
 
     # This takes all the source files from the source jar and creates a javadoc.jar from it
-    native.genrule(
+    sources_javadocs(
         name = _javadocs_name,
-        srcs = [_sources_name + "_deploy-src.jar"],
-        outs = [_javadocs_name + ".jar"],
-        message = "Generating javadocs...",
-        cmd = """
-        original_directory=$$PWD
-        sources_dir=$$(mktemp -d)
-        unzip $(SRCS) -d $$sources_dir > /dev/null
-        tmp_dir=$$(mktemp -d)
-        java -jar $(location @kotlin_dokka//jar) \
-            $$sources_dir \
-            -format javadoc \
-            -noStdlibLink -noJdkLink \
-            -output $$tmp_dir > /dev/null
-        cd $$tmp_dir
-        zip -r $$original_directory/$@ . > /dev/null
-        """,
-        local = True,
-        tools = ["@kotlin_dokka//jar"],
+        sources_jar = _sources_name + "_deploy-src.jar",
     )
 
     return _sources_name, _javadocs_name

--- a/bazel/dokka.bzl
+++ b/bazel/dokka.bzl
@@ -1,0 +1,113 @@
+def _sources_javadocs_impl(ctx):
+    javabase = ctx.attr._javabase[java_common.JavaRuntimeInfo]
+    plugins_classpath = ";".join([
+        ctx.file._dokka_base_jar.path,
+        ctx.file._dokka_analysis_jar.path,
+        ctx.file._dokka_kotlin_as_java_jar.path,
+        ctx.file._dokka_analysis_intellij_jar.path,
+        ctx.file._dokka_analysis_compiler_jar.path,
+        ctx.file._korte_jvm_jar.path,
+        ctx.file._dokka_javadoc_jar.path,
+    ])
+    output_jar = ctx.actions.declare_file("{}.jar".format(ctx.attr.name))
+
+    ctx.actions.run_shell(
+        command = """
+        set -euo pipefail
+
+        java=$1
+        dokka_cli_jar=$2
+        plugin_classpath=$3
+        sources_jar=$4
+        output_jar=$5
+
+        sources_dir=$(mktemp -d)
+        tmp_dir=$(mktemp -d)
+        trap 'rm -rf "$sources_dir" "$tmp_dir"' EXIT
+
+        unzip $sources_jar -d $sources_dir > /dev/null
+
+        $java \
+            -jar $dokka_cli_jar \
+            -pluginsClasspath $plugin_classpath \
+            -moduleName "Envoy Mobile" \
+            -sourceSet "-src $sources_dir -noStdlibLink -noJdkLink" \
+            -outputDir $tmp_dir > /dev/null
+
+        original_directory=$PWD
+        cd $tmp_dir
+        zip -r $original_directory/$output_jar . > /dev/null
+        """,
+        arguments = [
+            javabase.java_executable_exec_path,
+            ctx.file._dokka_cli_jar.path,
+            plugins_classpath,
+            ctx.file.sources_jar.path,
+            output_jar.path,
+        ],
+        inputs = [
+            ctx.file._dokka_cli_jar,
+            ctx.file._dokka_base_jar,
+            ctx.file._dokka_analysis_jar,
+            ctx.file._dokka_kotlin_as_java_jar,
+            ctx.file._dokka_analysis_intellij_jar,
+            ctx.file._dokka_analysis_compiler_jar,
+            ctx.file._korte_jvm_jar,
+            ctx.file._dokka_javadoc_jar,
+            ctx.file.sources_jar,
+        ] + ctx.files._javabase,
+        outputs = [output_jar],
+        mnemonic = "EnvoyMobileDokka",
+        progress_message = "Generating javadocs...",
+    )
+
+    return [
+        DefaultInfo(files = depset([output_jar])),
+    ]
+
+sources_javadocs = rule(
+    implementation = _sources_javadocs_impl,
+    attrs = {
+        "sources_jar": attr.label(allow_single_file = True),
+        # Dokka CLI
+        "_dokka_cli_jar": attr.label(
+            default = "@maven//:org_jetbrains_dokka_dokka_cli",
+            allow_single_file = True,
+        ),
+        # Dokka Javadoc plugin and dependencies
+        "_dokka_analysis_jar": attr.label(
+            default = "@maven//:org_jetbrains_dokka_dokka_analysis",
+            allow_single_file = True,
+        ),
+        "_dokka_analysis_compiler_jar": attr.label(
+            default = "@maven//:org_jetbrains_dokka_kotlin_analysis_compiler",
+            allow_single_file = True,
+        ),
+        "_dokka_analysis_intellij_jar": attr.label(
+            default = "@maven//:org_jetbrains_dokka_kotlin_analysis_intellij",
+            allow_single_file = True,
+        ),
+        "_dokka_base_jar": attr.label(
+            default = "@maven//:org_jetbrains_dokka_dokka_base",
+            allow_single_file = True,
+        ),
+        "_dokka_javadoc_jar": attr.label(
+            default = "@maven//:org_jetbrains_dokka_javadoc_plugin",
+            allow_single_file = True,
+        ),
+        "_dokka_kotlin_as_java_jar": attr.label(
+            default = "@maven//:org_jetbrains_dokka_kotlin_as_java_plugin",
+            allow_single_file = True,
+        ),
+        "_korte_jvm_jar": attr.label(
+            default = "@maven//:com_soywiz_korlibs_korte_korte_jvm",
+            allow_single_file = True,
+        ),
+        # Java Runtime
+        "_javabase": attr.label(
+            default = Label("@bazel_tools//tools/jdk:current_java_runtime"),
+            allow_files = True,
+            providers = [java_common.JavaRuntimeInfo],
+        ),
+    },
+)

--- a/bazel/envoy_mobile_dependencies.bzl
+++ b/bazel/envoy_mobile_dependencies.bzl
@@ -65,6 +65,9 @@ def kotlin_dependencies():
             "org.jetbrains.kotlin:kotlin-stdlib-jdk8:1.3.11",
             "androidx.recyclerview:recyclerview:1.1.0",
             "androidx.core:core:1.3.2",
+            # Dokka
+            "org.jetbrains.dokka:dokka-cli:1.5.31",
+            "org.jetbrains.dokka:javadoc-plugin:1.5.31",
             # Test artifacts
             "org.assertj:assertj-core:3.12.0",
             "junit:junit:4.12",

--- a/bazel/envoy_mobile_repositories.bzl
+++ b/bazel/envoy_mobile_repositories.bzl
@@ -113,14 +113,6 @@ def kotlin_repos():
         urls = ["https://github.com/rules-proto-grpc/rules_proto_grpc/archive/0.2.0.tar.gz"],
     )
 
-    # Dokka 0.10.0 introduced a bug which makes the CLI tool error out:
-    # https://github.com/Kotlin/dokka/issues/942
-    http_jar(
-        name = "kotlin_dokka",
-        sha256 = "4c73eee92dd652ea8e2afd7b20732cf863d4938a30f634d12c88fe64def89fd8",
-        url = "https://github.com/Kotlin/dokka/releases/download/0.9.18/dokka-fatjar-0.9.18.jar",
-    )
-
     http_file(
         name = "kotlin_formatter",
         executable = 1,


### PR DESCRIPTION
Description: Upgrade Dokka to 1.5.31. This is needed in order to use JDK 11.
Risk Level: Low.
Testing: Compared old javadocs output to new output. Attached are both the outputs.
Docs Changes: Javadocs now output in a more modern format. The main change is having a search bar instead of iFrames. This matches JDK 11 javadocs output.
Release Notes: N/A

[new_javadocs.jar.zip](https://github.com/envoyproxy/envoy-mobile/files/7286482/new_javadocs.jar.zip)
[old_javadocs.jar.zip](https://github.com/envoyproxy/envoy-mobile/files/7286483/old_javadocs.jar.zip)

Signed-off-by: Brentley Jones <brentleyjones@lyft.com>