### PR TITLE
cc: support setLogger on cc EngineBuilder 

### DIFF
--- a/library/cc/engine_builder.cc
+++ b/library/cc/engine_builder.cc
@@ -150,10 +150,14 @@ void cc_logger_delete(const void* logger) {
 }
 } // namespace
 EngineSharedPtr EngineBuilder::build() {
-  envoy_logger logger;
-  logger.log = cc_engine_on_log;
-  logger.release = cc_logger_delete;
-  logger.context = new LoggerFunc(logger_);
+  envoy_logger logger{};
+  if (logger_ != nullptr) {
+    logger.log = cc_engine_on_log;
+    logger.release = cc_logger_delete;
+    logger.context = new LoggerFunc(logger_);
+  } else {
+    logger.release = envoy_noop_const_release;
+  }
 
   envoy_event_tracker null_tracker{};
 

--- a/library/cc/engine_builder.h
+++ b/library/cc/engine_builder.h
@@ -18,6 +18,9 @@ public:
   EngineBuilder& addLogLevel(LogLevel log_level);
   EngineBuilder& setOnEngineRunning(std::function<void()> closure);
 
+  using LoggerFunc = std::function<void(absl::string_view)>;
+  EngineBuilder& addLogger(LoggerFunc logger);
+
   EngineBuilder& addGrpcStatsDomain(const std::string& stats_domain);
   EngineBuilder& addConnectTimeoutSeconds(int connect_timeout_seconds);
   EngineBuilder& addDnsRefreshSeconds(int dns_refresh_seconds);
@@ -48,6 +51,7 @@ public:
 private:
   LogLevel log_level_ = LogLevel::info;
   EngineCallbacksSharedPtr callbacks_;
+  LoggerFunc logger_;
 
   std::string config_template_;
   std::string stats_domain_ = "0.0.0.0";

--- a/library/cc/engine_builder.h
+++ b/library/cc/engine_builder.h
@@ -19,7 +19,7 @@ public:
   EngineBuilder& setOnEngineRunning(std::function<void()> closure);
 
   using LoggerFunc = std::function<void(absl::string_view)>;
-  EngineBuilder& addLogger(LoggerFunc logger);
+  EngineBuilder& setLogger(LoggerFunc logger);
 
   EngineBuilder& addGrpcStatsDomain(const std::string& stats_domain);
   EngineBuilder& addConnectTimeoutSeconds(int connect_timeout_seconds);

--- a/test/cc/integration/BUILD
+++ b/test/cc/integration/BUILD
@@ -5,6 +5,15 @@ licenses(["notice"])  # Apache 2
 envoy_package()
 
 envoy_cc_test(
+    name = "engine_logger_test",
+    srcs = ["engine_logger_test.cc"],
+    repository = "@envoy",
+    deps = [
+        "//library/cc:envoy_engine_cc_lib_no_stamp",
+    ],
+)
+
+envoy_cc_test(
     name = "send_headers_test",
     srcs = ["send_headers_test.cc"],
     repository = "@envoy",

--- a/test/cc/integration/engine_logger_test.cc
+++ b/test/cc/integration/engine_logger_test.cc
@@ -5,7 +5,8 @@
 
 namespace Envoy {
 namespace {
-TEST(EngineLoggerTest, CanRegisterLogger) {
+
+TEST(EngineLoggerTest, SetLogger) {
   auto engine_builder = Platform::EngineBuilder();
   absl::Notification startup_log_seen;
   auto engine = engine_builder.addLogLevel(Platform::LogLevel::debug)
@@ -18,6 +19,19 @@ TEST(EngineLoggerTest, CanRegisterLogger) {
                     .build();
 
   startup_log_seen.WaitForNotification();
+
+  engine->terminate();
+}
+
+// Verifies that we can start up without specifying a logger.
+TEST(EngineLoggerTest, LoggerNotSet) {
+  auto engine_builder = Platform::EngineBuilder();
+  absl::Notification startup;
+  auto engine = engine_builder.addLogLevel(Platform::LogLevel::debug)
+                    .setOnEngineRunning([&]() { startup.Notify(); })
+                    .build();
+
+  startup.WaitForNotification();
 
   engine->terminate();
 }

--- a/test/cc/integration/engine_logger_test.cc
+++ b/test/cc/integration/engine_logger_test.cc
@@ -1,0 +1,26 @@
+#include "absl/strings/match.h"
+#include "absl/synchronization/notification.h"
+#include "gtest/gtest.h"
+#include "library/cc/engine_builder.h"
+
+namespace Envoy {
+namespace {
+TEST(EngineLoggerTest, CanRegisterLogger) {
+  auto engine_builder = Platform::EngineBuilder();
+  absl::Notification startup_log_seen;
+  auto engine = engine_builder.addLogLevel(Platform::LogLevel::debug)
+                    .setOnEngineRunning([]() {})
+                    .setLogger([&](auto msg) {
+                      if (absl::StrContains(msg, ("starting main dispatch loop"))) {
+                        startup_log_seen.Notify();
+                      }
+                    })
+                    .build();
+
+  startup_log_seen.WaitForNotification();
+
+  engine->terminate();
+}
+
+} // namespace
+} // namespace Envoy


### PR DESCRIPTION
Adds a setLogger function that mirrors the functionality of the Kotlin/Swift EngineBuilder

Risk Level: Medium
Testing: New integration tests
Docs Changes: n/a
Release Notes: n/a
