### PR TITLE
Update CONTRIBUTING.md to include updating subrepos

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -95,6 +95,8 @@ root and run:
 ./envoy/support/bootstrap
 ```
 
+(Note, you will need to have git submodules initialized first `git submodule update --init --recursive`)
+
 From here, simply commit as normal, and you will see the signoff at the bottom
 of each commit.
 


### PR DESCRIPTION
Signed-off-by: Will Martin <will@engflow.com>

Description: Update CONTRIBUTING.md to specify that you must initialize sub-repos before setting up DCO.
Risk Level: Low
Testing: N/A
Docs Changes: Added a line to CONTRIBUTING.md
Release Notes: N/A
