### PR TITLE
[Project] Establish a Lyft support rotation

### DIFF
--- a/.github/lyft_maintainers.yml
+++ b/.github/lyft_maintainers.yml
@@ -1,0 +1,7 @@
+current: jpsim
+maintainers:
+  - buildbreaker
+  - junr03
+  - snowp
+  - goaway
+  - jpsim

--- a/.github/workflows/bump_support_rotation.yml
+++ b/.github/workflows/bump_support_rotation.yml
@@ -1,0 +1,23 @@
+name: bump_support_rotation
+
+on:
+  workflow_dispatch:
+  schedule:
+    # Mondays at 2pm UTC (9am EST)
+    - cron: "0 14 * * 1"
+
+jobs:
+  bump_support_rotation:
+    runs-on: ubuntu-latest
+    steps:
+      - name: git checkout
+        uses: actions/checkout@v2
+      - name: Bump Lyft Support Rotation
+        run: ./tools/bump_lyft_support_rotation.sh
+      - name: Commit Changes
+        run: |
+          git config --global user.email "${GITHUB_ACTOR}"
+          git config --global user.name "${GITHUB_ACTOR}@users.noreply.github.com"
+          git add .github/lyft_maintainers.yml
+          git commit -am "Bump Lyft Support Rotation"
+          git push

--- a/.github/workflows/bump_support_rotation.yml
+++ b/.github/workflows/bump_support_rotation.yml
@@ -9,15 +9,30 @@ on:
 jobs:
   bump_support_rotation:
     runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write
     steps:
       - name: git checkout
         uses: actions/checkout@v2
       - name: Bump Lyft Support Rotation
         run: ./tools/bump_lyft_support_rotation.sh
+      - name: Set Branch
+        id: branch
+        run: |
+          echo "::set-output name=BRANCH_NAME::support-bump-${GITHUB_RUN_ID}"
       - name: Commit Changes
         run: |
+          git checkout -b "${{ steps.branch.outputs.BRANCH_NAME }}"
           git config --global user.email "${GITHUB_ACTOR}"
           git config --global user.name "${GITHUB_ACTOR}@users.noreply.github.com"
           git add .github/lyft_maintainers.yml
           git commit -am "Bump Lyft Support Rotation"
           git push
+      - name: Submit Pull Request
+        run: |
+          curl \
+            -X POST \
+            -H "Accept: application/vnd.github.v3+json" \
+            -H "Authorization: token ${{ secrets.GITHUB_TOKEN }}" \
+            https://api.github.com/repos/octocat/hello-world/pulls \
+            -d '{"head":"${{ steps.branch.outputs.BRANCH_NAME }}","base":"main", "title": "Bump Lyft Support Rotation"}'

--- a/docs/Support.md
+++ b/docs/Support.md
@@ -25,4 +25,4 @@ reasonable effort to engage with discussions within 1 business day.
 Envoy Mobile is a project maintained by contributors from multiple
 companies, as highlighted in [OWNERS.md](../OWNERS.md), but as the
 project grows we believe it will be helpful to have a point of contact
-within a company that has bee using Envoy Mobile in production.
+within a company that has been using Envoy Mobile in production.

--- a/docs/Support.md
+++ b/docs/Support.md
@@ -1,0 +1,28 @@
+# Support Rotation
+
+Envoy Mobile has a support rotation system to ensure that discussions,
+issues and pull requests are handled in a timely manner from someone who
+works on Envoy Mobile at Lyft.
+
+## Who's this week's current support maintainer?
+
+The current support maintainer's GitHub username is defined
+[here](https://github.com/envoyproxy/envoy-mobile/blob/main/.github/lyft_maintainers.yml#L1).
+
+## Responsibilities
+
+* **Monitor GitHub Issues & Pull Requests:** Ensure that discussions on
+  GitHub are engaged with in a prompt manner.
+* **Monitor Slack:** Engage with Slack discussions in the Envoy slack
+  org ([#envoy-mobile](https://envoyproxy.slack.com/archives/CKQ2LK23G),
+  [#envoy-mobile-engflow-ci](https://envoyproxy.slack.com/archives/C02QMNG92A3)).
+
+Even though there is no concrete SLA, the support maintainer will make a
+reasonable effort to engage with discussions within 1-3 business days.
+
+## Why is the rotation limited to Lyft employees?
+
+Envoy Mobile is a project maintained by contributors from multiple
+companies, as highlighted in [OWNERS.md](../OWNERS.md), but as the
+project grows we believe it will be helpful to have a point of contact
+within a company that has bee using Envoy Mobile in production.

--- a/docs/Support.md
+++ b/docs/Support.md
@@ -18,7 +18,7 @@ The current support maintainer's GitHub username is defined
   [#envoy-mobile-engflow-ci](https://envoyproxy.slack.com/archives/C02QMNG92A3)).
 
 Even though there is no concrete SLA, the support maintainer will make a
-reasonable effort to engage with discussions within 1-3 business days.
+reasonable effort to engage with discussions within 1 business day.
 
 ## Why is the rotation limited to Lyft employees?
 

--- a/tools/bump_lyft_support_rotation.sh
+++ b/tools/bump_lyft_support_rotation.sh
@@ -1,0 +1,50 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+#######################################################
+# bump_lyft_support_rotation.sh
+#
+# Assigns the next person in the Lyft maintainers list.
+#######################################################
+
+# TODO(jpsim): Use a yaml parsing library if the format ever expands
+# beyond its current very simple form.
+
+function next_maintainer() {
+  current="$1"
+  file="$2"
+
+  while IFS= read -r line; do
+    maintainers+=("${line#"  - "}")
+  done <<< "$(sed -n '/^  - /p' "$file")"
+
+  for i in "${!maintainers[@]}"; do
+    if [[ "${maintainers[$i]}" = "${current}" ]]; then
+      last_index=$((${#maintainers[@]}-1))
+      if [[ $i == "$last_index" ]]; then
+        echo "${maintainers[0]}"
+        break
+      else
+        echo "${maintainers[$((i + 1))]}"
+        break
+      fi
+    fi
+  done
+}
+
+function set_maintainer() {
+  maintainer="$1"
+  file="$2"
+
+  echo "current: $maintainer" > "$file.tmp"
+  tail -n +2 "$file" >> "$file.tmp"
+  mv "$file.tmp" "$file"
+}
+
+maintainers_file=".github/lyft_maintainers.yml"
+first_line="$(head -n 1 "$maintainers_file")"
+current=${first_line#"current: "}
+next="$(next_maintainer "$current" "$maintainers_file")"
+set_maintainer "$next" "$maintainers_file"
+echo "Lyft support maintainer changing from $current to $next"


### PR DESCRIPTION
This change includes:

* Documentation stating the purpose, function and reasoning behind the Lyft support rotation.
* A YAML file capturing the rotation list of GitHub user names and who's currently on rotation.
* A script to bump who's on rotation to the next person.
* A GitHub Action that runs weekly to automatically update who's on rotation.

There's a lot of room for growth in this system, such as posting who's on rotation to Slack, generating a calendar viewable in Google Calendar or other calendar clients, automatically assigning PRs, extending to have rotations for different companies or project areas etc.

Signed-off-by: JP Simard <jp@jpsim.com>