### PR TITLE
stream intel: wire iOS FinalStreamIntel for parity with jvm/android

### DIFF
--- a/examples/objective-c/hello_world/ViewController.m
+++ b/examples/objective-c/hello_world/ViewController.m
@@ -103,7 +103,7 @@ NSString *_REQUEST_SCHEME = @"https";
 
     [weakSelf addResponseMessage:message headerMessage:headerMessage error:nil];
   }];
-  [prototype setOnErrorWithClosure:^(EnvoyError *error, StreamIntel *ignored) {
+  [prototype setOnErrorWithClosure:^(EnvoyError *error, FinalStreamIntel *ignored) {
     // TODO: expose attemptCount. https://github.com/envoyproxy/envoy-mobile/issues/823
     NSString *message =
         [NSString stringWithFormat:@"failed within Envoy library %@", error.message];

--- a/examples/swift/hello_world/AsyncDemoFilter.swift
+++ b/examples/swift/hello_world/AsyncDemoFilter.swift
@@ -59,7 +59,9 @@ final class AsyncDemoFilter: AsyncResponseFilter {
     return .resumeIteration(headers: builder.build(), data: data, trailers: trailers)
   }
 
-  func onError(_ error: EnvoyError, streamIntel: StreamIntel) {}
+  func onError(_ error: EnvoyError, streamIntel: FinalStreamIntel) {}
 
-  func onCancel(streamIntel: StreamIntel) {}
+  func onCancel(streamIntel: FinalStreamIntel) {}
+
+  func onComplete(streamIntel: FinalStreamIntel) {}
 }

--- a/examples/swift/hello_world/BufferDemoFilter.swift
+++ b/examples/swift/hello_world/BufferDemoFilter.swift
@@ -40,7 +40,9 @@ final class BufferDemoFilter: ResponseFilter {
     return .resumeIteration(headers: builder.build(), data: self.body, trailers: trailers)
   }
 
-  func onError(_ error: EnvoyError, streamIntel: StreamIntel) {}
+  func onError(_ error: EnvoyError, streamIntel: FinalStreamIntel) {}
 
-  func onCancel(streamIntel: StreamIntel) {}
+  func onCancel(streamIntel: FinalStreamIntel) {}
+
+  func onComplete(streamIntel: FinalStreamIntel) {}
 }

--- a/examples/swift/hello_world/DemoFilter.swift
+++ b/examples/swift/hello_world/DemoFilter.swift
@@ -25,7 +25,9 @@ struct DemoFilter: ResponseFilter {
     return .continue(trailers: trailers)
   }
 
-  func onError(_ error: EnvoyError, streamIntel: StreamIntel) {}
+  func onError(_ error: EnvoyError, streamIntel: FinalStreamIntel) {}
 
-  func onCancel(streamIntel: StreamIntel) {}
+  func onCancel(streamIntel: FinalStreamIntel) {}
+
+  func onComplete(streamIntel: FinalStreamIntel) {}
 }

--- a/library/kotlin/io/envoyproxy/envoymobile/StreamPrototype.kt
+++ b/library/kotlin/io/envoyproxy/envoymobile/StreamPrototype.kt
@@ -61,6 +61,7 @@ open class StreamPrototype(private val engine: EnvoyEngine) {
 
   /**
    * Specify a callback for when response headers are received by the stream.
+   * If `endStream` is `true`, the stream is complete, pending an onComplete callback.
    *
    * @param closure Closure which will receive the headers and flag indicating if the stream
    * is headers-only.
@@ -75,7 +76,7 @@ open class StreamPrototype(private val engine: EnvoyEngine) {
 
   /**
    * Specify a callback for when a data frame is received by the stream.
-   * If `endStream` is `true`, the stream is complete.
+   * If `endStream` is `true`, the stream is complete, pending an onComplete callback.
    *
    * @param closure Closure which will receive the data and flag indicating whether this
    * is the last data frame.
@@ -90,7 +91,7 @@ open class StreamPrototype(private val engine: EnvoyEngine) {
 
   /**
    * Specify a callback for when trailers are received by the stream.
-   * If the closure is called, the stream is complete.
+   * If the closure is called, the stream is complete, pending an onComplete callback.
    *
    * @param closure Closure which will receive the trailers.
    * @return This stream, for chaining syntax.

--- a/library/kotlin/io/envoyproxy/envoymobile/filters/ResponseFilter.kt
+++ b/library/kotlin/io/envoyproxy/envoymobile/filters/ResponseFilter.kt
@@ -50,6 +50,7 @@ interface ResponseFilter : Filter {
   /**
    * Called at most once when an error within Envoy occurs.
    *
+   * Only one of onError, onCancel, or onComplete will be called per stream.
    * This should be considered a terminal state, and invalidates any previous attempts to
    * `stopIteration{...}`.
    *
@@ -62,6 +63,7 @@ interface ResponseFilter : Filter {
   /**
    * Called at most once when the client cancels the stream.
    *
+   * Only one of onError, onCancel, or onComplete will be called per stream.
    * This should be considered a terminal state, and invalidates any previous attempts to
    * `stopIteration{...}`.
    *
@@ -71,8 +73,9 @@ interface ResponseFilter : Filter {
   fun onCancel(streamIntel: StreamIntel, finalStreamIntel: FinalStreamIntel)
 
 /**
-   * Called at most once when the stream is complete.
+   * Called at most once when the stream completes gracefully.
    *
+   * Only one of onError, onCancel, or onComplete will be called per stream.
    * This should be considered a terminal state, and invalidates any previous attempts to
    * `stopIteration{...}`.
    *

--- a/library/objective-c/EnvoyEngine.h
+++ b/library/objective-c/EnvoyEngine.h
@@ -17,6 +17,9 @@ typedef NSDictionary<NSString *, NSString *> EnvoyEvent;
 /// Contains internal HTTP stream metrics, context, and other details.
 typedef envoy_stream_intel EnvoyStreamIntel;
 
+// Contains one time HTTP stream metrics, context, and other details.
+typedef envoy_final_stream_intel EnvoyFinalStreamIntel;
+
 #pragma mark - EnvoyHTTPCallbacks
 
 /// Interface that can handle callbacks from an HTTP stream.

--- a/library/objective-c/EnvoyEngine.h
+++ b/library/objective-c/EnvoyEngine.h
@@ -63,9 +63,11 @@ typedef envoy_final_stream_intel EnvoyFinalStreamIntel;
 /**
  * Called when the async HTTP stream has an error.
  * @param streamIntel internal HTTP stream metrics, context, and other details.
+ * @param finalStreamIntel one time HTTP stream metrics, context, and other details.
  */
 @property (nonatomic, copy) void (^onError)
-    (uint64_t errorCode, NSString *message, int32_t attemptCount, EnvoyStreamIntel streamIntel);
+    (uint64_t errorCode, NSString *message, int32_t attemptCount, EnvoyStreamIntel streamIntel,
+     EnvoyFinalStreamIntel finalStreamIntel);
 
 /**
  * Called when the async HTTP stream is canceled.
@@ -73,8 +75,20 @@ typedef envoy_final_stream_intel EnvoyFinalStreamIntel;
  * response is already complete. It will fire no more than once, and no other callbacks for the
  * stream will be issued afterwards.
  * @param streamIntel internal HTTP stream metrics, context, and other details.
+ * @param finalStreamIntel one time HTTP stream metrics, context, and other details.
  */
-@property (nonatomic, copy) void (^onCancel)(EnvoyStreamIntel streamIntel);
+@property (nonatomic, copy) void (^onCancel)
+    (EnvoyStreamIntel streamIntel, EnvoyFinalStreamIntel finalStreamIntel);
+
+/**
+ * Final call made when an HTTP stream is closed gracefully.
+ * Note this may already be inferred from a prior callback with endStream=TRUE, and this only needs
+ * to be handled if information from finalStreamIntel is desired.
+ * @param streamIntel internal HTTP stream metrics, context, and other details.
+ * @param finalStreamIntel one time HTTP stream metrics, context, and other details.
+ */
+@property (nonatomic, copy) void (^onComplete)
+    (EnvoyStreamIntel streamIntel, EnvoyFinalStreamIntel finalStreamIntel);
 
 @end
 
@@ -120,49 +134,54 @@ extern const int kEnvoyFilterResumeStatusResumeIteration;
 /// Returns tuple of:
 /// 0 - NSNumber *,filter status
 /// 1 - EnvoyHeaders *, forward headers
-@property (nonatomic, copy) NSArray * (^onRequestHeaders)
-    (EnvoyHeaders *headers, BOOL endStream, EnvoyStreamIntel streamIntel);
+@property (nonatomic, copy) NSArray * (^onRequestHeaders)(EnvoyHeaders *headers, BOOL endStream,
+                                                          EnvoyStreamIntel streamIntel);
 
 /// Returns tuple of:
 /// 0 - NSNumber *,filter status
 /// 1 - NSData *, forward data
 /// 2 - EnvoyHeaders *, optional pending headers
-@property (nonatomic, copy) NSArray * (^onRequestData)
-    (NSData *data, BOOL endStream, EnvoyStreamIntel streamIntel);
+@property (nonatomic, copy)
+    NSArray * (^onRequestData)(NSData *data, BOOL endStream, EnvoyStreamIntel streamIntel);
 
 /// Returns tuple of:
 /// 0 - NSNumber *,filter status
 /// 1 - EnvoyHeaders *, forward trailers
 /// 2 - EnvoyHeaders *, optional pending headers
 /// 3 - NSData *, optional pending data
-@property (nonatomic, copy) NSArray * (^onRequestTrailers)
-    (EnvoyHeaders *trailers, EnvoyStreamIntel streamIntel);
+@property (nonatomic, copy)
+    NSArray * (^onRequestTrailers)(EnvoyHeaders *trailers, EnvoyStreamIntel streamIntel);
 
 /// Returns tuple of:
 /// 0 - NSNumber *,filter status
 /// 1 - EnvoyHeaders *, forward headers
-@property (nonatomic, copy) NSArray * (^onResponseHeaders)
-    (EnvoyHeaders *headers, BOOL endStream, EnvoyStreamIntel streamIntel);
+@property (nonatomic, copy) NSArray * (^onResponseHeaders)(EnvoyHeaders *headers, BOOL endStream,
+                                                           EnvoyStreamIntel streamIntel);
 
 /// Returns tuple of:
 /// 0 - NSNumber *,filter status
 /// 1 - NSData *, forward data
 /// 2 - EnvoyHeaders *, optional pending headers
-@property (nonatomic, copy) NSArray * (^onResponseData)
-    (NSData *data, BOOL endStream, EnvoyStreamIntel streamIntel);
+@property (nonatomic, copy)
+    NSArray * (^onResponseData)(NSData *data, BOOL endStream, EnvoyStreamIntel streamIntel);
 
 /// Returns tuple of:
 /// 0 - NSNumber *,filter status
 /// 1 - EnvoyHeaders *, forward trailers
 /// 2 - EnvoyHeaders *, optional pending headers
 /// 3 - NSData *, optional pending data
-@property (nonatomic, copy) NSArray * (^onResponseTrailers)
-    (EnvoyHeaders *trailers, EnvoyStreamIntel streamIntel);
+@property (nonatomic, copy)
+    NSArray * (^onResponseTrailers)(EnvoyHeaders *trailers, EnvoyStreamIntel streamIntel);
 
-@property (nonatomic, copy) void (^onCancel)(EnvoyStreamIntel streamIntel);
+@property (nonatomic, copy) void (^onCancel)
+    (EnvoyStreamIntel streamIntel, EnvoyFinalStreamIntel finalStreamIntel);
 
 @property (nonatomic, copy) void (^onError)
-    (uint64_t errorCode, NSString *message, int32_t attemptCount, EnvoyStreamIntel streamIntel);
+    (uint64_t errorCode, NSString *message, int32_t attemptCount, EnvoyStreamIntel streamIntel,
+     EnvoyFinalStreamIntel finalStreamIntel);
+
+@property (nonatomic, copy) void (^onComplete)
+    (EnvoyStreamIntel streamIntel, EnvoyFinalStreamIntel finalStreamIntel);
 
 @property (nonatomic, copy) void (^setRequestFilterCallbacks)
     (id<EnvoyHTTPFilterCallbacks> callbacks);

--- a/library/objective-c/EnvoyEngine.h
+++ b/library/objective-c/EnvoyEngine.h
@@ -133,84 +133,86 @@ extern const int kEnvoyFilterResumeStatusResumeIteration;
 
 @interface EnvoyHTTPFilter : NSObject
 
-/// Returns tuple of:
-/// 0 - NSNumber *,filter status
-/// 1 - EnvoyHeaders *, forward headers
-@property (nonatomic, copy) NSArray * (^onRequestHeaders)(EnvoyHeaders *headers, BOOL endStream,
-                                                          EnvoyStreamIntel streamIntel);
-
-/// Returns tuple of:
-/// 0 - NSNumber *,filter status
-/// 1 - NSData *, forward data
-/// 2 - EnvoyHeaders *, optional pending headers
-@property (nonatomic, copy)
-    NSArray * (^onRequestData)(NSData *data, BOOL endStream, EnvoyStreamIntel streamIntel);
-
-/// Returns tuple of:
-/// 0 - NSNumber *,filter status
-/// 1 - EnvoyHeaders *, forward trailers
-/// 2 - EnvoyHeaders *, optional pending headers
-/// 3 - NSData *, optional pending data
-@property (nonatomic, copy)
-    NSArray * (^onRequestTrailers)(EnvoyHeaders *trailers, EnvoyStreamIntel streamIntel);
-
-/// Returns tuple of:
-/// 0 - NSNumber *,filter status
-/// 1 - EnvoyHeaders *, forward headers
-@property (nonatomic, copy) NSArray * (^onResponseHeaders)(EnvoyHeaders *headers, BOOL endStream,
-                                                           EnvoyStreamIntel streamIntel);
-
-/// Returns tuple of:
-/// 0 - NSNumber *,filter status
-/// 1 - NSData *, forward data
-/// 2 - EnvoyHeaders *, optional pending headers
-@property (nonatomic, copy)
-    NSArray * (^onResponseData)(NSData *data, BOOL endStream, EnvoyStreamIntel streamIntel);
-
-/// Returns tuple of:
-/// 0 - NSNumber *,filter status
-/// 1 - EnvoyHeaders *, forward trailers
-/// 2 - EnvoyHeaders *, optional pending headers
-/// 3 - NSData *, optional pending data
-@property (nonatomic, copy)
-    NSArray * (^onResponseTrailers)(EnvoyHeaders *trailers, EnvoyStreamIntel streamIntel);
-
-@property (nonatomic, copy) void (^onCancel)
-    (EnvoyStreamIntel streamIntel, EnvoyFinalStreamIntel finalStreamIntel);
-
-@property (nonatomic, copy) void (^onError)
-    (uint64_t errorCode, NSString *message, int32_t attemptCount, EnvoyStreamIntel streamIntel,
-     EnvoyFinalStreamIntel finalStreamIntel);
-
-@property (nonatomic, copy) void (^onComplete)
-    (EnvoyStreamIntel streamIntel, EnvoyFinalStreamIntel finalStreamIntel);
-
-@property (nonatomic, copy) void (^setRequestFilterCallbacks)
-    (id<EnvoyHTTPFilterCallbacks> callbacks);
-
+// Formatting for block properties is inconsistent and not configurable.
 // clang-format off
+
+/// Returns tuple of:
+/// 0 - NSNumber *,filter status
+/// 1 - EnvoyHeaders *, forward headers
+@property (nonatomic, copy) NSArray * (^onRequestHeaders)(
+    EnvoyHeaders *headers, BOOL endStream, EnvoyStreamIntel streamIntel);
+
+/// Returns tuple of:
+/// 0 - NSNumber *,filter status
+/// 1 - NSData *, forward data
+/// 2 - EnvoyHeaders *, optional pending headers
+@property (nonatomic, copy) NSArray * (^onRequestData)(
+    NSData *data, BOOL endStream, EnvoyStreamIntel streamIntel);
+
+/// Returns tuple of:
+/// 0 - NSNumber *,filter status
+/// 1 - EnvoyHeaders *, forward trailers
+/// 2 - EnvoyHeaders *, optional pending headers
+/// 3 - NSData *, optional pending data
+@property (nonatomic, copy) NSArray * (^onRequestTrailers)(
+    EnvoyHeaders *trailers, EnvoyStreamIntel streamIntel);
+
+/// Returns tuple of:
+/// 0 - NSNumber *,filter status
+/// 1 - EnvoyHeaders *, forward headers
+@property (nonatomic, copy) NSArray * (^onResponseHeaders)(
+    EnvoyHeaders *headers, BOOL endStream, EnvoyStreamIntel streamIntel);
+
+/// Returns tuple of:
+/// 0 - NSNumber *,filter status
+/// 1 - NSData *, forward data
+/// 2 - EnvoyHeaders *, optional pending headers
+@property (nonatomic, copy) NSArray * (^onResponseData)(
+    NSData *data, BOOL endStream, EnvoyStreamIntel streamIntel);
+
+/// Returns tuple of:
+/// 0 - NSNumber *,filter status
+/// 1 - EnvoyHeaders *, forward trailers
+/// 2 - EnvoyHeaders *, optional pending headers
+/// 3 - NSData *, optional pending data
+@property (nonatomic, copy)NSArray * (^onResponseTrailers)(
+    EnvoyHeaders *trailers, EnvoyStreamIntel streamIntel);
+
+@property (nonatomic, copy) void (^onCancel)(
+    EnvoyStreamIntel streamIntel, EnvoyFinalStreamIntel finalStreamIntel);
+
+@property (nonatomic, copy) void (^onError)(
+    uint64_t errorCode, NSString *message, int32_t attemptCount, EnvoyStreamIntel streamIntel,
+    EnvoyFinalStreamIntel finalStreamIntel);
+
+@property (nonatomic, copy) void (^onComplete)(
+    EnvoyStreamIntel streamIntel, EnvoyFinalStreamIntel finalStreamIntel);
+
+@property (nonatomic, copy) void (^setRequestFilterCallbacks)(
+    id<EnvoyHTTPFilterCallbacks> callbacks);
+
 /// Returns tuple of:
 /// 0 - NSNumber *,filter status
 /// 1 - EnvoyHeaders *, optional pending headers
 /// 2 - NSData *, optional pending data
 /// 3 - EnvoyHeaders *, optional pending trailers
-@property (nonatomic, copy) NSArray * (^onResumeRequest)
-    (EnvoyHeaders *_Nullable headers, NSData *_Nullable data, EnvoyHeaders *_Nullable trailers,
-     BOOL endStream, EnvoyStreamIntel streamIntel);
+@property (nonatomic, copy) NSArray * (^onResumeRequest)(
+    EnvoyHeaders *_Nullable headers, NSData *_Nullable data, EnvoyHeaders *_Nullable trailers,
+    BOOL endStream, EnvoyStreamIntel streamIntel);
 
-@property (nonatomic, copy) void (^setResponseFilterCallbacks)
-    (id<EnvoyHTTPFilterCallbacks> callbacks);
+@property (nonatomic, copy) void (^setResponseFilterCallbacks)(
+    id<EnvoyHTTPFilterCallbacks> callbacks);
 
 /// Returns tuple of:
 /// 0 - NSNumber *,filter status
 /// 1 - EnvoyHeaders *, optional pending headers
 /// 2 - NSData *, optional pending data
 /// 3 - EnvoyHeaders *, optional pending trailers
-@property (nonatomic, copy) NSArray * (^onResumeResponse)
-    (EnvoyHeaders *_Nullable headers, NSData *_Nullable data, EnvoyHeaders *_Nullable trailers,
-     BOOL endStream, EnvoyStreamIntel streamIntel);
+@property (nonatomic, copy) NSArray * (^onResumeResponse)(
+    EnvoyHeaders *_Nullable headers, NSData *_Nullable data, EnvoyHeaders *_Nullable trailers,
+    BOOL endStream, EnvoyStreamIntel streamIntel);
+
 // clang-format on
-
 @end
 
 #pragma mark - EnvoyHTTPFilterFactory

--- a/library/objective-c/EnvoyEngine.h
+++ b/library/objective-c/EnvoyEngine.h
@@ -30,14 +30,17 @@ typedef envoy_final_stream_intel EnvoyFinalStreamIntel;
  */
 @property (nonatomic, assign) dispatch_queue_t dispatchQueue;
 
+// Formatting for block properties is inconsistent and not configurable.
+// clang-format off
+
 /**
  * Called when all headers get received on the async HTTP stream.
  * @param headers the headers received.
  * @param endStream whether the response is headers-only.
  * @param streamIntel internal HTTP stream metrics, context, and other details.
  */
-@property (nonatomic, copy) void (^onHeaders)
-    (EnvoyHeaders *headers, BOOL endStream, EnvoyStreamIntel streamIntel);
+@property (nonatomic, copy) void (^onHeaders)(
+    EnvoyHeaders *headers, BOOL endStream, EnvoyStreamIntel streamIntel);
 
 /**
  * Called when a data frame gets received on the async HTTP stream.
@@ -46,28 +49,26 @@ typedef envoy_final_stream_intel EnvoyFinalStreamIntel;
  * @param endStream whether the data is the last data frame.
  * @param streamIntel internal HTTP stream metrics, context, and other details.
  */
-@property (nonatomic, copy) void (^onData)
-    (NSData *data, BOOL endStream, EnvoyStreamIntel streamIntel);
+@property (nonatomic, copy) void (^onData)(
+    NSData *data, BOOL endStream, EnvoyStreamIntel streamIntel);
 
-// clang-format off
 /**
  * Called when all trailers get received on the async HTTP stream.
  * Note that end stream is implied when on_trailers is called.
  * @param trailers the trailers received.
  * @param streamIntel internal HTTP stream metrics, context, and other details.
  */
-@property (nonatomic, copy) void (^onTrailers)
-    (EnvoyHeaders *trailers, EnvoyStreamIntel streamIntel);
-// clang-format on
+@property (nonatomic, copy) void (^onTrailers)(
+    EnvoyHeaders *trailers, EnvoyStreamIntel streamIntel);
 
 /**
  * Called when the async HTTP stream has an error.
  * @param streamIntel internal HTTP stream metrics, context, and other details.
  * @param finalStreamIntel one time HTTP stream metrics, context, and other details.
  */
-@property (nonatomic, copy) void (^onError)
-    (uint64_t errorCode, NSString *message, int32_t attemptCount, EnvoyStreamIntel streamIntel,
-     EnvoyFinalStreamIntel finalStreamIntel);
+@property (nonatomic, copy) void (^onError)(
+    uint64_t errorCode, NSString *message, int32_t attemptCount, EnvoyStreamIntel streamIntel,
+    EnvoyFinalStreamIntel finalStreamIntel);
 
 /**
  * Called when the async HTTP stream is canceled.
@@ -77,8 +78,8 @@ typedef envoy_final_stream_intel EnvoyFinalStreamIntel;
  * @param streamIntel internal HTTP stream metrics, context, and other details.
  * @param finalStreamIntel one time HTTP stream metrics, context, and other details.
  */
-@property (nonatomic, copy) void (^onCancel)
-    (EnvoyStreamIntel streamIntel, EnvoyFinalStreamIntel finalStreamIntel);
+@property (nonatomic, copy) void (^onCancel)(
+    EnvoyStreamIntel streamIntel, EnvoyFinalStreamIntel finalStreamIntel);
 
 /**
  * Final call made when an HTTP stream is closed gracefully.
@@ -87,9 +88,10 @@ typedef envoy_final_stream_intel EnvoyFinalStreamIntel;
  * @param streamIntel internal HTTP stream metrics, context, and other details.
  * @param finalStreamIntel one time HTTP stream metrics, context, and other details.
  */
-@property (nonatomic, copy) void (^onComplete)
-    (EnvoyStreamIntel streamIntel, EnvoyFinalStreamIntel finalStreamIntel);
+@property (nonatomic, copy) void (^onComplete)(
+    EnvoyStreamIntel streamIntel, EnvoyFinalStreamIntel finalStreamIntel);
 
+// clang-format on
 @end
 
 #pragma mark - EnvoyHTTPFilter

--- a/library/objective-c/EnvoyEngineImpl.m
+++ b/library/objective-c/EnvoyEngineImpl.m
@@ -332,6 +332,20 @@ static void ios_http_filter_set_response_callbacks(envoy_http_filter_callbacks c
   }
 }
 
+static void ios_http_filter_on_complete(envoy_stream_intel stream_intel,
+                                        envoy_final_stream_intel final_stream_intel,
+                                        const void *context) {
+  // This code block runs inside the Envoy event loop. Therefore, an explicit autoreleasepool block
+  // is necessary to act as a breaker for any Objective-C allocation that happens.
+  @autoreleasepool {
+    EnvoyHTTPFilter *filter = (__bridge EnvoyHTTPFilter *)context;
+    if (filter.onComplete == nil) {
+      return;
+    }
+    filter.onComplete(stream_intel, final_stream_intel);
+  }
+}
+
 static void ios_http_filter_on_cancel(envoy_stream_intel stream_intel,
                                       envoy_final_stream_intel final_stream_intel,
                                       const void *context) {
@@ -342,7 +356,7 @@ static void ios_http_filter_on_cancel(envoy_stream_intel stream_intel,
     if (filter.onCancel == nil) {
       return;
     }
-    filter.onCancel(stream_intel);
+    filter.onCancel(stream_intel, final_stream_intel);
   }
 }
 
@@ -363,7 +377,8 @@ static void ios_http_filter_on_error(envoy_error error, envoy_stream_intel strea
                                                     encoding:NSUTF8StringEncoding];
 
     release_envoy_error(error);
-    filter.onError(error.error_code, errorMessage, error.attempt_count, stream_intel);
+    filter.onError(error.error_code, errorMessage, error.attempt_count, stream_intel,
+                   final_stream_intel);
   }
 }
 

--- a/library/objective-c/EnvoyEngineImpl.m
+++ b/library/objective-c/EnvoyEngineImpl.m
@@ -473,7 +473,7 @@ static void ios_track_event(envoy_map map, const void *context) {
   api->set_response_callbacks = ios_http_filter_set_response_callbacks;
   api->on_resume_response = ios_http_filter_on_resume_response;
   // TODO(goaway) HTTP filter on_complete not currently implemented.
-  //api->on_complete = ios_http_filter_on_complete;
+  // api->on_complete = ios_http_filter_on_complete;
   api->on_cancel = ios_http_filter_on_cancel;
   api->on_error = ios_http_filter_on_error;
   api->release_filter = ios_http_filter_release;

--- a/library/objective-c/EnvoyEngineImpl.m
+++ b/library/objective-c/EnvoyEngineImpl.m
@@ -472,6 +472,7 @@ static void ios_track_event(envoy_map map, const void *context) {
   api->on_resume_request = ios_http_filter_on_resume_request;
   api->set_response_callbacks = ios_http_filter_set_response_callbacks;
   api->on_resume_response = ios_http_filter_on_resume_response;
+  api->on_complete = ios_http_filter_on_complete;
   api->on_cancel = ios_http_filter_on_cancel;
   api->on_error = ios_http_filter_on_error;
   api->release_filter = ios_http_filter_release;

--- a/library/objective-c/EnvoyEngineImpl.m
+++ b/library/objective-c/EnvoyEngineImpl.m
@@ -472,7 +472,8 @@ static void ios_track_event(envoy_map map, const void *context) {
   api->on_resume_request = ios_http_filter_on_resume_request;
   api->set_response_callbacks = ios_http_filter_set_response_callbacks;
   api->on_resume_response = ios_http_filter_on_resume_response;
-  api->on_complete = ios_http_filter_on_complete;
+  // TODO(goaway) HTTP filter on_complete not currently implemented.
+  //api->on_complete = ios_http_filter_on_complete;
   api->on_cancel = ios_http_filter_on_cancel;
   api->on_error = ios_http_filter_on_error;
   api->release_filter = ios_http_filter_release;

--- a/library/swift/BUILD
+++ b/library/swift/BUILD
@@ -12,6 +12,7 @@ swift_library(
         "EngineBuilder.swift",
         "EngineImpl.swift",
         "EnvoyError.swift",
+        "FinalStreamIntel.swift",
         "Headers.swift",
         "HeadersBuilder.swift",
         "LogLevel.swift",

--- a/library/swift/FinalStreamIntel.swift
+++ b/library/swift/FinalStreamIntel.swift
@@ -1,0 +1,90 @@
+@_implementationOnly import EnvoyEngine
+import Foundation
+
+/// Exposes one time HTTP stream metrics, context, and other details.
+@objcMembers
+public final class FinalStreamIntel: NSObject, Error {
+  /// The time the request started, in ms since the epoch.
+  public let requestStartMs: UInt64
+  /// The time the DNS resolution for this request started, in ms since the epoch.
+  public let dnsStartMs: UInt64
+  /// The time the DNS resolution for this request completed, in ms since the epoch.
+  public let dnsEndMs: UInt64
+  /// The time the upstream connection started, in ms since the epoch. (1)
+  public let connectStartMs: UInt64
+  /// The time the upstream connection completed, in ms since the epoch. (1)
+  public let connectEndMs: UInt64
+  /// The time the SSL handshake started, in ms since the epoch. (1)
+  public let sslStartMs: UInt64
+  /// The time the SSL handshake completed, in ms since the epoch. (1)
+  public let sslEndMs: UInt64
+  /// The time the first byte of the request was sent upstream, in ms since the epoch.
+  public let sendingStartMs: UInt64
+  /// The time the last byte of the request was sent upstream, in ms since the epoch.
+  public let sendingEndMs: UInt64
+  /// The time the first byte of the response was received, in ms since the epoch.
+  public let responseStartMs: UInt64
+  /// The time the last byte of the request was received, in ms since the epoch.
+  public let requestEndMs: UInt64
+  /// True if the upstream socket had been used previously.
+  public let socketReused: Bool
+  /// The number of bytes sent upstream.
+  public let sentByteCount: UInt64
+  /// The number of bytes received from upstream.
+  public let receivedByteCount: UInt64
+
+  // NOTE(1): These fields may not be set if socket_reused is false.
+
+  public init(
+    requestStartMs: UInt64,
+    dnsStartMs: UInt64,
+    dnsEndMs: UInt64,
+    connectStartMs: UInt64,
+    connectEndMs: UInt64,
+    sslStartMs: UInt64,
+    sslEndMs: UInt64,
+    sendingStartMs: UInt64,
+    sendingEndMs: UInt64,
+    responseStartMs: UInt64,
+    requestEndMs: UInt64,
+    socketReused: Bool,
+    sentByteCount: UInt64,
+    receivedByteCount: UInt64
+  ) {
+    self.requestStartMs = requestStartMs
+    self.dnsStartMs = dnsStartMs
+    self.dnsEndMs = dnsEndMs
+    self.connectStartMs = connectStartMs
+    self.connectEndMs = connectEndMs
+    self.sslStartMs = sslStartMs
+    self.sslEndMs = sslEndMs
+    self.sendingStartMs = sendingStartMs
+    self.sendingEndMs = sendingEndMs
+    self.responseStartMs = responseStartMs
+    self.requestEndMs = requestEndMs
+    self.socketReused = socketReused
+    self.sentByteCount = sentByteCount
+    self.receivedByteCount = receivedByteCount
+  }
+}
+
+extension FinalStreamIntel {
+  internal convenience init(_ cStruct: EnvoyFinalStreamIntel) {
+    self.init(
+      requestStartMs: cStruct.request_start_ms,
+      dnsStartMs: cStruct.dns_start_ms,
+      dnsEndMs: cStruct.dns_end_ms,
+      connectStartMs: cStruct.connect_start_ms,
+      connectEndMs: cStruct.connect_end_ms,
+      sslStartMs: cStruct.ssl_start_ms,
+      sslEndMs: cStruct.ssl_end_ms,
+      sendingStartMs: cStruct.sending_start_ms,
+      sendingEndMs: cStruct.sending_end_ms,
+      responseStartMs: cStruct.response_start_ms,
+      requestEndMs: cStruct.request_end_ms,
+      socketReused: cStruct.socket_reused != 0,
+      sentByteCount: cStruct.sent_byte_count,
+      receivedByteCount: cStruct.received_byte_count
+    )
+  }
+}

--- a/library/swift/FinalStreamIntel.swift
+++ b/library/swift/FinalStreamIntel.swift
@@ -3,7 +3,7 @@ import Foundation
 
 /// Exposes one time HTTP stream metrics, context, and other details.
 @objcMembers
-public final class FinalStreamIntel: NSObject, Error {
+public final class FinalStreamIntel: StreamIntel {
   /// The time the request started, in ms since the epoch.
   public let requestStartMs: UInt64
   /// The time the DNS resolution for this request started, in ms since the epoch.
@@ -36,6 +36,9 @@ public final class FinalStreamIntel: NSObject, Error {
   // NOTE(1): These fields may not be set if socket_reused is false.
 
   public init(
+    streamId: Int64,
+    connectionId: Int64,
+    attemptCount: UInt64,
     requestStartMs: UInt64,
     dnsStartMs: UInt64,
     dnsEndMs: UInt64,
@@ -65,26 +68,30 @@ public final class FinalStreamIntel: NSObject, Error {
     self.socketReused = socketReused
     self.sentByteCount = sentByteCount
     self.receivedByteCount = receivedByteCount
+    super.init(streamId: streamId, connectionId: connectionId, attemptCount: attemptCount)
   }
 }
 
 extension FinalStreamIntel {
-  internal convenience init(_ cStruct: EnvoyFinalStreamIntel) {
+  internal convenience init(_ cIntel: EnvoyStreamIntel, _ cFinalIntel: EnvoyFinalStreamIntel) {
     self.init(
-      requestStartMs: cStruct.request_start_ms,
-      dnsStartMs: cStruct.dns_start_ms,
-      dnsEndMs: cStruct.dns_end_ms,
-      connectStartMs: cStruct.connect_start_ms,
-      connectEndMs: cStruct.connect_end_ms,
-      sslStartMs: cStruct.ssl_start_ms,
-      sslEndMs: cStruct.ssl_end_ms,
-      sendingStartMs: cStruct.sending_start_ms,
-      sendingEndMs: cStruct.sending_end_ms,
-      responseStartMs: cStruct.response_start_ms,
-      requestEndMs: cStruct.request_end_ms,
-      socketReused: cStruct.socket_reused != 0,
-      sentByteCount: cStruct.sent_byte_count,
-      receivedByteCount: cStruct.received_byte_count
+      streamId: cIntel.stream_id,
+      connectionId: cIntel.connection_id,
+      attemptCount: cIntel.attempt_count,
+      requestStartMs: cFinalIntel.request_start_ms,
+      dnsStartMs: cFinalIntel.dns_start_ms,
+      dnsEndMs: cFinalIntel.dns_end_ms,
+      connectStartMs: cFinalIntel.connect_start_ms,
+      connectEndMs: cFinalIntel.connect_end_ms,
+      sslStartMs: cFinalIntel.ssl_start_ms,
+      sslEndMs: cFinalIntel.ssl_end_ms,
+      sendingStartMs: cFinalIntel.sending_start_ms,
+      sendingEndMs: cFinalIntel.sending_end_ms,
+      responseStartMs: cFinalIntel.response_start_ms,
+      requestEndMs: cFinalIntel.request_end_ms,
+      socketReused: cFinalIntel.socket_reused != 0,
+      sentByteCount: cFinalIntel.sent_byte_count,
+      receivedByteCount: cFinalIntel.received_byte_count
     )
   }
 }

--- a/library/swift/StreamCallbacks.swift
+++ b/library/swift/StreamCallbacks.swift
@@ -12,9 +12,9 @@ final class StreamCallbacks {
   )?
   var onData: ((_ body: Data, _ endStream: Bool, _ streamIntel: StreamIntel) -> Void)?
   var onTrailers: ((_ trailers: ResponseTrailers, _ streamIntel: StreamIntel) -> Void)?
-  var onComplete: ((_ streamIntel: StreamIntel, _ finalStreamintel: FinalStreamIntel) -> Void)?
-  var onCancel: ((_ streamIntel: StreamIntel, _ finalStreamintel: FinalStreamIntel) -> Void)?
-  var onError: ((_ error: EnvoyError, _ streamIntel: StreamIntel, _ finalStreamIntel: FinalStreamIntel) -> Void)?
+  var onComplete: ((_ streamintel: FinalStreamIntel) -> Void)?
+  var onCancel: ((_ streamintel: FinalStreamIntel) -> Void)?
+  var onError: ((_ error: EnvoyError, _ streamIntel: FinalStreamIntel) -> Void)?
 }
 
 extension EnvoyHTTPCallbacks {
@@ -28,14 +28,14 @@ extension EnvoyHTTPCallbacks {
     self.onHeaders = { callbacks.onHeaders?(ResponseHeaders(headers: $0), $1, StreamIntel($2)) }
     self.onData = { callbacks.onData?($0, $1, StreamIntel($2)) }
     self.onTrailers = { callbacks.onTrailers?(ResponseTrailers(headers: $0), StreamIntel($1)) }
-    self.onComplete = { callbacks.onCancel?(StreamIntel($0), FinalStreamIntel($1)) }
-    self.onCancel = { callbacks.onCancel?(StreamIntel($0), FinalStreamIntel($1)) }
+    self.onComplete = { callbacks.onCancel?(FinalStreamIntel($0, $1)) }
+    self.onCancel = { callbacks.onCancel?(FinalStreamIntel($0, $1)) }
     self.onError = { errorCode, message, attemptCount, streamIntel, finalStreamIntel in
       // The initializer below will return nil if `attemptCount` is negative.
       // This is the desired behavior because the bridge layer uses -1 to signify absence.
       let error = EnvoyError(errorCode: errorCode, message: message,
                              attemptCount: UInt32(exactly: attemptCount), cause: nil)
-      callbacks.onError?(error, StreamIntel(streamIntel), FinalStreamIntel(finalStreamIntel))
+      callbacks.onError?(error, FinalStreamIntel(streamIntel, finalStreamIntel))
     }
   }
 }

--- a/library/swift/StreamCallbacks.swift
+++ b/library/swift/StreamCallbacks.swift
@@ -12,8 +12,9 @@ final class StreamCallbacks {
   )?
   var onData: ((_ body: Data, _ endStream: Bool, _ streamIntel: StreamIntel) -> Void)?
   var onTrailers: ((_ trailers: ResponseTrailers, _ streamIntel: StreamIntel) -> Void)?
-  var onCancel: ((_ streamIntel: StreamIntel) -> Void)?
-  var onError: ((_ error: EnvoyError, _ streamIntel: StreamIntel) -> Void)?
+  var onComplete: ((_ streamIntel: StreamIntel, _ finalStreamintel: FinalStreamIntel) -> Void)?
+  var onCancel: ((_ streamIntel: StreamIntel, _ finalStreamintel: FinalStreamIntel) -> Void)?
+  var onError: ((_ error: EnvoyError, _ streamIntel: StreamIntel, _ finalStreamIntel: FinalStreamIntel) -> Void)?
 }
 
 extension EnvoyHTTPCallbacks {
@@ -27,13 +28,14 @@ extension EnvoyHTTPCallbacks {
     self.onHeaders = { callbacks.onHeaders?(ResponseHeaders(headers: $0), $1, StreamIntel($2)) }
     self.onData = { callbacks.onData?($0, $1, StreamIntel($2)) }
     self.onTrailers = { callbacks.onTrailers?(ResponseTrailers(headers: $0), StreamIntel($1)) }
-    self.onCancel = { callbacks.onCancel?(StreamIntel($0)) }
-    self.onError = { errorCode, message, attemptCount, streamIntel in
+    self.onComplete = { callbacks.onCancel?(StreamIntel($0), FinalStreamIntel($1)) }
+    self.onCancel = { callbacks.onCancel?(StreamIntel($0), FinalStreamIntel($1)) }
+    self.onError = { errorCode, message, attemptCount, streamIntel, finalStreamIntel in
       // The initializer below will return nil if `attemptCount` is negative.
       // This is the desired behavior because the bridge layer uses -1 to signify absence.
       let error = EnvoyError(errorCode: errorCode, message: message,
                              attemptCount: UInt32(exactly: attemptCount), cause: nil)
-      callbacks.onError?(error, StreamIntel(streamIntel))
+      callbacks.onError?(error, StreamIntel(streamIntel), FinalStreamIntel(finalStreamIntel))
     }
   }
 }

--- a/library/swift/StreamIntel.swift
+++ b/library/swift/StreamIntel.swift
@@ -3,7 +3,7 @@ import Foundation
 
 /// Exposes internal HTTP stream metrics, context, and other details.
 @objcMembers
-public final class StreamIntel: NSObject, Error {
+public class StreamIntel: NSObject, Error {
   // An internal identifier for the stream. -1 if not set.
   public let streamId: Int64
   // An internal identifier for the connection carrying the stream. -1 if not set.

--- a/library/swift/StreamPrototype.swift
+++ b/library/swift/StreamPrototype.swift
@@ -111,7 +111,7 @@ public class StreamPrototype: NSObject {
   /// - returns: This stream, for chaining syntax.
   @discardableResult
   public func setOnError(
-    closure: @escaping (_ error: EnvoyError, _ streamIntel: StreamIntel, _ finalStreamIntel: FinalStreamIntel) -> Void
+    closure: @escaping (_ error: EnvoyError, _ streamIntel: FinalStreamIntel) -> Void
   ) -> StreamPrototype {
     self.callbacks.onError = closure
     return self
@@ -125,7 +125,7 @@ public class StreamPrototype: NSObject {
   /// - returns: This stream, for chaining syntax.
   @discardableResult
   public func setOnCancel(
-    closure: @escaping (_ streamIntel: StreamIntel, _ finalStreamIntel: FinalStreamIntel) -> Void
+    closure: @escaping (_ streamIntel: FinalStreamIntel) -> Void
   ) -> StreamPrototype {
     self.callbacks.onCancel = closure
     return self
@@ -139,7 +139,7 @@ public class StreamPrototype: NSObject {
   /// - returns: This stream, for chaining syntax.
   @discardableResult
   public func setOnComplete(
-    closure: @escaping (_ streamIntel: StreamIntel, _ finalStreamIntel: FinalStreamIntel) -> Void
+    closure: @escaping (_ streamIntel: FinalStreamIntel) -> Void
   ) -> StreamPrototype {
     self.callbacks.onCancel = closure
     return self

--- a/library/swift/StreamPrototype.swift
+++ b/library/swift/StreamPrototype.swift
@@ -59,6 +59,7 @@ public class StreamPrototype: NSObject {
   }
 
   /// Specify a callback for when response headers are received by the stream.
+  /// If `endStream` is `true`, the stream is complete, pending an onComplete callback.
   ///
   /// - parameter closure: Closure which will receive the headers
   ///                      and flag indicating if the stream is headers-only.
@@ -74,7 +75,7 @@ public class StreamPrototype: NSObject {
   }
 
   /// Specify a callback for when a data frame is received by the stream.
-  /// If `endStream` is `true`, the stream is complete.
+  /// If `endStream` is `true`, the stream is complete, pending an onComplete callback.
   ///
   /// - parameter closure: Closure which will receive the data
   ///                      and flag indicating whether this is the last data frame.
@@ -89,7 +90,7 @@ public class StreamPrototype: NSObject {
   }
 
   /// Specify a callback for when trailers are received by the stream.
-  /// If the closure is called, the stream is complete.
+  /// If the closure is called, the stream is complete, pending an onComplete callback.
   ///
   /// - parameter closure: Closure which will receive the trailers.
   ///
@@ -110,7 +111,7 @@ public class StreamPrototype: NSObject {
   /// - returns: This stream, for chaining syntax.
   @discardableResult
   public func setOnError(
-    closure: @escaping (_ error: EnvoyError, _ streamIntel: StreamIntel) -> Void
+    closure: @escaping (_ error: EnvoyError, _ streamIntel: StreamIntel, _ finalStreamIntel: FinalStreamIntel) -> Void
   ) -> StreamPrototype {
     self.callbacks.onError = closure
     return self
@@ -124,7 +125,21 @@ public class StreamPrototype: NSObject {
   /// - returns: This stream, for chaining syntax.
   @discardableResult
   public func setOnCancel(
-    closure: @escaping (_ streamIntel: StreamIntel) -> Void
+    closure: @escaping (_ streamIntel: StreamIntel, _ finalStreamIntel: FinalStreamIntel) -> Void
+  ) -> StreamPrototype {
+    self.callbacks.onCancel = closure
+    return self
+  }
+
+  /// Specify a callback for when the stream completes gracefully.
+  /// If the closure is called, the stream is complete.
+  ///
+  /// - parameter closure: Closure which will be called when the stream is canceled.
+  ///
+  /// - returns: This stream, for chaining syntax.
+  @discardableResult
+  public func setOnCancel(
+    closure: @escaping (_ streamIntel: StreamIntel, _ finalStreamIntel: FinalStreamIntel) -> Void
   ) -> StreamPrototype {
     self.callbacks.onCancel = closure
     return self

--- a/library/swift/StreamPrototype.swift
+++ b/library/swift/StreamPrototype.swift
@@ -138,7 +138,7 @@ public class StreamPrototype: NSObject {
   ///
   /// - returns: This stream, for chaining syntax.
   @discardableResult
-  public func setOnCancel(
+  public func setOnComplete(
     closure: @escaping (_ streamIntel: StreamIntel, _ finalStreamIntel: FinalStreamIntel) -> Void
   ) -> StreamPrototype {
     self.callbacks.onCancel = closure

--- a/library/swift/filters/Filter.swift
+++ b/library/swift/filters/Filter.swift
@@ -111,14 +111,21 @@ extension EnvoyHTTPFilter {
         }
       }
 
-      self.onError = { errorCode, message, attemptCount, streamIntel in
+      self.onError = { errorCode, message, attemptCount, streamIntel, finalStreamIntel in
         let error = EnvoyError(errorCode: errorCode, message: message,
                                attemptCount: UInt32(exactly: attemptCount), cause: nil)
-        responseFilter.onError(error, streamIntel: StreamIntel(streamIntel))
+        responseFilter.onError(error, streamIntel: StreamIntel(streamIntel),
+                               finalStreamIntel: FinalStreamIntel(finalStreamIntel))
       }
 
-      self.onCancel = { streamIntel in
-        responseFilter.onCancel(streamIntel: StreamIntel(streamIntel))
+      self.onCancel = { streamIntel, finalStreamIntel in
+        responseFilter.onCancel(streamIntel: StreamIntel(streamIntel),
+                                finalStreamIntel: FinalStreamIntel(finalStreamIntel))
+      }
+
+      self.onComplete = { streamIntel, finalStreamIntel in
+        responseFilter.onComplete(streamIntel: StreamIntel(streamIntel),
+                                  finalStreamIntel: FinalStreamIntel(finalStreamIntel))
       }
     }
 

--- a/library/swift/filters/Filter.swift
+++ b/library/swift/filters/Filter.swift
@@ -114,18 +114,15 @@ extension EnvoyHTTPFilter {
       self.onError = { errorCode, message, attemptCount, streamIntel, finalStreamIntel in
         let error = EnvoyError(errorCode: errorCode, message: message,
                                attemptCount: UInt32(exactly: attemptCount), cause: nil)
-        responseFilter.onError(error, streamIntel: StreamIntel(streamIntel),
-                               finalStreamIntel: FinalStreamIntel(finalStreamIntel))
+        responseFilter.onError(error, streamIntel: FinalStreamIntel(streamIntel, finalStreamIntel))
       }
 
       self.onCancel = { streamIntel, finalStreamIntel in
-        responseFilter.onCancel(streamIntel: StreamIntel(streamIntel),
-                                finalStreamIntel: FinalStreamIntel(finalStreamIntel))
+        responseFilter.onCancel(streamIntel: FinalStreamIntel(streamIntel, finalStreamIntel))
       }
 
       self.onComplete = { streamIntel, finalStreamIntel in
-        responseFilter.onComplete(streamIntel: StreamIntel(streamIntel),
-                                  finalStreamIntel: FinalStreamIntel(finalStreamIntel))
+        responseFilter.onComplete(streamIntel: FinalStreamIntel(streamIntel, finalStreamIntel))
       }
     }
 

--- a/library/swift/filters/ResponseFilter.swift
+++ b/library/swift/filters/ResponseFilter.swift
@@ -44,9 +44,8 @@ public protocol ResponseFilter: Filter {
   /// `stopIteration{...}`.
   ///
   /// - parameter error:       The error that occurred within Envoy.
-  /// - parameter streamIntel: Internal HTTP stream metrics, context, and other details.
-  /// - param finalStreamIntel: Final internal HTTP stream metrics, context, and other details.
-  func onError(_ error: EnvoyError, streamIntel: StreamIntel, finalStreamIntel: FinalStreamIntel)
+  /// - parameter streamIntel: Final internal HTTP stream metrics, context, and other details.
+  func onError(_ error: EnvoyError, streamIntel: FinalStreamIntel)
 
   /// Called at most once when the client cancels the stream.
   ///
@@ -54,9 +53,8 @@ public protocol ResponseFilter: Filter {
   /// This should be considered a terminal state, and invalidates any previous attempts to
   /// `stopIteration{...}`.
   ///
-  /// - parameter streamIntel: Internal HTTP stream metrics, context, and other details.
-  /// - param finalStreamIntel: Final internal HTTP stream metrics, context, and other details.
-  func onCancel(streamIntel: StreamIntel, finalStreamIntel: FinalStreamIntel)
+  /// - parameter streamIntel: Final internal HTTP stream metrics, context, and other details.
+  func onCancel(streamIntel: FinalStreamIntel)
 
   /// Called at most once when the stream completes gracefully.
   ///
@@ -64,7 +62,6 @@ public protocol ResponseFilter: Filter {
   /// This should be considered a terminal state, and invalidates any previous attempts to
   /// `stopIteration{...}`.
   ///
-  /// - parameter streamIntel: Internal HTTP stream metrics, context, and other details.
-  /// - param finalStreamIntel: Final internal HTTP stream metrics, context, and other details.
-  func onComplete(streamIntel: StreamIntel, finalStreamIntel: FinalStreamIntel)
+  /// - parameter streamIntel: Final internal HTTP stream metrics, context, and other details.
+  func onComplete(streamIntel: FinalStreamIntel)
 }

--- a/library/swift/filters/ResponseFilter.swift
+++ b/library/swift/filters/ResponseFilter.swift
@@ -39,18 +39,32 @@ public protocol ResponseFilter: Filter {
 
   /// Called at most once when an error within Envoy occurs.
   ///
+  /// Only one of `onError`, `onCancel`, or `onComplete` will be called per stream.
   /// This should be considered a terminal state, and invalidates any previous attempts to
   /// `stopIteration{...}`.
   ///
   /// - parameter error:       The error that occurred within Envoy.
   /// - parameter streamIntel: Internal HTTP stream metrics, context, and other details.
-  func onError(_ error: EnvoyError, streamIntel: StreamIntel)
+  /// - param finalStreamIntel: Final internal HTTP stream metrics, context, and other details.
+  func onError(_ error: EnvoyError, streamIntel: StreamIntel, finalStreamIntel: FinalStreamIntel)
 
   /// Called at most once when the client cancels the stream.
   ///
+  /// Only one of `onError`, `onCancel`, or `onComplete` will be called per stream.
   /// This should be considered a terminal state, and invalidates any previous attempts to
   /// `stopIteration{...}`.
   ///
   /// - parameter streamIntel: Internal HTTP stream metrics, context, and other details.
-  func onCancel(streamIntel: StreamIntel)
+  /// - param finalStreamIntel: Final internal HTTP stream metrics, context, and other details.
+  func onCancel(streamIntel: StreamIntel, finalStreamIntel: FinalStreamIntel)
+
+  /// Called at most once when the stream completes gracefully.
+  ///
+  /// Only one of `onError`, `onCancel`, or `onComplete` will be called per stream.
+  /// This should be considered a terminal state, and invalidates any previous attempts to
+  /// `stopIteration{...}`.
+  ///
+  /// - parameter streamIntel: Internal HTTP stream metrics, context, and other details.
+  /// - param finalStreamIntel: Final internal HTTP stream metrics, context, and other details.
+  func onComplete(streamIntel: StreamIntel, finalStreamIntel: FinalStreamIntel)
 }

--- a/library/swift/grpc/GRPCStreamPrototype.swift
+++ b/library/swift/grpc/GRPCStreamPrototype.swift
@@ -87,7 +87,7 @@ public final class GRPCStreamPrototype: NSObject {
   /// - returns: This handler, which may be used for chaining syntax.
   @discardableResult
   public func setOnError(
-    _ closure: @escaping (_ error: EnvoyError, _ streamIntel: StreamIntel, _ finalStreamIntel: FinalStreamIntel) -> Void
+    _ closure: @escaping (_ error: EnvoyError, _ streamIntel: FinalStreamIntel) -> Void
   ) -> GRPCStreamPrototype {
     self.underlyingStream.setOnError(closure: closure)
     return self
@@ -101,7 +101,7 @@ public final class GRPCStreamPrototype: NSObject {
   /// - returns: This stream, for chaining syntax.
   @discardableResult
   public func setOnCancel(
-    closure: @escaping (_ streamIntel: StreamIntel, _ finalStreamIntel: FinalStreamIntel) -> Void
+    closure: @escaping (_ streamIntel: FinalStreamIntel) -> Void
   ) -> GRPCStreamPrototype {
     self.underlyingStream.setOnCancel(closure: closure)
     return self
@@ -115,7 +115,7 @@ public final class GRPCStreamPrototype: NSObject {
   /// - returns: This stream, for chaining syntax.
   @discardableResult
   public func setOnComplete(
-    closure: @escaping (_ streamIntel: StreamIntel, _ finalStreamIntel: FinalStreamIntel) -> Void
+    closure: @escaping (_ streamIntel: FinalStreamIntel) -> Void
   ) -> GRPCStreamPrototype {
     self.underlyingStream.setOnComplete(closure: closure)
     return self

--- a/library/swift/grpc/GRPCStreamPrototype.swift
+++ b/library/swift/grpc/GRPCStreamPrototype.swift
@@ -87,7 +87,7 @@ public final class GRPCStreamPrototype: NSObject {
   /// - returns: This handler, which may be used for chaining syntax.
   @discardableResult
   public func setOnError(
-    _ closure: @escaping (_ error: EnvoyError, _ streamIntel: StreamIntel) -> Void
+    _ closure: @escaping (_ error: EnvoyError, _ streamIntel: StreamIntel, _ finalStreamIntel: FinalStreamIntel) -> Void
   ) -> GRPCStreamPrototype {
     self.underlyingStream.setOnError(closure: closure)
     return self
@@ -101,9 +101,23 @@ public final class GRPCStreamPrototype: NSObject {
   /// - returns: This stream, for chaining syntax.
   @discardableResult
   public func setOnCancel(
-    closure: @escaping (_ streamInte: StreamIntel) -> Void
+    closure: @escaping (_ streamIntel: StreamIntel, _ finalStreamIntel: FinalStreamIntel) -> Void
   ) -> GRPCStreamPrototype {
     self.underlyingStream.setOnCancel(closure: closure)
+    return self
+  }
+
+  /// Specify a callback for when the stream completes gracefully.
+  /// If the closure is called, the stream is complete.
+  ///
+  /// - parameter closure: Closure which will be called when the stream is closed.
+  ///
+  /// - returns: This stream, for chaining syntax.
+  @discardableResult
+  public func setOnComplete(
+    closure: @escaping (_ streamIntel: StreamIntel, _ finalStreamIntel: FinalStreamIntel) -> Void
+  ) -> GRPCStreamPrototype {
+    self.underlyingStream.setOnComplete(closure: closure)
     return self
   }
 }

--- a/library/swift/mocks/MockStream.swift
+++ b/library/swift/mocks/MockStream.swift
@@ -81,6 +81,6 @@ public final class MockStream: Stream {
   public func receiveError(_ error: EnvoyError) {
     self.mockStream.callbacks.onError(error.errorCode, error.message,
                                       Int32(error.attemptCount ?? 0),
-                                      EnvoyStreamIntel())
+                                      EnvoyStreamIntel(), EnvoyFinalStreamIntel())
   }
 }

--- a/library/swift/mocks/MockStream.swift
+++ b/library/swift/mocks/MockStream.swift
@@ -72,7 +72,7 @@ public final class MockStream: Stream {
 
   /// Simulate the stream receiving a cancellation signal from Envoy.
   public func receiveCancel() {
-    self.mockStream.callbacks.onCancel(EnvoyStreamIntel())
+    self.mockStream.callbacks.onCancel(EnvoyStreamIntel(), EnvoyFinalStreamIntel())
   }
 
   /// Simulate Envoy returning an error.

--- a/test/swift/integration/CancelStreamTest.swift
+++ b/test/swift/integration/CancelStreamTest.swift
@@ -77,11 +77,13 @@ static_resources:
         return .continue(trailers: trailers)
       }
 
-      func onError(_ error: EnvoyError, streamIntel: StreamIntel) {}
+      func onError(_ error: EnvoyError, streamIntel: FinalStreamIntel) {}
 
-      func onCancel(streamIntel: StreamIntel) {
+      func onCancel(streamIntel: FinalStreamIntel) {
         self.expectation.fulfill()
       }
+
+      func onComplete(streamIntel: FinalStreamIntel) {}
     }
 
     let runExpectation = self.expectation(description: "Run called with expected cancellation")

--- a/test/swift/integration/CancelStreamTest.swift
+++ b/test/swift/integration/CancelStreamTest.swift
@@ -77,13 +77,11 @@ static_resources:
         return .continue(trailers: trailers)
       }
 
-      func onError(_ error: EnvoyError, streamIntel: FinalStreamIntel) {}
+      func onError(_ error: EnvoyError, streamIntel: StreamIntel) {}
 
-      func onCancel(streamIntel: FinalStreamIntel) {
+      func onCancel(streamIntel: StreamIntel) {
         self.expectation.fulfill()
       }
-
-      func onComplete(streamIntel: FinalStreamIntel) {}
     }
 
     let runExpectation = self.expectation(description: "Run called with expected cancellation")

--- a/test/swift/integration/FilterResetIdleTest.swift
+++ b/test/swift/integration/FilterResetIdleTest.swift
@@ -168,11 +168,13 @@ static_resources:
         return .stopIteration
       }
 
-      func onError(_ error: EnvoyError, streamIntel: StreamIntel) {}
+      func onError(_ error: EnvoyError, streamIntel: FinalStreamIntel) {}
 
-      func onCancel(streamIntel: StreamIntel) {
+      func onCancel(streamIntel: FinalStreamIntel) {
         cancelExpectation.fulfill()
       }
+
+      func onComplete(streamIntel: FinalStreamIntel) {}
     }
 
     let resetExpectation = self.expectation(description: "Stream idle timer reset 3 times")

--- a/test/swift/integration/GRPCReceiveErrorTest.swift
+++ b/test/swift/integration/GRPCReceiveErrorTest.swift
@@ -66,15 +66,17 @@ static_resources:
         return .continue(trailers: trailers)
       }
 
-      func onError(_ error: EnvoyError, streamIntel: StreamIntel) {
+      func onError(_ error: EnvoyError, streamIntel: FinalStreamIntel) {
         XCTAssertEqual(error.errorCode, 2) // 503/Connection Failure
         self.receivedError.fulfill()
       }
 
-      func onCancel(streamIntel: StreamIntel) {
+      func onCancel(streamIntel: FinalStreamIntel) {
         XCTFail("Unexpected call to onCancel filter callback")
         self.notCancelled.fulfill()
       }
+
+      func onComplete(streamIntel: FinalStreamIntel) {}
     }
 
     let callbackReceivedError = self.expectation(description: "Run called with expected error")

--- a/test/swift/integration/IdleTimeoutTest.swift
+++ b/test/swift/integration/IdleTimeoutTest.swift
@@ -125,14 +125,16 @@ static_resources:
         return .stopIteration
       }
 
-      func onError(_ error: EnvoyError, streamIntel: StreamIntel) {
+      func onError(_ error: EnvoyError, streamIntel: FinalStreamIntel) {
         XCTAssertEqual(error.errorCode, 4)
         timeoutExpectation.fulfill()
       }
 
-      func onCancel(streamIntel: StreamIntel) {
+      func onCancel(streamIntel: FinalStreamIntel) {
         XCTFail("Unexpected call to onCancel filter callback")
       }
+
+      func onComplete(streamIntel: FinalStreamIntel) {}
     }
 
     let filterExpectation = self.expectation(description: "Stream idle timeout received by filter")

--- a/test/swift/integration/ReceiveErrorTest.swift
+++ b/test/swift/integration/ReceiveErrorTest.swift
@@ -66,15 +66,17 @@ static_resources:
         return .continue(trailers: trailers)
       }
 
-      func onError(_ error: EnvoyError, streamIntel: StreamIntel) {
+      func onError(_ error: EnvoyError, streamIntel: FinalStreamIntel) {
         XCTAssertEqual(error.errorCode, 2) // 503/Connection Failure
         self.receivedError.fulfill()
       }
 
-      func onCancel(streamIntel: StreamIntel) {
+      func onCancel(streamIntel: FinalStreamIntel) {
         XCTFail("Unexpected call to onCancel filter callback")
         self.notCancelled.fulfill()
       }
+
+      func onComplete(streamIntel: FinalStreamIntel) {}
     }
 
     let callbackReceivedError = self.expectation(description: "Run called with expected error")


### PR DESCRIPTION
Description: I've changed up my approach here. Previously, I mirrored Android/core APIs by having a separate struct for FinalStreamIntel. Upon further consideration, I feel it's a significant improvement to the API's usability and future flexibility to have FinalStreamIntel be a true superset (and derivative) of StreamIntel. With this change the terminal callbacks - onComplete (previously not exposed in the public API), onCancel, and onError contain a FinalStreamIntel object, and other callbacks contain the prior StreamIntel subset.
Risk Level: Moderate
Testing: Unit, Integration