### PR TITLE
bazel: Rename objdump output

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,7 @@
 /dist/*.aar
 /dist/*.jar
 /dist/*.objdump
+/dist/*.objdump.gz
 /dist/envoy_aar_sources.zip
 /dist/Envoy.framework
 /dist/*.asc

--- a/bazel/android_debug_info.bzl
+++ b/bazel/android_debug_info.bzl
@@ -20,7 +20,7 @@ def _impl(ctx):
         cc_toolchain = ctx.split_attr._cc_toolchain[platform][cc_common.CcToolchainInfo]
         lib = dep.files.to_list()[0]
         platform_name = platform or ctx.fragments.android.android_cpu
-        objdump_output = ctx.actions.declare_file(platform_name + "/" + platform_name + ".objdump")
+        objdump_output = ctx.actions.declare_file(platform_name + "/" + platform_name + ".objdump.gz")
 
         ctx.actions.run_shell(
             inputs = [lib],


### PR DESCRIPTION
This makes it clear it's a gzip archive

Signed-off-by: Keith Smiley <keithbsmiley@gmail.com>