### PR TITLE
cc: remove redundant this-> usage

### DIFF
--- a/library/cc/engine_builder.cc
+++ b/library/cc/engine_builder.cc
@@ -12,108 +12,108 @@ EngineBuilder::EngineBuilder(std::string config_template) : config_template_(con
 EngineBuilder::EngineBuilder() : EngineBuilder(std::string(config_template)) {}
 
 EngineBuilder& EngineBuilder::addLogLevel(LogLevel log_level) {
-  this->log_level_ = log_level;
-  this->callbacks_ = std::make_shared<EngineCallbacks>();
+  log_level_ = log_level;
+  callbacks_ = std::make_shared<EngineCallbacks>();
   return *this;
 }
 
 EngineBuilder& EngineBuilder::setOnEngineRunning(std::function<void()> closure) {
-  this->callbacks_->on_engine_running = closure;
+  callbacks_->on_engine_running = closure;
   return *this;
 }
 
 EngineBuilder& EngineBuilder::addGrpcStatsDomain(const std::string& stats_domain) {
-  this->stats_domain_ = stats_domain;
+  stats_domain_ = stats_domain;
   return *this;
 }
 
 EngineBuilder& EngineBuilder::addConnectTimeoutSeconds(int connect_timeout_seconds) {
-  this->connect_timeout_seconds_ = connect_timeout_seconds;
+  connect_timeout_seconds_ = connect_timeout_seconds;
   return *this;
 }
 
 EngineBuilder& EngineBuilder::addDnsRefreshSeconds(int dns_refresh_seconds) {
-  this->dns_refresh_seconds_ = dns_refresh_seconds;
+  dns_refresh_seconds_ = dns_refresh_seconds;
   return *this;
 }
 
 EngineBuilder& EngineBuilder::addDnsFailureRefreshSeconds(int base, int max) {
-  this->dns_failure_refresh_seconds_base_ = base;
-  this->dns_failure_refresh_seconds_max_ = max;
+  dns_failure_refresh_seconds_base_ = base;
+  dns_failure_refresh_seconds_max_ = max;
   return *this;
 }
 
 EngineBuilder& EngineBuilder::addDnsQueryTimeoutSeconds(int dns_query_timeout_seconds) {
-  this->dns_query_timeout_seconds_ = dns_query_timeout_seconds;
+  dns_query_timeout_seconds_ = dns_query_timeout_seconds;
   return *this;
 }
 
 EngineBuilder&
 EngineBuilder::addDnsPreresolveHostnames(const std::string& dns_preresolve_hostnames) {
-  this->dns_preresolve_hostnames_ = dns_preresolve_hostnames;
+  dns_preresolve_hostnames_ = dns_preresolve_hostnames;
   return *this;
 }
 
 EngineBuilder& EngineBuilder::addH2ConnectionKeepaliveIdleIntervalMilliseconds(
     int h2_connection_keepalive_idle_interval_milliseconds) {
-  this->h2_connection_keepalive_idle_interval_milliseconds_ =
+  h2_connection_keepalive_idle_interval_milliseconds_ =
       h2_connection_keepalive_idle_interval_milliseconds;
   return *this;
 }
 
 EngineBuilder&
 EngineBuilder::addH2ConnectionKeepaliveTimeoutSeconds(int h2_connection_keepalive_timeout_seconds) {
-  this->h2_connection_keepalive_timeout_seconds_ = h2_connection_keepalive_timeout_seconds;
+  h2_connection_keepalive_timeout_seconds_ = h2_connection_keepalive_timeout_seconds;
   return *this;
 }
 
 EngineBuilder& EngineBuilder::addStatsFlushSeconds(int stats_flush_seconds) {
-  this->stats_flush_seconds_ = stats_flush_seconds;
+  stats_flush_seconds_ = stats_flush_seconds;
   return *this;
 }
 
 EngineBuilder& EngineBuilder::addVirtualClusters(const std::string& virtual_clusters) {
-  this->virtual_clusters_ = virtual_clusters;
+  virtual_clusters_ = virtual_clusters;
   return *this;
 }
 
 EngineBuilder& EngineBuilder::setAppVersion(const std::string& app_version) {
-  this->app_version_ = app_version;
+  app_version_ = app_version;
   return *this;
 }
 
 EngineBuilder& EngineBuilder::setAppId(const std::string& app_id) {
-  this->app_id_ = app_id;
+  app_id_ = app_id;
   return *this;
 }
 
 EngineBuilder& EngineBuilder::setDeviceOs(const std::string& device_os) {
-  this->device_os_ = device_os;
+  device_os_ = device_os;
   return *this;
 }
 
 std::string EngineBuilder::generateConfigStr() {
   std::vector<std::pair<std::string, std::string>> replacements{
-      {"connect_timeout", fmt::format("{}s", this->connect_timeout_seconds_)},
-      {"dns_fail_base_interval", fmt::format("{}s", this->dns_failure_refresh_seconds_base_)},
-      {"dns_fail_max_interval", fmt::format("{}s", this->dns_failure_refresh_seconds_max_)},
-      {"dns_preresolve_hostnames", this->dns_preresolve_hostnames_},
-      {"dns_refresh_rate", fmt::format("{}s", this->dns_refresh_seconds_)},
-      {"dns_query_timeout", fmt::format("{}s", this->dns_query_timeout_seconds_)},
+      {"connect_timeout", fmt::format("{}s", connect_timeout_seconds_)},
+      {"dns_fail_base_interval", fmt::format("{}s", dns_failure_refresh_seconds_base_)},
+      {"dns_fail_max_interval", fmt::format("{}s", dns_failure_refresh_seconds_max_)},
+      {"dns_preresolve_hostnames", dns_preresolve_hostnames_},
+      {"dns_refresh_rate", fmt::format("{}s", dns_refresh_seconds_)},
+      {"dns_query_timeout", fmt::format("{}s", dns_query_timeout_seconds_)},
       {"h2_connection_keepalive_idle_interval",
-       fmt::format("{}s", this->h2_connection_keepalive_idle_interval_milliseconds_ / 1000.0)},
+       fmt::format("{}s", h2_connection_keepalive_idle_interval_milliseconds_ / 1000.0)},
       {"h2_connection_keepalive_timeout",
-       fmt::format("{}s", this->h2_connection_keepalive_timeout_seconds_)},
+       fmt::format("{}s", h2_connection_keepalive_timeout_seconds_)},
       {
           "metadata",
-          fmt::format("{{ device_os: {}, app_version: {}, app_id: {} }}", this->device_os_,
-                      this->app_version_, this->app_id_),
+          fmt::format("{{ device_os: {}, app_version: {}, app_id: {} }}", device_os_, app_version_,
+                      app_id_),
       },
-      {"stats_domain", this->stats_domain_},
-      {"stats_flush_interval", fmt::format("{}s", this->stats_flush_seconds_)},
-      {"stream_idle_timeout", fmt::format("{}s", this->stream_idle_timeout_seconds_)},
-      {"per_try_idle_timeout", fmt::format("{}s", this->per_try_idle_timeout_seconds_)},
-      {"virtual_clusters", this->virtual_clusters_},
+      {"stats_domain", stats_domain_},
+      {"stats_flush_interval", fmt::format("{}s", stats_flush_seconds_)},
+      {"stream_idle_timeout", fmt::format("{}s", stream_idle_timeout_seconds_)},
+      {"per_try_idle_timeout", fmt::format("{}s", per_try_idle_timeout_seconds_)},
+      {"virtual_clusters", virtual_clusters_},
   };
 
   // NOTE: this does not include support for custom filters
@@ -140,10 +140,9 @@ EngineSharedPtr EngineBuilder::build() {
 
   envoy_event_tracker null_tracker{};
 
-  auto config_str = this->generateConfigStr();
-  auto envoy_engine =
-      init_engine(this->callbacks_->asEnvoyEngineCallbacks(), null_logger, null_tracker);
-  run_engine(envoy_engine, config_str.c_str(), logLevelToString(this->log_level_).c_str());
+  auto config_str = generateConfigStr();
+  auto envoy_engine = init_engine(callbacks_->asEnvoyEngineCallbacks(), null_logger, null_tracker);
+  run_engine(envoy_engine, config_str.c_str(), logLevelToString(log_level_).c_str());
 
   // we can't construct via std::make_shared
   // because Engine is only constructible as a friend

--- a/library/cc/engine_callbacks.cc
+++ b/library/cc/engine_callbacks.cc
@@ -21,7 +21,7 @@ envoy_engine_callbacks EngineCallbacks::asEnvoyEngineCallbacks() {
   return envoy_engine_callbacks{
       .on_engine_running = &c_on_engine_running,
       .on_exit = &c_on_exit,
-      .context = new EngineCallbacksSharedPtr(this->shared_from_this()),
+      .context = new EngineCallbacksSharedPtr(shared_from_this()),
   };
 }
 

--- a/library/cc/headers.cc
+++ b/library/cc/headers.cc
@@ -4,20 +4,18 @@ namespace Envoy {
 namespace Platform {
 
 Headers::const_iterator Headers::begin() const {
-  return Headers::const_iterator(this->allHeaders().begin());
+  return Headers::const_iterator(allHeaders().begin());
 }
 
-Headers::const_iterator Headers::end() const {
-  return Headers::const_iterator(this->allHeaders().end());
-}
+Headers::const_iterator Headers::end() const { return Headers::const_iterator(allHeaders().end()); }
 
 const std::vector<std::string>& Headers::operator[](const std::string& key) const {
-  return this->headers_.at(key);
+  return headers_.at(key);
 }
 
-const RawHeaderMap& Headers::allHeaders() const { return this->headers_; }
+const RawHeaderMap& Headers::allHeaders() const { return headers_; }
 
-bool Headers::contains(const std::string& key) const { return this->headers_.contains(key); }
+bool Headers::contains(const std::string& key) const { return headers_.contains(key); }
 
 Headers::Headers(const RawHeaderMap& headers) : headers_(headers) {}
 

--- a/library/cc/headers.h
+++ b/library/cc/headers.h
@@ -26,7 +26,7 @@ public:
     pointer operator->() { return &position_->first; }
 
     const_iterator& operator++() {
-      this->position_++;
+      position_++;
       return *this;
     }
     const_iterator operator++(int) {

--- a/library/cc/headers_builder.cc
+++ b/library/cc/headers_builder.cc
@@ -4,27 +4,27 @@ namespace Envoy {
 namespace Platform {
 
 HeadersBuilder& HeadersBuilder::add(const std::string& name, const std::string& value) {
-  if (this->isRestrictedHeader(name)) {
+  if (isRestrictedHeader(name)) {
     return *this;
   }
-  this->headers_[name].push_back(value);
+  headers_[name].push_back(value);
   return *this;
 }
 
 HeadersBuilder& HeadersBuilder::set(const std::string& name,
                                     const std::vector<std::string>& values) {
-  if (this->isRestrictedHeader(name)) {
+  if (isRestrictedHeader(name)) {
     return *this;
   }
-  this->headers_[name] = values;
+  headers_[name] = values;
   return *this;
 }
 
 HeadersBuilder& HeadersBuilder::remove(const std::string& name) {
-  if (this->isRestrictedHeader(name)) {
+  if (isRestrictedHeader(name)) {
     return *this;
   }
-  this->headers_.erase(name);
+  headers_.erase(name);
   return *this;
 }
 
@@ -32,11 +32,11 @@ HeadersBuilder::HeadersBuilder() {}
 
 HeadersBuilder& HeadersBuilder::internalSet(const std::string& name,
                                             const std::vector<std::string>& values) {
-  this->headers_[name] = values;
+  headers_[name] = values;
   return *this;
 }
 
-const RawHeaderMap& HeadersBuilder::allHeaders() const { return this->headers_; }
+const RawHeaderMap& HeadersBuilder::allHeaders() const { return headers_; }
 
 bool HeadersBuilder::isRestrictedHeader(const std::string& name) const {
   return name.find(":") == 0 || name.find("x-envoy-mobile") == 0;

--- a/library/cc/request_headers.cc
+++ b/library/cc/request_headers.cc
@@ -15,7 +15,7 @@ const std::string& RequestHeaders::path() const { return (*this)[":path"][0]; }
 
 absl::optional<RetryPolicy> RequestHeaders::retryPolicy() const {
   try {
-    return absl::optional<RetryPolicy>(RetryPolicy::fromRawHeaderMap(this->allHeaders()));
+    return absl::optional<RetryPolicy>(RetryPolicy::fromRawHeaderMap(allHeaders()));
   } catch (const std::exception&) {
     return absl::optional<RetryPolicy>();
   }
@@ -23,16 +23,15 @@ absl::optional<RetryPolicy> RequestHeaders::retryPolicy() const {
 
 absl::optional<UpstreamHttpProtocol> RequestHeaders::upstreamHttpProtocol() const {
   const auto header_name = "x-envoy-mobile-upstream-protocol";
-  if (!this->contains(header_name)) {
+  if (!contains(header_name)) {
     return absl::optional<UpstreamHttpProtocol>();
   }
   return upstreamHttpProtocolFromString((*this)[header_name][0]);
 }
 
 RequestHeadersBuilder RequestHeaders::toRequestHeadersBuilder() const {
-  RequestHeadersBuilder builder(this->requestMethod(), this->scheme(), this->authority(),
-                                this->path());
-  for (const auto& pair : this->allHeaders()) {
+  RequestHeadersBuilder builder(requestMethod(), scheme(), authority(), path());
+  for (const auto& pair : allHeaders()) {
     builder.set(pair.first, pair.second);
   }
   return builder;

--- a/library/cc/request_headers_builder.cc
+++ b/library/cc/request_headers_builder.cc
@@ -7,28 +7,28 @@ RequestHeadersBuilder::RequestHeadersBuilder(RequestMethod request_method,
                                              const std::string& scheme,
                                              const std::string& authority,
                                              const std::string& path) {
-  this->internalSet(":method", std::vector<std::string>{requestMethodToString(request_method)});
-  this->internalSet(":scheme", std::vector<std::string>{scheme});
-  this->internalSet(":authority", std::vector<std::string>{authority});
-  this->internalSet(":path", std::vector<std::string>{path});
+  internalSet(":method", std::vector<std::string>{requestMethodToString(request_method)});
+  internalSet(":scheme", std::vector<std::string>{scheme});
+  internalSet(":authority", std::vector<std::string>{authority});
+  internalSet(":path", std::vector<std::string>{path});
 }
 
 RequestHeadersBuilder& RequestHeadersBuilder::addRetryPolicy(const RetryPolicy& retry_policy) {
   const RawHeaderMap retry_policy_headers = retry_policy.asRawHeaderMap();
   for (const auto& pair : retry_policy_headers) {
-    this->internalSet(pair.first, pair.second);
+    internalSet(pair.first, pair.second);
   }
   return *this;
 }
 
 RequestHeadersBuilder&
 RequestHeadersBuilder::addUpstreamHttpProtocol(UpstreamHttpProtocol upstream_http_protocol) {
-  this->internalSet("x-envoy-mobile-upstream-protocol",
-                    std::vector<std::string>{upstreamHttpProtocolToString(upstream_http_protocol)});
+  internalSet("x-envoy-mobile-upstream-protocol",
+              std::vector<std::string>{upstreamHttpProtocolToString(upstream_http_protocol)});
   return *this;
 }
 
-RequestHeaders RequestHeadersBuilder::build() const { return RequestHeaders(this->allHeaders()); }
+RequestHeaders RequestHeadersBuilder::build() const { return RequestHeaders(allHeaders()); }
 
 } // namespace Platform
 } // namespace Envoy

--- a/library/cc/request_trailers.cc
+++ b/library/cc/request_trailers.cc
@@ -5,7 +5,7 @@ namespace Platform {
 
 RequestTrailersBuilder RequestTrailers::toRequestTrailersBuilder() const {
   RequestTrailersBuilder builder;
-  for (const auto& pair : this->allHeaders()) {
+  for (const auto& pair : allHeaders()) {
     builder.set(pair.first, pair.second);
   }
   return builder;

--- a/library/cc/request_trailers_builder.cc
+++ b/library/cc/request_trailers_builder.cc
@@ -3,9 +3,7 @@
 namespace Envoy {
 namespace Platform {
 
-RequestTrailers RequestTrailersBuilder::build() const {
-  return RequestTrailers(this->allHeaders());
-}
+RequestTrailers RequestTrailersBuilder::build() const { return RequestTrailers(allHeaders()); }
 
 } // namespace Platform
 } // namespace Envoy

--- a/library/cc/response_headers.cc
+++ b/library/cc/response_headers.cc
@@ -4,7 +4,7 @@ namespace Envoy {
 namespace Platform {
 
 int ResponseHeaders::httpStatus() const {
-  if (!this->contains(":status")) {
+  if (!contains(":status")) {
     throw std::logic_error("ResponseHeaders does not contain :status");
   }
   return stoi((*this)[":status"][0]);
@@ -12,10 +12,10 @@ int ResponseHeaders::httpStatus() const {
 
 ResponseHeadersBuilder ResponseHeaders::toResponseHeadersBuilder() {
   ResponseHeadersBuilder builder;
-  if (this->contains(":status")) {
-    builder.addHttpStatus(this->httpStatus());
+  if (contains(":status")) {
+    builder.addHttpStatus(httpStatus());
   }
-  for (const auto& pair : this->allHeaders()) {
+  for (const auto& pair : allHeaders()) {
     builder.set(pair.first, pair.second);
   }
   return builder;

--- a/library/cc/response_headers_builder.cc
+++ b/library/cc/response_headers_builder.cc
@@ -4,12 +4,12 @@ namespace Envoy {
 namespace Platform {
 
 ResponseHeadersBuilder& ResponseHeadersBuilder::addHttpStatus(int status) {
-  this->internalSet(":status", std::vector<std::string>{std::to_string(status)});
+  internalSet(":status", std::vector<std::string>{std::to_string(status)});
   return *this;
 }
 
 ResponseHeadersSharedPtr ResponseHeadersBuilder::build() const {
-  ResponseHeaders* headers = new ResponseHeaders(this->allHeaders());
+  ResponseHeaders* headers = new ResponseHeaders(allHeaders());
   return ResponseHeadersSharedPtr(headers);
 }
 

--- a/library/cc/response_trailers.cc
+++ b/library/cc/response_trailers.cc
@@ -5,7 +5,7 @@ namespace Platform {
 
 ResponseTrailersBuilder ResponseTrailers::toResponseTrailersBuilder() {
   ResponseTrailersBuilder builder;
-  for (const auto& pair : this->allHeaders()) {
+  for (const auto& pair : allHeaders()) {
     builder.set(pair.first, pair.second);
   }
   return builder;

--- a/library/cc/response_trailers_builder.cc
+++ b/library/cc/response_trailers_builder.cc
@@ -4,7 +4,7 @@ namespace Envoy {
 namespace Platform {
 
 ResponseTrailersSharedPtr ResponseTrailersBuilder::build() const {
-  ResponseTrailers* trailers = new ResponseTrailers(this->allHeaders());
+  ResponseTrailers* trailers = new ResponseTrailers(allHeaders());
   return ResponseTrailersSharedPtr(trailers);
 }
 

--- a/library/cc/retry_policy.cc
+++ b/library/cc/retry_policy.cc
@@ -33,25 +33,24 @@ RetryRule retryRuleFromString(const std::string& str) {
 
 RawHeaderMap RetryPolicy::asRawHeaderMap() const {
   RawHeaderMap outbound_headers{
-      {"x-envoy-max-retries", {std::to_string(this->max_retry_count)}},
-      {"x-envoy-upstream-rq-timeout-ms",
-       {std::to_string(this->total_upstream_timeout_ms.value_or(0))}},
+      {"x-envoy-max-retries", {std::to_string(max_retry_count)}},
+      {"x-envoy-upstream-rq-timeout-ms", {std::to_string(total_upstream_timeout_ms.value_or(0))}},
   };
 
-  if (this->per_try_timeout_ms.has_value()) {
+  if (per_try_timeout_ms.has_value()) {
     outbound_headers["x-envoy-upstream-rq-per-try-timeout-ms"] =
-        std::vector<std::string>{std::to_string(this->per_try_timeout_ms.value())};
+        std::vector<std::string>{std::to_string(per_try_timeout_ms.value())};
   }
 
   std::vector<std::string> retry_on;
-  for (const auto& retry_rule : this->retry_on) {
+  for (const auto& retry_rule : retry_on) {
     retry_on.push_back(retryRuleToString(retry_rule));
   }
 
-  if (this->retry_status_codes.size() > 0) {
+  if (retry_status_codes.size() > 0) {
     retry_on.push_back("retriable-status-codes");
     std::vector<std::string> retry_status_codes;
-    for (const auto& status_code : this->retry_status_codes) {
+    for (const auto& status_code : retry_status_codes) {
       retry_status_codes.push_back(std::to_string(status_code));
     }
     outbound_headers["x-envoy-retriable-status-codes"] = retry_status_codes;

--- a/library/cc/retry_policy.h
+++ b/library/cc/retry_policy.h
@@ -26,11 +26,11 @@ std::string retryRuleToString(RetryRule retry_rule);
 RetryRule retryRuleFromString(const std::string& str);
 
 struct RetryPolicy {
-  int max_retry_count;
-  std::vector<RetryRule> retry_on;
-  std::vector<int> retry_status_codes;
-  absl::optional<int> per_try_timeout_ms;
-  absl::optional<int> total_upstream_timeout_ms;
+  int max_retry_count_;
+  std::vector<RetryRule> retry_on_;
+  std::vector<int> retry_status_codes_;
+  absl::optional<int> per_try_timeout_ms_;
+  absl::optional<int> total_upstream_timeout_ms_;
 
   RawHeaderMap asRawHeaderMap() const;
   static RetryPolicy fromRawHeaderMap(const RawHeaderMap& headers);

--- a/library/cc/stream.cc
+++ b/library/cc/stream.cc
@@ -11,23 +11,23 @@ Stream::Stream(envoy_stream_t handle) : handle_(handle) {}
 
 Stream& Stream::sendHeaders(RequestHeadersSharedPtr headers, bool end_stream) {
   envoy_headers raw_headers = rawHeaderMapAsEnvoyHeaders(headers->allHeaders());
-  ::send_headers(this->handle_, raw_headers, end_stream);
+  ::send_headers(handle_, raw_headers, end_stream);
   return *this;
 }
 
 Stream& Stream::sendData(envoy_data data) {
-  ::send_data(this->handle_, data, false);
+  ::send_data(handle_, data, false);
   return *this;
 }
 
 void Stream::close(RequestTrailersSharedPtr trailers) {
   envoy_headers raw_headers = rawHeaderMapAsEnvoyHeaders(trailers->allHeaders());
-  ::send_trailers(this->handle_, raw_headers);
+  ::send_trailers(handle_, raw_headers);
 }
 
-void Stream::close(envoy_data data) { ::send_data(this->handle_, data, true); }
+void Stream::close(envoy_data data) { ::send_data(handle_, data, true); }
 
-void Stream::cancel() { reset_stream(this->handle_); }
+void Stream::cancel() { reset_stream(handle_); }
 
 } // namespace Platform
 } // namespace Envoy

--- a/library/cc/stream_callbacks.cc
+++ b/library/cc/stream_callbacks.cc
@@ -110,7 +110,7 @@ envoy_http_callbacks StreamCallbacks::asEnvoyHttpCallbacks() {
       .on_complete = &c_on_complete,
       .on_cancel = &c_on_cancel,
       .on_send_window_available = &c_on_send_window_available,
-      .context = new StreamCallbacksSharedPtr(this->shared_from_this()),
+      .context = new StreamCallbacksSharedPtr(shared_from_this()),
   };
 }
 

--- a/library/cc/stream_client.cc
+++ b/library/cc/stream_client.cc
@@ -6,7 +6,7 @@ namespace Platform {
 StreamClient::StreamClient(EngineSharedPtr engine) : engine_(engine) {}
 
 StreamPrototypeSharedPtr StreamClient::newStreamPrototype() {
-  return std::make_shared<StreamPrototype>(this->engine_);
+  return std::make_shared<StreamPrototype>(engine_);
 }
 
 } // namespace Platform

--- a/library/cc/stream_prototype.cc
+++ b/library/cc/stream_prototype.cc
@@ -6,47 +6,47 @@ namespace Envoy {
 namespace Platform {
 
 StreamPrototype::StreamPrototype(EngineSharedPtr engine) : engine_(engine) {
-  this->callbacks_ = std::make_shared<StreamCallbacks>();
+  callbacks_ = std::make_shared<StreamCallbacks>();
 }
 
 StreamSharedPtr StreamPrototype::start() {
-  auto envoy_stream = init_stream(this->engine_->engine_);
-  start_stream(envoy_stream, this->callbacks_->asEnvoyHttpCallbacks(), false);
+  auto envoy_stream = init_stream(engine_->engine_);
+  start_stream(envoy_stream, callbacks_->asEnvoyHttpCallbacks(), false);
   return std::make_shared<Stream>(envoy_stream);
 }
 
 StreamPrototype& StreamPrototype::setOnHeaders(OnHeadersCallback closure) {
-  this->callbacks_->on_headers = closure;
+  callbacks_->on_headers = closure;
   return *this;
 }
 
 StreamPrototype& StreamPrototype::setOnData(OnDataCallback closure) {
-  this->callbacks_->on_data = closure;
+  callbacks_->on_data = closure;
   return *this;
 }
 
 StreamPrototype& StreamPrototype::setOnTrailers(OnTrailersCallback closure) {
-  this->callbacks_->on_trailers = closure;
+  callbacks_->on_trailers = closure;
   return *this;
 }
 
 StreamPrototype& StreamPrototype::setOnError(OnErrorCallback closure) {
-  this->callbacks_->on_error = closure;
+  callbacks_->on_error = closure;
   return *this;
 }
 
 StreamPrototype& StreamPrototype::setOnComplete(OnCompleteCallback closure) {
-  this->callbacks_->on_complete = closure;
+  callbacks_->on_complete = closure;
   return *this;
 }
 
 StreamPrototype& StreamPrototype::setOnCancel(OnCancelCallback closure) {
-  this->callbacks_->on_cancel = closure;
+  callbacks_->on_cancel = closure;
   return *this;
 }
 
 StreamPrototype& StreamPrototype::setOnSendWindowAvailable(OnSendWindowAvailableCallback closure) {
-  this->callbacks_->on_send_window_available = closure;
+  callbacks_->on_send_window_available = closure;
   return *this;
 }
 

--- a/library/python/module_definition.cc
+++ b/library/python/module_definition.cc
@@ -199,11 +199,11 @@ PYBIND11_MODULE(envoy_engine, m) {
       .value("Reset", RetryRule::Reset);
 
   py::class_<RetryPolicy, RetryPolicySharedPtr>(m, "RetryPolicy")
-      .def_readwrite("max_retry_count", &RetryPolicy::max_retry_count)
-      .def_readwrite("retry_on", &RetryPolicy::retry_on)
-      .def_readwrite("retry_status_codes", &RetryPolicy::retry_status_codes)
-      .def_readwrite("per_try_timeout_ms", &RetryPolicy::per_try_timeout_ms)
-      .def_readwrite("total_upstream_timeout_ms", &RetryPolicy::total_upstream_timeout_ms);
+      .def_readwrite("max_retry_count", &RetryPolicy::max_retry_count_)
+      .def_readwrite("retry_on", &RetryPolicy::retry_on_)
+      .def_readwrite("retry_status_codes", &RetryPolicy::retry_status_codes_)
+      .def_readwrite("per_try_timeout_ms", &RetryPolicy::per_try_timeout_ms_)
+      .def_readwrite("total_upstream_timeout_ms", &RetryPolicy::total_upstream_timeout_ms_);
 
   // TODO(crockeo): fill out stubs here once stats client impl
   py::class_<PulseClient, PulseClientSharedPtr>(m, "PulseClient");


### PR DESCRIPTION
Cleans up usage of this->, instead favoring field_member_ naming convention to disambiguate per the Google style guide.

Risk Level: Low
Testing: n/a
Docs Changes: n/a
Release Notes: n/a
