### PR TITLE
[EnvoyBridgeUtility] Fix NSString to envoy_data conversion

### DIFF
--- a/.github/workflows/ios_tests.yml
+++ b/.github/workflows/ios_tests.yml
@@ -32,3 +32,28 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: ./bazelw test --test_output=all --config=ios --build_tests_only --config=remote-ci-macos --remote_header="Authorization=Bearer $GITHUB_TOKEN" //test/swift/...
+  objctests:
+    name: objc_tests
+    runs-on: macos-11
+    timeout-minutes: 120
+    steps:
+      - uses: actions/checkout@v1
+        with:
+          submodules: true
+      - id: check_context
+        name: 'Check whether to run'
+        run: |
+          if git rev-parse --abbrev-ref HEAD | grep -q ^main$ || git diff --name-only origin/main | grep -qe common/ -e objective-c/ -e swift/ -e bazel/ -e ^\.bazelrc$ -e ^envoy$ -e ^WORKSPACE$ -e ^.github/workflows/ios_tests.yml$ ; then
+            echo "Tests will run."
+            echo "::set-output name=run_tests::true"
+          else
+            echo "Skipping tests."
+            echo "::set-output name=run_tests::false"
+          fi
+      - name: 'Install dependencies'
+        run: ./ci/mac_ci_setup.sh
+      - name: 'Run Objective-C library tests'
+        if: steps.check_context.outputs.run_tests == 'true'
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: ./bazelw test --test_output=all --config=ios --build_tests_only --config=remote-ci-macos --remote_header="Authorization=Bearer $GITHUB_TOKEN" //test/objective-c/...

--- a/library/objective-c/EnvoyBridgeUtility.h
+++ b/library/objective-c/EnvoyBridgeUtility.h
@@ -24,7 +24,7 @@ static inline envoy_data *toNativeDataPtr(NSData *data) {
 }
 
 static inline envoy_data toManagedNativeString(NSString *s) {
-  size_t length = s.length;
+  size_t length = [s lengthOfBytesUsingEncoding:NSUTF8StringEncoding];
   uint8_t *native_string = (uint8_t *)safe_malloc(sizeof(uint8_t) * length);
   memcpy(native_string, s.UTF8String, length); // NOLINT(safe-memcpy)
   envoy_data ret = {length, native_string, free, native_string};

--- a/library/objective-c/EnvoyBridgeUtility.h
+++ b/library/objective-c/EnvoyBridgeUtility.h
@@ -24,8 +24,7 @@ static inline envoy_data *toNativeDataPtr(NSData *data) {
 }
 
 static inline envoy_data toManagedNativeString(NSString *s) {
-  // +1 for the terminating NULL character
-  size_t length = [s lengthOfBytesUsingEncoding:NSUTF8StringEncoding] + 1;
+  size_t length = [s lengthOfBytesUsingEncoding:NSUTF8StringEncoding];
   uint8_t *native_string = (uint8_t *)safe_malloc(sizeof(uint8_t) * length);
   memcpy(native_string, s.UTF8String, length); // NOLINT(safe-memcpy)
   envoy_data ret = {length, native_string, free, native_string};

--- a/library/objective-c/EnvoyBridgeUtility.h
+++ b/library/objective-c/EnvoyBridgeUtility.h
@@ -24,7 +24,8 @@ static inline envoy_data *toNativeDataPtr(NSData *data) {
 }
 
 static inline envoy_data toManagedNativeString(NSString *s) {
-  size_t length = [s lengthOfBytesUsingEncoding:NSUTF8StringEncoding];
+  // +1 for the terminating NULL character
+  size_t length = [s lengthOfBytesUsingEncoding:NSUTF8StringEncoding] + 1;
   uint8_t *native_string = (uint8_t *)safe_malloc(sizeof(uint8_t) * length);
   memcpy(native_string, s.UTF8String, length); // NOLINT(safe-memcpy)
   envoy_data ret = {length, native_string, free, native_string};

--- a/test/objective-c/EnvoyBridgeUtilityTest.m
+++ b/test/objective-c/EnvoyBridgeUtilityTest.m
@@ -18,7 +18,7 @@ typedef NSDictionary<NSString *, NSString *> EnvoyTags;
   XCTAssertEqual(memcmp(nativeData.bytes, testData.bytes, 3), 0);
 }
 
-- (void)testToManagedNativeString {
+- (void)testToManagedNativeStringUsingUTF8Chars {
   NSString *testString = @"台灣大哥大";
   envoy_data stringData = toManagedNativeString(testString);
   NSString *roundtripString = to_ios_string(stringData);

--- a/test/objective-c/EnvoyBridgeUtilityTest.m
+++ b/test/objective-c/EnvoyBridgeUtilityTest.m
@@ -18,4 +18,11 @@ typedef NSDictionary<NSString *, NSString *> EnvoyTags;
   XCTAssertEqual(memcmp(nativeData.bytes, testData.bytes, 3), 0);
 }
 
+- (void)testToManagedNativeString {
+  NSString *testString = @"台灣大哥大";
+  envoy_data stringData = toManagedNativeString(testString);
+  NSString *roundtripString = to_ios_string(stringData);
+  XCTAssertEqual(testString, roundtripString);
+}
+
 @end

--- a/test/objective-c/EnvoyBridgeUtilityTest.m
+++ b/test/objective-c/EnvoyBridgeUtilityTest.m
@@ -1,8 +1,8 @@
 #import <XCTest/XCTest.h>
 
 typedef NSDictionary<NSString *, NSArray<NSString *> *> EnvoyHeaders;
-
 typedef NSDictionary<NSString *, NSString *> EnvoyTags;
+typedef NSDictionary<NSString *, NSString *> EnvoyEvent;
 
 #import "library/objective-c/EnvoyBridgeUtility.h"
 
@@ -22,7 +22,7 @@ typedef NSDictionary<NSString *, NSString *> EnvoyTags;
   NSString *testString = @"台灣大哥大";
   envoy_data stringData = toManagedNativeString(testString);
   NSString *roundtripString = to_ios_string(stringData);
-  XCTAssertEqual(testString, roundtripString);
+  XCTAssertEqual([testString compare:roundtripString options:0], NSOrderedSame);
 }
 
 @end


### PR DESCRIPTION
Description: Fix `NSString` to `envoy_data` conversion for non-ascii strings such as '台灣大哥大'. `-length` is the number of UTF-16 code units in the receiver whereas `-lengthOfBytesUsingEncoding:` is the number of UTF8 bytes. Using the latter is necessary since we're using this value to determine how many bytes to copy from the string.
Risk Level: Low.
Testing: Added an Objective-C unit test, and enabled running on CI.
Docs Changes:
Release Notes:
[Optional Fixes #Issue]
[Optional Deprecated:]