### PR TITLE
ios: add explicit flow control onSendWindowAvailable to public interface

### DIFF
--- a/library/java/io/envoyproxy/envoymobile/engine/types/EnvoyHTTPCallbacks.java
+++ b/library/java/io/envoyproxy/envoymobile/engine/types/EnvoyHTTPCallbacks.java
@@ -63,7 +63,7 @@ public interface EnvoyHTTPCallbacks {
   void onCancel(EnvoyStreamIntel streamIntel, EnvoyFinalStreamIntel finalStreamIntel);
 
   /**
-   * Callback signature which notify when there is buffer available for request body upload.
+   * Called to signal there is buffer space available for continued request body upload.
    *
    * This is only ever called when the library is in explicit flow control mode. When enabled,
    * the issuer should wait for this callback after calling sendData, before making another call

--- a/library/objective-c/EnvoyEngine.h
+++ b/library/objective-c/EnvoyEngine.h
@@ -62,6 +62,16 @@ typedef envoy_final_stream_intel EnvoyFinalStreamIntel;
     EnvoyHeaders *trailers, EnvoyStreamIntel streamIntel);
 
 /**
+ * Called to signal there is buffer space available for continued request body upload.
+ *
+ * This is only ever called when the library is in explicit flow control mode. When enabled,
+ * the issuer should wait for this callback after calling sendData, before making another call
+ * to sendData.
+ * @param streamIntel internal HTTP stream metrics, context, and other details.
+ */
+@property (nonatomic, copy) void (^onSendWindowAvailable)(EnvoyStreamIntel streamIntel);
+
+/**
  * Called when the async HTTP stream has an error.
  * @param streamIntel internal HTTP stream metrics, context, and other details.
  * @param finalStreamIntel one time HTTP stream metrics, context, and other details.

--- a/library/objective-c/EnvoyHTTPStreamImpl.m
+++ b/library/objective-c/EnvoyHTTPStreamImpl.m
@@ -62,6 +62,17 @@ static void *ios_on_trailers(envoy_headers trailers, envoy_stream_intel stream_i
   return NULL;
 }
 
+static void *ios_on_send_window_available(envoy_stream_intel stream_intel, void *context) {
+  ios_context *c = (ios_context *)context;
+  EnvoyHTTPCallbacks *callbacks = c->callbacks;
+  dispatch_async(callbacks.dispatchQueue, ^{
+    if (callbacks.onSendWindowAvailable) {
+      callbacks.onSendWindowAvailable(stream_intel);
+    }
+  });
+  return NULL;
+}
+
 static void *ios_on_complete(envoy_stream_intel stream_intel,
                              envoy_final_stream_intel final_stream_intel, void *context) {
   ios_context *c = (ios_context *)context;
@@ -75,11 +86,6 @@ static void *ios_on_complete(envoy_stream_intel stream_intel,
     assert(stream);
     [stream cleanUp];
   });
-  return NULL;
-}
-
-// TODO(goaway) fix this up to call ios_on_send_window_available
-static void *ios_on_send_window_available(envoy_stream_intel stream_intel, void *context) {
   return NULL;
 }
 

--- a/library/swift/StreamCallbacks.swift
+++ b/library/swift/StreamCallbacks.swift
@@ -12,6 +12,7 @@ final class StreamCallbacks {
   )?
   var onData: ((_ body: Data, _ endStream: Bool, _ streamIntel: StreamIntel) -> Void)?
   var onTrailers: ((_ trailers: ResponseTrailers, _ streamIntel: StreamIntel) -> Void)?
+  var onSendWindowAvailable: ((_ streamintel: StreamIntel) -> Void)?
   var onComplete: ((_ streamintel: FinalStreamIntel) -> Void)?
   var onCancel: ((_ streamintel: FinalStreamIntel) -> Void)?
   var onError: ((_ error: EnvoyError, _ streamIntel: FinalStreamIntel) -> Void)?
@@ -28,6 +29,7 @@ extension EnvoyHTTPCallbacks {
     self.onHeaders = { callbacks.onHeaders?(ResponseHeaders(headers: $0), $1, StreamIntel($2)) }
     self.onData = { callbacks.onData?($0, $1, StreamIntel($2)) }
     self.onTrailers = { callbacks.onTrailers?(ResponseTrailers(headers: $0), StreamIntel($1)) }
+    self.onSendWindowAvailable = { callbacks.onSendWindowAvailable?(StreamIntel($0)) }
     self.onComplete = { callbacks.onCancel?(FinalStreamIntel($0, $1)) }
     self.onCancel = { callbacks.onCancel?(FinalStreamIntel($0, $1)) }
     self.onError = { errorCode, message, attemptCount, streamIntel, finalStreamIntel in

--- a/library/swift/StreamPrototype.swift
+++ b/library/swift/StreamPrototype.swift
@@ -103,6 +103,22 @@ public class StreamPrototype: NSObject {
     return self
   }
 
+  /// Specify a callback for when additional send window becomes available.
+  /// This is only ever called when the library is in explicit flow control mode. When enabled,
+  /// the issuer should wait for this callback after calling sendData, before making another call
+  /// to sendData.
+  ///
+  /// - parameter closure: Closure which will be called when additional send window becomes available.
+  ///
+  /// - returns: This stream, for chaining syntax.
+  @discardableResult
+  public func setOnSendWindowAvailable(
+    closure: @escaping (_ streamIntel: StreamIntel) -> Void
+  ) -> StreamPrototype {
+    callbacks.onSendWindowAvailable = closure
+    return self
+  }
+
   /// Specify a callback for when an internal Envoy exception occurs with the stream.
   /// If the closure is called, the stream is complete.
   ///

--- a/library/swift/StreamPrototype.swift
+++ b/library/swift/StreamPrototype.swift
@@ -58,7 +58,7 @@ public class StreamPrototype: NSObject {
     return self
   }
 
-  /// Specify a callback for when response headers are received by the stream.
+  /// Specify a callback to be invoked when response headers are received by the stream.
   /// If `endStream` is `true`, the stream is complete, pending an onComplete callback.
   ///
   /// - parameter closure: Closure which will receive the headers
@@ -74,7 +74,7 @@ public class StreamPrototype: NSObject {
     return self
   }
 
-  /// Specify a callback for when a data frame is received by the stream.
+  /// Specify a callback to be invoked when a data frame is received by the stream.
   /// If `endStream` is `true`, the stream is complete, pending an onComplete callback.
   ///
   /// - parameter closure: Closure which will receive the data
@@ -89,7 +89,7 @@ public class StreamPrototype: NSObject {
     return self
   }
 
-  /// Specify a callback for when trailers are received by the stream.
+  /// Specify a callback to be invoked when trailers are received by the stream.
   /// If the closure is called, the stream is complete, pending an onComplete callback.
   ///
   /// - parameter closure: Closure which will receive the trailers.
@@ -103,12 +103,13 @@ public class StreamPrototype: NSObject {
     return self
   }
 
-  /// Specify a callback for when additional send window becomes available.
+  /// Specify a callback to be invoked when additional send window becomes available.
   /// This is only ever called when the library is in explicit flow control mode. When enabled,
   /// the issuer should wait for this callback after calling sendData, before making another call
   /// to sendData.
   ///
-  /// - parameter closure: Closure which will be called when additional send window becomes available.
+  /// - parameter closure: Closure which will be called when additional send window becomes
+  ///                      available.
   ///
   /// - returns: This stream, for chaining syntax.
   @discardableResult
@@ -119,7 +120,7 @@ public class StreamPrototype: NSObject {
     return self
   }
 
-  /// Specify a callback for when an internal Envoy exception occurs with the stream.
+  /// Specify a callback to be invoked when an internal Envoy exception occurs with the stream.
   /// If the closure is called, the stream is complete.
   ///
   /// - parameter closure: Closure which will be called when an error occurs.
@@ -133,7 +134,7 @@ public class StreamPrototype: NSObject {
     return self
   }
 
-  /// Specify a callback for when the stream is canceled.
+  /// Specify a callback to be invoked when the stream is canceled.
   /// If the closure is called, the stream is complete.
   ///
   /// - parameter closure: Closure which will be called when the stream is canceled.
@@ -147,7 +148,7 @@ public class StreamPrototype: NSObject {
     return self
   }
 
-  /// Specify a callback for when the stream completes gracefully.
+  /// Specify a callback to be invoked when the stream completes gracefully.
   /// If the closure is called, the stream is complete.
   ///
   /// - parameter closure: Closure which will be called when the stream is canceled.


### PR DESCRIPTION
Description: Adds the previously Kotlin-only feature to the iOS public interface.
Risk Level: Low
Testing: Manual
Release Notes: Added onSendWindowAvailable callback on iOS for when explicit flow control is enabled. This brings it in line with the Kotlin API.

Signed-off-by: Mike Schore <mike.schore@gmail.com>