### PR TITLE
Update Objective-C on error/cancel to include final_stream_intel

### DIFF
--- a/library/objective-c/EnvoyEngineImpl.m
+++ b/library/objective-c/EnvoyEngineImpl.m
@@ -332,7 +332,9 @@ static void ios_http_filter_set_response_callbacks(envoy_http_filter_callbacks c
   }
 }
 
-static void ios_http_filter_on_cancel(envoy_stream_intel stream_intel, const void *context) {
+static void ios_http_filter_on_cancel(envoy_stream_intel stream_intel,
+                                      envoy_final_stream_intel final_stream_intel,
+                                      const void *context) {
   // This code block runs inside the Envoy event loop. Therefore, an explicit autoreleasepool block
   // is necessary to act as a breaker for any Objective-C allocation that happens.
   @autoreleasepool {
@@ -345,6 +347,7 @@ static void ios_http_filter_on_cancel(envoy_stream_intel stream_intel, const voi
 }
 
 static void ios_http_filter_on_error(envoy_error error, envoy_stream_intel stream_intel,
+                                     envoy_final_stream_intel final_stream_intel,
                                      const void *context) {
   // This code block runs inside the Envoy event loop. Therefore, an explicit autoreleasepool block
   // is necessary to act as a breaker for any Objective-C allocation that happens.

--- a/library/objective-c/EnvoyHTTPStreamImpl.m
+++ b/library/objective-c/EnvoyHTTPStreamImpl.m
@@ -150,9 +150,11 @@ static void *ios_on_error(envoy_error error, envoy_stream_intel stream_intel,
   atomic_store(context->closed, NO);
 
   // Create native callbacks
-  envoy_http_callbacks native_callbacks = {ios_on_headers,  ios_on_data,                  ios_on_metadata,
-                                           ios_on_trailers, ios_on_error,                 ios_on_complete,
-                                           ios_on_cancel,   ios_on_send_window_available, context};
+  envoy_http_callbacks native_callbacks = {
+      ios_on_headers, ios_on_data,     ios_on_metadata, ios_on_trailers,
+      ios_on_error,   ios_on_complete, ios_on_cancel,   ios_on_send_window_available,
+      context
+  };
   _nativeCallbacks = native_callbacks;
 
   // We need create the native-held strong ref on this stream before we call start_stream because

--- a/library/objective-c/EnvoyHTTPStreamImpl.m
+++ b/library/objective-c/EnvoyHTTPStreamImpl.m
@@ -153,8 +153,7 @@ static void *ios_on_error(envoy_error error, envoy_stream_intel stream_intel,
   envoy_http_callbacks native_callbacks = {
       ios_on_headers, ios_on_data,     ios_on_metadata, ios_on_trailers,
       ios_on_error,   ios_on_complete, ios_on_cancel,   ios_on_send_window_available,
-      context
-  };
+      context};
   _nativeCallbacks = native_callbacks;
 
   // We need create the native-held strong ref on this stream before we call start_stream because

--- a/library/objective-c/EnvoyHTTPStreamImpl.m
+++ b/library/objective-c/EnvoyHTTPStreamImpl.m
@@ -150,10 +150,9 @@ static void *ios_on_error(envoy_error error, envoy_stream_intel stream_intel,
 
   // Create native callbacks
   // TODO(goaway) fix this up to call ios_on_send_window_available
-  envoy_http_callbacks native_callbacks = {
-      ios_on_headers, ios_on_data,     ios_on_metadata, ios_on_trailers,
-      ios_on_error,   ios_on_complete, ios_on_cancel,   ios_on_cancel_impl,
-      context};
+  envoy_http_callbacks native_callbacks = {ios_on_headers,  ios_on_data,        ios_on_metadata,
+                                           ios_on_trailers, ios_on_error,       ios_on_complete,
+                                           ios_on_cancel,   ios_on_cancel_impl, context};
   _nativeCallbacks = native_callbacks;
 
   // We need create the native-held strong ref on this stream before we call start_stream because

--- a/library/objective-c/EnvoyHTTPStreamImpl.m
+++ b/library/objective-c/EnvoyHTTPStreamImpl.m
@@ -83,7 +83,7 @@ static void *ios_on_send_window_available(envoy_stream_intel stream_intel, void 
   EnvoyHTTPCallbacks *callbacks = c->callbacks;
   EnvoyHTTPStreamImpl *stream = c->stream;
   dispatch_async(callbacks.dispatchQueue, ^{
-    // TODO(jpsim): fix this up to call ios_on_send_window_available
+    // TODO(jpsim): add EnvoyHTTPCallbacks.onSendWindowAvailable
     if (callbacks.onCancel) {
       callbacks.onCancel(stream_intel);
     }

--- a/library/objective-c/EnvoyHTTPStreamImpl.m
+++ b/library/objective-c/EnvoyHTTPStreamImpl.m
@@ -75,7 +75,13 @@ static void *ios_on_complete(envoy_stream_intel stream_intel,
   return NULL;
 }
 
-static void *ios_on_cancel_impl(envoy_stream_intel stream_intel, void *context) {
+// TODO(goaway) fix this up to call ios_on_send_window_available
+static void *ios_on_send_window_available(envoy_stream_intel stream_intel, void *context) {
+  return NULL;
+}
+
+static void *ios_on_cancel(envoy_stream_intel stream_intel,
+                           envoy_final_stream_intel final_stream_intel, void *context) {
   // This call is atomically gated at the call-site and will only happen once. It may still fire
   // after a complete response or error callback, but no other callbacks for the stream will ever
   // fire AFTER the cancellation callback.
@@ -92,11 +98,6 @@ static void *ios_on_cancel_impl(envoy_stream_intel stream_intel, void *context) 
     [stream cleanUp];
   });
   return NULL;
-}
-
-static void *ios_on_cancel(envoy_stream_intel stream_intel,
-                           envoy_final_stream_intel final_stream_intel, void *context) {
-  return ios_on_cancel_impl(stream_intel, context);
 }
 
 static void *ios_on_error(envoy_error error, envoy_stream_intel stream_intel,
@@ -149,10 +150,10 @@ static void *ios_on_error(envoy_error error, envoy_stream_intel stream_intel,
   atomic_store(context->closed, NO);
 
   // Create native callbacks
-  // TODO(goaway) fix this up to call ios_on_send_window_available
-  envoy_http_callbacks native_callbacks = {ios_on_headers,  ios_on_data,        ios_on_metadata,
-                                           ios_on_trailers, ios_on_error,       ios_on_complete,
-                                           ios_on_cancel,   ios_on_cancel_impl, context};
+  envoy_http_callbacks native_callbacks = {
+      ios_on_headers, ios_on_data,     ios_on_metadata, ios_on_trailers,
+      ios_on_error,   ios_on_complete, ios_on_cancel,   ios_on_send_window_available,
+      context};
   _nativeCallbacks = native_callbacks;
 
   // We need create the native-held strong ref on this stream before we call start_stream because

--- a/library/objective-c/EnvoyHTTPStreamImpl.m
+++ b/library/objective-c/EnvoyHTTPStreamImpl.m
@@ -62,7 +62,8 @@ static void *ios_on_trailers(envoy_headers trailers, envoy_stream_intel stream_i
   return NULL;
 }
 
-static void *ios_on_complete(envoy_stream_intel stream_intel, void *context) {
+static void *ios_on_complete(envoy_stream_intel stream_intel,
+                             envoy_final_stream_intel final_stream_intel, void *context) {
   ios_context *c = (ios_context *)context;
   EnvoyHTTPCallbacks *callbacks = c->callbacks;
   EnvoyHTTPStreamImpl *stream = c->stream;
@@ -74,7 +75,8 @@ static void *ios_on_complete(envoy_stream_intel stream_intel, void *context) {
   return NULL;
 }
 
-static void *ios_on_cancel(envoy_stream_intel stream_intel, void *context) {
+static void *ios_on_cancel(envoy_stream_intel stream_intel,
+                           envoy_final_stream_intel final_stream_intel, void *context) {
   // This call is atomically gated at the call-site and will only happen once. It may still fire
   // after a complete response or error callback, but no other callbacks for the stream will ever
   // fire AFTER the cancellation callback.
@@ -93,7 +95,8 @@ static void *ios_on_cancel(envoy_stream_intel stream_intel, void *context) {
   return NULL;
 }
 
-static void *ios_on_error(envoy_error error, envoy_stream_intel stream_intel, void *context) {
+static void *ios_on_error(envoy_error error, envoy_stream_intel stream_intel,
+                          envoy_final_stream_intel final_stream_intel, void *context) {
   ios_context *c = (ios_context *)context;
   EnvoyHTTPCallbacks *callbacks = c->callbacks;
   EnvoyHTTPStreamImpl *stream = c->stream;


### PR DESCRIPTION
Description: This is a followup to https://github.com/envoyproxy/envoy-mobile/pull/1937.
Risk Level: I believe these extra parameters are safe to ignore if we don't need to propagate them to the Objective-C interface, but would like someone else to confirm that.
Testing: Example apps still work, and downstream (closed source) consumers now compile again.
Docs Changes:
Release Notes:
[Optional Fixes #Issue]
[Optional Deprecated:]