### PR TITLE
bazel: remove java-related .bazelrc flags that have no effect

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -18,8 +18,6 @@ build --workspace_status_command=envoy/bazel/get_workspace_status
 build --xcode_version=13.0
 build --host_javabase=@bazel_tools//tools/jdk:remote_jdk11
 build --javabase=@bazel_tools//tools/jdk:remote_jdk11
-build --tool_java_runtime_version=remotejdk_11
-build --java_runtime_version=remotejdk_11
 # https://github.com/bazelbuild/rules_jvm_external/issues/445
 build --repo_env=JAVA_HOME=../bazel_tools/jdk
 build --define disable_known_issue_asserts=true
@@ -172,7 +170,6 @@ build:remote-ci-linux-tsan --config=remote-ci-common
 #############################################################################
 # remote-ci-linux-local-java8: These options are linux-only using a local Java 8 (JDK)
 #############################################################################
-build:remote-ci-linux-local-java8 --extra_toolchains=@local_jdk//:all
 build:remote-ci-linux-local-java8 --host_java_toolchain=@bazel_tools//tools/jdk:toolchain_java8
 build:remote-ci-linux-local-java8 --java_toolchain=@bazel_tools//tools/jdk:toolchain_java8
 build:remote-ci-linux-local-java8 --config=remote-ci-common


### PR DESCRIPTION
Description: These flags have to do with toolchain resolution, which is not used in Bazel 4.x for Java rules.
Risk Level: low
Testing: run CI
Docs Changes: N/A

Signed-off-by: Benjamin Peterson <benjamin@engflow.com>