### PR TITLE
swift: remove outdated documentation

### DIFF
--- a/library/swift/grpc/GRPCStreamPrototype.swift
+++ b/library/swift/grpc/GRPCStreamPrototype.swift
@@ -55,8 +55,6 @@ public final class GRPCStreamPrototype: NSObject {
     var buffer = Data()
     var state = GRPCMessageProcessor.State.expectingCompressionFlag
     self.underlyingStream.setOnResponseData { chunk, _, streamIntel in
-      // This closure deliberately retains `self` while the underlying handler's
-      // `onData` closure is kept in memory so that messages/errors can be processed.
       // Appending might result in extra copying that can be optimized in the future.
       buffer.append(chunk)
       // gRPC always sends trailers, so the stream will not complete here.


### PR DESCRIPTION
As of https://github.com/envoyproxy/envoy-mobile/commit/d7b6af3e3e02c2f1152e9ee7f179418c4b5062c4 this no longer retains `self`.

Signed-off-by: Michael Rebello <me@michaelrebello.com>
