### PR TITLE
cc: avoid use of designated initializers

### DIFF
--- a/library/cc/BUILD
+++ b/library/cc/BUILD
@@ -57,9 +57,6 @@ envoy_cc_library(
         "trailers.h",
         "upstream_http_protocol.h",
     ],
-    copts = [
-        "-std=c++2a",
-    ],
     external_deps = ["abseil_optional"],
     repository = "@envoy",
     visibility = ["//visibility:public"],

--- a/library/cc/BUILD
+++ b/library/cc/BUILD
@@ -58,7 +58,7 @@ envoy_cc_library(
         "upstream_http_protocol.h",
     ],
     copts = [
-        "-std=c++20",
+        "-std=c++2a",
     ],
     external_deps = ["abseil_optional"],
     repository = "@envoy",

--- a/library/cc/BUILD
+++ b/library/cc/BUILD
@@ -60,6 +60,9 @@ envoy_cc_library(
     external_deps = ["abseil_optional"],
     repository = "@envoy",
     visibility = ["//visibility:public"],
+    copts = [
+        "-std=c++20",
+    ],
     deps = [
         "//library/common:envoy_main_interface_lib_no_stamp",
         "//library/common/data:utility_lib",

--- a/library/cc/BUILD
+++ b/library/cc/BUILD
@@ -6,16 +6,16 @@ envoy_package()
 
 envoy_cc_library(
     name = "engine_builder_lib",
-    repository = "@envoy",
-    hdrs = [
-        "engine_builder.h",
-    ],
     srcs = [
         "engine_builder.cc",
     ],
+    hdrs = [
+        "engine_builder.h",
+    ],
+    repository = "@envoy",
     deps = [
         ":envoy_engine_cc_lib_no_stamp",
-    ]
+    ],
 )
 
 envoy_cc_library(
@@ -82,8 +82,8 @@ envoy_cc_library(
     name = "envoy_engine_cc_lienvoy_engine_cc_libb",
     repository = "@envoy",
     deps = [
-        ":envoy_engine_cc_lib_no_stamp",
         ":engine_builder_lib",
+        ":envoy_engine_cc_lib_no_stamp",
         "//library/common:engine_common_lib_stamped",
     ],
 )

--- a/library/cc/BUILD
+++ b/library/cc/BUILD
@@ -57,12 +57,12 @@ envoy_cc_library(
         "trailers.h",
         "upstream_http_protocol.h",
     ],
-    external_deps = ["abseil_optional"],
-    repository = "@envoy",
-    visibility = ["//visibility:public"],
     copts = [
         "-std=c++20",
     ],
+    external_deps = ["abseil_optional"],
+    repository = "@envoy",
+    visibility = ["//visibility:public"],
     deps = [
         "//library/common:envoy_main_interface_lib_no_stamp",
         "//library/common/data:utility_lib",

--- a/library/cc/BUILD
+++ b/library/cc/BUILD
@@ -79,7 +79,7 @@ envoy_cc_library(
 )
 
 envoy_cc_library(
-    name = "envoy_engine_cc_lienvoy_engine_cc_libb",
+    name = "envoy_engine_cc_lib",
     repository = "@envoy",
     deps = [
         ":engine_builder_lib",

--- a/library/cc/BUILD
+++ b/library/cc/BUILD
@@ -5,11 +5,24 @@ licenses(["notice"])  # Apache 2
 envoy_package()
 
 envoy_cc_library(
+    name = "engine_builder_lib",
+    repository = "@envoy",
+    hdrs = [
+        "engine_builder.h",
+    ],
+    srcs = [
+        "engine_builder.cc",
+    ],
+    deps = [
+        ":envoy_engine_cc_lib_no_stamp",
+    ]
+)
+
+envoy_cc_library(
     name = "envoy_engine_cc_lib_no_stamp",
     srcs = [
         "bridge_utility.cc",
         "engine.cc",
-        "engine_builder.cc",
         "engine_callbacks.cc",
         "headers.cc",
         "headers_builder.cc",
@@ -33,7 +46,6 @@ envoy_cc_library(
     hdrs = [
         "bridge_utility.h",
         "engine.h",
-        "engine_builder.h",
         "engine_callbacks.h",
         "envoy_error.h",
         "headers.h",
@@ -67,10 +79,11 @@ envoy_cc_library(
 )
 
 envoy_cc_library(
-    name = "envoy_engine_cc_lib",
+    name = "envoy_engine_cc_lienvoy_engine_cc_libb",
     repository = "@envoy",
     deps = [
         ":envoy_engine_cc_lib_no_stamp",
+        ":engine_builder_lib",
         "//library/common:engine_common_lib_stamped",
     ],
 )

--- a/library/cc/bridge_utility.cc
+++ b/library/cc/bridge_utility.cc
@@ -27,8 +27,8 @@ envoy_headers rawHeaderMapAsEnvoyHeaders(const RawHeaderMap& headers) {
   }
 
   envoy_headers raw_headers{
-      .length = static_cast<envoy_map_size_t>(header_count),
-      .entries = headers_list,
+      static_cast<envoy_map_size_t>(header_count),
+      headers_list,
   };
   return raw_headers;
 }

--- a/library/cc/bridge_utility.cc
+++ b/library/cc/bridge_utility.cc
@@ -45,7 +45,7 @@ RawHeaderMap envoyHeadersAsRawHeaderMap(envoy_headers raw_headers) {
     headers[key].push_back(value);
   }
   // free instead of release_envoy_headers
-  // because we already free each envoy_data piecewise
+  // because we already free each envoy_data individually
   // during calls to envoy_data_as_string
   free(raw_headers.entries);
   return headers;

--- a/library/cc/engine_builder.cc
+++ b/library/cc/engine_builder.cc
@@ -9,7 +9,7 @@ namespace Envoy {
 namespace Platform {
 
 EngineBuilder::EngineBuilder(std::string config_template)
-    : config_template_(config_template), callbacks_(std::make_shared<EngineCallbacks>()) {}
+    : callbacks_(std::make_shared<EngineCallbacks>()), config_template_(config_template) {}
 EngineBuilder::EngineBuilder() : EngineBuilder(std::string(config_template)) {}
 
 EngineBuilder& EngineBuilder::addLogLevel(LogLevel log_level) {

--- a/library/cc/engine_builder.cc
+++ b/library/cc/engine_builder.cc
@@ -8,12 +8,12 @@
 namespace Envoy {
 namespace Platform {
 
-EngineBuilder::EngineBuilder(std::string config_template) : config_template_(config_template) {}
+EngineBuilder::EngineBuilder(std::string config_template)
+    : config_template_(config_template), callbacks_(std::make_shared<EngineCallbacks>()) {}
 EngineBuilder::EngineBuilder() : EngineBuilder(std::string(config_template)) {}
 
 EngineBuilder& EngineBuilder::addLogLevel(LogLevel log_level) {
   this->log_level_ = log_level;
-  this->callbacks_ = std::make_shared<EngineCallbacks>();
   return *this;
 }
 

--- a/library/cc/engine_callbacks.cc
+++ b/library/cc/engine_callbacks.cc
@@ -19,9 +19,9 @@ void c_on_exit(void* context) {
 
 envoy_engine_callbacks EngineCallbacks::asEnvoyEngineCallbacks() {
   return envoy_engine_callbacks{
-      .on_engine_running = &c_on_engine_running,
-      .on_exit = &c_on_exit,
-      .context = new EngineCallbacksSharedPtr(this->shared_from_this()),
+      &c_on_engine_running,
+      &c_on_exit,
+      new EngineCallbacksSharedPtr(shared_from_this()),
   };
 }
 

--- a/library/cc/stream_callbacks.cc
+++ b/library/cc/stream_callbacks.cc
@@ -102,15 +102,15 @@ void* c_on_send_window_available(envoy_stream_intel, void* context) {
 
 envoy_http_callbacks StreamCallbacks::asEnvoyHttpCallbacks() {
   return envoy_http_callbacks{
-      .on_headers = &c_on_headers,
-      .on_data = &c_on_data,
-      .on_metadata = nullptr,
-      .on_trailers = &c_on_trailers,
-      .on_error = &c_on_error,
-      .on_complete = &c_on_complete,
-      .on_cancel = &c_on_cancel,
-      .on_send_window_available = &c_on_send_window_available,
-      .context = new StreamCallbacksSharedPtr(this->shared_from_this()),
+      &c_on_headers,
+      &c_on_data,
+      nullptr,
+      &c_on_trailers,
+      &c_on_error,
+      &c_on_complete,
+      &c_on_cancel,
+      &c_on_send_window_available,
+      new StreamCallbacksSharedPtr(shared_from_this()),
   };
 }
 

--- a/library/python/BUILD
+++ b/library/python/BUILD
@@ -22,8 +22,8 @@ pybind_library(
     ],
     visibility = ["//visibility:public"],
     deps = [
-        "//library/cc:envoy_engine_cc_lib",
         "//library/cc:engine_builder_lib",
+        "//library/cc:envoy_engine_cc_lib",
     ],
 )
 

--- a/library/python/BUILD
+++ b/library/python/BUILD
@@ -23,6 +23,7 @@ pybind_library(
     visibility = ["//visibility:public"],
     deps = [
         "//library/cc:envoy_engine_cc_lib",
+        "//library/cc:engine_builder_lib",
     ],
 )
 

--- a/test/cc/integration/BUILD
+++ b/test/cc/integration/BUILD
@@ -9,8 +9,8 @@ envoy_cc_test(
     srcs = ["send_headers_test.cc"],
     repository = "@envoy",
     deps = [
-        "//library/cc:envoy_engine_cc_lib_no_stamp",
         "//library/cc:engine_builder_lib",
+        "//library/cc:envoy_engine_cc_lib_no_stamp",
     ],
 )
 
@@ -19,7 +19,7 @@ envoy_cc_test(
     srcs = ["lifetimes_test.cc"],
     repository = "@envoy",
     deps = [
-        "//library/cc:envoy_engine_cc_lib_no_stamp",
         "//library/cc:engine_builder_lib",
+        "//library/cc:envoy_engine_cc_lib_no_stamp",
     ],
 )

--- a/test/cc/integration/BUILD
+++ b/test/cc/integration/BUILD
@@ -10,6 +10,7 @@ envoy_cc_test(
     repository = "@envoy",
     deps = [
         "//library/cc:envoy_engine_cc_lib_no_stamp",
+        "//library/cc:engine_builder_lib",
     ],
 )
 
@@ -19,5 +20,6 @@ envoy_cc_test(
     repository = "@envoy",
     deps = [
         "//library/cc:envoy_engine_cc_lib_no_stamp",
+        "//library/cc:engine_builder_lib",
     ],
 )

--- a/test/cc/unit/BUILD
+++ b/test/cc/unit/BUILD
@@ -9,6 +9,7 @@ envoy_cc_test(
     srcs = ["envoy_config_test.cc"],
     repository = "@envoy",
     deps = [
+        "//library/cc:engine_builder_lib",
         "//library/cc:envoy_engine_cc_lib_no_stamp",
     ],
 )


### PR DESCRIPTION
This fixes an issue where depending on this library would fail due to the use of C++ 20 designated initializers.

Risk Level: Low, build only
Testing: Existing tests
Docs Changes: n/a 
Release Notes: n/a
