### PR TITLE
cronet: disable cronet_url_request_test

### DIFF
--- a/test/java/org/chromium/net/BUILD
+++ b/test/java/org/chromium/net/BUILD
@@ -60,26 +60,27 @@ envoy_mobile_android_test(
     ],
 )
 
-envoy_mobile_android_test(
-    name = "cronet_url_request_test",
-    srcs = [
-        "CronetUrlRequestTest.java",
-    ],
-    exec_properties = {
-        # TODO(lfpino): Remove this once the sandboxNetwork=off works for ipv4 localhost addresses.
-        "sandboxNetwork": "standard",
-    },
-    native_deps = [
-        "//library/common/jni:libndk_envoy_jni.so",
-        "//library/common/jni:libndk_envoy_jni.jnilib",
-    ],
-    deps = [
-        "//library/java/io/envoyproxy/envoymobile/engine:envoy_base_engine_lib",
-        "//library/java/io/envoyproxy/envoymobile/engine:envoy_engine_lib",
-        "//library/java/org/chromium/net",
-        "//library/java/org/chromium/net/impl:cronvoy",
-        "//library/kotlin/io/envoyproxy/envoymobile:envoy_interfaces_lib",
-        "//library/kotlin/io/envoyproxy/envoymobile:envoy_lib",
-        "//test/java/org/chromium/net/testing",
-    ],
-)
+# FIXME(carloseltuerto): this test has become flaky and needs to be debugged.
+# envoy_mobile_android_test(
+#     name = "cronet_url_request_test",
+#     srcs = [
+#         "CronetUrlRequestTest.java",
+#     ],
+#     exec_properties = {
+#         # TODO(lfpino): Remove this once the sandboxNetwork=off works for ipv4 localhost addresses.
+#         "sandboxNetwork": "standard",
+#     },
+#     native_deps = [
+#         "//library/common/jni:libndk_envoy_jni.so",
+#         "//library/common/jni:libndk_envoy_jni.jnilib",
+#     ],
+#     deps = [
+#         "//library/java/io/envoyproxy/envoymobile/engine:envoy_base_engine_lib",
+#         "//library/java/io/envoyproxy/envoymobile/engine:envoy_engine_lib",
+#         "//library/java/org/chromium/net",
+#         "//library/java/org/chromium/net/impl:cronvoy",
+#         "//library/kotlin/io/envoyproxy/envoymobile:envoy_interfaces_lib",
+#         "//library/kotlin/io/envoyproxy/envoymobile:envoy_lib",
+#         "//test/java/org/chromium/net/testing",
+#     ],
+# )


### PR DESCRIPTION
This test has been flaky in several unrelated PRs. I am disabling for now to investigate in parallel so it does not block forward progress on other PRs.

Signed-off-by: Jose Nino <jnino@lyft.com>
