### PR TITLE
bazel: change .bazelversion to be symlink from envoy

### DIFF
--- a/.bazelversion
+++ b/.bazelversion
@@ -1,1 +1,1 @@
-4.2.1
+envoy/.bazelversion


### PR DESCRIPTION
These should likely always match since envoy's build configs could
depend on it.

Signed-off-by: Keith Smiley <keithbsmiley@gmail.com>