### PR TITLE
Fixed network policy of client_integration_test

### DIFF
--- a/test/common/integration/BUILD
+++ b/test/common/integration/BUILD
@@ -7,11 +7,11 @@ envoy_package()
 envoy_cc_test(
     name = "client_integration_test",
     srcs = ["client_integration_test.cc"],
-    repository = "@envoy",
     exec_properties = {
         # TODO(willengflow): Remove this once the sandboxNetwork=off works for ipv4 localhost addresses.
         "sandboxNetwork": "standard",
     },
+    repository = "@envoy",
     deps = [
         "//library/common/extensions/filters/http/local_error:config",
         "//library/common/extensions/filters/http/local_error:filter_cc_proto",

--- a/test/common/integration/BUILD
+++ b/test/common/integration/BUILD
@@ -8,10 +8,10 @@ envoy_cc_test(
     name = "client_integration_test",
     srcs = ["client_integration_test.cc"],
     repository = "@envoy",
-    # TODO(jpsim): Fix remote execution for these tests
-    tags = [
-        "no-remote-exec",
-    ],
+    exec_properties = {
+        # TODO(willengflow): Remove this once the sandboxNetwork=off works for ipv4 localhost addresses.
+        "sandboxNetwork": "standard",
+    },
     deps = [
         "//library/common/extensions/filters/http/local_error:config",
         "//library/common/extensions/filters/http/local_error:filter_cc_proto",


### PR DESCRIPTION
//test/common/integration:client_integration_test requires networking
which is not allowed by default. This allows the test to use the
localhost network.

Signed-off-by: Will <will@engflow.com>

Description: //test/common/integration:client_integration_test requires networking which is not allowed by default. This allows the  test to use the localhost network.
Risk Level: Low
Testing: See  unit_tests  workflow
Docs Changes: N/A
Release Notes: N/A
Fixes #2020