### PR TITLE
bazel: Don't cache or remote exec `ios_framework`

### DIFF
--- a/library/swift/BUILD
+++ b/library/swift/BUILD
@@ -62,6 +62,11 @@ ios_static_framework(
     hdrs = ["ios_lib_headers"],
     bundle_name = "Envoy",
     minimum_os_version = "11.0",
+    # Currently the framework is over 2GB, and is not worth caching
+    tags = [
+        "no-cache",
+        "no-remote",
+    ],
     visibility = ["//visibility:public"],
     deps = ["ios_lib"],
 )


### PR DESCRIPTION
Description: Don't cache or remote exec `ios_framework`. Since this file changes frequently, and it's very large, it's more performant to not cache it and not run it remotely. Requires Bazel 5.0 and newer rules_apple to work.
Risk Level: Low.
Testing: Local builds.
Docs Changes: N/A.
Release Notes: N/A.
