### PR TITLE
swift: Fix Swift version in podspec

### DIFF
--- a/EnvoyMobile.podspec
+++ b/EnvoyMobile.podspec
@@ -8,7 +8,7 @@ Pod::Spec.new do |s|
     s.social_media_url = 'https://twitter.com/EnvoyProxy'
     s.license = { type: 'Apache-2.0', file: 'LICENSE' }
     s.platform = :ios, '11.0'
-    s.swift_version = '5.1'
+    s.swift_versions = ['5.5']
     s.libraries = 'resolv.9', 'c++'
     s.frameworks = 'SystemConfiguration', 'UIKit'
     s.source = { http: "https://github.com/lyft/envoy-mobile/releases/download/v#{s.version}/envoy_ios_cocoapods.zip" }

--- a/docs/root/start/building/building.rst
+++ b/docs/root/start/building/building.rst
@@ -56,7 +56,6 @@ iOS requirements
 ----------------
 
 - Xcode 13.0
-- Swift 5.x
 - Note: Requirements are listed in the :repo:`.bazelrc file <.bazelrc>` and CI scripts
 
 .. _android_aar:


### PR DESCRIPTION
Syntax reference: https://guides.cocoapods.org/syntax/podspec.html#swift_versions

Also remove Swift 5.x from requirements since we already specify Xcode 13 as required, which automatically implies Swift 5.5, so this was wrong and redundant.

Description: Fix Swift versions in docs and podspec
Risk Level: Low
Testing: N/A
Docs Changes: Added
Release Notes: N/A