### PR TITLE
API for H2 Buffer Limit config

### DIFF
--- a/docs/root/api/starting_envoy.rst
+++ b/docs/root/api/starting_envoy.rst
@@ -202,6 +202,21 @@ for further information.
   // Swift
   builder.addPerTryIdleTimeoutSeconds(5)
 
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+``addH2StreamBufferLimitBytes``
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Specifies the limit in bytes that the engine will buffer for h2 streams when using Envoy filters
+that buffer data e.g., any filter added via ``addPlatformFilter``.
+
+**Example::
+
+  // Kotlin
+  builder.addH2StreamBufferLimitBytes(5242880)
+
+  // Swift
+  builder.addH2StreamBufferLimitBytes(5242880)
+
 ~~~~~~~~~~~~~~~~~
 ``addAppVersion``
 ~~~~~~~~~~~~~~~~~

--- a/docs/root/api/starting_envoy.rst
+++ b/docs/root/api/starting_envoy.rst
@@ -209,7 +209,7 @@ for further information.
 Specifies the limit in bytes that the engine will buffer for h2 streams when using Envoy filters
 that buffer data e.g., any filter added via ``addPlatformFilter``.
 
-**Example::
+**Example**::
 
   // Kotlin
   builder.addH2StreamBufferLimitBytes(5242880)

--- a/library/cc/engine_builder.cc
+++ b/library/cc/engine_builder.cc
@@ -67,8 +67,7 @@ EngineBuilder::addH2ConnectionKeepaliveTimeoutSeconds(int h2_connection_keepaliv
   return *this;
 }
 
-EngineBuilder&
-EngineBuilder::addH2StreamBufferLimitBytes(int h2_stream_buffer_limit_bytes) {
+EngineBuilder& EngineBuilder::addH2StreamBufferLimitBytes(int h2_stream_buffer_limit_bytes) {
   this->h2_stream_buffer_limit_bytes_ = h2_stream_buffer_limit_bytes;
   return *this;
 }
@@ -110,8 +109,7 @@ std::string EngineBuilder::generateConfigStr() {
        fmt::format("{}s", this->h2_connection_keepalive_idle_interval_milliseconds_ / 1000.0)},
       {"h2_connection_keepalive_timeout",
        fmt::format("{}s", this->h2_connection_keepalive_timeout_seconds_)},
-      {"h2_stream_buffer_limit_bytes",
-       fmt::format("{}s", this->h2_stream_buffer_limit_bytes_)},
+      {"h2_stream_buffer_limit_bytes", fmt::format("{}s", this->h2_stream_buffer_limit_bytes_)},
       {
           "metadata",
           fmt::format("{{ device_os: {}, app_version: {}, app_id: {} }}", this->device_os_,

--- a/library/cc/engine_builder.cc
+++ b/library/cc/engine_builder.cc
@@ -67,6 +67,12 @@ EngineBuilder::addH2ConnectionKeepaliveTimeoutSeconds(int h2_connection_keepaliv
   return *this;
 }
 
+EngineBuilder&
+EngineBuilder::addH2StreamBufferLimitBytes(int h2_stream_buffer_limit_bytes) {
+  this->h2_stream_buffer_limit_bytes_ = h2_stream_buffer_limit_bytes;
+  return *this;
+}
+
 EngineBuilder& EngineBuilder::addStatsFlushSeconds(int stats_flush_seconds) {
   this->stats_flush_seconds_ = stats_flush_seconds;
   return *this;
@@ -104,6 +110,8 @@ std::string EngineBuilder::generateConfigStr() {
        fmt::format("{}s", this->h2_connection_keepalive_idle_interval_milliseconds_ / 1000.0)},
       {"h2_connection_keepalive_timeout",
        fmt::format("{}s", this->h2_connection_keepalive_timeout_seconds_)},
+      {"h2_stream_buffer_limit_bytes",
+       fmt::format("{}s", this->h2_stream_buffer_limit_bytes_)},
       {
           "metadata",
           fmt::format("{{ device_os: {}, app_version: {}, app_id: {} }}", this->device_os_,

--- a/library/cc/engine_builder.cc
+++ b/library/cc/engine_builder.cc
@@ -109,7 +109,7 @@ std::string EngineBuilder::generateConfigStr() {
        fmt::format("{}s", this->h2_connection_keepalive_idle_interval_milliseconds_ / 1000.0)},
       {"h2_connection_keepalive_timeout",
        fmt::format("{}s", this->h2_connection_keepalive_timeout_seconds_)},
-      {"h2_stream_buffer_limit_bytes", fmt::format("{}s", this->h2_stream_buffer_limit_bytes_)},
+      {"h2_stream_buffer_limit_bytes", fmt::format("{}", this->h2_stream_buffer_limit_bytes_)},
       {
           "metadata",
           fmt::format("{{ device_os: {}, app_version: {}, app_id: {} }}", this->device_os_,

--- a/library/cc/engine_builder.h
+++ b/library/cc/engine_builder.h
@@ -28,6 +28,7 @@ public:
       int h2_connection_keepalive_idle_interval_milliseconds);
   EngineBuilder&
   addH2ConnectionKeepaliveTimeoutSeconds(int h2_connection_keepalive_timeout_seconds);
+  EngineBuilder& addH2StreamBufferLimitBytes(int h2_stream_buffer_limit_bytes);
   EngineBuilder& addStatsFlushSeconds(int stats_flush_seconds);
   EngineBuilder& addVirtualClusters(const std::string& virtual_clusters);
   EngineBuilder& setAppVersion(const std::string& app_version);
@@ -59,6 +60,8 @@ private:
   std::string dns_preresolve_hostnames_ = "[]";
   int h2_connection_keepalive_idle_interval_milliseconds_ = 100000000;
   int h2_connection_keepalive_timeout_seconds_ = 10;
+  // 10Mb default (10 * 1024 * 1024)
+  int h2_stream_buffer_limit_bytes_ = 10485760;
   int stats_flush_seconds_ = 60;
   std::string app_version_ = "unspecified";
   std::string app_id_ = "unspecified";

--- a/library/common/config/config.cc
+++ b/library/common/config/config.cc
@@ -42,6 +42,7 @@ const std::string config_header = R"(
 - &enable_interface_binding false
 - &h2_connection_keepalive_idle_interval 100000s
 - &h2_connection_keepalive_timeout 10s
+- &h2_stream_buffer_limit_bytes 1048576
 - &metadata {}
 - &stats_domain 127.0.0.1
 - &stats_flush_interval 60s
@@ -213,6 +214,8 @@ static_resources:
           stat_prefix: hcm
           server_header_transformation: PASS_THROUGH
           stream_idle_timeout: *stream_idle_timeout
+          http2_protocol_options:
+            initial_stream_window_size: *h2_stream_buffer_limit_bytes
           route_config:
             name: api_router
             virtual_hosts:

--- a/library/java/io/envoyproxy/envoymobile/engine/EnvoyConfiguration.java
+++ b/library/java/io/envoyproxy/envoymobile/engine/EnvoyConfiguration.java
@@ -69,10 +69,10 @@ public class EnvoyConfiguration {
                             int dnsFailureRefreshSecondsMax, int dnsQueryTimeoutSeconds,
                             String dnsPreresolveHostnames, boolean enableInterfaceBinding,
                             int h2ConnectionKeepaliveIdleIntervalMilliseconds,
-                            int h2ConnectionKeepaliveTimeoutSeconds, int h2StreamBufferLimitBytes, int statsFlushSeconds,
-                            int streamIdleTimeoutSeconds, int perTryIdleTimeoutSeconds,
-                            String appVersion, String appId, String virtualClusters,
-                            List<EnvoyNativeFilterConfig> nativeFilterChain,
+                            int h2ConnectionKeepaliveTimeoutSeconds, int h2StreamBufferLimitBytes,
+                            int statsFlushSeconds, int streamIdleTimeoutSeconds,
+                            int perTryIdleTimeoutSeconds, String appVersion, String appId,
+                            String virtualClusters, List<EnvoyNativeFilterConfig> nativeFilterChain,
                             List<EnvoyHTTPFilterFactory> httpPlatformFilterFactories,
                             Map<String, EnvoyStringAccessor> stringAccessors) {
     this.adminInterfaceEnabled = adminInterfaceEnabled;
@@ -144,8 +144,7 @@ public class EnvoyConfiguration {
                               h2ConnectionKeepaliveIdleIntervalMilliseconds / 1000.0))
         .append(String.format("- &h2_connection_keepalive_timeout %ss\n",
                               h2ConnectionKeepaliveTimeoutSeconds))
-        .append(String.format("- &h2_stream_buffer_limit_bytes %s\n",
-                              h2StreamBufferLimitBytes))
+        .append(String.format("- &h2_stream_buffer_limit_bytes %s\n", h2StreamBufferLimitBytes))
         .append(String.format("- &stream_idle_timeout %ss\n", streamIdleTimeoutSeconds))
         .append(String.format("- &per_try_idle_timeout %ss\n", perTryIdleTimeoutSeconds))
         .append(String.format("- &metadata { device_os: %s, app_version: %s, app_id: %s }\n",

--- a/library/java/io/envoyproxy/envoymobile/engine/EnvoyConfiguration.java
+++ b/library/java/io/envoyproxy/envoymobile/engine/EnvoyConfiguration.java
@@ -23,6 +23,7 @@ public class EnvoyConfiguration {
   public final String dnsPreresolveHostnames;
   public final Integer h2ConnectionKeepaliveIdleIntervalMilliseconds;
   public final Integer h2ConnectionKeepaliveTimeoutSeconds;
+  public final Integer h2StreamBufferLimitBytes;
   public final List<EnvoyHTTPFilterFactory> httpPlatformFilterFactories;
   public final Integer statsFlushSeconds;
   public final Integer streamIdleTimeoutSeconds;
@@ -51,6 +52,7 @@ public class EnvoyConfiguration {
    * @param h2ConnectionKeepaliveIdleIntervalMilliseconds rate in milliseconds seconds to send h2
    *     pings on stream creation.
    * @param h2ConnectionKeepaliveTimeoutSeconds rate in seconds to timeout h2 pings.
+   * @param h2StreamBufferLimitBytes     size in bytes that h2 streams are allowed to buffer.
    * @param statsFlushSeconds            interval at which to flush Envoy stats.
    * @param streamIdleTimeoutSeconds     idle timeout for HTTP streams.
    * @param perTryIdleTimeoutSeconds     per try idle timeout for HTTP streams.
@@ -67,7 +69,7 @@ public class EnvoyConfiguration {
                             int dnsFailureRefreshSecondsMax, int dnsQueryTimeoutSeconds,
                             String dnsPreresolveHostnames, boolean enableInterfaceBinding,
                             int h2ConnectionKeepaliveIdleIntervalMilliseconds,
-                            int h2ConnectionKeepaliveTimeoutSeconds, int statsFlushSeconds,
+                            int h2ConnectionKeepaliveTimeoutSeconds, int h2StreamBufferLimitBytes, int statsFlushSeconds,
                             int streamIdleTimeoutSeconds, int perTryIdleTimeoutSeconds,
                             String appVersion, String appId, String virtualClusters,
                             List<EnvoyNativeFilterConfig> nativeFilterChain,
@@ -86,6 +88,7 @@ public class EnvoyConfiguration {
     this.h2ConnectionKeepaliveIdleIntervalMilliseconds =
         h2ConnectionKeepaliveIdleIntervalMilliseconds;
     this.h2ConnectionKeepaliveTimeoutSeconds = h2ConnectionKeepaliveTimeoutSeconds;
+    this.h2StreamBufferLimitBytes = h2StreamBufferLimitBytes;
     this.statsFlushSeconds = statsFlushSeconds;
     this.streamIdleTimeoutSeconds = streamIdleTimeoutSeconds;
     this.perTryIdleTimeoutSeconds = perTryIdleTimeoutSeconds;
@@ -141,6 +144,8 @@ public class EnvoyConfiguration {
                               h2ConnectionKeepaliveIdleIntervalMilliseconds / 1000.0))
         .append(String.format("- &h2_connection_keepalive_timeout %ss\n",
                               h2ConnectionKeepaliveTimeoutSeconds))
+        .append(String.format("- &h2_stream_buffer_limit_bytes %s\n",
+                              h2StreamBufferLimitBytes))
         .append(String.format("- &stream_idle_timeout %ss\n", streamIdleTimeoutSeconds))
         .append(String.format("- &per_try_idle_timeout %ss\n", perTryIdleTimeoutSeconds))
         .append(String.format("- &metadata { device_os: %s, app_version: %s, app_id: %s }\n",

--- a/library/java/org/chromium/net/impl/NativeCronetEngineBuilderImpl.java
+++ b/library/java/org/chromium/net/impl/NativeCronetEngineBuilderImpl.java
@@ -37,6 +37,8 @@ public class NativeCronetEngineBuilderImpl extends CronetEngineBuilderImpl {
   private boolean mEnableInterfaceBinding = false;
   private int mH2ConnectionKeepaliveIdleIntervalMilliseconds = 100000000;
   private int mH2ConnectionKeepaliveTimeoutSeconds = 10;
+  // 10Mb default (10 * 1024 * 1024)
+  private int mH2StreamBufferLimitBytes = 10485760;
   private int mStatsFlushSeconds = 60;
   private int mStreamIdleTimeoutSeconds = 15;
   private int mPerTryIdleTimeoutSeconds = 15;
@@ -76,7 +78,7 @@ public class NativeCronetEngineBuilderImpl extends CronetEngineBuilderImpl {
         mAdminInterfaceEnabled, mGrpcStatsDomain, mStatsDPort, mConnectTimeoutSeconds,
         mDnsRefreshSeconds, mDnsFailureRefreshSecondsBase, mDnsFailureRefreshSecondsMax,
         mDnsQueryTimeoutSeconds, mDnsPreresolveHostnames, mEnableInterfaceBinding,
-        mH2ConnectionKeepaliveIdleIntervalMilliseconds, mH2ConnectionKeepaliveTimeoutSeconds,
+        mH2ConnectionKeepaliveIdleIntervalMilliseconds, mH2ConnectionKeepaliveTimeoutSeconds, mH2StreamBufferLimitBytes,
         mStatsFlushSeconds, mStreamIdleTimeoutSeconds, mPerTryIdleTimeoutSeconds, mAppVersion,
         mAppId, mVirtualClusters, mNativeFilterChain, mPlatformFilterChain, mStringAccessors);
   }

--- a/library/java/org/chromium/net/impl/NativeCronetEngineBuilderImpl.java
+++ b/library/java/org/chromium/net/impl/NativeCronetEngineBuilderImpl.java
@@ -78,8 +78,9 @@ public class NativeCronetEngineBuilderImpl extends CronetEngineBuilderImpl {
         mAdminInterfaceEnabled, mGrpcStatsDomain, mStatsDPort, mConnectTimeoutSeconds,
         mDnsRefreshSeconds, mDnsFailureRefreshSecondsBase, mDnsFailureRefreshSecondsMax,
         mDnsQueryTimeoutSeconds, mDnsPreresolveHostnames, mEnableInterfaceBinding,
-        mH2ConnectionKeepaliveIdleIntervalMilliseconds, mH2ConnectionKeepaliveTimeoutSeconds, mH2StreamBufferLimitBytes,
-        mStatsFlushSeconds, mStreamIdleTimeoutSeconds, mPerTryIdleTimeoutSeconds, mAppVersion,
-        mAppId, mVirtualClusters, mNativeFilterChain, mPlatformFilterChain, mStringAccessors);
+        mH2ConnectionKeepaliveIdleIntervalMilliseconds, mH2ConnectionKeepaliveTimeoutSeconds,
+        mH2StreamBufferLimitBytes, mStatsFlushSeconds, mStreamIdleTimeoutSeconds,
+        mPerTryIdleTimeoutSeconds, mAppVersion, mAppId, mVirtualClusters, mNativeFilterChain,
+        mPlatformFilterChain, mStringAccessors);
   }
 }

--- a/library/kotlin/io/envoyproxy/envoymobile/EngineBuilder.kt
+++ b/library/kotlin/io/envoyproxy/envoymobile/EngineBuilder.kt
@@ -194,12 +194,12 @@ open class EngineBuilder(
   /**
    * Add the limit that h2 streams are able to buffer.
    *
-   * @param h2StreamBufferBytes size in bytes that h2 streams are allowed to buffer.
+   * @param h2StreamBufferLimitBytes size in bytes that h2 streams are allowed to buffer.
    *
    * @return this builder.
    */
-  fun addH2StreamBufferBytes(h2StreamBufferBytes: Int): EngineBuilder {
-    this.h2StreamBufferBytes = h2StreamBufferBytes
+  fun addH2StreamBufferLimitBytes(h2StreamBufferLimitBytes: Int): EngineBuilder {
+    this.h2StreamBufferLimitBytes = h2StreamBufferLimitBytes
     return this
   }
 
@@ -389,7 +389,7 @@ open class EngineBuilder(
             adminInterfaceEnabled, grpcStatsDomain, statsDPort, connectTimeoutSeconds,
             dnsRefreshSeconds, dnsFailureRefreshSecondsBase, dnsFailureRefreshSecondsMax,
             dnsQueryTimeoutSeconds, dnsPreresolveHostnames, enableInterfaceBinding,
-            h2ConnectionKeepaliveIdleIntervalMilliseconds, h2ConnectionKeepaliveTimeoutSeconds, h2StreamBufferBytes,
+            h2ConnectionKeepaliveIdleIntervalMilliseconds, h2ConnectionKeepaliveTimeoutSeconds, h2StreamBufferLimitBytes,
             statsFlushSeconds, streamIdleTimeoutSeconds, perTryIdleTimeoutSeconds, appVersion,
             appId, virtualClusters, nativeFilterChain, platformFilterChain, stringAccessors
           ),
@@ -404,7 +404,7 @@ open class EngineBuilder(
             adminInterfaceEnabled, grpcStatsDomain, statsDPort, connectTimeoutSeconds,
             dnsRefreshSeconds, dnsFailureRefreshSecondsBase, dnsFailureRefreshSecondsMax,
             dnsQueryTimeoutSeconds, dnsPreresolveHostnames, enableInterfaceBinding,
-            h2ConnectionKeepaliveIdleIntervalMilliseconds, h2ConnectionKeepaliveTimeoutSeconds, h2StreamBufferBytes,
+            h2ConnectionKeepaliveIdleIntervalMilliseconds, h2ConnectionKeepaliveTimeoutSeconds, h2StreamBufferLimitBytes,
             statsFlushSeconds, streamIdleTimeoutSeconds, perTryIdleTimeoutSeconds, appVersion,
             appId, virtualClusters, nativeFilterChain, platformFilterChain, stringAccessors
           ),

--- a/library/kotlin/io/envoyproxy/envoymobile/EngineBuilder.kt
+++ b/library/kotlin/io/envoyproxy/envoymobile/EngineBuilder.kt
@@ -39,7 +39,7 @@ open class EngineBuilder(
   private var h2ConnectionKeepaliveIdleIntervalMilliseconds = 100000000
   private var h2ConnectionKeepaliveTimeoutSeconds = 10
   // 10Mb default (10 * 1024 * 1024)
-  private var h2StreamBufferLimitBytes = 10485760;
+  private var h2StreamBufferLimitBytes = 10485760
   private var streamIdleTimeoutSeconds = 15
   private var perTryIdleTimeoutSeconds = 15
   private var appVersion = "unspecified"

--- a/library/kotlin/io/envoyproxy/envoymobile/EngineBuilder.kt
+++ b/library/kotlin/io/envoyproxy/envoymobile/EngineBuilder.kt
@@ -40,6 +40,7 @@ open class EngineBuilder(
   private var h2ConnectionKeepaliveTimeoutSeconds = 10
   // 10Mb default (10 * 1024 * 1024)
   private var h2StreamBufferLimitBytes = 10485760
+  private var statsFlushSeconds = 60
   private var streamIdleTimeoutSeconds = 15
   private var perTryIdleTimeoutSeconds = 15
   private var appVersion = "unspecified"

--- a/library/kotlin/io/envoyproxy/envoymobile/EngineBuilder.kt
+++ b/library/kotlin/io/envoyproxy/envoymobile/EngineBuilder.kt
@@ -38,7 +38,8 @@ open class EngineBuilder(
   private var enableInterfaceBinding = false
   private var h2ConnectionKeepaliveIdleIntervalMilliseconds = 100000000
   private var h2ConnectionKeepaliveTimeoutSeconds = 10
-  private var statsFlushSeconds = 60
+  // 10Mb default (10 * 1024 * 1024)
+  private var h2StreamBufferLimitBytes = 10485760;
   private var streamIdleTimeoutSeconds = 15
   private var perTryIdleTimeoutSeconds = 15
   private var appVersion = "unspecified"
@@ -187,6 +188,18 @@ open class EngineBuilder(
    */
   fun addH2ConnectionKeepaliveTimeoutSeconds(timeoutSeconds: Int): EngineBuilder {
     this.h2ConnectionKeepaliveTimeoutSeconds = timeoutSeconds
+    return this
+  }
+
+  /**
+   * Add the limit that h2 streams are able to buffer.
+   *
+   * @param h2StreamBufferBytes size in bytes that h2 streams are allowed to buffer.
+   *
+   * @return this builder.
+   */
+  fun addH2StreamBufferBytes(h2StreamBufferBytes: Int): EngineBuilder {
+    this.h2StreamBufferBytes = h2StreamBufferBytes
     return this
   }
 
@@ -376,7 +389,7 @@ open class EngineBuilder(
             adminInterfaceEnabled, grpcStatsDomain, statsDPort, connectTimeoutSeconds,
             dnsRefreshSeconds, dnsFailureRefreshSecondsBase, dnsFailureRefreshSecondsMax,
             dnsQueryTimeoutSeconds, dnsPreresolveHostnames, enableInterfaceBinding,
-            h2ConnectionKeepaliveIdleIntervalMilliseconds, h2ConnectionKeepaliveTimeoutSeconds,
+            h2ConnectionKeepaliveIdleIntervalMilliseconds, h2ConnectionKeepaliveTimeoutSeconds, h2StreamBufferBytes,
             statsFlushSeconds, streamIdleTimeoutSeconds, perTryIdleTimeoutSeconds, appVersion,
             appId, virtualClusters, nativeFilterChain, platformFilterChain, stringAccessors
           ),
@@ -391,7 +404,7 @@ open class EngineBuilder(
             adminInterfaceEnabled, grpcStatsDomain, statsDPort, connectTimeoutSeconds,
             dnsRefreshSeconds, dnsFailureRefreshSecondsBase, dnsFailureRefreshSecondsMax,
             dnsQueryTimeoutSeconds, dnsPreresolveHostnames, enableInterfaceBinding,
-            h2ConnectionKeepaliveIdleIntervalMilliseconds, h2ConnectionKeepaliveTimeoutSeconds,
+            h2ConnectionKeepaliveIdleIntervalMilliseconds, h2ConnectionKeepaliveTimeoutSeconds, h2StreamBufferBytes,
             statsFlushSeconds, streamIdleTimeoutSeconds, perTryIdleTimeoutSeconds, appVersion,
             appId, virtualClusters, nativeFilterChain, platformFilterChain, stringAccessors
           ),

--- a/library/kotlin/io/envoyproxy/envoymobile/EngineBuilder.kt
+++ b/library/kotlin/io/envoyproxy/envoymobile/EngineBuilder.kt
@@ -390,9 +390,10 @@ open class EngineBuilder(
             adminInterfaceEnabled, grpcStatsDomain, statsDPort, connectTimeoutSeconds,
             dnsRefreshSeconds, dnsFailureRefreshSecondsBase, dnsFailureRefreshSecondsMax,
             dnsQueryTimeoutSeconds, dnsPreresolveHostnames, enableInterfaceBinding,
-            h2ConnectionKeepaliveIdleIntervalMilliseconds, h2ConnectionKeepaliveTimeoutSeconds, h2StreamBufferLimitBytes,
-            statsFlushSeconds, streamIdleTimeoutSeconds, perTryIdleTimeoutSeconds, appVersion,
-            appId, virtualClusters, nativeFilterChain, platformFilterChain, stringAccessors
+            h2ConnectionKeepaliveIdleIntervalMilliseconds, h2ConnectionKeepaliveTimeoutSeconds,
+            h2StreamBufferLimitBytes, statsFlushSeconds, streamIdleTimeoutSeconds,
+            perTryIdleTimeoutSeconds, appVersion, appId, virtualClusters, nativeFilterChain,
+            platformFilterChain, stringAccessors
           ),
           configuration.yaml,
           logLevel
@@ -405,9 +406,10 @@ open class EngineBuilder(
             adminInterfaceEnabled, grpcStatsDomain, statsDPort, connectTimeoutSeconds,
             dnsRefreshSeconds, dnsFailureRefreshSecondsBase, dnsFailureRefreshSecondsMax,
             dnsQueryTimeoutSeconds, dnsPreresolveHostnames, enableInterfaceBinding,
-            h2ConnectionKeepaliveIdleIntervalMilliseconds, h2ConnectionKeepaliveTimeoutSeconds, h2StreamBufferLimitBytes,
-            statsFlushSeconds, streamIdleTimeoutSeconds, perTryIdleTimeoutSeconds, appVersion,
-            appId, virtualClusters, nativeFilterChain, platformFilterChain, stringAccessors
+            h2ConnectionKeepaliveIdleIntervalMilliseconds, h2ConnectionKeepaliveTimeoutSeconds,
+            h2StreamBufferLimitBytes, statsFlushSeconds, streamIdleTimeoutSeconds,
+            perTryIdleTimeoutSeconds, appVersion, appId, virtualClusters, nativeFilterChain,
+            platformFilterChain, stringAccessors
           ),
           logLevel
         )

--- a/library/objective-c/EnvoyConfiguration.m
+++ b/library/objective-c/EnvoyConfiguration.m
@@ -16,7 +16,7 @@
     h2ConnectionKeepaliveIdleIntervalMilliseconds:
         (UInt32)h2ConnectionKeepaliveIdleIntervalMilliseconds
               h2ConnectionKeepaliveTimeoutSeconds:(UInt32)h2ConnectionKeepaliveTimeoutSeconds
-                              h2StreamBufferBytes:(UInt32)h2StreamBufferBytes
+                              h2StreamBufferLimitBytes:(UInt32)h2StreamBufferLimitBytes
                                 statsFlushSeconds:(UInt32)statsFlushSeconds
                          streamIdleTimeoutSeconds:(UInt32)streamIdleTimeoutSeconds
                          perTryIdleTimeoutSeconds:(UInt32)perTryIdleTimeoutSeconds
@@ -49,7 +49,7 @@
   self.h2ConnectionKeepaliveIdleIntervalMilliseconds =
       h2ConnectionKeepaliveIdleIntervalMilliseconds;
   self.h2ConnectionKeepaliveTimeoutSeconds = h2ConnectionKeepaliveTimeoutSeconds;
-  sefl.h2StreamBufferBytes = h2StreamBufferBytes;
+  sefl.h2StreamBufferLimitBytes = h2StreamBufferLimitBytes;
   self.statsFlushSeconds = statsFlushSeconds;
   self.streamIdleTimeoutSeconds = streamIdleTimeoutSeconds;
   self.perTryIdleTimeoutSeconds = perTryIdleTimeoutSeconds;

--- a/library/objective-c/EnvoyConfiguration.m
+++ b/library/objective-c/EnvoyConfiguration.m
@@ -16,7 +16,7 @@
     h2ConnectionKeepaliveIdleIntervalMilliseconds:
         (UInt32)h2ConnectionKeepaliveIdleIntervalMilliseconds
               h2ConnectionKeepaliveTimeoutSeconds:(UInt32)h2ConnectionKeepaliveTimeoutSeconds
-                              h2StreamBufferLimitBytes:(UInt32)h2StreamBufferLimitBytes
+                         h2StreamBufferLimitBytes:(UInt32)h2StreamBufferLimitBytes
                                 statsFlushSeconds:(UInt32)statsFlushSeconds
                          streamIdleTimeoutSeconds:(UInt32)streamIdleTimeoutSeconds
                          perTryIdleTimeoutSeconds:(UInt32)perTryIdleTimeoutSeconds

--- a/library/objective-c/EnvoyConfiguration.m
+++ b/library/objective-c/EnvoyConfiguration.m
@@ -49,7 +49,7 @@
   self.h2ConnectionKeepaliveIdleIntervalMilliseconds =
       h2ConnectionKeepaliveIdleIntervalMilliseconds;
   self.h2ConnectionKeepaliveTimeoutSeconds = h2ConnectionKeepaliveTimeoutSeconds;
-  sefl.h2StreamBufferLimitBytes = h2StreamBufferLimitBytes;
+  self.h2StreamBufferLimitBytes = h2StreamBufferLimitBytes;
   self.statsFlushSeconds = statsFlushSeconds;
   self.streamIdleTimeoutSeconds = streamIdleTimeoutSeconds;
   self.perTryIdleTimeoutSeconds = perTryIdleTimeoutSeconds;

--- a/library/objective-c/EnvoyConfiguration.m
+++ b/library/objective-c/EnvoyConfiguration.m
@@ -16,6 +16,7 @@
     h2ConnectionKeepaliveIdleIntervalMilliseconds:
         (UInt32)h2ConnectionKeepaliveIdleIntervalMilliseconds
               h2ConnectionKeepaliveTimeoutSeconds:(UInt32)h2ConnectionKeepaliveTimeoutSeconds
+                              h2StreamBufferBytes:(UInt32)h2StreamBufferBytes
                                 statsFlushSeconds:(UInt32)statsFlushSeconds
                          streamIdleTimeoutSeconds:(UInt32)streamIdleTimeoutSeconds
                          perTryIdleTimeoutSeconds:(UInt32)perTryIdleTimeoutSeconds
@@ -48,6 +49,7 @@
   self.h2ConnectionKeepaliveIdleIntervalMilliseconds =
       h2ConnectionKeepaliveIdleIntervalMilliseconds;
   self.h2ConnectionKeepaliveTimeoutSeconds = h2ConnectionKeepaliveTimeoutSeconds;
+  sefl.h2StreamBufferBytes = h2StreamBufferBytes;
   self.statsFlushSeconds = statsFlushSeconds;
   self.streamIdleTimeoutSeconds = streamIdleTimeoutSeconds;
   self.perTryIdleTimeoutSeconds = perTryIdleTimeoutSeconds;
@@ -126,6 +128,8 @@
                             (double)self.h2ConnectionKeepaliveIdleIntervalMilliseconds / 1000.0];
   [definitions appendFormat:@"- &h2_connection_keepalive_timeout %lus\n",
                             (unsigned long)self.h2ConnectionKeepaliveTimeoutSeconds];
+  [definitions appendFormat:@"- &h2_stream_buffer_limit_bytes %lu\n",
+                            (unsigned long)self.h2StreamBufferLimitBytes];
   [definitions
       appendFormat:@"- &stream_idle_timeout %lus\n", (unsigned long)self.streamIdleTimeoutSeconds];
   [definitions

--- a/library/objective-c/EnvoyEngine.h
+++ b/library/objective-c/EnvoyEngine.h
@@ -332,7 +332,7 @@ extern const int kEnvoyFilterResumeStatusResumeIteration;
     h2ConnectionKeepaliveIdleIntervalMilliseconds:
         (UInt32)h2ConnectionKeepaliveIdleIntervalMilliseconds
               h2ConnectionKeepaliveTimeoutSeconds:(UInt32)h2ConnectionKeepaliveTimeoutSeconds
-                              h2StreamBufferLimitBytes:(UInt32)h2StreamBufferLimitBytes
+                         h2StreamBufferLimitBytes:(UInt32)h2StreamBufferLimitBytes
                                 statsFlushSeconds:(UInt32)statsFlushSeconds
                          streamIdleTimeoutSeconds:(UInt32)streamIdleTimeoutSeconds
                          perTryIdleTimeoutSeconds:(UInt32)perTryIdleTimeoutSeconds

--- a/library/objective-c/EnvoyEngine.h
+++ b/library/objective-c/EnvoyEngine.h
@@ -304,6 +304,7 @@ extern const int kEnvoyFilterResumeStatusResumeIteration;
 @property (nonatomic, assign) BOOL enableInterfaceBinding;
 @property (nonatomic, assign) UInt32 h2ConnectionKeepaliveIdleIntervalMilliseconds;
 @property (nonatomic, assign) UInt32 h2ConnectionKeepaliveTimeoutSeconds;
+@property (nonatomic, assign) UInt32 h2StreamBufferBytes;
 @property (nonatomic, assign) UInt32 statsFlushSeconds;
 @property (nonatomic, assign) UInt32 streamIdleTimeoutSeconds;
 @property (nonatomic, assign) UInt32 perTryIdleTimeoutSeconds;
@@ -331,6 +332,7 @@ extern const int kEnvoyFilterResumeStatusResumeIteration;
     h2ConnectionKeepaliveIdleIntervalMilliseconds:
         (UInt32)h2ConnectionKeepaliveIdleIntervalMilliseconds
               h2ConnectionKeepaliveTimeoutSeconds:(UInt32)h2ConnectionKeepaliveTimeoutSeconds
+                              h2StreamBufferBytes:(UInt32)h2StreamBufferBytes
                                 statsFlushSeconds:(UInt32)statsFlushSeconds
                          streamIdleTimeoutSeconds:(UInt32)streamIdleTimeoutSeconds
                          perTryIdleTimeoutSeconds:(UInt32)perTryIdleTimeoutSeconds

--- a/library/objective-c/EnvoyEngine.h
+++ b/library/objective-c/EnvoyEngine.h
@@ -304,7 +304,7 @@ extern const int kEnvoyFilterResumeStatusResumeIteration;
 @property (nonatomic, assign) BOOL enableInterfaceBinding;
 @property (nonatomic, assign) UInt32 h2ConnectionKeepaliveIdleIntervalMilliseconds;
 @property (nonatomic, assign) UInt32 h2ConnectionKeepaliveTimeoutSeconds;
-@property (nonatomic, assign) UInt32 h2StreamBufferBytes;
+@property (nonatomic, assign) UInt32 h2StreamBufferLimitBytes;
 @property (nonatomic, assign) UInt32 statsFlushSeconds;
 @property (nonatomic, assign) UInt32 streamIdleTimeoutSeconds;
 @property (nonatomic, assign) UInt32 perTryIdleTimeoutSeconds;
@@ -332,7 +332,7 @@ extern const int kEnvoyFilterResumeStatusResumeIteration;
     h2ConnectionKeepaliveIdleIntervalMilliseconds:
         (UInt32)h2ConnectionKeepaliveIdleIntervalMilliseconds
               h2ConnectionKeepaliveTimeoutSeconds:(UInt32)h2ConnectionKeepaliveTimeoutSeconds
-                              h2StreamBufferBytes:(UInt32)h2StreamBufferBytes
+                              h2StreamBufferLimitBytes:(UInt32)h2StreamBufferLimitBytes
                                 statsFlushSeconds:(UInt32)statsFlushSeconds
                          streamIdleTimeoutSeconds:(UInt32)streamIdleTimeoutSeconds
                          perTryIdleTimeoutSeconds:(UInt32)perTryIdleTimeoutSeconds

--- a/library/swift/EngineBuilder.swift
+++ b/library/swift/EngineBuilder.swift
@@ -24,6 +24,8 @@ open class EngineBuilder: NSObject {
   private var enableInterfaceBinding: Bool = false
   private var h2ConnectionKeepaliveIdleIntervalMilliseconds: UInt32 = 100000000
   private var h2ConnectionKeepaliveTimeoutSeconds: UInt32 = 10
+  // 10Mb default (10 * 1024 * 1024)
+  private var h2StreamBufferLimitBytes: UInt32 = 10485760;
   private var statsFlushSeconds: UInt32 = 60
   private var streamIdleTimeoutSeconds: UInt32 = 15
   private var perTryIdleTimeoutSeconds: UInt32 = 15
@@ -170,6 +172,16 @@ open class EngineBuilder: NSObject {
   public func addH2ConnectionKeepaliveTimeoutSeconds(
     _ h2ConnectionKeepaliveTimeoutSeconds: UInt32) -> Self {
     self.h2ConnectionKeepaliveTimeoutSeconds = h2ConnectionKeepaliveTimeoutSeconds
+    return self
+  }
+
+   /// Add the limit that h2 streams are able to buffer.
+   ///
+   /// - parameter h2StreamBufferBytes: Size in bytes that h2 streams are allowed to buffer.
+   ///
+   /// - returns: This builder.
+  public func addH2StreamBufferBytes(_ h2StreamBufferBytes: UInt32) -> Self {
+    self.h2StreamBufferBytes = h2StreamBufferBytes
     return self
   }
 
@@ -368,6 +380,7 @@ open class EngineBuilder: NSObject {
       h2ConnectionKeepaliveIdleIntervalMilliseconds:
         self.h2ConnectionKeepaliveIdleIntervalMilliseconds,
       h2ConnectionKeepaliveTimeoutSeconds: self.h2ConnectionKeepaliveTimeoutSeconds,
+      h2StreamBufferBytes: self.h2StreamBufferBytes,
       statsFlushSeconds: self.statsFlushSeconds,
       streamIdleTimeoutSeconds: self.streamIdleTimeoutSeconds,
       perTryIdleTimeoutSeconds: self.perTryIdleTimeoutSeconds,

--- a/library/swift/EngineBuilder.swift
+++ b/library/swift/EngineBuilder.swift
@@ -177,11 +177,11 @@ open class EngineBuilder: NSObject {
 
    /// Add the limit that h2 streams are able to buffer.
    ///
-   /// - parameter h2StreamBufferBytes: Size in bytes that h2 streams are allowed to buffer.
+   /// - parameter h2StreamBufferLimitBytes: Size in bytes that h2 streams are allowed to buffer.
    ///
    /// - returns: This builder.
-  public func addH2StreamBufferBytes(_ h2StreamBufferBytes: UInt32) -> Self {
-    self.h2StreamBufferBytes = h2StreamBufferBytes
+  public func addH2StreamBufferLimitBytes(_ h2StreamBufferLimitBytes: UInt32) -> Self {
+    self.h2StreamBufferLimitBytes = h2StreamBufferLimitBytes
     return self
   }
 
@@ -380,7 +380,7 @@ open class EngineBuilder: NSObject {
       h2ConnectionKeepaliveIdleIntervalMilliseconds:
         self.h2ConnectionKeepaliveIdleIntervalMilliseconds,
       h2ConnectionKeepaliveTimeoutSeconds: self.h2ConnectionKeepaliveTimeoutSeconds,
-      h2StreamBufferBytes: self.h2StreamBufferBytes,
+      h2StreamBufferLimitBytes: self.h2StreamBufferLimitBytes,
       statsFlushSeconds: self.statsFlushSeconds,
       streamIdleTimeoutSeconds: self.streamIdleTimeoutSeconds,
       perTryIdleTimeoutSeconds: self.perTryIdleTimeoutSeconds,

--- a/library/swift/EngineBuilder.swift
+++ b/library/swift/EngineBuilder.swift
@@ -25,7 +25,7 @@ open class EngineBuilder: NSObject {
   private var h2ConnectionKeepaliveIdleIntervalMilliseconds: UInt32 = 100000000
   private var h2ConnectionKeepaliveTimeoutSeconds: UInt32 = 10
   // 10Mb default (10 * 1024 * 1024)
-  private var h2StreamBufferLimitBytes: UInt32 = 10485760;
+  private var h2StreamBufferLimitBytes: UInt32 = 10485760
   private var statsFlushSeconds: UInt32 = 60
   private var streamIdleTimeoutSeconds: UInt32 = 15
   private var perTryIdleTimeoutSeconds: UInt32 = 15

--- a/test/cc/unit/envoy_config_test.cc
+++ b/test/cc/unit/envoy_config_test.cc
@@ -21,6 +21,7 @@ TEST(TestConfig, ConfigIsApplied) {
       .addDnsPreresolveHostnames("[hostname]")
       .addH2ConnectionKeepaliveIdleIntervalMilliseconds(222)
       .addH2ConnectionKeepaliveTimeoutSeconds(333)
+      .addH2StreamBufferLimitBytes(888)
       .addStatsFlushSeconds(654)
       .addVirtualClusters("[virtual-clusters]")
       .setAppVersion("1.2.3")
@@ -38,6 +39,7 @@ TEST(TestConfig, ConfigIsApplied) {
       "- &dns_preresolve_hostnames [hostname]",
       "- &h2_connection_keepalive_idle_interval 0.222s",
       "- &h2_connection_keepalive_timeout 333s",
+      "- &h2_stream_buffer_limit_bytes 888",
       "- &stats_flush_interval 654s",
       "- &virtual_clusters [virtual-clusters]",
       ("- &metadata { device_os: probably-ubuntu-on-CI, "

--- a/test/java/io/envoyproxy/envoymobile/engine/EnvoyConfigurationTest.kt
+++ b/test/java/io/envoyproxy/envoymobile/engine/EnvoyConfigurationTest.kt
@@ -28,7 +28,7 @@ class EnvoyConfigurationTest {
   @Test
   fun `resolving with default configuration resolves with values`() {
     val envoyConfiguration = EnvoyConfiguration(
-      false, "stats.foo.com", null, 123, 234, 345, 456, 321, "[hostname]", true, 222, 333, 567, 678, 910, "v1.2.3", "com.mydomain.myapp", "[test]",
+      false, "stats.foo.com", null, 123, 234, 345, 456, 321, "[hostname]", true, 222, 333, 888, 567, 678, 910, "v1.2.3", "com.mydomain.myapp", "[test]",
       listOf(EnvoyNativeFilterConfig("filter_name", "test_config")),
       emptyList(), emptyMap()
     )
@@ -54,6 +54,9 @@ class EnvoyConfigurationTest {
     assertThat(resolvedTemplate).contains("&h2_connection_keepalive_idle_interval 0.222s")
     assertThat(resolvedTemplate).contains("&h2_connection_keepalive_timeout 333s")
 
+    // H2 Buffer Limit
+    assertThat(resolvedTemplate).contains("&h2_stream_buffer_limit_bytes 888")
+
     // Metadata
     assertThat(resolvedTemplate).contains("os: Android")
     assertThat(resolvedTemplate).contains("app_version: v1.2.3")
@@ -77,7 +80,7 @@ class EnvoyConfigurationTest {
   @Test
   fun `resolve templates with invalid templates will throw on build`() {
     val envoyConfiguration = EnvoyConfiguration(
-      false, "stats.foo.com", null, 123, 234, 345, 456, 321, "[hostname]", false, 123, 123, 567, 678, 910, "v1.2.3", "com.mydomain.myapp", "[test]",
+      false, "stats.foo.com", null, 123, 234, 345, 456, 321, "[hostname]", false, 123, 123, 888, 567, 678, 910, "v1.2.3", "com.mydomain.myapp", "[test]",
       emptyList(), emptyList(), emptyMap()
     )
 
@@ -92,7 +95,7 @@ class EnvoyConfigurationTest {
   @Test
   fun `cannot configure both statsD and gRPC stat sink`() {
     val envoyConfiguration = EnvoyConfiguration(
-      false, "stats.foo.com", 5050, 123, 234, 345, 456, 321, "[hostname]", false, 123, 123, 567, 678, 910, "v1.2.3", "com.mydomain.myapp", "[test]",
+      false, "stats.foo.com", 5050, 123, 234, 345, 456, 321, "[hostname]", false, 123, 123, 888, 567, 678, 910, "v1.2.3", "com.mydomain.myapp", "[test]",
       emptyList(), emptyList(), emptyMap()
     )
 

--- a/test/kotlin/io/envoyproxy/envoymobile/EngineBuilderTest.kt
+++ b/test/kotlin/io/envoyproxy/envoymobile/EngineBuilderTest.kt
@@ -107,7 +107,7 @@ class EngineBuilderTest {
     engineBuilder.addH2StreamBufferLimitBytes(888)
 
     val engine = engineBuilder.build() as EngineImpl
-    assertThat(engine.envoyConfiguration!!.h2addH2StreamBufferLimitBytes).isEqualTo(888)
+    assertThat(engine.envoyConfiguration!!.h2StreamBufferLimitBytes).isEqualTo(888)
   }
 
   @Test

--- a/test/kotlin/io/envoyproxy/envoymobile/EngineBuilderTest.kt
+++ b/test/kotlin/io/envoyproxy/envoymobile/EngineBuilderTest.kt
@@ -104,10 +104,10 @@ class EngineBuilderTest {
   fun `specifying H2 Stream buffer limit overrides default`() {
     engineBuilder = EngineBuilder(Standard())
     engineBuilder.addEngineType { envoyEngine }
-    engineBuilder.addH2StreamBufferBytes(888)
+    engineBuilder.addH2StreamBufferLimitBytes(888)
 
     val engine = engineBuilder.build() as EngineImpl
-    assertThat(engine.envoyConfiguration!!.h2addH2StreamBufferBytes).isEqualTo(888)
+    assertThat(engine.envoyConfiguration!!.h2addH2StreamBufferLimitBytes).isEqualTo(888)
   }
 
   @Test

--- a/test/kotlin/io/envoyproxy/envoymobile/EngineBuilderTest.kt
+++ b/test/kotlin/io/envoyproxy/envoymobile/EngineBuilderTest.kt
@@ -101,6 +101,16 @@ class EngineBuilderTest {
   }
 
   @Test
+  fun `specifying H2 Stream buffer limit overrides default`() {
+    engineBuilder = EngineBuilder(Standard())
+    engineBuilder.addEngineType { envoyEngine }
+    engineBuilder.addH2StreamBufferBytes(888)
+
+    val engine = engineBuilder.build() as EngineImpl
+    assertThat(engine.envoyConfiguration!!.h2addH2StreamBufferBytes).isEqualTo(888)
+  }
+
+  @Test
   fun `specifying stats flush overrides default`() {
     engineBuilder = EngineBuilder(Standard())
     engineBuilder.addEngineType { envoyEngine }

--- a/test/swift/EngineBuilderTests.swift
+++ b/test/swift/EngineBuilderTests.swift
@@ -195,6 +195,20 @@ final class EngineBuilderTests: XCTestCase {
     self.waitForExpectations(timeout: 0.01)
   }
 
+  func testAddingH2StreamBufferLimitBytesAddsToConfigurationWhenRunningEnvoy() {
+    let expectation = self.expectation(description: "Run called with expected data")
+    MockEnvoyEngine.onRunWithConfig = { config, _ in
+      XCTAssertEqual(888, config.h2StreamBufferLimitBytes)
+      expectation.fulfill()
+    }
+
+    _ = EngineBuilder()
+      .addEngineType(MockEnvoyEngine.self)
+      .addH2StreamBufferLimitBytes(888)
+      .build()
+    self.waitForExpectations(timeout: 0.01)
+  }
+
   func testAddingPlatformFiltersToConfigurationWhenRunningEnvoy() {
     let expectation = self.expectation(description: "Run called with expected data")
     MockEnvoyEngine.onRunWithConfig = { config, _ in
@@ -334,6 +348,7 @@ final class EngineBuilderTests: XCTestCase {
       enableInterfaceBinding: false,
       h2ConnectionKeepaliveIdleIntervalMilliseconds: 1,
       h2ConnectionKeepaliveTimeoutSeconds: 333,
+      h2StreamBufferLimitBytes: 888,
       statsFlushSeconds: 600,
       streamIdleTimeoutSeconds: 700,
       perTryIdleTimeoutSeconds: 777,
@@ -361,6 +376,8 @@ final class EngineBuilderTests: XCTestCase {
 
     XCTAssertTrue(resolvedYAML.contains("&h2_connection_keepalive_idle_interval 0.001s"))
     XCTAssertTrue(resolvedYAML.contains("&h2_connection_keepalive_timeout 333s"))
+
+    XCTAssertTrue(resolvedYAML.contains("&h2_stream_buffer_limit_bytes 888"))
 
     XCTAssertTrue(resolvedYAML.contains("&stream_idle_timeout 700s"))
     XCTAssertTrue(resolvedYAML.contains("&per_try_idle_timeout 777s"))
@@ -397,6 +414,7 @@ final class EngineBuilderTests: XCTestCase {
       enableInterfaceBinding: false,
       h2ConnectionKeepaliveIdleIntervalMilliseconds: 222,
       h2ConnectionKeepaliveTimeoutSeconds: 333,
+      h2BufferLimitBytes: 333,
       statsFlushSeconds: 600,
       streamIdleTimeoutSeconds: 700,
       perTryIdleTimeoutSeconds: 700,

--- a/test/swift/EngineBuilderTests.swift
+++ b/test/swift/EngineBuilderTests.swift
@@ -414,7 +414,7 @@ final class EngineBuilderTests: XCTestCase {
       enableInterfaceBinding: false,
       h2ConnectionKeepaliveIdleIntervalMilliseconds: 222,
       h2ConnectionKeepaliveTimeoutSeconds: 333,
-      h2BufferLimitBytes: 333,
+      h2StreamBufferLimitBytes: 333,
       statsFlushSeconds: 600,
       streamIdleTimeoutSeconds: 700,
       perTryIdleTimeoutSeconds: 700,


### PR DESCRIPTION
Description: this PR adds an EngineBuilder API to configure the allowed buffer limit for H2 streams. Under the hood this configures Envoy's H2 protocol's initial_stream_window_size.
Risk Level: med new opt-in API, but the default moves the buffer limit from 65kb to 10mb.
Testing: added Engine Builder tests.
Docs Changes: added