### PR TITLE
tests: Fix `EnvoyMobileTestSuite` for JDK 11

### DIFF
--- a/bazel/BUILD
+++ b/bazel/BUILD
@@ -12,6 +12,7 @@ kt_jvm_library(
     ],
     visibility = ["//visibility:public"],
     deps = [
+        "@maven//:io_github_classgraph_classgraph",
         "@maven//:junit_junit",
     ],
 )

--- a/bazel/EnvoyMobileTestSuite.kt
+++ b/bazel/EnvoyMobileTestSuite.kt
@@ -1,68 +1,31 @@
 package io.envoyproxy.envoymobile.bazel
 
-import java.io.File
-import java.net.URLClassLoader
-import java.util.zip.ZipFile
+import io.github.classgraph.ClassGraph
 import junit.framework.JUnit4TestAdapter
 import junit.framework.TestSuite
 import org.junit.runner.RunWith
 
-/**
- * This is class is taken from https://stackoverflow.com/questions/46365464/how-to-run-all-tests-in-bazel-from-a-single-java-test-rule
- *
- * Translated to Kotlin and slightly modified
- *
- * Requirements:
- * 1. This only allows tests to be run if the package is within `io.envoyproxy.envoymobile`
- * 2. This requires at least one test to be defined in the test target
- */
 @RunWith(org.junit.runners.AllTests::class)
 object EnvoyMobileTestSuite {
-  private const val TEST_SUFFIX = "Test"
-  private const val CLASS_SUFFIX = ".class"
+  private val junitTestAnnotation = org.junit.Test::class.java.name
 
   @JvmStatic
   fun suite(): TestSuite {
     val suite = TestSuite()
-    val classLoader = Thread.currentThread().contextClassLoader as URLClassLoader
-    val testAdapters = mutableListOf<JUnit4TestAdapter>()
-    // The first entry on the classpath contains the srcs from java_test
-    val classesInJar = findClassesInJar(File(classLoader.urLs[0].path))
-    for (clazz in classesInJar) {
-      val name = Class.forName(clazz)
-      val testAdapter = JUnit4TestAdapter(name)
-      testAdapters.add(testAdapter)
-    }
 
-    if (testAdapters.isEmpty()) {
-      throw NoTestFoundException("Unable to find any tests in test target")
-    }
+    val scan = ClassGraph()
+      .disableModuleScanning()
+      .enableAnnotationInfo()
+      .enableMethodInfo()
+      .ignoreClassVisibility()
+      .acceptPackages("io.envoyproxy")
+      .scan()
+    scan.getClassesWithMethodAnnotation(junitTestAnnotation)
+      .asSequence()
+      .sortedByDescending { it.name }
+      .map { JUnit4TestAdapter(it.loadClass()) }
+      .forEach(suite::addTest)
 
-    for (testAdapter in testAdapters) {
-      suite.addTest(testAdapter)
-    }
     return suite
   }
-
-  private fun findClassesInJar(jarFile: File): Set<String> {
-    val classNames = mutableSetOf<String>()
-
-    ZipFile(jarFile).use { zipFile ->
-      val entries = zipFile.entries()
-      for (entry in entries) {
-        val entryName = entry.name
-
-        if (entryName.endsWith(CLASS_SUFFIX)) {
-          val classNameEnd = entryName.length - CLASS_SUFFIX.length
-          val resolvedClass = entryName.substring(0, classNameEnd).replace('/', '.')
-          if (resolvedClass.endsWith(TEST_SUFFIX)) {
-            classNames.add(resolvedClass)
-          }
-        }
-      }
-    }
-    return classNames
-  }
 }
-
-class NoTestFoundException(message: String) : RuntimeException(message)

--- a/bazel/EnvoyMobileTestSuite.kt
+++ b/bazel/EnvoyMobileTestSuite.kt
@@ -18,6 +18,7 @@ object EnvoyMobileTestSuite {
       .enableAnnotationInfo()
       .enableMethodInfo()
       .ignoreClassVisibility()
+      .acceptPackages("io.envoyproxy", "test.kotlin.integration", "org.chromium.net")
       .scan()
     scan.getClassesWithMethodAnnotation(junitTestAnnotation)
       .asSequence()

--- a/bazel/EnvoyMobileTestSuite.kt
+++ b/bazel/EnvoyMobileTestSuite.kt
@@ -18,7 +18,6 @@ object EnvoyMobileTestSuite {
       .enableAnnotationInfo()
       .enableMethodInfo()
       .ignoreClassVisibility()
-      .acceptPackages("io.envoyproxy")
       .scan()
     scan.getClassesWithMethodAnnotation(junitTestAnnotation)
       .asSequence()

--- a/bazel/envoy_mobile_dependencies.bzl
+++ b/bazel/envoy_mobile_dependencies.bzl
@@ -75,6 +75,7 @@ def kotlin_dependencies():
             "org.mockito:mockito-core:2.28.2",
             "com.squareup.okhttp3:okhttp:4.9.1",
             "com.squareup.okhttp3:mockwebserver:4.9.1",
+            "io.github.classgraph:classgraph:4.8.121",
             # Android test artifacts
             "androidx.test:core:1.3.0",
             "androidx.test:rules:1.3.0",


### PR DESCRIPTION
Description: Fixed `EnvoyMobileTestSuite` for JDK 11. In JDK 9 you can no longer cast `ClassLoader` to `URLClassLoader`.
Risk Level: Low. Affects tests only.
Testing: Ran locally.
Docs Changes: N/A
Release Notes: N/A

Thanks to @bencodes for helping me resolve this.

Signed-off-by: Brentley Jones <brentleyjones@lyft.com>