### PR TITLE
[OWNERS] Update Envoy Mobile owners

### DIFF
--- a/OWNERS.md
+++ b/OWNERS.md
@@ -11,10 +11,10 @@ routing PRs, questions, etc. to the right place.
   * Envoy mobile core, C bridge layer, C++ extensions, build system, Envoy upstream.
 * Snow Pettersen ([snowp](https://github.com/snowp)) (aickck@gmail.com)
   * Envoy Upstream. Stats.
-* Michael Rebello ([rebello95](https://github.com/rebello95)) (mrebello@lyft.com)
-  * iOS (swift/objective-c) platform bindings.
 * Mike Schore ([goaway](https://github.com/goaway)) (mschore@lyft.com)
   * General.
+* JP Simard ([jpsim](https://github.com/jpsim)) (jp@lyft.com)
+  * iOS (swift/objective-c) platform bindings.
 
 # Friends of Envoy Mobile
 
@@ -31,3 +31,7 @@ matter expert reviews. Feel free to loop them in as needed.
   * Cronet API shim aka "Cronvoy".
 * Keith Smiley ([keith](https://github.com/keith)) (keithbsmiley@gmail.com)
   * Bazel build magician
+
+# Emeritus maintainers
+
+* Michael Rebello ([rebello95](https://github.com/rebello95)) (mrebello@lyft.com)


### PR DESCRIPTION
If I may be so bold, I'm adding myself as an owner and moving Michael Rebello to a new "Emiritus maintainers" section to match the structure and naming used by the Envoy project.

Signed-off-by: JP Simard <jp@jpsim.com>