### PR TITLE
network: make SrcAddrSocketOptionImpl safely handle null addresses

### DIFF
--- a/library/common/network/src_addr_socket_option_impl.cc
+++ b/library/common/network/src_addr_socket_option_impl.cc
@@ -10,13 +10,12 @@ namespace Network {
 SrcAddrSocketOptionImpl::SrcAddrSocketOptionImpl(
     Network::Address::InstanceConstSharedPtr source_address)
     : source_address_(std::move(source_address)) {
-  ASSERT(source_address_->type() == Network::Address::Type::Ip);
+  ASSERT(!source_address_ || source_address_->type() == Network::Address::Type::Ip);
 }
 
 bool SrcAddrSocketOptionImpl::setOption(
     Network::Socket& socket, envoy::config::core::v3::SocketOption::SocketState state) const {
-
-  if (state == envoy::config::core::v3::SocketOption::STATE_PREBIND) {
+  if (source_address_ && state == envoy::config::core::v3::SocketOption::STATE_PREBIND) {
     socket.connectionInfoProvider().setLocalAddress(source_address_);
   }
 
@@ -39,11 +38,11 @@ void SrcAddrSocketOptionImpl::hashKey(std::vector<uint8_t>& key) const {
   // the same.
   if (source_address_->ip()->version() == Network::Address::IpVersion::v4) {
     // note raw_address is already in network order
-    uint32_t raw_address = source_address_->ip()->ipv4()->address();
+    uint32_t raw_address = source_address_ ? source_address_->ip()->ipv4()->address() : 0;
     addressIntoVector(key, raw_address);
   } else if (source_address_->ip()->version() == Network::Address::IpVersion::v6) {
     // note raw_address is already in network order
-    absl::uint128 raw_address = source_address_->ip()->ipv6()->address();
+    absl::uint128 raw_address = source_address_ ? source_address_->ip()->ipv6()->address() : 0;
     addressIntoVector(key, raw_address);
   }
 }

--- a/test/common/network/BUILD
+++ b/test/common/network/BUILD
@@ -15,6 +15,16 @@ envoy_cc_test(
 )
 
 envoy_cc_test(
+    name = "src_addr_socket_option_impl_test",
+    srcs = ["src_addr_socket_option_impl_test.cc"],
+    repository = "@envoy",
+    deps = [
+        "//library/common/network:src_addr_socket_option_lib",
+        "@envoy//test/mocks/network:network_mocks",
+    ],
+)
+
+envoy_cc_test(
     name = "synthetic_address_impl_test",
     srcs = ["synthetic_address_impl_test.cc"],
     repository = "@envoy",

--- a/test/common/network/BUILD
+++ b/test/common/network/BUILD
@@ -21,6 +21,7 @@ envoy_cc_test(
     deps = [
         "//library/common/network:src_addr_socket_option_lib",
         "@envoy//test/mocks/network:network_mocks",
+        "@envoy_api//envoy/config/core/v3:pkg_cc_proto",
     ],
 )
 

--- a/test/common/network/src_addr_socket_option_impl_test.cc
+++ b/test/common/network/src_addr_socket_option_impl_test.cc
@@ -3,14 +3,13 @@
 
 #include "source/common/network/utility.h"
 
-#include "library/common/network/src_addr_socket_option_impl.h"
-
 #include "test/mocks/common.h"
 #include "test/mocks/network/mocks.h"
 #include "test/test_common/printers.h"
 
 #include "gmock/gmock.h"
 #include "gtest/gtest.h"
+#include "library/common/network/src_addr_socket_option_impl.h"
 
 using testing::_;
 

--- a/test/common/network/src_addr_socket_option_impl_test.cc
+++ b/test/common/network/src_addr_socket_option_impl_test.cc
@@ -1,0 +1,114 @@
+#include "envoy/config/core/v3/base.pb.h"
+#include "envoy/network/address.h"
+
+#include "source/common/network/utility.h"
+
+#include "library/common/network/src_addr_socket_option_impl.h"
+
+#include "test/mocks/common.h"
+#include "test/mocks/network/mocks.h"
+#include "test/test_common/printers.h"
+
+#include "gmock/gmock.h"
+#include "gtest/gtest.h"
+
+using testing::_;
+
+namespace Envoy {
+namespace Network {
+namespace {
+
+class SrcAddrSocketOptionImplTest : public testing::Test {
+public:
+  std::unique_ptr<SrcAddrSocketOptionImpl>
+  makeOptionByAddress(const Network::Address::InstanceConstSharedPtr& address) {
+    return std::make_unique<SrcAddrSocketOptionImpl>(address);
+  }
+
+protected:
+  NiceMock<Network::MockConnectionSocket> socket_;
+  std::vector<uint8_t> key_;
+};
+
+TEST_F(SrcAddrSocketOptionImplTest, TestSetOptionPreBindSetsAddress) {
+  const auto address = Network::Utility::parseInternetAddress("127.0.0.2");
+  auto option = makeOptionByAddress(address);
+  EXPECT_TRUE(option->setOption(socket_, envoy::config::core::v3::SocketOption::STATE_PREBIND));
+  EXPECT_EQ(*socket_.connection_info_provider_->localAddress(), *address);
+}
+
+TEST_F(SrcAddrSocketOptionImplTest, TestSetOptionPreBindSetsAddressSecond) {
+  const auto address = Network::Utility::parseInternetAddress("1.2.3.4");
+  auto option = makeOptionByAddress(address);
+  EXPECT_TRUE(option->setOption(socket_, envoy::config::core::v3::SocketOption::STATE_PREBIND));
+  EXPECT_EQ(*socket_.connection_info_provider_->localAddress(), *address);
+}
+
+TEST_F(SrcAddrSocketOptionImplTest, TestSetOptionNotPrebindDoesNotSetAddress) {
+  const auto address = Network::Utility::parseInternetAddress("1.2.3.4");
+  auto option = makeOptionByAddress(address);
+  EXPECT_TRUE(option->setOption(socket_, envoy::config::core::v3::SocketOption::STATE_LISTENING));
+  EXPECT_NE(*socket_.connection_info_provider_->localAddress(), *address);
+}
+
+TEST_F(SrcAddrSocketOptionImplTest, TestSetOptionSafeWithNullAddress) {
+  const auto address = Network::Utility::parseInternetAddress("4.3.2.1");
+  socket_.connection_info_provider_->setLocalAddress(address);
+  auto option = std::make_unique<SrcAddrSocketOptionImpl>(nullptr);
+  EXPECT_TRUE(option->setOption(socket_, envoy::config::core::v3::SocketOption::STATE_PREBIND));
+  EXPECT_EQ(*socket_.connection_info_provider_->localAddress(), *address);
+}
+
+TEST_F(SrcAddrSocketOptionImplTest, TestIpv4HashKey) {
+  const auto address = Network::Utility::parseInternetAddress("1.2.3.4");
+  auto option = makeOptionByAddress(address);
+  option->hashKey(key_);
+
+  // The ip address broken into big-endian octets.
+  std::vector<uint8_t> expected_key = {1, 2, 3, 4};
+  EXPECT_EQ(key_, expected_key);
+}
+
+TEST_F(SrcAddrSocketOptionImplTest, TestIpv4HashKeyOther) {
+  const auto address = Network::Utility::parseInternetAddress("255.254.253.0");
+  auto option = makeOptionByAddress(address);
+  option->hashKey(key_);
+
+  // The ip address broken into big-endian octets.
+  std::vector<uint8_t> expected_key = {255, 254, 253, 0};
+  EXPECT_EQ(key_, expected_key);
+}
+
+TEST_F(SrcAddrSocketOptionImplTest, TestIpv6HashKey) {
+  const auto address = Network::Utility::parseInternetAddress("102:304:506:708:90a:b0c:d0e:f00");
+  auto option = makeOptionByAddress(address);
+  option->hashKey(key_);
+
+  std::vector<uint8_t> expected_key = {0x1, 0x2, 0x3, 0x4, 0x5, 0x6, 0x7, 0x8,
+                                       0x9, 0xa, 0xb, 0xc, 0xd, 0xe, 0xf, 0x0};
+  EXPECT_EQ(key_, expected_key);
+}
+
+TEST_F(SrcAddrSocketOptionImplTest, TestIpv6HashKeyOther) {
+  const auto address = Network::Utility::parseInternetAddress("F02:304:519:708:90a:b0e:FFFF:0000");
+  auto option = makeOptionByAddress(address);
+  option->hashKey(key_);
+
+  std::vector<uint8_t> expected_key = {0xF, 0x2, 0x3, 0x4, 0x5,  0x19, 0x7, 0x8,
+                                       0x9, 0xa, 0xb, 0xe, 0xff, 0xff, 0x0, 0x0};
+  EXPECT_EQ(key_, expected_key);
+}
+
+TEST_F(SrcAddrSocketOptionImplTest, TestOptionDetailsNotSupported) {
+  const auto address = Network::Utility::parseInternetAddress("255.254.253.0");
+  auto option = makeOptionByAddress(address);
+
+  auto details =
+      option->getOptionDetails(socket_, envoy::config::core::v3::SocketOption::STATE_PREBIND);
+
+  EXPECT_FALSE(details.has_value());
+}
+
+} // namespace
+} // namespace Network
+} // namespace Envoy


### PR DESCRIPTION
Description: Adds defensive handling since returned addresses may be null (especially after filtering: #1901).
Risk Level: Low
Testing: Local & On Device

Signed-off-by: Mike Schore <mike.schore@gmail.com>