### PR TITLE
bazel: Change swift dependency loading order

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -13,6 +13,12 @@ local_repository(
     path = "envoy_build_config",
 )
 
+load("@envoy_mobile//bazel:envoy_mobile_swift_bazel_support.bzl", "swift_support")
+swift_support()
+
+load("@envoy_mobile//bazel:envoy_mobile_dependencies.bzl", "envoy_mobile_dependencies")
+envoy_mobile_dependencies()
+
 load("@envoy//bazel:api_binding.bzl", "envoy_api_binding")
 envoy_api_binding()
 
@@ -27,12 +33,6 @@ envoy_dependencies_extra()
 
 load("@envoy//bazel:dependency_imports.bzl", "envoy_dependency_imports")
 envoy_dependency_imports()
-
-load("@envoy_mobile//bazel:envoy_mobile_swift_bazel_support.bzl", "swift_support")
-swift_support()
-
-load("@envoy_mobile//bazel:envoy_mobile_dependencies.bzl", "envoy_mobile_dependencies")
-envoy_mobile_dependencies()
 
 load("@envoy_mobile//bazel:envoy_mobile_toolchains.bzl", "envoy_mobile_toolchains")
 envoy_mobile_toolchains()

--- a/bazel/envoy_mobile_repositories.bzl
+++ b/bazel/envoy_mobile_repositories.bzl
@@ -82,9 +82,9 @@ def upstream_envoy_overrides():
 def swift_repos():
     http_archive(
         name = "build_bazel_rules_apple",
-        sha256 = "747d30a8d96e0f4d093c55ebcdc07ac5ef2529c7aa5c41b45788a36ca3a4cb05",
-        strip_prefix = "rules_apple-8b42998e2086325c3290f4e68752a50cf077fb92",
-        url = "https://github.com/bazelbuild/rules_apple/archive/8b42998e2086325c3290f4e68752a50cf077fb92.tar.gz",
+        sha256 = "d6735ed25754dbcb4fce38e6d72c55b55f6afa91408e0b72f1357640b88bb49c",
+        strip_prefix = "rules_apple-0.31.3",
+        url = "https://github.com/bazelbuild/rules_apple/archive/0.31.3.tar.gz",
     )
 
     http_archive(

--- a/bazel/envoy_mobile_swift_bazel_support.bzl
+++ b/bazel/envoy_mobile_swift_bazel_support.bzl
@@ -3,7 +3,7 @@ load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
 def swift_support():
     http_archive(
         name = "build_bazel_apple_support",
-        sha256 = "595a6652d8d65380a3d764826bf1a856a8cc52371bbd961dfcd942fdb14bc133",
-        strip_prefix = "apple_support-e16463ef91ed77622c17441f9569bda139d45b18",
-        urls = ["https://github.com/bazelbuild/apple_support/archive/e16463ef91ed77622c17441f9569bda139d45b18.tar.gz"],
+        sha256 = "c02a8c902f405e5ea12b815f426fbe429bc39a2628b290e50703d956d40f5542",
+        strip_prefix = "apple_support-0.10.0",
+        urls = ["https://github.com/bazelbuild/apple_support/archive/0.10.0.tar.gz"],
     )


### PR DESCRIPTION
Description: Change swift dependency loading order. This allows our version of rules_apple to be used, instead of the one specifed by envoy. Also updates our rules_apple and apple_support to match what we were getting from envoy.
Risk Level: Low.
Testing: Local builds.
Docs Changes: N/A.
Release Notes: N/A.
