### PR TITLE
Default timestamp to -1 for envoy_final_stream_intel

### DIFF
--- a/library/common/extensions/filters/http/platform_bridge/filter.cc
+++ b/library/common/extensions/filters/http/platform_bridge/filter.cc
@@ -192,8 +192,7 @@ Http::LocalErrorStatus PlatformBridgeFilter::onLocalReply(const LocalReplyData& 
 envoy_final_stream_intel PlatformBridgeFilter::finalStreamIntel() {
   RELEASE_ASSERT(decoder_callbacks_, "StreamInfo accessed before filter callbacks are set");
   // FIXME: Stream handle cannot currently be set from the filter context.
-  envoy_final_stream_intel final_stream_intel;
-  memset(&final_stream_intel, 0, sizeof(final_stream_intel));
+  envoy_final_stream_intel final_stream_intel{-1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, 0, 0, 0};
   setFinalStreamIntel(decoder_callbacks_->streamInfo(), final_stream_intel);
   return final_stream_intel;
 }

--- a/library/common/http/client.h
+++ b/library/common/http/client.h
@@ -280,7 +280,8 @@ private:
     bool explicit_flow_control_ = false;
     // Latest intel data retrieved from the StreamInfo.
     envoy_stream_intel stream_intel_{-1, -1, 0};
-    envoy_final_stream_intel envoy_final_stream_intel_;
+    envoy_final_stream_intel envoy_final_stream_intel_{-1, -1, -1, -1, -1, -1, -1,
+                                                       -1, -1, -1, -1, 0,  0,  0};
     StreamInfo::BytesMeterSharedPtr bytes_meter_;
   };
 

--- a/library/common/stream_info/extra_stream_info.cc
+++ b/library/common/stream_info/extra_stream_info.cc
@@ -52,9 +52,6 @@ void setFinalStreamIntel(StreamInfo& stream_info, envoy_final_stream_intel& fina
     final_intel.sent_byte_count = stream_info.getUpstreamBytesMeter()->wireBytesSent();
     final_intel.received_byte_count = stream_info.getUpstreamBytesMeter()->wireBytesReceived();
   }
-  std::cout << "extra request_start_ms: " << final_intel.request_start_ms << std::endl;
-  std::cout << "extra dns_start_ms: " << final_intel.dns_start_ms << std::endl;
-  std::cout << "extra dns_end_ms: " << final_intel.dns_end_ms << std::endl;
 }
 
 } // namespace StreamInfo

--- a/library/common/stream_info/extra_stream_info.cc
+++ b/library/common/stream_info/extra_stream_info.cc
@@ -6,14 +6,14 @@ namespace Envoy {
 namespace StreamInfo {
 namespace {
 
-void setFromOptional(uint64_t& to_set, const absl::optional<MonotonicTime>& time) {
+void setFromOptional(int64_t& to_set, const absl::optional<MonotonicTime>& time) {
   if (time.has_value()) {
     to_set = std::chrono::duration_cast<std::chrono::milliseconds>(time.value().time_since_epoch())
                  .count();
   }
 }
 
-void setFromOptional(uint64_t& to_set, absl::optional<std::chrono::nanoseconds> time, long offset) {
+void setFromOptional(int64_t& to_set, absl::optional<std::chrono::nanoseconds> time, long offset) {
   if (time.has_value()) {
     to_set = offset + std::chrono::duration_cast<std::chrono::milliseconds>(time.value()).count();
   }
@@ -52,6 +52,9 @@ void setFinalStreamIntel(StreamInfo& stream_info, envoy_final_stream_intel& fina
     final_intel.sent_byte_count = stream_info.getUpstreamBytesMeter()->wireBytesSent();
     final_intel.received_byte_count = stream_info.getUpstreamBytesMeter()->wireBytesReceived();
   }
+  std::cout << "extra request_start_ms: " << final_intel.request_start_ms << std::endl;
+  std::cout << "extra dns_start_ms: " << final_intel.dns_start_ms << std::endl;
+  std::cout << "extra dns_end_ms: " << final_intel.dns_end_ms << std::endl;
 }
 
 } // namespace StreamInfo

--- a/library/common/types/c_types.h
+++ b/library/common/types/c_types.h
@@ -157,34 +157,36 @@ typedef struct {
 
 /**
  * Contains internal HTTP stream metrics which sent at stream end.
+ *
+ * Note: for the signed fields, -1 means not present.
  */
 typedef struct {
   // The time the request started, in ms since the epoch.
-  uint64_t request_start_ms;
+  int64_t request_start_ms;
   // The time the DNS resolution for this request started, in ms since the epoch.
-  uint64_t dns_start_ms;
+  int64_t dns_start_ms;
   // The time the DNS resolution for this request completed, in ms since the epoch.
-  uint64_t dns_end_ms;
+  int64_t dns_end_ms;
   // The time the upstream connection started, in ms since the epoch.
   // This may not be set if socket_reused is false.
-  uint64_t connect_start_ms;
+  int64_t connect_start_ms;
   // The time the upstream connection completed, in ms since the epoch.
   // This may not be set if socket_reused is false.
-  uint64_t connect_end_ms;
+  int64_t connect_end_ms;
   // The time the SSL handshake started, in ms since the epoch.
   // This may not be set if socket_reused is false.
-  uint64_t ssl_start_ms;
+  int64_t ssl_start_ms;
   // The time the SSL handshake completed, in ms since the epoch.
   // This may not be set if socket_reused is false.
-  uint64_t ssl_end_ms;
+  int64_t ssl_end_ms;
   // The time the first byte of the request was sent upstream, in ms since the epoch.
-  uint64_t sending_start_ms;
+  int64_t sending_start_ms;
   // The time the last byte of the request was sent upstream, in ms since the epoch.
-  uint64_t sending_end_ms;
+  int64_t sending_end_ms;
   // The time the first byte of the response was received, in ms since the epoch.
-  uint64_t response_start_ms;
+  int64_t response_start_ms;
   // The time the last byte of the request was received, in ms since the epoch.
-  uint64_t request_end_ms;
+  int64_t request_end_ms;
   // True if the upstream socket had been used previously.
   uint64_t socket_reused;
   // The number of bytes sent upstream.

--- a/library/swift/FinalStreamIntel.swift
+++ b/library/swift/FinalStreamIntel.swift
@@ -2,30 +2,31 @@
 import Foundation
 
 /// Exposes one time HTTP stream metrics, context, and other details.
+/// Note: -1 means "not present" for the fields of type Int64.
 @objcMembers
 public final class FinalStreamIntel: StreamIntel {
   /// The time the request started, in ms since the epoch.
-  public let requestStartMs: UInt64
+  public let requestStartMs: Int64
   /// The time the DNS resolution for this request started, in ms since the epoch.
-  public let dnsStartMs: UInt64
+  public let dnsStartMs: Int64
   /// The time the DNS resolution for this request completed, in ms since the epoch.
-  public let dnsEndMs: UInt64
+  public let dnsEndMs: Int64
   /// The time the upstream connection started, in ms since the epoch. (1)
-  public let connectStartMs: UInt64
+  public let connectStartMs: Int64
   /// The time the upstream connection completed, in ms since the epoch. (1)
-  public let connectEndMs: UInt64
+  public let connectEndMs: Int64
   /// The time the SSL handshake started, in ms since the epoch. (1)
-  public let sslStartMs: UInt64
+  public let sslStartMs: Int64
   /// The time the SSL handshake completed, in ms since the epoch. (1)
-  public let sslEndMs: UInt64
+  public let sslEndMs: Int64
   /// The time the first byte of the request was sent upstream, in ms since the epoch.
-  public let sendingStartMs: UInt64
+  public let sendingStartMs: Int64
   /// The time the last byte of the request was sent upstream, in ms since the epoch.
-  public let sendingEndMs: UInt64
+  public let sendingEndMs: Int64
   /// The time the first byte of the response was received, in ms since the epoch.
-  public let responseStartMs: UInt64
+  public let responseStartMs: Int64
   /// The time the last byte of the request was received, in ms since the epoch.
-  public let requestEndMs: UInt64
+  public let requestEndMs: Int64
   /// True if the upstream socket had been used previously.
   public let socketReused: Bool
   /// The number of bytes sent upstream.
@@ -39,17 +40,17 @@ public final class FinalStreamIntel: StreamIntel {
     streamId: Int64,
     connectionId: Int64,
     attemptCount: UInt64,
-    requestStartMs: UInt64,
-    dnsStartMs: UInt64,
-    dnsEndMs: UInt64,
-    connectStartMs: UInt64,
-    connectEndMs: UInt64,
-    sslStartMs: UInt64,
-    sslEndMs: UInt64,
-    sendingStartMs: UInt64,
-    sendingEndMs: UInt64,
-    responseStartMs: UInt64,
-    requestEndMs: UInt64,
+    requestStartMs: Int64,
+    dnsStartMs: Int64,
+    dnsEndMs: Int64,
+    connectStartMs: Int64,
+    connectEndMs: Int64,
+    sslStartMs: Int64,
+    sslEndMs: Int64,
+    sendingStartMs: Int64,
+    sendingEndMs: Int64,
+    responseStartMs: Int64,
+    requestEndMs: Int64,
     socketReused: Bool,
     sentByteCount: UInt64,
     receivedByteCount: UInt64


### PR DESCRIPTION
Description: Default timestamp to -1 for envoy_final_stream_intel
Risk Level: small
Testing: CI
Docs Changes: N/A
Release Notes: N/A
Signed-off-by: Charles Le Borgne <cleborgne@google.com>
