### PR TITLE
size: optimizations for dynamic library

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -25,6 +25,9 @@ build --features=-per_object_debug_info
 # Suppress deprecated declaration warnings due to extensive transitive noise from protobuf.
 build --copt -Wno-deprecated-declarations
 
+# Override PGV validation with NOP functions
+build --@com_envoyproxy_protoc_gen_validate//bazel:template-flavor=nop
+
 # Enable source map for debugging in IDEs
 build:dbg --copt="-fdebug-compilation-dir" --copt="/proc/self/cwd"
 

--- a/.bazelrc
+++ b/.bazelrc
@@ -74,6 +74,9 @@ build:release-common --define=no_debug_info=1
 # Compile releases optimizing for size (eg -Os, etc).
 build:release-common --config=sizeopt
 
+# Set default symbols visibility to hidden to reduce .dynstr and the symbol table size
+build:release-common --copt=-fvisibility=hidden
+
 # Flags for release builds targeting iOS
 build:release-ios --apple_bitcode=embedded
 build:release-ios --config=ios

--- a/.bazelrc
+++ b/.bazelrc
@@ -71,6 +71,9 @@ build:tsan-dev --test_env="TSAN_OPTIONS=report_atomic_races=0"
 # into a zip file. This shouldn't affect crash reports.
 build:release-common --define=no_debug_info=1
 
+# Compile releases optimizing for size (eg -Os, etc).
+build:release-common --config=sizeopt
+
 # Flags for release builds targeting iOS
 build:release-ios --apple_bitcode=embedded
 build:release-ios --config=ios

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -1,5 +1,16 @@
 workspace(name = "envoy_mobile")
 
+# TODO[fz]: Remove once envoy updates PGV
+load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
+http_archive(
+    name = "bazel_gazelle",
+    sha256 = "de69a09dc70417580aabf20a28619bb3ef60d038470c7cf8442fafcf627c21cb",
+    urls = [
+        "https://mirror.bazel.build/github.com/bazelbuild/bazel-gazelle/releases/download/v0.24.0/bazel-gazelle-v0.24.0.tar.gz",
+        "https://github.com/bazelbuild/bazel-gazelle/releases/download/v0.24.0/bazel-gazelle-v0.24.0.tar.gz",
+    ],
+)
+
 load("@envoy_mobile//bazel:envoy_mobile_repositories.bzl", "envoy_mobile_repositories")
 envoy_mobile_repositories()
 

--- a/bazel/envoy_mobile_repositories.bzl
+++ b/bazel/envoy_mobile_repositories.bzl
@@ -1,3 +1,5 @@
+load("@bazel_gazelle//:deps.bzl", "go_repository")
+load("@bazel_tools//tools/build_defs/repo:git.bzl", "git_repository")
 load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive", "http_file", "http_jar")
 
 def envoy_mobile_repositories():
@@ -8,11 +10,29 @@ def envoy_mobile_repositories():
         urls = ["https://github.com/google/bazel-common/archive/413b433b91f26dbe39cdbc20f742ad6555dd1e27.zip"],
     )
 
+    # Uses PGV that includes the CC NOP template to disable validation.
+    # TODO(fz): Remove this once PGV is updated on envoy
+    override_pgv()
+
     upstream_envoy_overrides()
     swift_repos()
     kotlin_repos()
     android_repos()
     python_repos()
+
+def override_pgv():
+    go_repository(
+        name = "com_github_lyft_protoc_gen_star",
+        importpath = "github.com/lyft/protoc-gen-star",
+        sum = "h1:xOpFu4vwmIoUeUrRuAtdCrZZymT/6AkW/bsUWA506Fo=",
+        version = "v0.6.0",
+    )
+
+    git_repository(
+        name = "com_envoyproxy_protoc_gen_validate",
+        commit = "79071f0f8b04188b297a0517a6e55b2d3641ab5a",
+        remote = "https://github.com/envoyproxy/protoc-gen-validate"
+    )
 
 def upstream_envoy_overrides():
     # Workaround due to a Detekt version compatibility with protobuf: https://github.com/envoyproxy/envoy-mobile/issues/1869


### PR DESCRIPTION
These are the different low hanging fruit fixes to reduce the dynamic library size. Note wins were calculated in isolation against a fixed target for just one architecture so they are not necesarily additive.

- remove api v2 dependency (Mostly done here: https://github.com/envoyproxy/envoy/pull/18817)
    - Estamated wins: -1.8Mi

- compile optimizing for size
    - [commit c2d7084] Estimated wins: -0.66Mi

- set default visibility to hidden
    - [commit ed2975e] Estimated wins: -5.66Mi

- override pgv validations with NOP functions
    - [commit 255eb5a] Estimated wins: -3.7Mi

**For the measured case (a few months back) the size reduction accounted for about -46.2%**

This PR is better reviewed commit by commit. 