### PR TITLE
Fix race condition for last resumeData

### DIFF
--- a/library/common/http/client.cc
+++ b/library/common/http/client.cc
@@ -85,6 +85,7 @@ void Client::DirectStreamCallbacks::encodeData(Buffer::Instance& data, bool end_
   if (explicit_flow_control_ && !response_data_) {
     response_data_ = std::make_unique<Buffer::WatermarkBuffer>(
         [this]() -> void {
+          // This call is asynchronous, and may occur for a closed stream.
           if (!this->remote_end_stream_received_) {
             this->onBufferedDataDrained();
           }

--- a/library/common/http/client.cc
+++ b/library/common/http/client.cc
@@ -84,12 +84,7 @@ void Client::DirectStreamCallbacks::encodeData(Buffer::Instance& data, bool end_
   // incur an asynchronous callback to sendDataToBridge.
   if (explicit_flow_control_ && !response_data_) {
     response_data_ = std::make_unique<Buffer::WatermarkBuffer>(
-        [this]() -> void {
-          // This call is asynchronous, and may occur for a closed stream.
-          if (!this->remote_end_stream_received_) {
-            this->onBufferedDataDrained();
-          }
-        },
+        [this]() -> void { this->onBufferedDataDrained(); },
         [this]() -> void { this->onHasBufferedData(); }, []() -> void {});
     // Default to 1M per stream. This is fairly arbitrary and will result in
     // Envoy buffering up to 1M + flow-control-window for HTTP/2 and HTTP/3,
@@ -254,6 +249,20 @@ void Client::DirectStreamCallbacks::onCancel() {
   ENVOY_LOG(debug, "[S{}] dispatching to platform cancel stream", direct_stream_.stream_handle_);
   http_client_.stats().stream_cancel_.inc();
   bridge_callbacks_.on_cancel(streamIntel(), bridge_callbacks_.context);
+}
+
+void Client::DirectStreamCallbacks::onHasBufferedData() {
+  // This call is potentially asynchronous, and may occur for a closed stream.
+  if (!remote_end_stream_received_) {
+    direct_stream_.runHighWatermarkCallbacks();
+  }
+}
+
+void Client::DirectStreamCallbacks::onBufferedDataDrained() {
+  // This call is potentially asynchronous, and may occur for a closed stream.
+  if (!remote_end_stream_received_) {
+    direct_stream_.runLowWatermarkCallbacks();
+  }
 }
 
 envoy_stream_intel Client::DirectStreamCallbacks::streamIntel() {

--- a/library/common/http/client.cc
+++ b/library/common/http/client.cc
@@ -84,7 +84,11 @@ void Client::DirectStreamCallbacks::encodeData(Buffer::Instance& data, bool end_
   // incur an asynchronous callback to sendDataToBridge.
   if (explicit_flow_control_ && !response_data_) {
     response_data_ = std::make_unique<Buffer::WatermarkBuffer>(
-        [this]() -> void { this->onBufferedDataDrained(); },
+        [this]() -> void {
+          if (!this->remote_end_stream_received_) {
+            this->onBufferedDataDrained();
+          }
+        },
         [this]() -> void { this->onHasBufferedData(); }, []() -> void {});
     // Default to 1M per stream. This is fairly arbitrary and will result in
     // Envoy buffering up to 1M + flow-control-window for HTTP/2 and HTTP/3,

--- a/library/common/http/client.h
+++ b/library/common/http/client.h
@@ -152,8 +152,8 @@ private:
 
     void encodeMetadata(const MetadataMapVector&) override { NOT_IMPLEMENTED_GCOVR_EXCL_LINE; }
 
-    void onHasBufferedData() { direct_stream_.runHighWatermarkCallbacks(); }
-    void onBufferedDataDrained() { direct_stream_.runLowWatermarkCallbacks(); }
+    void onHasBufferedData();
+    void onBufferedDataDrained();
 
     // To be called by mobile library when in explicit flow control mode and more data is wanted.
     // If bytes are available, the bytes available (up to the limit of


### PR DESCRIPTION
Description: Race condition between stream destruction and runLowWatermarkCallbacks
Risk Level: small
Testing: CI, and a new test failing if the fix is absent.
Docs Changes: N/A
Release Notes: N/A
Fixes #1931
Signed-off-by: Charles Le Borgne <cleborgne@google.com>
