### PR TITLE
Define platform target for macOS CI

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -211,8 +211,10 @@ build:remote-ci-linux-coverage --test_env=ENVOY_IP_TEST_VERSIONS=v4only
 #############################################################################
 # remote-ci-macos: These options are macOS-only
 #############################################################################
-build:remote-ci-macos --remote_default_exec_properties=Pool=macos
 build:remote-ci-macos --config=remote-ci-common
+build:remote-ci-macos --host_platform=//ci/platform:macos
+build:remote-ci-macos --platforms=//ci/platform:macos
+build:remote-ci-macos --extra_execution_platforms=//ci/platform:macos
 build:remote-ci-macos --xcode_version_config=//ci:xcode_config
 #############################################################################
 # remote-ci-debug: Various Bazel debugging flags

--- a/ci/platform/BUILD
+++ b/ci/platform/BUILD
@@ -1,0 +1,12 @@
+licenses(["notice"])  # Apache 2
+
+platform(
+    name = "macos",
+    constraint_values = [
+        "@platforms//cpu:x86_64",
+        "@platforms//os:macos",
+    ],
+    exec_properties = {
+        "Pool": "macos",
+    },
+)


### PR DESCRIPTION
This adds an explicit platform to use for remote execution on macOS.

While this is more verbose than using `--remote_default_exec_properties`, it has the benefit that Bazel will
merge the specified platform properties with the ones specified by actions/targets instead of replacing them
(e.g., if a target has `exec_properties = {"cache-silo-key": "1"}`, the actions for this target will have
`{"Pool": "macos", "cache-silo-key": "1"}`. With `--remote_default_exec_properties=Pool=macos`, the actions
would only get `{"cache-silo-key": "1"}`, i.e. it would be executed on the "default" pool which doesn't exist
on the backend).

Risk Level: Low
Testing: See workflows
Docs Changes: N/A
Release Notes: N/A