### PR TITLE
CI: Add "macos" pool explicitly to fix CI failures

### DIFF
--- a/test/java/integration/BUILD
+++ b/test/java/integration/BUILD
@@ -11,8 +11,9 @@ envoy_mobile_android_test(
         "AndroidEnvoyEngineStartUpTest.java",
     ],
     exec_properties = {
-        # TODO(lfpino): Remove this once the sandboxNetwork=off works for ipv4 localhost addresses.
+        # TODO(lfpino): Remove these once the sandboxNetwork=off works for ipv4 localhost addresses.
         "sandboxNetwork": "standard",
+        "Pool": "macos",
     },
     native_deps = [
         "//library/common/jni:libndk_envoy_jni.so",
@@ -29,8 +30,9 @@ envoy_mobile_android_test(
         "AndroidEnvoyFlowTest.java",
     ],
     exec_properties = {
-        # TODO(lfpino): Remove this once the sandboxNetwork=off works for ipv4 localhost addresses.
+        # TODO(lfpino): Remove these once the sandboxNetwork=off works for ipv4 localhost addresses.
         "sandboxNetwork": "standard",
+        "Pool": "macos",
     },
     native_deps = [
         "//library/common/jni:libndk_envoy_jni.so",
@@ -47,8 +49,9 @@ envoy_mobile_android_test(
         "AndroidEnvoyExplicitFlowTest.java",
     ],
     exec_properties = {
-        # TODO(lfpino): Remove this once the sandboxNetwork=off works for ipv4 localhost addresses.
+        # TODO(lfpino): Remove these once the sandboxNetwork=off works for ipv4 localhost addresses.
         "sandboxNetwork": "standard",
+        "Pool": "macos",
     },
     native_deps = [
         "//library/common/jni:libndk_envoy_jni.so",

--- a/test/java/org/chromium/net/BUILD
+++ b/test/java/org/chromium/net/BUILD
@@ -18,8 +18,9 @@ envoy_mobile_android_test(
         "UrlResponseInfoTest.java",
     ],
     exec_properties = {
-        # TODO(lfpino): Remove this once the sandboxNetwork=off works for ipv4 localhost addresses.
+        # TODO(lfpino): Remove these once the sandboxNetwork=off works for ipv4 localhost addresses.
         "sandboxNetwork": "standard",
+        "Pool": "macos",
     },
     native_deps = [
         "//library/common/jni:libndk_envoy_jni.so",
@@ -42,8 +43,9 @@ envoy_mobile_android_test(
         "CronetUrlRequestContextTest.java",
     ],
     exec_properties = {
-        # TODO(lfpino): Remove this once the sandboxNetwork=off works for ipv4 localhost addresses.
+        # TODO(lfpino): Remove these once the sandboxNetwork=off works for ipv4 localhost addresses.
         "sandboxNetwork": "standard",
+        "Pool": "macos",
     },
     native_deps = [
         "//library/common/jni:libndk_envoy_jni.so",
@@ -66,8 +68,9 @@ envoy_mobile_android_test(
         "CronetUrlRequestTest.java",
     ],
     exec_properties = {
-        # TODO(lfpino): Remove this once the sandboxNetwork=off works for ipv4 localhost addresses.
+        # TODO(lfpino): Remove these once the sandboxNetwork=off works for ipv4 localhost addresses.
         "sandboxNetwork": "standard",
+        "Pool": "macos",
     },
     native_deps = [
         "//library/common/jni:libndk_envoy_jni.so",

--- a/test/java/org/chromium/net/impl/BUILD
+++ b/test/java/org/chromium/net/impl/BUILD
@@ -12,8 +12,9 @@ envoy_mobile_android_test(
         "UrlRequestCallbackTester.java",
     ],
     exec_properties = {
-        # TODO(lfpino): Remove this once the sandboxNetwork=off works for ipv4 localhost addresses.
+        # TODO(lfpino): Remove these once the sandboxNetwork=off works for ipv4 localhost addresses.
         "sandboxNetwork": "standard",
+        "Pool": "macos",
     },
     native_deps = [
         "//library/common/jni:libndk_envoy_jni.so",

--- a/test/java/org/chromium/net/urlconnection/BUILD
+++ b/test/java/org/chromium/net/urlconnection/BUILD
@@ -18,8 +18,9 @@ envoy_mobile_android_test(
         "TestUtil.java",
     ],
     exec_properties = {
-        # TODO(lfpino): Remove this once the sandboxNetwork=off works for ipv4 localhost addresses.
+        # TODO(lfpino): Remove these once the sandboxNetwork=off works for ipv4 localhost addresses.
         "sandboxNetwork": "standard",
+        "Pool": "macos",
     },
     native_deps = [
         "//library/common/jni:libndk_envoy_jni.so",

--- a/test/kotlin/integration/BUILD
+++ b/test/kotlin/integration/BUILD
@@ -119,8 +119,9 @@ envoy_mobile_jni_kt_test(
         "ReceiveDataTest.kt",
     ],
     exec_properties = {
-        # TODO(lfpino): Remove this once the sandboxNetwork=off works for ipv4 localhost addresses.
+        # TODO(lfpino): Remove these once the sandboxNetwork=off works for ipv4 localhost addresses.
         "sandboxNetwork": "standard",
+        "Pool": "macos",
     },
     native_deps = [
         "//library/common/jni:libjava_jni_lib.so",


### PR DESCRIPTION
Description:
We're using --remote_default_exec_properties=Pool=macos (https://github.com/envoyproxy/envoy-mobile/blob/main/.bazelrc#L214) to set the pool name for the MacOS builds on Engflow, however, we also set some other exec_properties in some tests https://github.com/lfpino/envoy-mobile/blob/20caa5a61508b1abd8aa3578cc3eae528d5274b0/test/java/integration/BUILD#L51 and Bazel doesn't merge the exec properties set in the bazelrc with the ones in the rule (i.e. the ones in the rule takes precedence). Because of this we end up sending the MacOS builds to a non-existent "_default_" pool which triggers build failures (https://github.com/envoyproxy/envoy-mobile/runs/4095145581?check_suite_focus=true#step:7:1373).

This PR fixes this by setting the pool name explicitly (until we get rid of the sandbox exec property in the next PR)

Risk Level: Low
Testing: See workflows
Docs Changes: N/A
Release Notes: N/A
