### PR TITLE
bazel: Remove useless `swift_support()` macro

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -28,9 +28,6 @@ envoy_dependencies_extra()
 load("@envoy//bazel:dependency_imports.bzl", "envoy_dependency_imports")
 envoy_dependency_imports()
 
-load("@envoy_mobile//bazel:envoy_mobile_swift_bazel_support.bzl", "swift_support")
-swift_support()
-
 load("@envoy_mobile//bazel:envoy_mobile_dependencies.bzl", "envoy_mobile_dependencies")
 envoy_mobile_dependencies()
 

--- a/bazel/envoy_mobile_swift_bazel_support.bzl
+++ b/bazel/envoy_mobile_swift_bazel_support.bzl
@@ -1,9 +1,0 @@
-load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
-
-def swift_support():
-    http_archive(
-        name = "build_bazel_apple_support",
-        sha256 = "595a6652d8d65380a3d764826bf1a856a8cc52371bbd961dfcd942fdb14bc133",
-        strip_prefix = "apple_support-e16463ef91ed77622c17441f9569bda139d45b18",
-        urls = ["https://github.com/bazelbuild/apple_support/archive/e16463ef91ed77622c17441f9569bda139d45b18.tar.gz"],
-    )


### PR DESCRIPTION
Description: Remove useless `swift_support()` macro. It was being called, but `build_bazel_apple_support` is already being declared with `apple_rules_dependencies()`.
Risk Level: Low.
Testing: Local builds.
Docs Changes: N/A.
Release Notes: N/A.
