### PR TITLE
bazel: Add androidndk fetching workaround

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -40,5 +40,8 @@ python_configure(name = "local_config_python", python_version = "3")
 load("//bazel:python.bzl", "declare_python_abi")
 declare_python_abi(name = "python_abi", python_version = "3")
 
-android_sdk_repository(name = "androidsdk", api_level = 30, build_tools_version = "30.0.2")
-android_ndk_repository(name = "androidndk", api_level = 21)
+load("//bazel:android_configure.bzl", "android_configure")
+android_configure(name = "local_config_android")
+
+load("@local_config_android//:android_configure.bzl", "android_workspace")
+android_workspace()

--- a/bazel/android_configure.bzl
+++ b/bazel/android_configure.bzl
@@ -1,0 +1,53 @@
+"""Repository rule for Android SDK and NDK autoconfiguration.
+
+This rule is a no-op unless the required android environment variables are set.
+"""
+
+# Based on https://github.com/tensorflow/tensorflow/tree/34c03ed67692eb76cb3399cebca50ea8bcde064c/third_party/android
+# Workaround for https://github.com/bazelbuild/bazel/issues/14260
+
+_ANDROID_NDK_HOME = "ANDROID_NDK_HOME"
+_ANDROID_SDK_HOME = "ANDROID_HOME"
+
+def _android_autoconf_impl(repository_ctx):
+    sdk_home = repository_ctx.os.environ.get(_ANDROID_SDK_HOME)
+    ndk_home = repository_ctx.os.environ.get(_ANDROID_NDK_HOME)
+
+    sdk_rule = ""
+    if sdk_home:
+        sdk_rule = """
+    native.android_sdk_repository(
+        name="androidsdk",
+        path="{}",
+        api_level=30,
+        build_tools_version="30.0.2",
+    )
+""".format(sdk_home)
+
+    ndk_rule = ""
+    if ndk_home:
+        ndk_rule = """
+    native.android_ndk_repository(
+        name="androidndk",
+        path="{}",
+        api_level=21,
+    )
+""".format(ndk_home)
+
+    if ndk_rule == "" and sdk_rule == "":
+        sdk_rule = "pass"
+
+    repository_ctx.file("BUILD.bazel", "")
+    repository_ctx.file("android_configure.bzl", """
+def android_workspace():
+    {}
+    {}
+    """.format(sdk_rule, ndk_rule))
+
+android_configure = repository_rule(
+    implementation = _android_autoconf_impl,
+    environ = [
+        _ANDROID_NDK_HOME,
+        _ANDROID_SDK_HOME,
+    ],
+)


### PR DESCRIPTION
This works around https://github.com/bazelbuild/bazel/issues/14260

This is based on tensorflow's implementation https://github.com/tensorflow/tensorflow/tree/34c03ed67692eb76cb3399cebca50ea8bcde064c/third_party/android

Signed-off-by: Keith Smiley <keithbsmiley@gmail.com>