### PR TITLE
build: generate android symbols as part of the build

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -67,16 +67,17 @@ build:tsan-dev --copt -DEVENT__DISABLE_DEBUG_MODE
 # https://github.com/google/sanitizers/issues/953
 build:tsan-dev --test_env="TSAN_OPTIONS=report_atomic_races=0"
 
-# Exclude debug info from the release binary since it makes it too large to fit
-# into a zip file. This shouldn't affect crash reports.
-build:release-common --define=no_debug_info=1
-
 # Flags for release builds targeting iOS
 build:release-ios --apple_bitcode=embedded
 build:release-ios --config=ios
 build:release-ios --config=release-common
 build:release-ios --copt=-fembed-bitcode
 build:release-ios --compilation_mode=opt
+
+# Exclude debug info from the release binary since it makes it too large to fit
+# into a zip file. This shouldn't affect crash reports. For Android we strip the
+# binary as part of the build.
+build:release-ios --define=no_debug_info=1
 
 # Flags for release builds targeting Android or the JVM
 # Release does not use the option --define=logger=android


### PR DESCRIPTION
For an explanation of how to fill out the fields, please see the relevant section
in [PULL_REQUESTS.md](https://github.com/envoyproxy/envoy/blob/master/PULL_REQUESTS.md)

Description:
Risk Level:
Testing:
Docs Changes:
Release Notes:
[Optional Fixes #Issue]
[Optional Deprecated:]
