### PR TITLE
[examples] Add Swift async/await example app

### DIFF
--- a/.github/workflows/ios_build.yml
+++ b/.github/workflows/ios_build.yml
@@ -68,6 +68,40 @@ jobs:
       - run: cat /tmp/envoy.log
         if: ${{ failure() || cancelled() }}
         name: 'Log app run'
+  swiftasyncawait:
+    name: swift_async_await
+    needs: iosbuild
+    runs-on: macos-11
+    timeout-minutes: 25
+    steps:
+      - uses: actions/checkout@v1
+        with:
+          submodules: true
+      - run: ./ci/mac_ci_setup.sh
+        name: 'Install dependencies'
+      - uses: actions/cache@v2
+        id: check-cache
+        with:
+          key: framework-${{ github.sha }}
+          path: dist/Envoy.framework
+        name: 'Download framework'
+      - run: exit 1
+        if: steps.check-cache.outputs.cache-hit != 'true'
+        name: 'Short-circuit'
+      - env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: bazelisk build --config=ios --config=remote-ci-macos --remote_header="Authorization=Bearer $GITHUB_TOKEN" //examples/swift/hello_world:app
+        name: 'Build swift app'
+      # Run the app in the background and redirect logs.
+      - env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: bazelisk run --config=ios --config=remote-ci-macos --remote_header="Authorization=Bearer $GITHUB_TOKEN" //examples/swift/async_await:app &> /tmp/envoy.log &
+        name: 'Run swift app'
+      - run: sed '/[2] Uploaded 7 MB of data/q' <(touch /tmp/envoy.log && tail -F /tmp/envoy.log)
+        name: 'Check upload succeeded'
+      - run: cat /tmp/envoy.log
+        if: ${{ failure() || cancelled() }}
+        name: 'Log app run'
   objchelloworld:
     name: objc_helloworld
     needs: iosbuild

--- a/.github/workflows/ios_build.yml
+++ b/.github/workflows/ios_build.yml
@@ -97,7 +97,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: bazelisk run --config=ios --config=remote-ci-macos --remote_header="Authorization=Bearer $GITHUB_TOKEN" //examples/swift/async_await:app &> /tmp/envoy.log &
         name: 'Run swift app'
-      - run: sed '/[2] Uploaded 7 MB of data/q' <(touch /tmp/envoy.log && tail -F /tmp/envoy.log)
+      - run: sed '/\[2\] Uploaded 7 MB of data/q' <(touch /tmp/envoy.log && tail -F /tmp/envoy.log)
         name: 'Check upload succeeded'
       - run: cat /tmp/envoy.log
         if: ${{ failure() || cancelled() }}

--- a/.github/workflows/ios_build.yml
+++ b/.github/workflows/ios_build.yml
@@ -90,7 +90,7 @@ jobs:
         name: 'Short-circuit'
       - env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: bazelisk build --config=ios --config=remote-ci-macos --remote_header="Authorization=Bearer $GITHUB_TOKEN" //examples/swift/hello_world:app
+        run: bazelisk build --config=ios --config=remote-ci-macos --remote_header="Authorization=Bearer $GITHUB_TOKEN" //examples/swift/async_await:app
         name: 'Build swift app'
       # Run the app in the background and redirect logs.
       - env:

--- a/examples/swift/async_await/AppDelegate.swift
+++ b/examples/swift/async_await/AppDelegate.swift
@@ -1,0 +1,18 @@
+import SwiftUI
+import UIKit
+
+@UIApplicationMain
+final class AppDelegate: UIResponder, UIApplicationDelegate {
+    var window: UIWindow?
+
+    func application(
+        _ application: UIApplication,
+        didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]?) -> Bool
+    {
+        let window = UIWindow(frame: UIScreen.main.bounds)
+        window.rootViewController = UIHostingController(rootView: ContentView())
+        window.makeKeyAndVisible()
+        self.window = window
+        return true
+    }
+}

--- a/examples/swift/async_await/BUILD
+++ b/examples/swift/async_await/BUILD
@@ -1,0 +1,20 @@
+load("@build_bazel_rules_apple//apple:ios.bzl", "ios_application")
+load("@build_bazel_rules_swift//swift:swift.bzl", "swift_library")
+
+licenses(["notice"])  # Apache 2
+
+swift_library(
+    name = "appmain",
+    srcs = glob(["*.swift"]),
+    linkopts = ["-lNetwork"],
+    deps = ["//dist:envoy_mobile_ios"],
+)
+
+ios_application(
+    name = "app",
+    bundle_id = "io.envoyproxy.envoymobile.asyncawait",
+    families = ["iphone"],
+    infoplists = ["Info.plist"],
+    minimum_os_version = "15.0",
+    deps = ["appmain"],
+)

--- a/examples/swift/async_await/Base.lproj/LaunchScreen.storyboard
+++ b/examples/swift/async_await/Base.lproj/LaunchScreen.storyboard
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="13122.16" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" launchScreen="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="01J-lp-oVM">
+    <dependencies>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="13104.12"/>
+        <capability name="Safe area layout guides" minToolsVersion="9.0"/>
+        <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
+    </dependencies>
+    <scenes>
+        <!--View Controller-->
+        <scene sceneID="EHf-IW-A2E">
+            <objects>
+                <viewController id="01J-lp-oVM" sceneMemberID="viewController">
+                    <view key="view" contentMode="scaleToFill" id="Ze5-6b-2t3">
+                        <rect key="frame" x="0.0" y="0.0" width="375" height="667"/>
+                        <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+                        <color key="backgroundColor" red="1" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+                        <viewLayoutGuide key="safeArea" id="6Tk-OE-BBY"/>
+                    </view>
+                </viewController>
+                <placeholder placeholderIdentifier="IBFirstResponder" id="iYj-Kq-Ea1" userLabel="First Responder" sceneMemberID="firstResponder"/>
+            </objects>
+            <point key="canvasLocation" x="53" y="375"/>
+        </scene>
+    </scenes>
+</document>

--- a/examples/swift/async_await/ContentView.swift
+++ b/examples/swift/async_await/ContentView.swift
@@ -1,0 +1,116 @@
+import Envoy
+import Foundation
+import SwiftUI
+
+// MARK: - Content View
+
+private struct ContentRow: Identifiable {
+    let id = UUID()
+    let content: String
+}
+
+private extension EngineBuilder {
+    static let demoEngine = EngineBuilder()
+        .addLogLevel(.debug)
+        .build()
+}
+
+struct ContentView: View {
+    @State private var rows: [ContentRow] = []
+    private let start = Date()
+
+    var body: some View {
+        List {
+            ForEach(rows) { row in
+                Text(row.content)
+            }
+        }
+        .task {
+            writeLog("Generating data")
+            let data = Data.ones(byteCount: 5 * 1_024 * 1_024)
+
+            writeLog("Initializing Envoy Engine")
+            let streamClient = EngineBuilder.demoEngine
+                .streamClient()
+
+            writeLog("Dispatching requests")
+            for index in 0..<3 {
+                await streamClient.postToHTTPBin(data: data, logger: { log in
+                    Task.detached {
+                        await writeLog("[\(index)] \(log)")
+                    }
+                })
+            }
+        }
+    }
+
+    @MainActor
+    private func writeLog(_ log: String) {
+        let logWithTiming = String(format: "\(log) (%.2f)", -start.timeIntervalSinceNow)
+        NSLog(logWithTiming)
+        withAnimation {
+            rows.insert(ContentRow(content: logWithTiming), at: 0)
+        }
+    }
+}
+
+// MARK: - Post Data To HTTP Bin
+
+private extension StreamClient {
+    func postToHTTPBin(data: Data, logger: @escaping (String) -> Void) async {
+        await withCheckedContinuation { (continuation: CheckedContinuation<Void, Never>) in
+            DispatchQueue.networking.async {
+                self.postToHTTPBin(data: data, logger: logger)
+                continuation.resume()
+            }
+        }
+    }
+
+    func postToHTTPBin(data: Data, logger: @escaping (String) -> Void) {
+        logger("Initiating upload")
+
+        let stream = self
+            .newStreamPrototype()
+            .setOnResponseHeaders { headers, _, _ in
+                let allHeaders = headers.allHeaders()
+
+                if allHeaders[":status"]?.first == "200",
+                   let contentLengthValue = allHeaders["Content-Length"],
+                   let firstContentLength = contentLengthValue.first,
+                   let contentLengthInt = Int64(firstContentLength)
+                {
+                    logger("Uploaded \(ByteCountFormatter().string(fromByteCount: contentLengthInt)) of data")
+                    return
+                }
+
+                let headerMessage = allHeaders
+                    .map { "\($0.key): \($0.value.joined(separator: ", "))" }
+                    .joined(separator: "\n")
+
+                logger("Upload failed.\nHeaders: \(headerMessage)")
+            }
+            .start(queue: .networking)
+
+        let headers = RequestHeadersBuilder(method: .post, scheme: "https",
+                                            authority: "httpbin.org", path: "/post")
+            .build()
+        stream.sendHeaders(headers, endStream: false)
+        stream.close(data: data)
+        logger("Finished scheduling upload")
+    }
+}
+
+// MARK: - Data Utilities
+
+private extension Data {
+    static func ones(byteCount: Int) -> Data {
+        return Data(bytes: Array(repeating: UInt8.max, count: byteCount), count: byteCount)
+    }
+}
+
+// MARK: - Networking Concurrent Queue
+
+private extension DispatchQueue {
+    static let networking = DispatchQueue(label: "com.lyft.envoymobile.networking", qos: .userInitiated,
+                                          attributes: .concurrent)
+}

--- a/examples/swift/async_await/ContentView.swift
+++ b/examples/swift/async_await/ContentView.swift
@@ -79,7 +79,9 @@ private extension StreamClient {
                    let firstContentLength = contentLengthValue.first,
                    let contentLengthInt = Int64(firstContentLength)
                 {
-                    logger("Uploaded \(ByteCountFormatter().string(fromByteCount: contentLengthInt)) of data")
+                    let formattedByteCount = ByteCountFormatter()
+                        .string(fromByteCount: contentLengthInt)
+                    logger("Uploaded \(formattedByteCount) of data")
                     return
                 }
 
@@ -111,6 +113,6 @@ private extension Data {
 // MARK: - Networking Concurrent Queue
 
 private extension DispatchQueue {
-    static let networking = DispatchQueue(label: "com.lyft.envoymobile.networking", qos: .userInitiated,
-                                          attributes: .concurrent)
+    static let networking = DispatchQueue(label: "com.lyft.envoymobile.networking",
+                                          qos: .userInitiated, attributes: .concurrent)
 }

--- a/examples/swift/async_await/Info.plist
+++ b/examples/swift/async_await/Info.plist
@@ -1,0 +1,36 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>CFBundleDevelopmentRegion</key>
+	<string>en</string>
+	<key>CFBundleExecutable</key>
+	<string>$(EXECUTABLE_NAME)</string>
+	<key>CFBundleIdentifier</key>
+	<string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
+	<key>CFBundleInfoDictionaryVersion</key>
+	<string>6.0</string>
+	<key>CFBundleName</key>
+	<string>$(PRODUCT_NAME)</string>
+	<key>CFBundlePackageType</key>
+	<string>APPL</string>
+	<key>CFBundleShortVersionString</key>
+	<string>0.1</string>
+	<key>CFBundleSignature</key>
+	<string>????</string>
+	<key>CFBundleVersion</key>
+	<string>0.1</string>
+	<key>ITSAppUsesNonExemptEncryption</key>
+	<false/>
+	<key>LSRequiresIPhoneOS</key>
+	<true/>
+	<key>UIRequiredDeviceCapabilities</key>
+	<array>
+		<string>armv7</string>
+	</array>
+	<key>UIStatusBarStyle</key>
+	<string>UIStatusBarStyleLightContent</string>
+	<key>UILaunchStoryboardName</key>
+	<string>LaunchScreen</string>
+</dict>
+</plist>


### PR DESCRIPTION
I built this while debugging an issue a user had reported, and thought it would be useful to keep as an example app.

This example showcases a few integrations that weren't being exercised elsewhere I could find:

* Swift 5.5's new async/await & structured concurrency features
* Concurrent uploads to https://httpbin.org
* Starting streams on concurrent GCD queues
* SwiftUI interface

Finally, also add a CI job to validate that this example builds and logs the expected output.

![swift-async-await-example](https://user-images.githubusercontent.com/474794/139924386-4b71a35c-7877-4bc2-a1b8-f5ef300079ff.gif)