### PR TITLE
common: cancel active streams on engine shutdown

### DIFF
--- a/library/common/engine.cc
+++ b/library/common/engine.cc
@@ -162,6 +162,8 @@ envoy_status_t Engine::terminate() {
 
     ASSERT(event_dispatcher_);
 
+    event_dispatcher_->post([this]() { http_client_->cancelAllStreams(); });
+
     // Exit the event loop and finish up in Engine::run(...)
     if (std::this_thread::get_id() == main_thread_.get_id()) {
       // TODO(goaway): figure out some way to support this.

--- a/library/common/http/client.cc
+++ b/library/common/http/client.cc
@@ -498,6 +498,7 @@ void Client::cancelStream(envoy_stream_t stream) {
     ScopeTrackerScopeState scope(direct_stream.get(), scopeTracker());
     removeStream(direct_stream->stream_handle_);
 
+    ENVOY_LOG(debug, "[S{}] canceling stream", stream);
     direct_stream->callbacks_->onCancel();
 
     // Since https://github.com/envoyproxy/envoy/pull/13052, the connection manager expects that
@@ -514,6 +515,13 @@ void Client::cancelStream(envoy_stream_t stream) {
       // reset from a wide variety of contexts without apparent issue.
       direct_stream->runResetCallbacks(StreamResetReason::RemoteReset);
     }
+  }
+}
+
+void Client::cancelAllStreams() {
+  ENVOY_LOG(debug, "canceling all streams");
+  while (!streams_.empty()) {
+    cancelStream(streams_.begin()->first);
   }
 }
 

--- a/library/common/http/client.h
+++ b/library/common/http/client.h
@@ -105,6 +105,12 @@ public:
    */
   void cancelStream(envoy_stream_t stream);
 
+  /**
+   * Cancel all active streams. This is equivalent to calling cancelStream on all streams that
+   * haven't already completed.
+   */
+  void cancelAllStreams();
+
   const HttpClientStats& stats() const;
   Event::ScopeTracker& scopeTracker() const { return dispatcher_; }
 

--- a/test/common/integration/BUILD
+++ b/test/common/integration/BUILD
@@ -25,11 +25,11 @@ envoy_cc_test(
     srcs = ["engine_integration_test.cc"],
     repository = "@envoy",
     deps = [
+        "//library/common:envoy_main_interface_lib_no_stamp",
+        "//library/common/bridge:utility_lib",
         "//library/common/http:client_lib",
         "//library/common/http:header_utility_lib",
         "//library/common/types:c_types_lib",
-        "//library/common/bridge:utility_lib",
-        "//library/common:envoy_main_interface_lib_no_stamp",
         "@envoy//test/common/http:common_lib",
         "@envoy//test/integration:http_integration_lib",
         "@envoy//test/server:utility_lib",

--- a/test/common/integration/BUILD
+++ b/test/common/integration/BUILD
@@ -19,3 +19,19 @@ envoy_cc_test(
         "@envoy//test/server:utility_lib",
     ],
 )
+
+envoy_cc_test(
+    name = "engine_integration_test",
+    srcs = ["engine_integration_test.cc"],
+    repository = "@envoy",
+    deps = [
+        "//library/common/http:client_lib",
+        "//library/common/http:header_utility_lib",
+        "//library/common/types:c_types_lib",
+        "//library/common/bridge:utility_lib",
+        "//library/common:envoy_main_interface_lib_no_stamp",
+        "@envoy//test/common/http:common_lib",
+        "@envoy//test/integration:http_integration_lib",
+        "@envoy//test/server:utility_lib",
+    ],
+)

--- a/test/common/integration/client_integration_test.cc
+++ b/test/common/integration/client_integration_test.cc
@@ -240,12 +240,6 @@ TEST_P(ClientIntegrationTest, ActiveStreamsResetOnShutdown) {
     http_client_->cancelAllStreams();
   });
 
-  // Envoy::FakeHttpConnectionPtr upstream_connection;
-  // ASSERT_TRUE(fake_upstreams_.front()->waitForHttpConnection(*BaseIntegrationTest::dispatcher_, upstream_connection));
-
-  // dispatcher_->post([&]() -> void {
-  // });
-
   terminal_callback_.waitReady();
   EXPECT_EQ(cc_.on_cancel_calls, 1);
 }

--- a/test/common/integration/engine_integration_test.cc
+++ b/test/common/integration/engine_integration_test.cc
@@ -1,10 +1,9 @@
-#include "gtest/gtest.h"
-
 #include "test/integration/integration.h"
 
-#include "library/common/types/c_types.h"
+#include "gtest/gtest.h"
 #include "library/common/bridge/utility.h"
 #include "library/common/main_interface.h"
+#include "library/common/types/c_types.h"
 
 namespace Envoy {
 namespace {
@@ -15,8 +14,8 @@ public:
       : api_(Envoy::Api::createApiForTest(stats_, time_)),
         dispatcher_(api_->allocateDispatcher("test_thread")) {
     callbacks_.context = this;
-    callbacks_.on_error = +[](envoy_error error, envoy_stream_intel, envoy_final_stream_intel,
-                              void*) -> void* {
+    callbacks_.on_error =
+        +[](envoy_error error, envoy_stream_intel, envoy_final_stream_intel, void*) -> void* {
       release_envoy_error(error);
       // We don't expect to see errors with the current flows, update if we need more complex tests.
       EXPECT_TRUE(false);

--- a/test/common/integration/engine_integration_test.cc
+++ b/test/common/integration/engine_integration_test.cc
@@ -1,0 +1,104 @@
+#include "gtest/gtest.h"
+
+#include "test/integration/integration.h"
+
+#include "library/common/types/c_types.h"
+#include "library/common/bridge/utility.h"
+#include "library/common/main_interface.h"
+
+namespace Envoy {
+namespace {
+
+class EngineIntegrationTest : public testing::Test {
+public:
+  EngineIntegrationTest()
+      : api_(Envoy::Api::createApiForTest(stats_, time_)),
+        dispatcher_(api_->allocateDispatcher("test_thread")) {
+    callbacks_.context = this;
+    callbacks_.on_error = +[](envoy_error error, envoy_stream_intel, envoy_final_stream_intel,
+                              void*) -> void* {
+      release_envoy_error(error);
+      // We don't expect to see errors with the current flows, update if we need more complex tests.
+      EXPECT_TRUE(false);
+      return nullptr;
+    },
+    callbacks_.on_cancel =
+        +[](envoy_stream_intel, envoy_final_stream_intel, void* context) -> void* {
+      EngineIntegrationTest* this_ptr = static_cast<EngineIntegrationTest*>(context);
+      this_ptr->cancel_called_.Notify();
+      return nullptr;
+    };
+    Envoy::FakeUpstreamConfig config(time_);
+    config.upstream_protocol_ = Envoy::Http::CodecType::HTTP1;
+
+    fake_upstream_ =
+        std::make_unique<Envoy::FakeUpstream>(0, Envoy::Network::Address::IpVersion::v4, config);
+  }
+
+  void startEngine() {
+    envoy_engine_callbacks callbacks{[](void* context) -> void {
+                                       auto* this_ptr =
+                                           static_cast<EngineIntegrationTest*>(context);
+                                       this_ptr->engine_running_.Notify();
+                                     },
+                                     [](void* context) -> void {
+                                       auto* this_ptr =
+                                           static_cast<EngineIntegrationTest*>(context);
+                                       this_ptr->engine_exit_.Notify();
+                                     },
+                                     this};
+
+    engine_ = init_engine(callbacks, {}, {});
+    envoy_status_t rc = run_engine(engine_, config_template, "debug");
+    ASSERT_EQ(rc, ENVOY_SUCCESS);
+
+    engine_running_.WaitForNotification();
+  }
+
+  void shutdownEngine() {
+    terminate_engine(engine_);
+    engine_exit_.WaitForNotification();
+  }
+
+  envoy_engine_t engine_;
+  absl::Notification engine_running_;
+  absl::Notification engine_exit_;
+  envoy_http_callbacks callbacks_;
+  absl::Notification cancel_called_;
+  Envoy::FakeUpstreamPtr fake_upstream_;
+  Envoy::FakeHttpConnectionPtr fake_connection_;
+
+  Envoy::Stats::IsolatedStoreImpl stats_;
+  Envoy::Event::TestRealTimeSystem time_;
+  Envoy::Api::ApiPtr api_;
+  Envoy::Event::DispatcherPtr dispatcher_;
+};
+
+TEST_F(EngineIntegrationTest, ShutdownCancelsActiveStreams) {
+  startEngine();
+
+  envoy_stream_t stream = init_stream(engine_);
+  {
+    envoy_status_t rc = start_stream(stream, callbacks_, false);
+    ASSERT_EQ(rc, ENVOY_SUCCESS);
+  }
+
+  envoy_status_t rc =
+      send_headers(stream,
+                   Bridge::Utility::makeEnvoyMap(
+                       {{":authority",
+                         fmt::format("127.0.0.1:{}", fake_upstream_->localAddress()->ip()->port())},
+                        {":scheme", "http"},
+                        {":method", "GET"},
+                        {":path", "/"}}),
+                   false);
+  ASSERT_EQ(rc, ENVOY_SUCCESS);
+
+  ASSERT_TRUE(fake_upstream_->waitForHttpConnection(*dispatcher_, fake_connection_));
+
+  shutdownEngine();
+
+  cancel_called_.WaitForNotification();
+}
+} // namespace
+} // namespace Envoy

--- a/test/common/main_interface_test.cc
+++ b/test/common/main_interface_test.cc
@@ -215,7 +215,9 @@ TEST(MainInterfaceTest, SendMetadata) {
       nullptr /* on_trailers */,
       nullptr /* on_error */,
       nullptr /* on_complete */,
-      [](envoy_stream_intel, envoy_final_stream_intel, void*) -> void* { return nullptr; } /* on_cancel */,
+      [](envoy_stream_intel, envoy_final_stream_intel, void*) -> void* {
+        return nullptr;
+      } /* on_cancel */,
       nullptr /* on_send_window_available */,
       nullptr /* context */,
   };

--- a/test/common/main_interface_test.cc
+++ b/test/common/main_interface_test.cc
@@ -209,10 +209,14 @@ TEST(MainInterfaceTest, SendMetadata) {
       engine_cbs_context.on_engine_running.WaitForNotificationWithTimeout(absl::Seconds(10)));
 
   envoy_http_callbacks stream_cbs{
-      nullptr /* on_headers */,  nullptr /* on_data */,
-      nullptr /* on_metadata */, nullptr /* on_trailers */,
-      nullptr /* on_error */,    nullptr /* on_complete */,
-      nullptr /* on_cancel */,   nullptr /* on_send_window_available */,
+      nullptr /* on_headers */,
+      nullptr /* on_data */,
+      nullptr /* on_metadata */,
+      nullptr /* on_trailers */,
+      nullptr /* on_error */,
+      nullptr /* on_complete */,
+      [](envoy_stream_intel, envoy_final_stream_intel, void*) -> void* { return nullptr; } /* on_cancel */,
+      nullptr /* on_send_window_available */,
       nullptr /* context */,
   };
 


### PR DESCRIPTION
This ensures that during proper shutdown we cancel all pending streams, maintaining the invariant that all streams receive
 a terminal callback.

Signed-off-by: Snow Pettersen <snowp@lyft.com>

Risk Level: Medium
Testing: Integration tests
Docs Changes: n/a
Release Notes: n/a
