### PR TITLE
Fix iOS termination crash in `ProvisionalDispatcher`

### DIFF
--- a/library/common/event/provisional_dispatcher.cc
+++ b/library/common/event/provisional_dispatcher.cc
@@ -25,8 +25,12 @@ envoy_status_t ProvisionalDispatcher::post(Event::PostCb callback) {
   Thread::LockGuard lock(state_lock_);
 
   if (drained_) {
-    event_dispatcher_->post(callback);
-    return ENVOY_SUCCESS;
+    if (event_dispatcher_) {
+      event_dispatcher_->post(callback);
+      return ENVOY_SUCCESS;
+    } else {
+      return ENVOY_FAILURE;
+    }
   }
 
   init_queue_.push_back(callback);


### PR DESCRIPTION
When iOS is terminating a process, it may release some static memory, which could cause the `event_dispatcher_` variable to point to invalid memory, leading to a crash.

A crash that occurs when an app is already in the process of being terminated isn't too bad, considering it's already shutting down, but this matters to some extent, considering that crash reporters will report this as an app crash, and the OS may choose to penalize your app by not proactively suggesting it.

This should fix a crash with a backtrace such as this one:

```
EXC_BAD_ACCESS: Attempted to dereference garbage pointer 0x8000000000000010.

0 Envoy::Event::ProvisionalDispatcher::post(std::__1::function<void ()>)
1 Envoy::EngineHandle::runOnEngineDispatcher(long, std::__1::function<void (Envoy::Engine&)>)
2 start_stream
3 -[EnvoyHTTPStreamImpl initWithHandle:callbacks:explicitFlowControl:]
4 -[EnvoyEngineImpl startStreamWithCallbacks:explicitFlowControl:]
5 StreamPrototype.start(queue:)
```

Signed-off-by: JP Simard <jp@jpsim.com>