### PR TITLE
build: specify jni dep for jni_utility_lib

### DIFF
--- a/library/common/jni/BUILD
+++ b/library/common/jni/BUILD
@@ -7,7 +7,7 @@ licenses(["notice"])  # Apache 2
 
 envoy_package()
 
-envoy_cc_library(
+cc_library(
     name = "jni_utility_lib",
     srcs = [
         "jni_utility.cc",
@@ -18,9 +18,9 @@ envoy_cc_library(
         "jni_utility.h",
         "jni_version.h",
     ],
-    repository = "@envoy",
     deps = [
         "//library/common/types:c_types_lib",
+        "//bazel:jni",
         "@envoy//source/common/common:assert_lib",
     ],
 )

--- a/library/common/jni/BUILD
+++ b/library/common/jni/BUILD
@@ -1,6 +1,6 @@
 load("//bazel:kotlin_lib.bzl", "envoy_mobile_so_to_jni_lib")
 load("@rules_cc//cc:defs.bzl", "cc_binary", "cc_library")
-load("@envoy//bazel:envoy_build_system.bzl", "envoy_cc_library", "envoy_package")
+load("@envoy//bazel:envoy_build_system.bzl", "envoy_package")
 load("//bazel:envoy_mobile_test_extensions.bzl", "TEST_EXTENSIONS")
 
 licenses(["notice"])  # Apache 2
@@ -19,8 +19,8 @@ cc_library(
         "jni_version.h",
     ],
     deps = [
-        "//library/common/types:c_types_lib",
         "//bazel:jni",
+        "//library/common/types:c_types_lib",
         "@envoy//source/common/common:assert_lib",
     ],
 )


### PR DESCRIPTION
This target pulls in jni.h, so specify this dependency. Also build it as cc_library to avoid 
```
external/envoy_mobile/library/common/jni/jni_utility.cc:28:43: error: ISO C++11 does not allow conversion from string literal to 'char *' [-Werror,-Wwritable-strings]
    JavaVMAttachArgs args = {JNI_VERSION, "EnvoyMain", NULL};
```

(probably -Werror being set).

Signed-off-by: Snow Pettersen <snowp@lyft.com>

Risk Level: Low, build only
Testing: Manually built the target
Docs Changes: n/a
Release Notes: n/a
