### PR TITLE
bazel: Remove rules_jvm_external dep on JAVA_HOME

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -18,6 +18,8 @@ build --workspace_status_command=envoy/bazel/get_workspace_status
 build --xcode_version=13.0
 build --host_javabase=@bazel_tools//tools/jdk:remote_jdk11
 build --javabase=@bazel_tools//tools/jdk:remote_jdk11
+# https://github.com/bazelbuild/rules_jvm_external/issues/445
+build --repo_env=JAVA_HOME=../bazel_tools/jdk
 build --define disable_known_issue_asserts=true
 build --define cxxopts=-std=c++17
 # https://github.com/bazelbuild/bazel/issues/10674#issuecomment-658208918


### PR DESCRIPTION
This is a followup to a3296b86d5b296104d0e43f2e827d9c8f1e14251.

Description: Sets `--repo_env=JAVA_HOME` to work around https://github.com/bazelbuild/rules_jvm_external/issues/445, allowing builds without `JAVA_HOME` set.
Risk Level: Low.
Testing: Local builds.
Docs Changes: N/A.
Release Notes: N/A.
