### PR TITLE
Run Kotlin macOS tests without EngFlow

### DIFF
--- a/.github/workflows/android_tests.yml
+++ b/.github/workflows/android_tests.yml
@@ -45,8 +45,6 @@ jobs:
           ./bazelw test \
             --test_output=all \
             --build_tests_only \
-            --config=remote-ci-macos \
-            --remote_header="Authorization=Bearer $GITHUB_TOKEN" \
             //test/kotlin/io/...
   javatestsmac:
     name: java_tests_mac


### PR DESCRIPTION
These jobs fail when run with remote execution but pass when run directly on GitHub Actions agents.

Signed-off-by: JP Simard <jp@jpsim.com>