### PR TITLE
bazel: Allow configuring Android toolchain versions

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -41,7 +41,12 @@ load("//bazel:python.bzl", "declare_python_abi")
 declare_python_abi(name = "python_abi", python_version = "3")
 
 load("//bazel:android_configure.bzl", "android_configure")
-android_configure(name = "local_config_android")
+android_configure(
+    name = "local_config_android",
+    sdk_api_level = 30,
+    ndk_api_level = 21,
+    build_tools_version = "30.0.2"
+)
 
 load("@local_config_android//:android_configure.bzl", "android_workspace")
 android_workspace()

--- a/bazel/android_configure.bzl
+++ b/bazel/android_configure.bzl
@@ -13,16 +13,20 @@ def _android_autoconf_impl(repository_ctx):
     sdk_home = repository_ctx.os.environ.get(_ANDROID_SDK_HOME)
     ndk_home = repository_ctx.os.environ.get(_ANDROID_NDK_HOME)
 
+    sdk_api_level = repository_ctx.attr.sdk_api_level
+    ndk_api_level = repository_ctx.attr.ndk_api_level
+    build_tools_version = repository_ctx.attr.build_tools_version
+
     sdk_rule = ""
     if sdk_home:
         sdk_rule = """
     native.android_sdk_repository(
         name="androidsdk",
         path="{}",
-        api_level=30,
-        build_tools_version="30.0.2",
+        api_level={},
+        build_tools_version="{}",
     )
-""".format(sdk_home)
+""".format(sdk_home, sdk_api_level, build_tools_version)
 
     ndk_rule = ""
     if ndk_home:
@@ -30,9 +34,9 @@ def _android_autoconf_impl(repository_ctx):
     native.android_ndk_repository(
         name="androidndk",
         path="{}",
-        api_level=21,
+        api_level={},
     )
-""".format(ndk_home)
+""".format(ndk_home, ndk_api_level)
 
     if ndk_rule == "" and sdk_rule == "":
         sdk_rule = "pass"
@@ -50,4 +54,9 @@ android_configure = repository_rule(
         _ANDROID_NDK_HOME,
         _ANDROID_SDK_HOME,
     ],
+    attrs = {
+        "sdk_api_level": attr.int(mandatory = True),
+        "ndk_api_level": attr.int(mandatory = True),
+        "build_tools_version": attr.string(mandatory = True),
+    },
 )


### PR DESCRIPTION
So consumers can override which versions they want if it differs from the values used here.

Signed-off-by: JP Simard <jp@jpsim.com>