### PR TITLE
android: hardcode build_tools_version to 30.0.2

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -40,7 +40,7 @@ python_configure(name = "local_config_python", python_version = "3")
 load("//bazel:python.bzl", "declare_python_abi")
 declare_python_abi(name = "python_abi", python_version = "3")
 
-android_sdk_repository(name = "androidsdk", api_level = 30)
+android_sdk_repository(name = "androidsdk", api_level = 30, build_tools_version = "30.0.2")
 android_ndk_repository(name = "androidndk", api_level = 21)
 
 load("@bazel_tools//tools/build_defs/repo:git.bzl", "git_repository")


### PR DESCRIPTION
Bazel builds default to 32.0.0 build tools version. This is a work around till we update to bazel 5.x


Signed-off-by: Alan Chiu <achiu@lyft.com>

For an explanation of how to fill out the fields, please see the relevant section
in [PULL_REQUESTS.md](https://github.com/envoyproxy/envoy/blob/master/PULL_REQUESTS.md)

Description: android: hardcode build_tools_version to 30.0.2
Risk Level: low
Testing: n/a
Docs Changes: n/a
Release Notes: n/a
[Optional Fixes #Issue]
[Optional Deprecated:]
