### PR TITLE
Rename request_end to stream_end, and adjust documentation.

### DIFF
--- a/library/common/jni/jni_utility.cc
+++ b/library/common/jni/jni_utility.cc
@@ -114,7 +114,7 @@ jlongArray native_final_stream_intel_to_array(JNIEnv* env,
   critical_array[7] = static_cast<jlong>(final_stream_intel.sending_start_ms);
   critical_array[8] = static_cast<jlong>(final_stream_intel.sending_end_ms);
   critical_array[9] = static_cast<jlong>(final_stream_intel.response_start_ms);
-  critical_array[10] = static_cast<jlong>(final_stream_intel.request_end_ms);
+  critical_array[10] = static_cast<jlong>(final_stream_intel.stream_end_ms);
   critical_array[11] = static_cast<jlong>(final_stream_intel.socket_reused);
   critical_array[12] = static_cast<jlong>(final_stream_intel.sent_byte_count);
   critical_array[13] = static_cast<jlong>(final_stream_intel.received_byte_count);

--- a/library/common/jni/jni_utility.cc
+++ b/library/common/jni/jni_utility.cc
@@ -104,7 +104,7 @@ jlongArray native_final_stream_intel_to_array(JNIEnv* env,
   jlong* critical_array = static_cast<jlong*>(env->GetPrimitiveArrayCritical(j_array, nullptr));
   RELEASE_ASSERT(critical_array != nullptr, "unable to allocate memory in jni_utility");
 
-  critical_array[0] = static_cast<jlong>(final_stream_intel.request_start_ms);
+  critical_array[0] = static_cast<jlong>(final_stream_intel.stream_start_ms);
   critical_array[1] = static_cast<jlong>(final_stream_intel.dns_start_ms);
   critical_array[2] = static_cast<jlong>(final_stream_intel.dns_end_ms);
   critical_array[3] = static_cast<jlong>(final_stream_intel.connect_start_ms);

--- a/library/common/stream_info/extra_stream_info.cc
+++ b/library/common/stream_info/extra_stream_info.cc
@@ -43,9 +43,9 @@ void setFinalStreamIntel(StreamInfo& stream_info, TimeSource& time_source,
                                          .count();
 
   // Unfortunately, stream_info.requestComplete() is not set yet.
-  final_intel.request_end_ms = offset_ms + std::chrono::duration_cast<std::chrono::milliseconds>(
-                                               time_source.monotonicTime().time_since_epoch())
-                                               .count();
+  final_intel.stream_end_ms = offset_ms + std::chrono::duration_cast<std::chrono::milliseconds>(
+                                              time_source.monotonicTime().time_since_epoch())
+                                              .count();
 
   if (stream_info.upstreamInfo()) {
     const auto& upstream_info = stream_info.upstreamInfo();

--- a/library/common/stream_info/extra_stream_info.cc
+++ b/library/common/stream_info/extra_stream_info.cc
@@ -27,8 +27,8 @@ void setFinalStreamIntel(StreamInfo& stream_info, TimeSource& time_source,
   // ms goes to final_intel.stream_start_ms directly. This is the only value that was taken from
   // the "wall clock" (a.k.a std::chrono::system_clock:now())
   final_intel.stream_start_ms = std::chrono::duration_cast<std::chrono::milliseconds>(
-                                     stream_info.startTime().time_since_epoch())
-                                     .count();
+                                    stream_info.startTime().time_since_epoch())
+                                    .count();
 
   // All the following timestamps are monotonic, rebased on the above stream_info.startTime().
   // StreamInfo.startTimeMonotonic() is used to compute the offset for the rebasing. Both
@@ -39,8 +39,8 @@ void setFinalStreamIntel(StreamInfo& stream_info, TimeSource& time_source,
   //       a duration to a long (int64_t in this case).
   int64_t offset_ms =
       final_intel.stream_start_ms - std::chrono::duration_cast<std::chrono::milliseconds>(
-                                         stream_info.startTimeMonotonic().time_since_epoch())
-                                         .count();
+                                        stream_info.startTimeMonotonic().time_since_epoch())
+                                        .count();
 
   // Unfortunately, stream_info.requestComplete() is not set yet.
   final_intel.stream_end_ms = offset_ms + std::chrono::duration_cast<std::chrono::milliseconds>(

--- a/library/common/stream_info/extra_stream_info.cc
+++ b/library/common/stream_info/extra_stream_info.cc
@@ -24,9 +24,9 @@ const std::string& ExtraStreamInfo::key() {
 void setFinalStreamIntel(StreamInfo& stream_info, TimeSource& time_source,
                          envoy_final_stream_intel& final_intel) {
   // The wall clock starting time is the one provided by StreamInfo.startTime(). Its Epoch value in
-  // ms goes to final_intel.request_start_ms directly. This is the only value that was taken from
+  // ms goes to final_intel.stream_start_ms directly. This is the only value that was taken from
   // the "wall clock" (a.k.a std::chrono::system_clock:now())
-  final_intel.request_start_ms = std::chrono::duration_cast<std::chrono::milliseconds>(
+  final_intel.stream_start_ms = std::chrono::duration_cast<std::chrono::milliseconds>(
                                      stream_info.startTime().time_since_epoch())
                                      .count();
 
@@ -38,7 +38,7 @@ void setFinalStreamIntel(StreamInfo& stream_info, TimeSource& time_source,
   //       This is particularly counterintuitive, but that's the usual escape hatch to transform
   //       a duration to a long (int64_t in this case).
   int64_t offset_ms =
-      final_intel.request_start_ms - std::chrono::duration_cast<std::chrono::milliseconds>(
+      final_intel.stream_start_ms - std::chrono::duration_cast<std::chrono::milliseconds>(
                                          stream_info.startTimeMonotonic().time_since_epoch())
                                          .count();
 

--- a/library/common/types/c_types.h
+++ b/library/common/types/c_types.h
@@ -167,8 +167,8 @@ typedef struct {
  * Note: for the signed fields, -1 means not present.
  */
 typedef struct {
-  // The time the request started, in ms since the epoch.
-  int64_t request_start_ms;
+  // The time the stream started (a.k.a request started), in ms since the epoch.
+  int64_t stream_start_ms;
   // The time the DNS resolution for this request started, in ms since the epoch.
   int64_t dns_start_ms;
   // The time the DNS resolution for this request completed, in ms since the epoch.

--- a/library/common/types/c_types.h
+++ b/library/common/types/c_types.h
@@ -191,8 +191,8 @@ typedef struct {
   int64_t sending_end_ms;
   // The time the first byte of the response was received, in ms since the epoch.
   int64_t response_start_ms;
-  // The time the last byte of the request was received, in ms since the epoch.
-  int64_t request_end_ms;
+  // The time when the stream reached a final state: Error, Cancel, Success.
+  int64_t stream_end_ms;
   // True if the upstream socket had been used previously.
   uint64_t socket_reused;
   // The number of bytes sent upstream.

--- a/library/java/io/envoyproxy/envoymobile/engine/EnvoyFinalStreamIntelImpl.java
+++ b/library/java/io/envoyproxy/envoymobile/engine/EnvoyFinalStreamIntelImpl.java
@@ -13,7 +13,7 @@ class EnvoyFinalStreamIntelImpl implements EnvoyFinalStreamIntel {
   private long sendingStartMs;
   private long sendingEndMs;
   private long responseStartMs;
-  private long requestEndMs;
+  private long streamEndMs;
   private boolean socketReused;
   private long sentByteCount;
   private long receivedByteCount;
@@ -30,7 +30,7 @@ class EnvoyFinalStreamIntelImpl implements EnvoyFinalStreamIntel {
     sendingStartMs = values[7];
     sendingEndMs = values[8];
     responseStartMs = values[9];
-    requestEndMs = values[10];
+    streamEndMs = values[10];
     socketReused = values[11] != 0;
     sentByteCount = values[12];
     receivedByteCount = values[13];
@@ -78,8 +78,8 @@ class EnvoyFinalStreamIntelImpl implements EnvoyFinalStreamIntel {
     return responseStartMs;
   }
   @Override
-  public long getRequestEndMs() {
-    return requestEndMs;
+  public long getStreamEndMs() {
+    return streamEndMs;
   }
   @Override
   public boolean getSocketReused() {

--- a/library/java/io/envoyproxy/envoymobile/engine/EnvoyFinalStreamIntelImpl.java
+++ b/library/java/io/envoyproxy/envoymobile/engine/EnvoyFinalStreamIntelImpl.java
@@ -3,7 +3,7 @@ package io.envoyproxy.envoymobile.engine;
 import io.envoyproxy.envoymobile.engine.types.EnvoyFinalStreamIntel;
 
 class EnvoyFinalStreamIntelImpl implements EnvoyFinalStreamIntel {
-  private long requestStartMs;
+  private long streamStartMs;
   private long dnsStartMs;
   private long dnsEndMs;
   private long connectStartMs;
@@ -20,7 +20,7 @@ class EnvoyFinalStreamIntelImpl implements EnvoyFinalStreamIntel {
   private long responseFlags;
 
   EnvoyFinalStreamIntelImpl(long[] values) {
-    requestStartMs = values[0];
+    streamStartMs = values[0];
     dnsStartMs = values[1];
     dnsEndMs = values[2];
     connectStartMs = values[3];
@@ -38,8 +38,8 @@ class EnvoyFinalStreamIntelImpl implements EnvoyFinalStreamIntel {
   }
 
   @Override
-  public long getRequestStartMs() {
-    return requestStartMs;
+  public long getStreamStartMs() {
+    return streamStartMs;
   }
   @Override
   public long getDnsStartMs() {

--- a/library/java/io/envoyproxy/envoymobile/engine/types/EnvoyFinalStreamIntel.java
+++ b/library/java/io/envoyproxy/envoymobile/engine/types/EnvoyFinalStreamIntel.java
@@ -7,9 +7,9 @@ package io.envoyproxy.envoymobile.engine.types;
  */
 public interface EnvoyFinalStreamIntel {
   /*
-   * The time the request started, in ms since the epoch.
+   * The time the stream started (a.k.a request started), in ms since the epoch.
    */
-  public long getRequestStartMs();
+  public long getStreamStartMs();
   /*
    * The time the DNS resolution for this request started, in ms since the epoch.
    */

--- a/library/java/io/envoyproxy/envoymobile/engine/types/EnvoyFinalStreamIntel.java
+++ b/library/java/io/envoyproxy/envoymobile/engine/types/EnvoyFinalStreamIntel.java
@@ -51,9 +51,9 @@ public interface EnvoyFinalStreamIntel {
    */
   public long getResponseStartMs();
   /*
-   * The time the last byte of the request was received, in ms since the epoch.
+   * The time when the stream reached a final state (Error, Cancel, Success), in ms since the epoch.
    */
-  public long getRequestEndMs();
+  public long getStreamEndMs();
   /*
    * True if the upstream socket had been used previously.
    */

--- a/library/java/org/chromium/net/impl/CronetUrlRequest.java
+++ b/library/java/org/chromium/net/impl/CronetUrlRequest.java
@@ -704,7 +704,7 @@ public final class CronetUrlRequest extends UrlRequestBase {
         intel.getConnectStartMs(), intel.getConnectEndMs(), intel.getSslStartMs(),
         intel.getSslEndMs(), intel.getSendingStartMs(), intel.getSendingEndMs(),
         /* pushStartMs= */ -1, /* pushEndMs= */ -1, intel.getResponseStartMs(),
-        intel.getRequestEndMs(), intel.getSocketReused(), intel.getSentByteCount(),
+        intel.getStreamEndMs(), intel.getSocketReused(), intel.getSentByteCount(),
         intel.getReceivedByteCount() + bytesReceivedFromRedirects);
   }
 

--- a/library/java/org/chromium/net/impl/CronetUrlRequest.java
+++ b/library/java/org/chromium/net/impl/CronetUrlRequest.java
@@ -700,7 +700,7 @@ public final class CronetUrlRequest extends UrlRequestBase {
 
   private static Metrics getMetrics(EnvoyFinalStreamIntel intel, long bytesReceivedFromRedirects) {
     return new CronetMetrics(
-        intel.getRequestStartMs(), intel.getDnsStartMs(), intel.getDnsEndMs(),
+        intel.getStreamStartMs(), intel.getDnsStartMs(), intel.getDnsEndMs(),
         intel.getConnectStartMs(), intel.getConnectEndMs(), intel.getSslStartMs(),
         intel.getSslEndMs(), intel.getSendingStartMs(), intel.getSendingEndMs(),
         /* pushStartMs= */ -1, /* pushEndMs= */ -1, intel.getResponseStartMs(),

--- a/library/kotlin/io/envoyproxy/envoymobile/FinalStreamIntel.kt
+++ b/library/kotlin/io/envoyproxy/envoymobile/FinalStreamIntel.kt
@@ -5,6 +5,8 @@ import io.envoyproxy.envoymobile.engine.types.EnvoyStreamIntel
 
 /**
  * Exposes one time HTTP stream metrics, context, and other details.
+ *
+ * Note: a timestamp field (ends with "Ms") with a value of -1 indicates that it is absent.
  * @param requestStartMs The time the request started, in ms since the epoch.
  * @param dnsStartMs The time the DNS resolution for this request started, in ms since the epoch.
  * @param dnsEndMs The time the DNS resolution for this request completed, in ms since the epoch.
@@ -22,8 +24,8 @@ import io.envoyproxy.envoymobile.engine.types.EnvoyStreamIntel
  *        epoch.
  * @param responseStartMs The time the first byte of the response was received, in ms since the
  *        epoch.
- * @param @param requestEndMs The time the last byte of the request was received, in ms since the
- *        epoch.
+ * @param streamEndMs The time when the stream reached a final state (Error, Cancel, Success),
+ *        in ms since the epoch.
  * @param socket_reused True if the upstream socket had been used previously.
  * @param sentByteCount The number of bytes sent upstream.
  * @param receivedByteCount The number of bytes received from upstream.
@@ -44,7 +46,7 @@ class FinalStreamIntel constructor(
   val sendingStartMs: Long,
   val sendingEndMs: Long,
   val responseStartMs: Long,
-  val requestEndMs: Long,
+  val streamEndMs: Long,
   val socketReused: Boolean,
   val sentByteCount: Long,
   val receivedByteCount: Long,
@@ -57,7 +59,7 @@ class FinalStreamIntel constructor(
     base.connectEndMs, base.sslStartMs,
     base.sslEndMs, base.sendingStartMs,
     base.sendingEndMs,
-    base.responseStartMs, base.requestEndMs,
+    base.responseStartMs, base.streamEndMs,
     base.socketReused, base.sentByteCount,
     base.receivedByteCount, base.responseFlags
   )

--- a/library/kotlin/io/envoyproxy/envoymobile/FinalStreamIntel.kt
+++ b/library/kotlin/io/envoyproxy/envoymobile/FinalStreamIntel.kt
@@ -7,7 +7,7 @@ import io.envoyproxy.envoymobile.engine.types.EnvoyStreamIntel
  * Exposes one time HTTP stream metrics, context, and other details.
  *
  * Note: a timestamp field (ends with "Ms") with a value of -1 indicates that it is absent.
- * @param requestStartMs The time the request started, in ms since the epoch.
+ * @param streamStartMs The time the stream started (a.k.a. request started), in ms since the epoch.
  * @param dnsStartMs The time the DNS resolution for this request started, in ms since the epoch.
  * @param dnsEndMs The time the DNS resolution for this request completed, in ms since the epoch.
  * @param connectStartMsThe time the upstream connection started, in ms since the epoch.
@@ -36,7 +36,7 @@ class FinalStreamIntel constructor(
   streamId: Long,
   connectionId: Long,
   attemptCount: Long,
-  val requestStartMs: Long,
+  val streamStartMs: Long,
   val dnsStartMs: Long,
   val dnsEndMs: Long,
   val connectStartMs: Long,
@@ -54,7 +54,7 @@ class FinalStreamIntel constructor(
 ) : StreamIntel(streamId, connectionId, attemptCount) {
   constructor(superBase: EnvoyStreamIntel, base: EnvoyFinalStreamIntel) : this(
     superBase.streamId, superBase.connectionId, superBase.attemptCount,
-    base.requestStartMs, base.dnsStartMs,
+    base.streamStartMs, base.dnsStartMs,
     base.dnsEndMs, base.connectStartMs,
     base.connectEndMs, base.sslStartMs,
     base.sslEndMs, base.sendingStartMs,

--- a/library/kotlin/io/envoyproxy/envoymobile/mocks/MockStream.kt
+++ b/library/kotlin/io/envoyproxy/envoymobile/mocks/MockStream.kt
@@ -29,7 +29,7 @@ class MockStream internal constructor(underlyingStream: MockEnvoyHTTPStream) : S
     override fun getSendingStartMs(): Long { return 0 }
     override fun getSendingEndMs(): Long { return 0 }
     override fun getResponseStartMs(): Long { return 0 }
-    override fun getRequestEndMs(): Long { return 0 }
+    override fun getStreamEndMs(): Long { return 0 }
     override fun getSocketReused(): Boolean { return false }
     override fun getSentByteCount(): Long { return 0 }
     override fun getReceivedByteCount(): Long { return 0 }

--- a/library/kotlin/io/envoyproxy/envoymobile/mocks/MockStream.kt
+++ b/library/kotlin/io/envoyproxy/envoymobile/mocks/MockStream.kt
@@ -19,7 +19,7 @@ class MockStream internal constructor(underlyingStream: MockEnvoyHTTPStream) : S
   }
 
   private val mockFinalStreamIntel = object : EnvoyFinalStreamIntel {
-    override fun getRequestStartMs(): Long { return 0 }
+    override fun getStreamStartMs(): Long { return 0 }
     override fun getDnsStartMs(): Long { return 0 }
     override fun getDnsEndMs(): Long { return 0 }
     override fun getConnectStartMs(): Long { return 0 }

--- a/library/swift/FinalStreamIntel.swift
+++ b/library/swift/FinalStreamIntel.swift
@@ -6,7 +6,7 @@ import Foundation
 @objcMembers
 public final class FinalStreamIntel: StreamIntel {
   /// The time the request started, in ms since the epoch.
-  public let requestStartMs: Int64
+  public let streamStartMs: Int64
   /// The time the DNS resolution for this request started, in ms since the epoch.
   public let dnsStartMs: Int64
   /// The time the DNS resolution for this request completed, in ms since the epoch.
@@ -42,7 +42,7 @@ public final class FinalStreamIntel: StreamIntel {
     streamId: Int64,
     connectionId: Int64,
     attemptCount: UInt64,
-    requestStartMs: Int64,
+    streamStartMs: Int64,
     dnsStartMs: Int64,
     dnsEndMs: Int64,
     connectStartMs: Int64,
@@ -58,7 +58,7 @@ public final class FinalStreamIntel: StreamIntel {
     receivedByteCount: UInt64,
     responseFlags: UInt64
   ) {
-    self.requestStartMs = requestStartMs
+    self.streamStartMs = streamStartMs
     self.dnsStartMs = dnsStartMs
     self.dnsEndMs = dnsEndMs
     self.connectStartMs = connectStartMs
@@ -83,7 +83,7 @@ extension FinalStreamIntel {
       streamId: cIntel.stream_id,
       connectionId: cIntel.connection_id,
       attemptCount: cIntel.attempt_count,
-      requestStartMs: cFinalIntel.request_start_ms,
+      streamStartMs: cFinalIntel.stream_start_ms,
       dnsStartMs: cFinalIntel.dns_start_ms,
       dnsEndMs: cFinalIntel.dns_end_ms,
       connectStartMs: cFinalIntel.connect_start_ms,

--- a/library/swift/FinalStreamIntel.swift
+++ b/library/swift/FinalStreamIntel.swift
@@ -5,7 +5,7 @@ import Foundation
 /// Note: -1 means "not present" for the fields of type Int64.
 @objcMembers
 public final class FinalStreamIntel: StreamIntel {
-  /// The time the request started, in ms since the epoch.
+  /// The time the stream started (a.k.a. request started), in ms since the epoch.
   public let streamStartMs: Int64
   /// The time the DNS resolution for this request started, in ms since the epoch.
   public let dnsStartMs: Int64

--- a/library/swift/FinalStreamIntel.swift
+++ b/library/swift/FinalStreamIntel.swift
@@ -26,7 +26,7 @@ public final class FinalStreamIntel: StreamIntel {
   /// The time the first byte of the response was received, in ms since the epoch.
   public let responseStartMs: Int64
   /// The time the last byte of the request was received, in ms since the epoch.
-  public let requestEndMs: Int64
+  public let streamEndMs: Int64
   /// True if the upstream socket had been used previously.
   public let socketReused: Bool
   /// The number of bytes sent upstream.
@@ -52,7 +52,7 @@ public final class FinalStreamIntel: StreamIntel {
     sendingStartMs: Int64,
     sendingEndMs: Int64,
     responseStartMs: Int64,
-    requestEndMs: Int64,
+    streamEndMs: Int64,
     socketReused: Bool,
     sentByteCount: UInt64,
     receivedByteCount: UInt64,
@@ -68,7 +68,7 @@ public final class FinalStreamIntel: StreamIntel {
     self.sendingStartMs = sendingStartMs
     self.sendingEndMs = sendingEndMs
     self.responseStartMs = responseStartMs
-    self.requestEndMs = requestEndMs
+    self.streamEndMs = streamEndMs
     self.socketReused = socketReused
     self.sentByteCount = sentByteCount
     self.receivedByteCount = receivedByteCount
@@ -93,7 +93,7 @@ extension FinalStreamIntel {
       sendingStartMs: cFinalIntel.sending_start_ms,
       sendingEndMs: cFinalIntel.sending_end_ms,
       responseStartMs: cFinalIntel.response_start_ms,
-      requestEndMs: cFinalIntel.request_end_ms,
+      streamEndMs: cFinalIntel.stream_end_ms,
       socketReused: cFinalIntel.socket_reused != 0,
       sentByteCount: cFinalIntel.sent_byte_count,
       receivedByteCount: cFinalIntel.received_byte_count,

--- a/test/common/integration/client_integration_test.cc
+++ b/test/common/integration/client_integration_test.cc
@@ -56,13 +56,13 @@ void validateStreamIntel(const envoy_final_stream_intel& final_intel) {
   ASSERT_NE(-1, final_intel.sending_start_ms);
   ASSERT_NE(-1, final_intel.sending_end_ms);
   ASSERT_NE(-1, final_intel.response_start_ms);
-  ASSERT_NE(-1, final_intel.request_end_ms);
+  ASSERT_NE(-1, final_intel.stream_end_ms);
 
   ASSERT_LE(final_intel.request_start_ms, final_intel.connect_start_ms);
   ASSERT_LE(final_intel.connect_start_ms, final_intel.connect_end_ms);
   ASSERT_LE(final_intel.connect_end_ms, final_intel.sending_start_ms);
   ASSERT_LE(final_intel.sending_start_ms, final_intel.sending_end_ms);
-  ASSERT_LE(final_intel.response_start_ms, final_intel.request_end_ms);
+  ASSERT_LE(final_intel.response_start_ms, final_intel.stream_end_ms);
 }
 
 // TODO(junr03): move this to derive from the ApiListenerIntegrationTest after moving that class

--- a/test/common/integration/client_integration_test.cc
+++ b/test/common/integration/client_integration_test.cc
@@ -50,7 +50,7 @@ void validateStreamIntel(const envoy_final_stream_intel& final_intel) {
   EXPECT_EQ(-1, final_intel.ssl_start_ms);
   EXPECT_EQ(-1, final_intel.ssl_end_ms);
 
-  ASSERT_NE(-1, final_intel.request_start_ms);
+  ASSERT_NE(-1, final_intel.stream_start_ms);
   ASSERT_NE(-1, final_intel.connect_start_ms);
   ASSERT_NE(-1, final_intel.connect_end_ms);
   ASSERT_NE(-1, final_intel.sending_start_ms);
@@ -58,7 +58,7 @@ void validateStreamIntel(const envoy_final_stream_intel& final_intel) {
   ASSERT_NE(-1, final_intel.response_start_ms);
   ASSERT_NE(-1, final_intel.stream_end_ms);
 
-  ASSERT_LE(final_intel.request_start_ms, final_intel.connect_start_ms);
+  ASSERT_LE(final_intel.stream_start_ms, final_intel.connect_start_ms);
   ASSERT_LE(final_intel.connect_start_ms, final_intel.connect_end_ms);
   ASSERT_LE(final_intel.connect_end_ms, final_intel.sending_start_ms);
   ASSERT_LE(final_intel.sending_start_ms, final_intel.sending_end_ms);

--- a/test/common/stream_info/extra_stream_info_test.cc
+++ b/test/common/stream_info/extra_stream_info_test.cc
@@ -37,7 +37,7 @@ public:
     EXPECT_EQ(a.ssl_end_ms, b.ssl_end_ms);
     EXPECT_EQ(a.socket_reused, b.socket_reused);
     EXPECT_EQ(a.request_start_ms, b.request_start_ms);
-    EXPECT_EQ(a.request_end_ms, b.request_end_ms);
+    EXPECT_EQ(a.stream_end_ms, b.stream_end_ms);
     EXPECT_EQ(a.dns_start_ms, b.dns_start_ms);
     EXPECT_EQ(a.dns_end_ms, b.dns_end_ms);
     EXPECT_EQ(a.sent_byte_count, b.sent_byte_count);
@@ -54,7 +54,7 @@ TEST_F(FinalIntelTest, Unset) {
   expected_intel_.request_start_ms = SYSTEM_TIME_START_MS;
   // The SystemTime (11111) is irrelevant for the fake_current_time.
   StalledTimeSource fake_current_time(11111, MONOTONIC_TIME_START_MS + 500);
-  expected_intel_.request_end_ms = SYSTEM_TIME_START_MS + 500;
+  expected_intel_.stream_end_ms = SYSTEM_TIME_START_MS + 500;
 
   setFinalStreamIntel(stream_info, fake_current_time, final_intel_);
 
@@ -88,7 +88,7 @@ TEST_F(FinalIntelTest, SetWithSsl) {
       MonotonicTime(std::chrono::milliseconds(MONOTONIC_TIME_START_MS + 600));
   expected_intel_.ssl_end_ms = SYSTEM_TIME_START_MS + 600;
   StalledTimeSource fake_current_time(11111, MONOTONIC_TIME_START_MS + 700);
-  expected_intel_.request_end_ms = SYSTEM_TIME_START_MS + 700;
+  expected_intel_.stream_end_ms = SYSTEM_TIME_START_MS + 700;
 
   upstream_info->setUpstreamNumStreams(5);
   expected_intel_.socket_reused = 1;
@@ -123,7 +123,7 @@ TEST_F(FinalIntelTest, SetWithoutSsl) {
   expected_intel_.ssl_start_ms = -1;
   expected_intel_.ssl_end_ms = -1;
   StalledTimeSource fake_current_time(11111, MONOTONIC_TIME_START_MS + 600);
-  expected_intel_.request_end_ms = SYSTEM_TIME_START_MS + 600;
+  expected_intel_.stream_end_ms = SYSTEM_TIME_START_MS + 600;
 
   upstream_info->setUpstreamNumStreams(5);
   expected_intel_.socket_reused = 1;

--- a/test/common/stream_info/extra_stream_info_test.cc
+++ b/test/common/stream_info/extra_stream_info_test.cc
@@ -36,7 +36,7 @@ public:
     EXPECT_EQ(a.ssl_start_ms, b.ssl_start_ms);
     EXPECT_EQ(a.ssl_end_ms, b.ssl_end_ms);
     EXPECT_EQ(a.socket_reused, b.socket_reused);
-    EXPECT_EQ(a.request_start_ms, b.request_start_ms);
+    EXPECT_EQ(a.stream_start_ms, b.stream_start_ms);
     EXPECT_EQ(a.stream_end_ms, b.stream_end_ms);
     EXPECT_EQ(a.dns_start_ms, b.dns_start_ms);
     EXPECT_EQ(a.dns_end_ms, b.dns_end_ms);
@@ -51,7 +51,7 @@ public:
 TEST_F(FinalIntelTest, Unset) {
   StreamInfoImpl stream_info{Http::Protocol::Http2, start_time_source_, nullptr};
   // By convention the "StreamInfoImpl instantiation" is when the request starts.
-  expected_intel_.request_start_ms = SYSTEM_TIME_START_MS;
+  expected_intel_.stream_start_ms = SYSTEM_TIME_START_MS;
   // The SystemTime (11111) is irrelevant for the fake_current_time.
   StalledTimeSource fake_current_time(11111, MONOTONIC_TIME_START_MS + 500);
   expected_intel_.stream_end_ms = SYSTEM_TIME_START_MS + 500;
@@ -67,7 +67,7 @@ TEST_F(FinalIntelTest, SetWithSsl) {
   auto upstream_info = stream_info.upstreamInfo();
   auto& timing = upstream_info->upstreamTiming();
 
-  expected_intel_.request_start_ms = SYSTEM_TIME_START_MS;
+  expected_intel_.stream_start_ms = SYSTEM_TIME_START_MS;
   timing.first_upstream_tx_byte_sent_ =
       MonotonicTime(std::chrono::milliseconds(MONOTONIC_TIME_START_MS + 100));
   expected_intel_.sending_start_ms = SYSTEM_TIME_START_MS + 100;
@@ -104,7 +104,7 @@ TEST_F(FinalIntelTest, SetWithoutSsl) {
   auto upstream_info = stream_info.upstreamInfo();
   auto& timing = upstream_info->upstreamTiming();
 
-  expected_intel_.request_start_ms = SYSTEM_TIME_START_MS;
+  expected_intel_.stream_start_ms = SYSTEM_TIME_START_MS;
   timing.first_upstream_tx_byte_sent_ =
       MonotonicTime(std::chrono::milliseconds(MONOTONIC_TIME_START_MS + 100));
   expected_intel_.sending_start_ms = SYSTEM_TIME_START_MS + 100;


### PR DESCRIPTION
Pure refactoring.

For consistency, request_start has also been renamed to stream_start.

Description: Rename request_end to stream_end, and adjust documentation.
Risk Level: None
Testing: CI
Docs Changes: N/A
Release Notes: N/A
Signed-off-by: Charles Le Borgne <cleborgne@google.com>
