### PR TITLE
Make JniBridgeUtility public

### DIFF
--- a/library/java/io/envoyproxy/envoymobile/engine/JniBridgeUtility.java
+++ b/library/java/io/envoyproxy/envoymobile/engine/JniBridgeUtility.java
@@ -9,7 +9,7 @@ import java.util.Map;
  * Class to assist with passing types from the JVM to native code. Currently supports
  * HTTP headers.
  */
-final class JniBridgeUtility {
+public final class JniBridgeUtility {
 
   private JniBridgeUtility() {}
 


### PR DESCRIPTION
Description: making the class public for broader consumption
Risk Level: low
Testing: ci
Docs Changes: n/a
Release Notes: n/a
[Optional Fixes #Issue] n/a
[Optional Deprecated:] n/a

Signed-off-by: Jingwei Hao <jingwei.hao@gmail.com>