### PR TITLE
Decompress even when `no-transform` is specified

### DIFF
--- a/.github/workflows/core.yml
+++ b/.github/workflows/core.yml
@@ -18,6 +18,4 @@ jobs:
       - name: 'Install dependencies'
         run: ./ci/mac_ci_setup.sh
       - name: 'Run tests'
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: ./bazelw test --test_output=all --config=remote-ci-macos --remote_header="Authorization=Bearer $GITHUB_TOKEN"  //test/common/...
+        run: ./bazelw test --test_output=all //test/common/...

--- a/.github/workflows/core.yml
+++ b/.github/workflows/core.yml
@@ -18,4 +18,6 @@ jobs:
       - name: 'Install dependencies'
         run: ./ci/mac_ci_setup.sh
       - name: 'Run tests'
-        run: ./bazelw test --test_output=all //test/common/...
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: ./bazelw test --test_output=all --config=remote-ci-macos --remote_header="Authorization=Bearer $GITHUB_TOKEN"  //test/common/...

--- a/bazel/apple_test.bzl
+++ b/bazel/apple_test.bzl
@@ -18,7 +18,7 @@ load("@rules_cc//cc:defs.bzl", "objc_library")
 #     ],
 # )
 #
-def envoy_mobile_swift_test(name, srcs, data = [], deps = [], repository = ""):
+def envoy_mobile_swift_test(name, srcs, data = [], deps = [], tags = [], repository = ""):
     test_lib_name = name + "_lib"
     swift_library(
         name = test_lib_name,
@@ -36,9 +36,10 @@ def envoy_mobile_swift_test(name, srcs, data = [], deps = [], repository = ""):
         data = data,
         deps = [test_lib_name],
         minimum_os_version = "11.0",
+        tags = tags,
     )
 
-def envoy_mobile_objc_test(name, srcs, data = [], deps = []):
+def envoy_mobile_objc_test(name, srcs, data = [], deps = [], tags = []):
     test_lib_name = name + "_lib"
     objc_library(
         name = test_lib_name,
@@ -53,4 +54,5 @@ def envoy_mobile_objc_test(name, srcs, data = [], deps = []):
         data = data,
         deps = [test_lib_name],
         minimum_os_version = "11.0",
+        tags = tags,
     )

--- a/docs/root/intro/version_history.rst
+++ b/docs/root/intro/version_history.rst
@@ -6,6 +6,8 @@ Pending Release
 
 Bugfixes:
 
+- Decompressor: decompress even when `no-transform` is specified  (:issue:`#1995 <1995>`)
+
 Features:
 
 0.4.4 (December 30, 2021)

--- a/library/common/config/config.cc
+++ b/library/common/config/config.cc
@@ -294,6 +294,9 @@ R"(
                   enabled:
                     default_value: false
                     runtime_key: request_decompressor_enabled
+              response_direction_config:
+                common_config:
+                  ignore_no_transform_header: true
           - name: envoy.router
             typed_config:
               "@type": type.googleapis.com/envoy.extensions.filters.http.router.v3.Router

--- a/test/common/integration/BUILD
+++ b/test/common/integration/BUILD
@@ -8,6 +8,10 @@ envoy_cc_test(
     name = "client_integration_test",
     srcs = ["client_integration_test.cc"],
     repository = "@envoy",
+    # TODO(jpsim): Fix remote execution for these tests
+    tags = [
+        "no-remote-exec",
+    ],
     deps = [
         "//library/common/extensions/filters/http/local_error:config",
         "//library/common/extensions/filters/http/local_error:filter_cc_proto",
@@ -17,9 +21,5 @@ envoy_cc_test(
         "@envoy//test/common/http:common_lib",
         "@envoy//test/integration:http_integration_lib",
         "@envoy//test/server:utility_lib",
-    ],
-    # TODO(jpsim): Fix remote execution for these tests
-    tags = [
-        "no-remote-exec",
     ],
 )

--- a/test/common/integration/BUILD
+++ b/test/common/integration/BUILD
@@ -18,4 +18,8 @@ envoy_cc_test(
         "@envoy//test/integration:http_integration_lib",
         "@envoy//test/server:utility_lib",
     ],
+    # TODO(jpsim): Fix remote execution for these tests
+    tags = [
+        "no-remote-exec",
+    ],
 )

--- a/test/swift/integration/BUILD
+++ b/test/swift/integration/BUILD
@@ -30,13 +30,13 @@ envoy_mobile_swift_test(
         "SetLoggerTest.swift",
         "StatFlushIntegrationTest.swift",
     ],
-    deps = [
-        ":test_extensions",
-        "//library/objective-c:envoy_engine_objc_lib",
-    ],
     # TODO(jpsim): Fix remote execution for these tests
     tags = [
         "no-remote-exec",
+    ],
+    deps = [
+        ":test_extensions",
+        "//library/objective-c:envoy_engine_objc_lib",
     ],
 )
 

--- a/test/swift/integration/BUILD
+++ b/test/swift/integration/BUILD
@@ -34,6 +34,10 @@ envoy_mobile_swift_test(
         ":test_extensions",
         "//library/objective-c:envoy_engine_objc_lib",
     ],
+    # TODO(jpsim): Fix remote execution for these tests
+    tags = [
+        "no-remote-exec",
+    ],
 )
 
 envoy_cc_library(


### PR DESCRIPTION
Commit Message: Decompress even when `no-transform` is specified
Additional Description: This leverages the flag added in https://github.com/envoyproxy/envoy/pull/19399 to always decompress responses, regardless of the presence of a `no-transform` cache control header, matching the more lenient behavior of other client-side networking libraries such as OkHttp or URLSession, especially in cases where the remote server is not under the client developer's control.
Risk Level: Low, responses that would previously fail to decode will now succeed when a compressed response comes with a `no-transform` cache control header.
Testing: Added unit tests in Envoy and manually confirmed in an Android app that gzipped responses with `no-transform` that previously failed now succeed.
Docs Changes: Not needed.
Release Notes: Added.
Platform Specific Features: This is configured to apply regardless of the platform, so both iOS & Android will get this new behavior.