### PR TITLE
bazel: Improve android symbol map generation

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -69,7 +69,7 @@ build:tsan-dev --test_env="TSAN_OPTIONS=report_atomic_races=0"
 
 # Exclude debug info from the release binary since it makes it too large to fit
 # into a zip file. This shouldn't affect crash reports.
-build:release-ios --define=no_debug_info=1
+build:release-common --define=no_debug_info=1
 
 # Flags for release builds targeting iOS
 build:release-ios --apple_bitcode=embedded

--- a/BUILD
+++ b/BUILD
@@ -59,6 +59,7 @@ genrule(
     set -- $(SRCS)
     chmod 755 $$1
     chmod 755 $$2
+    chmod 755 dist/*.objdump
     cp $$1 dist/envoy.aar
     cp $$2 dist/envoy-pom.xml
     shift 2

--- a/bazel/android_debug_info.bzl
+++ b/bazel/android_debug_info.bzl
@@ -25,16 +25,18 @@ def _impl(ctx):
         ctx.actions.run_shell(
             inputs = [lib],
             outputs = [objdump_output],
-            command = cc_toolchain.objdump_executable + " --dwarf=info --dwarf=rawline " + lib.path + ">" + objdump_output.path,
+            command = cc_toolchain.objdump_executable + " --syms " + lib.path + "| gzip -c >" + objdump_output.path,
             tools = [cc_toolchain.all_files],
+            progress_message = "Generating symbol map " + platform_name,
         )
 
         strip_output = ctx.actions.declare_file(platform_name + "/" + lib.basename)
         ctx.actions.run_shell(
             inputs = [lib],
             outputs = [strip_output],
-            command = cc_toolchain.strip_executable + " --strip-debug " + lib.path + " -o " + strip_output.path,
+            command = cc_toolchain.strip_executable + " --strip-all " + lib.path + " -o " + strip_output.path,
             tools = [cc_toolchain.all_files],
+            progress_message = "Stripping library " + lib.path,
         )
 
         library_outputs.append(strip_output)

--- a/library/common/jni/BUILD
+++ b/library/common/jni/BUILD
@@ -39,7 +39,7 @@ cc_library(
         "-ldl",
     ] + select({
         "@envoy//bazel:dbg_build": ["-Wl,--build-id=sha1"],
-        "//conditions:default": ["-Wl,-s"],
+        "//conditions:default": [],
     }),
     deps = [
         ":jni_utility_lib",


### PR DESCRIPTION
There are a few changes here:

1. Add back debug info disables for release, the info we were creating
   here was ~6gb per architecture
2. Switch to just generating the symbol table which should be enough for
   crash reporting, and compressed is only ~10mb per architecture
3. Remove a rouge `-Wl,-s` that made this not work at all with my
   original change

Signed-off-by: Keith Smiley <keithbsmiley@gmail.com>