### PR TITLE
support building swift/obj-c targets on macos

### DIFF
--- a/library/objective-c/BUILD
+++ b/library/objective-c/BUILD
@@ -20,9 +20,14 @@ objc_library(
         "EnvoyHTTPStreamImpl.m",
         "EnvoyLogger.m",
         "EnvoyNativeFilterConfig.m",
-        "EnvoyNetworkMonitor.m",
         "EnvoyStringAccessor.m",
-    ],
+    ] + select({
+        "@platforms//os:macos": [
+        ],
+        "//conditions:default": [
+            "EnvoyNetworkMonitor.m",
+        ],
+    }),
     hdrs = [
         "EnvoyEngine.h",
     ],
@@ -30,8 +35,13 @@ objc_library(
     sdk_frameworks = [
         "Network",
         "SystemConfiguration",
-        "UIKit",
-    ],
+    ] + select({
+        "@platforms//os:macos": [
+        ],
+        "//conditions:default": [
+            "UIKit",
+        ],
+    }),
     visibility = ["//visibility:public"],
     deps = [
         ":envoy_objc_bridge_lib",

--- a/library/objective-c/EnvoyEngineImpl.m
+++ b/library/objective-c/EnvoyEngineImpl.m
@@ -7,7 +7,9 @@
 #import "library/common/main_interface.h"
 #import "library/common/types/c_types.h"
 
+#ifndef TARGET_OS_MAC
 #import <UIKit/UIKit.h>
+#endif
 
 static void ios_on_engine_running(void *context) {
   // This code block runs inside the Envoy event loop. Therefore, an explicit autoreleasepool block
@@ -438,6 +440,7 @@ static void ios_track_event(envoy_map map, const void *context) {
 
   _engineHandle = init_engine(native_callbacks, native_logger, native_event_tracker);
 
+#ifndef TARGET_OS_MAC
   if (enableNetworkPathMonitor) {
     if (@available(iOS 12, *)) {
       [EnvoyNetworkMonitor startPathMonitorIfNeeded];
@@ -449,6 +452,7 @@ static void ios_track_event(envoy_map map, const void *context) {
   } else {
     [EnvoyNetworkMonitor startReachabilityIfNeeded];
   }
+#endif
 
   return self;
 }
@@ -598,6 +602,7 @@ static void ios_track_event(envoy_map map, const void *context) {
 #pragma mark - Private
 
 - (void)startObservingLifecycleNotifications {
+#ifndef TARGET_OS_MAC
   // re-enable lifecycle-based stat flushing when
   // https://github.com/envoyproxy/envoy-mobile/issues/748 gets fixed.
   NSNotificationCenter *notificationCenter = [NSNotificationCenter defaultCenter];
@@ -605,6 +610,7 @@ static void ios_track_event(envoy_map map, const void *context) {
                          selector:@selector(terminateNotification:)
                              name:UIApplicationWillTerminateNotification
                            object:nil];
+#endif
 }
 
 - (void)terminateNotification:(NSNotification *)notification {


### PR DESCRIPTION
Right now the swift/obj-c targets cannot build on their own, relying on being wrapped in a ios_test or similar in order to
build with the right libraries. This makes some few surgical changes in order to let the targets build on their own. This opens up for running swift_binaries etc. that consume EM, with a few of the iOS specific bits disabled.

Risk Level: Low, macos only
Testing: Verified that we can build swift_binaries that target 
```
        "@envoy_mobile//library/swift:ios_lib",
        "@envoy_mobile//library/objective-c:envoy_engine_objc_lib",
```
on macos
Docs Changes: n/a
Release Notes: n/a
