### PR TITLE
envoy: c926499ed

### DIFF
--- a/bazel/envoy_mobile_repositories.bzl
+++ b/bazel/envoy_mobile_repositories.bzl
@@ -76,7 +76,7 @@ def upstream_envoy_overrides():
         sha256 = "081ed0f9f89805c2d96335c3acfa993b39a0a5b4b4cef7edb68dd2210a13458c",
         strip_prefix = "json-3.10.2",
         urls = ["https://github.com/nlohmann/json/archive/v3.10.2.tar.gz"],
-    ),
+    )
 
 def swift_repos():
     http_archive(

--- a/bazel/envoy_mobile_repositories.bzl
+++ b/bazel/envoy_mobile_repositories.bzl
@@ -69,6 +69,15 @@ def upstream_envoy_overrides():
         urls = ["https://github.com/bazelbuild/rules_python/archive/6f37aa9966f53e063c41b7509a386d53a9f156c3.tar.gz"],
     )
 
+    http_archive(
+        name = "com_github_nlohmann_json",
+        # 3.10.4 introduced incompatible changes with Envoy Mobile. Until Envoy Mobile updates it's
+        # minimum iOS version to 13+ this dependency cannot be updated.
+        sha256 = "081ed0f9f89805c2d96335c3acfa993b39a0a5b4b4cef7edb68dd2210a13458c",
+        strip_prefix = "json-3.10.2",
+        urls = ["https://github.com/nlohmann/json/archive/v3.10.2.tar.gz"],
+    ),
+
 def swift_repos():
     http_archive(
         name = "build_bazel_rules_apple",

--- a/bazel/envoy_mobile_repositories.bzl
+++ b/bazel/envoy_mobile_repositories.bzl
@@ -76,6 +76,7 @@ def upstream_envoy_overrides():
         sha256 = "081ed0f9f89805c2d96335c3acfa993b39a0a5b4b4cef7edb68dd2210a13458c",
         strip_prefix = "json-3.10.2",
         urls = ["https://github.com/nlohmann/json/archive/v3.10.2.tar.gz"],
+        build_file = "@envoy//bazel/external:json.BUILD",
     )
 
 def swift_repos():


### PR DESCRIPTION
Additional Info:
- v3.10.4 of  nlohmann/json introduced [CPP 17 specific functionality](https://github.com/nlohmann/json/compare/v3.10.2..v3.10.4#diff-8477168a53cf806fd7b9fba0ee3b7f4e28e378a5b0b2737cdddd8cf49f99b318R396). Envoy Mobile itself is compatible with CPP 17. However, there is specific functionality not available on iOS <13. This means that this dependency cannot be updated until Envoy Mobile moves the [minimum iOS version to 13](https://github.com/envoyproxy/envoy-mobile/blob/69a697d9052d8f6842e147d5e8b9d7a34e8fdf64/.bazelrc#L12).

Signed-off-by: Jose Nino <jnino@lyft.com>
