### PR TITLE
android: stub out jni logging by default

### DIFF
--- a/library/common/jni/ndk_jni_support.cc
+++ b/library/common/jni/ndk_jni_support.cc
@@ -5,11 +5,13 @@
 // NOLINT(namespace-envoy)
 
 int jni_log_fmt(const char* tag, const char* fmt, void* value) {
-  return __android_log_print(ANDROID_LOG_VERBOSE, tag, fmt, value);
+  // For debug logging, use __android_log_print(ANDROID_LOG_VERBOSE, tag, fmt, value);
+  return 0;
 }
 
 int jni_log(const char* tag, const char* str) {
-  return __android_log_write(ANDROID_LOG_VERBOSE, tag, str);
+  // For debug logging, use __android_log_write(ANDROID_LOG_VERBOSE, tag, str);
+  return 0;
 }
 
 jint attach_jvm(JavaVM* vm, JNIEnv** p_env, void* thr_args) {


### PR DESCRIPTION
These logs are quite spammy in practice without any meaningful information. The proposal here is to avoid spamming Android logs and rely on this for unit test debugging or local development debugging.

Signed-off-by: Alan Chiu <achiu@lyft.com>

For an explanation of how to fill out the fields, please see the relevant section
in [PULL_REQUESTS.md](https://github.com/envoyproxy/envoy/blob/master/PULL_REQUESTS.md)

Description: android: stub out jni logging by default
Risk Level: low
Testing: local
Docs Changes: n/a
Release Notes: n/a
[Optional Fixes #Issue]
[Optional Deprecated:]
