### PR TITLE
buffer size: expand response buffer limit to 1Mb

### DIFF
--- a/library/common/http/client.h
+++ b/library/common/http/client.h
@@ -228,7 +228,10 @@ private:
     // It only has an effect in explicit flow control mode, where when all buffers are drained,
     // on_send_window_available callbacks are called.
     void readDisable(bool disable) override;
-    uint32_t bufferLimit() override { return 65000; }
+    uint32_t bufferLimit() override {
+      // 1Mb
+      return 1024000;
+    }
     // Not applicable
     void setAccount(Buffer::BufferMemoryAccountSharedPtr) override {
       // Acounting became default in https://github.com/envoyproxy/envoy/pull/17702 but is a no=op.


### PR DESCRIPTION
Description: expands the buffer size of the DirectStream from 65kb to 1mb. 
Risk Level: low - previously responses reaching the limit size would have resulted in an error.
Testing: tested with the example apps and this Envoy diff
```
diff --git a/source/common/http/filter_manager.cc b/source/common/http/filter_manager.cc
index 2864da7758..ec102fa515 100644
--- a/source/common/http/filter_manager.cc
+++ b/source/common/http/filter_manager.cc
@@ -1531,6 +1531,7 @@ Buffer::InstancePtr ActiveStreamEncoderFilter::createBuffer() {
       [this]() -> void { this->responseDataDrained(); },
       [this]() -> void { this->responseDataTooLarge(); },
       []() -> void { /* TODO(adisuissa): Handle overflow watermark */ });
+  ENVOY_LOG_MISC(error, "setting buffer limit {}", parent_.buffer_limit_);
   buffer->setWatermarks(parent_.buffer_limit_);
   return buffer;
 }
```