### PR TITLE
common: make makeEnvoyMap more generic

### DIFF
--- a/library/common/bridge/utility.cc
+++ b/library/common/bridge/utility.cc
@@ -2,8 +2,6 @@
 
 #include <string>
 
-#include "library/common/data/utility.h"
-
 namespace Envoy {
 namespace Bridge {
 namespace Utility {
@@ -19,6 +17,10 @@ envoy_error_code_t errorCodeFromLocalStatus(Http::Code status) {
   default:
     return ENVOY_UNDEFINED_ERROR;
   }
+}
+
+envoy_map makeEnvoyMap(std::initializer_list<std::pair<std::string, std::string>> map) {
+  return makeEnvoyMap<std::initializer_list<std::pair<std::string, std::string>>>(map);
 }
 
 } // namespace Utility

--- a/library/common/bridge/utility.cc
+++ b/library/common/bridge/utility.cc
@@ -21,24 +21,6 @@ envoy_error_code_t errorCodeFromLocalStatus(Http::Code status) {
   }
 }
 
-envoy_map makeEnvoyMap(std::vector<std::pair<std::string, std::string>> pairs) {
-  envoy_map_entry* fields =
-      static_cast<envoy_map_entry*>(safe_malloc(sizeof(envoy_map_entry) * pairs.size()));
-  envoy_map new_event;
-  new_event.length = 0;
-  new_event.entries = fields;
-
-  for (const auto& pair : pairs) {
-    envoy_data key = Data::Utility::copyToBridgeData(pair.first);
-    envoy_data value = Data::Utility::copyToBridgeData(pair.second);
-
-    new_event.entries[new_event.length] = {key, value};
-    new_event.length++;
-  }
-
-  return new_event;
-}
-
 } // namespace Utility
 } // namespace Bridge
 } // namespace Envoy

--- a/library/common/bridge/utility.h
+++ b/library/common/bridge/utility.h
@@ -4,6 +4,7 @@
 
 #include "source/common/http/codes.h"
 
+#include "library/common/data/utility.h"
 #include "library/common/types/c_types.h"
 
 namespace Envoy {
@@ -28,6 +29,9 @@ template <class T> envoy_map makeEnvoyMap(const T& map) {
 
   return new_map;
 }
+
+// Function overload that helps resolve makeEnvoyMap({{"key", "value"}}).
+envoy_map makeEnvoyMap(std::initializer_list<std::pair<std::string, std::string>> map);
 
 } // namespace Utility
 } // namespace Bridge

--- a/library/common/bridge/utility.h
+++ b/library/common/bridge/utility.h
@@ -12,7 +12,22 @@ namespace Utility {
 
 envoy_error_code_t errorCodeFromLocalStatus(Http::Code status);
 
-envoy_map makeEnvoyMap(std::vector<std::pair<std::string, std::string>> pairs);
+// Helper that converts a C++ map-like (i.e. anything that iterates over a pair of strings) type
+// into an envoy_map, copying all the values.
+template <class T> envoy_map makeEnvoyMap(const T& map) {
+  envoy_map new_map;
+  new_map.length = std::size(map);
+  new_map.entries = new envoy_map_entry[std::size(map)];
+
+  uint64_t i = 0;
+  for (const auto& e : map) {
+    new_map.entries[i].key = Envoy::Data::Utility::copyToBridgeData(e.first);
+    new_map.entries[i].value = Envoy::Data::Utility::copyToBridgeData(e.second);
+    i++;
+  }
+
+  return new_map;
+}
 
 } // namespace Utility
 } // namespace Bridge


### PR DESCRIPTION
Changes makeEnvoyMap to work with not only a vector of pairs, but any
map-like container type.

Signed-off-by: Snow Pettersen <snowp@lyft.com>

Risk Level: Low
Testing: Existing tests
Docs Changes: n/a
Release Notes: n/a
