### PR TITLE
outlier detection: remove consecutive 5xx outlier detection

### DIFF
--- a/library/common/config/config.cc
+++ b/library/common/config/config.cc
@@ -319,11 +319,6 @@ R"(
     // Therefore, the ejection time is short and the interval for unejection is tight, but not too
     // tight to cause unnecessary churn.
 R"(
-    outlier_detection: &base_outlier_detection
-      consecutive_5xx: 3
-      base_ejection_time: 0.001s
-      max_ejection_time: 0.001s
-      interval: 1s
     typed_extension_protocol_options: *http1_protocol_options_defs
   - name: base_clear
     connect_timeout: *connect_timeout
@@ -332,7 +327,6 @@ R"(
     transport_socket: { name: envoy.transport_sockets.raw_buffer }
     upstream_connection_options: *upstream_opts
     circuit_breakers: *circuit_breakers_settings
-    outlier_detection: *base_outlier_detection
     typed_extension_protocol_options: *http1_protocol_options_defs
   - name: base_h2
     http2_protocol_options: {}
@@ -342,7 +336,6 @@ R"(
     transport_socket: *base_tls_h2_socket
     upstream_connection_options: *upstream_opts
     circuit_breakers: *circuit_breakers_settings
-    outlier_detection: *base_outlier_detection
     typed_extension_protocol_options: *base_protocol_options
   - name: base_alpn
     connect_timeout: *connect_timeout
@@ -351,7 +344,6 @@ R"(
     transport_socket: *base_tls_socket
     upstream_connection_options: *upstream_opts
     circuit_breakers: *circuit_breakers_settings
-    outlier_detection: *base_outlier_detection
     typed_extension_protocol_options: *base_protocol_options
 stats_flush_interval: *stats_flush_interval
 stats_sinks: *stats_sinks

--- a/library/common/extensions/filters/http/local_error/filter.cc
+++ b/library/common/extensions/filters/http/local_error/filter.cc
@@ -17,11 +17,6 @@ Http::LocalErrorStatus LocalErrorFilter::onLocalReply(const LocalReplyData& repl
   // ASSERT(reply.details_ == info.responseCodeDetails().value());
   info.setResponseCode(static_cast<uint32_t>(reply.code_));
 
-  // Charge failures to the upstream cluster to allow for passive healthchecking.
-  if (auto upstream = info.upstreamHost()) {
-    ENVOY_LOG(trace, "LocalErrorFilter::onLocalReply charging failure to upstream host");
-    upstream->outlierDetector().putHttpResponseCode(static_cast<uint64_t>(reply.code_));
-  }
   return Http::LocalErrorStatus::ContinueAndResetStream;
 }
 


### PR DESCRIPTION
Description: this PR removes outlier detection behavior on Envoy Mobile. Consecutive 5xx outlier detection has a few issues:
- It triggers on server 5xx(s) which has the potential of breaking clients on a service outage. 
- Not all dead connection situations end up on 5xx. This means outlier detection is not even triggering correctly on local cases. e.g.,  a stream idle timeout before a response header is received will end up on 4xx which won't trigger it for example. 

We believe passive health checking with [Local Origin outlier detection](https://www.envoyproxy.io/docs/envoy/latest/intro/arch_overview/upstream/outlier.html?highlight=outlier%20detection#consecutive-local-origin-failure) _will be_ beneficial. We will experiment with that behavior in the future. 

Risk Level: med - behavior change.
Testing: device testing.

Signed-off-by: Jose Nino <jnino@lyft.com>
