### PR TITLE
CI: Use MacOS sandbox with the remaining tests

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -197,13 +197,16 @@ build:remote-ci-linux-coverage --host_platform=@engflow_remote_config_clang_cove
 build:remote-ci-linux-coverage --platforms=@engflow_remote_config_clang_coverage//config:platform
 build:remote-ci-linux-coverage --host_java_toolchain=@bazel_tools//tools/jdk:toolchain_java11
 build:remote-ci-linux-coverage --java_toolchain=@bazel_tools//tools/jdk:toolchain_java11
-# Flags to run tests locally which are necessary since Bazel C++ LLVM coverage isn't fully supported for remote builds
-# TODO(lfpino): Reference upstream Bazel issue here on the incompatibility of remote test execution and LLVM coverage.
+# We set --remote_download_outputs to 'all' because coverage generation doesn't work with 'minimal' or 'toplevel'
+# See https://github.com/bazelbuild/bazel/issues/12592 for details.
 build:remote-ci-linux-coverage --remote_download_outputs=all
+# Flags to run tests locally which are necessary since Bazel C++ LLVM coverage isn't fully supported for remote builds
 build:remote-ci-linux-coverage --strategy=TestRunner=local,remote
 build:remote-ci-linux-coverage --strategy=CoverageReport=local,remote
 # Bazel remote caching is incompatible with C++ LLVM coverage so we need to deactivate it for coverage builds
-# TODO(lfpino): Reference upstream Bazel issue here on the incompatibility of remote caching and LLVM coverage.
+# Bazel LLVM C++ coverage generation seems to be incompatible with remote caching.
+# See original experiments in https://github.com/envoyproxy/envoy-mobile/pull/1757 and a similar Bazel issue
+# in https://github.com/tweag/rules_haskell/issues/1613
 build:remote-ci-linux-coverage --noremote_accept_cached
 build:remote-ci-linux-coverage --config=remote-ci-common
 # IPv6 tests fail on CI

--- a/.github/workflows/android_tests.yml
+++ b/.github/workflows/android_tests.yml
@@ -45,6 +45,7 @@ jobs:
             --build_tests_only \
             --config=remote-ci-macos \
             --remote_header="Authorization=Bearer $GITHUB_TOKEN" \
+            --flaky_test_attempts=3 \
             //test/kotlin/...
   javatestsmac:
     name: java_tests_mac
@@ -85,6 +86,7 @@ jobs:
             --config=remote-ci-macos \
             --remote_header="Authorization=Bearer $GITHUB_TOKEN" \
             --define=signal_trace=disabled \
+            --flaky_test_attempts=3 \
             --runs_per_test=10 \
             //test/java/...
   kotlintestslinux:
@@ -130,4 +132,5 @@ jobs:
             --config=remote-ci-linux-clang \
             --config=remote-ci-linux-local-java8 \
             --remote_header="Authorization=Bearer $GITHUB_TOKEN" \
+            --flaky_test_attempts=3 \
             //test/kotlin/...

--- a/.github/workflows/android_tests.yml
+++ b/.github/workflows/android_tests.yml
@@ -85,6 +85,7 @@ jobs:
             --config=remote-ci-macos \
             --remote_header="Authorization=Bearer $GITHUB_TOKEN" \
             --define=signal_trace=disabled \
+            --runs_per_test=10 \
             //test/java/...
   kotlintestslinux:
     # Only kotlin tests are executed since with linux:

--- a/bazel/kotlin_test.bzl
+++ b/bazel/kotlin_test.bzl
@@ -1,7 +1,7 @@
 load("@io_bazel_rules_kotlin//kotlin:kotlin.bzl", "kt_jvm_test")
 load("//bazel:kotlin_lib.bzl", "native_lib_name")
 
-def _internal_kt_test(name, srcs, deps = [], data = [], jvm_flags = [], repository = "", exec_properties = {}):
+def _internal_kt_test(name, srcs, deps = [], data = [], jvm_flags = [], repository = ""):
     # This is to work around the issue where we have specific implementation functionality which
     # we want to avoid consumers to use but we want to unit test
     dep_srcs = []
@@ -25,12 +25,11 @@ def _internal_kt_test(name, srcs, deps = [], data = [], jvm_flags = [], reposito
         ] + deps,
         data = data,
         jvm_flags = jvm_flags,
-        exec_properties = exec_properties,
     )
 
 # A basic macro to make it easier to declare and run kotlin tests which depend on a JNI lib
 # This will create the native .so binary (for linux) and a .jnilib (for OS X) look up
-def envoy_mobile_jni_kt_test(name, srcs, native_deps = [], deps = [], library_path = "library/common/jni", repository = "", exec_properties = {}):
+def envoy_mobile_jni_kt_test(name, srcs, native_deps = [], deps = [], library_path = "library/common/jni", repository = ""):
     lib_name = native_lib_name(native_deps[0])[3:]
     _internal_kt_test(
         name,
@@ -42,7 +41,6 @@ def envoy_mobile_jni_kt_test(name, srcs, native_deps = [], deps = [], library_pa
             "-Denvoy_jni_library_name={}".format(lib_name),
         ],
         repository = repository,
-        exec_properties = exec_properties,
     )
 
 # A basic macro to make it easier to declare and run kotlin tests

--- a/test/java/integration/BUILD
+++ b/test/java/integration/BUILD
@@ -10,11 +10,6 @@ envoy_mobile_android_test(
     srcs = [
         "AndroidEnvoyEngineStartUpTest.java",
     ],
-    exec_properties = {
-        # TODO(lfpino): Remove these once the sandboxNetwork=off works for ipv4 localhost addresses.
-        "sandboxNetwork": "standard",
-        "Pool": "macos",
-    },
     native_deps = [
         "//library/common/jni:libndk_envoy_jni.so",
         "//library/common/jni:libndk_envoy_jni.jnilib",
@@ -29,11 +24,6 @@ envoy_mobile_android_test(
     srcs = [
         "AndroidEnvoyFlowTest.java",
     ],
-    exec_properties = {
-        # TODO(lfpino): Remove these once the sandboxNetwork=off works for ipv4 localhost addresses.
-        "sandboxNetwork": "standard",
-        "Pool": "macos",
-    },
     native_deps = [
         "//library/common/jni:libndk_envoy_jni.so",
         "//library/common/jni:libndk_envoy_jni.jnilib",
@@ -48,11 +38,6 @@ envoy_mobile_android_test(
     srcs = [
         "AndroidEnvoyExplicitFlowTest.java",
     ],
-    exec_properties = {
-        # TODO(lfpino): Remove these once the sandboxNetwork=off works for ipv4 localhost addresses.
-        "sandboxNetwork": "standard",
-        "Pool": "macos",
-    },
     native_deps = [
         "//library/common/jni:libndk_envoy_jni.so",
         "//library/common/jni:libndk_envoy_jni.jnilib",

--- a/test/java/integration/BUILD
+++ b/test/java/integration/BUILD
@@ -11,8 +11,9 @@ envoy_mobile_android_test(
         "AndroidEnvoyEngineStartUpTest.java",
     ],
     exec_properties = {
-        # TODO(lfpino): Remove this once the sandboxNetwork=off works for ipv4 localhost addresses.
+        # TODO(lfpino): Remove these once the sandboxNetwork=off works for ipv4 localhost addresses.
         "sandboxNetwork": "standard",
+        "Pool": "macos",
     },
     native_deps = [
         "//library/common/jni:libndk_envoy_jni.so",
@@ -29,8 +30,9 @@ envoy_mobile_android_test(
         "AndroidEnvoyFlowTest.java",
     ],
     exec_properties = {
-        # TODO(lfpino): Remove this once the sandboxNetwork=off works for ipv4 localhost addresses.
+        # TODO(lfpino): Remove these once the sandboxNetwork=off works for ipv4 localhost addresses.
         "sandboxNetwork": "standard",
+        "Pool": "macos",
     },
     native_deps = [
         "//library/common/jni:libndk_envoy_jni.so",
@@ -47,8 +49,9 @@ envoy_mobile_android_test(
         "AndroidEnvoyExplicitFlowTest.java",
     ],
     exec_properties = {
-        # TODO(lfpino): Remove this once the sandboxNetwork=off works for ipv4 localhost addresses.
+        # TODO(lfpino): Remove these once the sandboxNetwork=off works for ipv4 localhost addresses.
         "sandboxNetwork": "standard",
+        "Pool": "macos",
     },
     native_deps = [
         "//library/common/jni:libndk_envoy_jni.so",

--- a/test/java/org/chromium/net/BUILD
+++ b/test/java/org/chromium/net/BUILD
@@ -17,11 +17,6 @@ envoy_mobile_android_test(
         "UploadDataProvidersTest.java",
         "UrlResponseInfoTest.java",
     ],
-    exec_properties = {
-        # TODO(lfpino): Remove these once the sandboxNetwork=off works for ipv4 localhost addresses.
-        "sandboxNetwork": "standard",
-        "Pool": "macos",
-    },
     native_deps = [
         "//library/common/jni:libndk_envoy_jni.so",
         "//library/common/jni:libndk_envoy_jni.jnilib",
@@ -42,11 +37,6 @@ envoy_mobile_android_test(
     srcs = [
         "CronetUrlRequestContextTest.java",
     ],
-    exec_properties = {
-        # TODO(lfpino): Remove these once the sandboxNetwork=off works for ipv4 localhost addresses.
-        "sandboxNetwork": "standard",
-        "Pool": "macos",
-    },
     native_deps = [
         "//library/common/jni:libndk_envoy_jni.so",
         "//library/common/jni:libndk_envoy_jni.jnilib",
@@ -67,11 +57,6 @@ envoy_mobile_android_test(
     srcs = [
         "CronetUrlRequestTest.java",
     ],
-    exec_properties = {
-        # TODO(lfpino): Remove these once the sandboxNetwork=off works for ipv4 localhost addresses.
-        "sandboxNetwork": "standard",
-        "Pool": "macos",
-    },
     native_deps = [
         "//library/common/jni:libndk_envoy_jni.so",
         "//library/common/jni:libndk_envoy_jni.jnilib",

--- a/test/java/org/chromium/net/BUILD
+++ b/test/java/org/chromium/net/BUILD
@@ -18,8 +18,9 @@ envoy_mobile_android_test(
         "UrlResponseInfoTest.java",
     ],
     exec_properties = {
-        # TODO(lfpino): Remove this once the sandboxNetwork=off works for ipv4 localhost addresses.
+        # TODO(lfpino): Remove these once the sandboxNetwork=off works for ipv4 localhost addresses.
         "sandboxNetwork": "standard",
+        "Pool": "macos",
     },
     native_deps = [
         "//library/common/jni:libndk_envoy_jni.so",
@@ -42,8 +43,9 @@ envoy_mobile_android_test(
         "CronetUrlRequestContextTest.java",
     ],
     exec_properties = {
-        # TODO(lfpino): Remove this once the sandboxNetwork=off works for ipv4 localhost addresses.
+        # TODO(lfpino): Remove these once the sandboxNetwork=off works for ipv4 localhost addresses.
         "sandboxNetwork": "standard",
+        "Pool": "macos",
     },
     native_deps = [
         "//library/common/jni:libndk_envoy_jni.so",
@@ -66,8 +68,9 @@ envoy_mobile_android_test(
         "CronetUrlRequestTest.java",
     ],
     exec_properties = {
-        # TODO(lfpino): Remove this once the sandboxNetwork=off works for ipv4 localhost addresses.
+        # TODO(lfpino): Remove these once the sandboxNetwork=off works for ipv4 localhost addresses.
         "sandboxNetwork": "standard",
+        "Pool": "macos",
     },
     native_deps = [
         "//library/common/jni:libndk_envoy_jni.so",

--- a/test/java/org/chromium/net/impl/BUILD
+++ b/test/java/org/chromium/net/impl/BUILD
@@ -11,11 +11,6 @@ envoy_mobile_android_test(
         "CronvoyEngineTest.java",
         "UrlRequestCallbackTester.java",
     ],
-    exec_properties = {
-        # TODO(lfpino): Remove these once the sandboxNetwork=off works for ipv4 localhost addresses.
-        "sandboxNetwork": "standard",
-        "Pool": "macos",
-    },
     native_deps = [
         "//library/common/jni:libndk_envoy_jni.so",
         "//library/common/jni:libndk_envoy_jni.jnilib",

--- a/test/java/org/chromium/net/impl/BUILD
+++ b/test/java/org/chromium/net/impl/BUILD
@@ -12,8 +12,9 @@ envoy_mobile_android_test(
         "UrlRequestCallbackTester.java",
     ],
     exec_properties = {
-        # TODO(lfpino): Remove this once the sandboxNetwork=off works for ipv4 localhost addresses.
+        # TODO(lfpino): Remove these once the sandboxNetwork=off works for ipv4 localhost addresses.
         "sandboxNetwork": "standard",
+        "Pool": "macos",
     },
     native_deps = [
         "//library/common/jni:libndk_envoy_jni.so",

--- a/test/java/org/chromium/net/urlconnection/BUILD
+++ b/test/java/org/chromium/net/urlconnection/BUILD
@@ -18,8 +18,9 @@ envoy_mobile_android_test(
         "TestUtil.java",
     ],
     exec_properties = {
-        # TODO(lfpino): Remove this once the sandboxNetwork=off works for ipv4 localhost addresses.
+        # TODO(lfpino): Remove these once the sandboxNetwork=off works for ipv4 localhost addresses.
         "sandboxNetwork": "standard",
+        "Pool": "macos",
     },
     native_deps = [
         "//library/common/jni:libndk_envoy_jni.so",

--- a/test/java/org/chromium/net/urlconnection/BUILD
+++ b/test/java/org/chromium/net/urlconnection/BUILD
@@ -17,11 +17,6 @@ envoy_mobile_android_test(
         "MessageLoopTest.java",
         "TestUtil.java",
     ],
-    exec_properties = {
-        # TODO(lfpino): Remove these once the sandboxNetwork=off works for ipv4 localhost addresses.
-        "sandboxNetwork": "standard",
-        "Pool": "macos",
-    },
     native_deps = [
         "//library/common/jni:libndk_envoy_jni.so",
         "//library/common/jni:libndk_envoy_jni.jnilib",

--- a/test/kotlin/integration/BUILD
+++ b/test/kotlin/integration/BUILD
@@ -118,11 +118,6 @@ envoy_mobile_jni_kt_test(
     srcs = [
         "ReceiveDataTest.kt",
     ],
-    exec_properties = {
-        # TODO(lfpino): Remove these once the sandboxNetwork=off works for ipv4 localhost addresses.
-        "sandboxNetwork": "standard",
-        "Pool": "macos",
-    },
     native_deps = [
         "//library/common/jni:libjava_jni_lib.so",
         "//library/common/jni:java_jni_lib.jnilib",

--- a/test/kotlin/integration/BUILD
+++ b/test/kotlin/integration/BUILD
@@ -119,8 +119,9 @@ envoy_mobile_jni_kt_test(
         "ReceiveDataTest.kt",
     ],
     exec_properties = {
-        # TODO(lfpino): Remove this once the sandboxNetwork=off works for ipv4 localhost addresses.
+        # TODO(lfpino): Remove these once the sandboxNetwork=off works for ipv4 localhost addresses.
         "sandboxNetwork": "standard",
+        "Pool": "macos",
     },
     native_deps = [
         "//library/common/jni:libjava_jni_lib.so",


### PR DESCRIPTION
Description:
The underlying issues with the MacOS sandbox and locahost binding in the Engflow RBE are fixed so we can remove the exec_properties from the tests that were requiring them. Clean up also a couple of pending TODOs along the way.

Risk Level: Low
Testing: See workflows
Docs Changes: N/A
Release Notes: N/A
