### PR TITLE
[deps] Update rules_android to a stable release URL

### DIFF
--- a/bazel/envoy_mobile_repositories.bzl
+++ b/bazel/envoy_mobile_repositories.bzl
@@ -143,7 +143,7 @@ def kotlin_repos():
 def android_repos():
     http_archive(
         name = "build_bazel_rules_android",
-        urls = ["https://github.com/bazelbuild/rules_android/archive/v0.1.1.zip"],
+        urls = ["https://github.com/bazelbuild/rules_android/archive/refs/tags/v0.1.1.zip"],
         sha256 = "cd06d15dd8bb59926e4d65f9003bfc20f9da4b2519985c27e190cddc8b7a7806",
         strip_prefix = "rules_android-0.1.1",
     )


### PR DESCRIPTION
Previous URL started returning a zip archive with a different checksum: https://github.com/bazelbuild/rules_android/issues/43

Signed-off-by: JP Simard <jp@jpsim.com>