### PR TITLE
Have QuicTestServer to support Cronet request

### DIFF
--- a/library/java/org/chromium/net/impl/CronetUrlRequest.java
+++ b/library/java/org/chromium/net/impl/CronetUrlRequest.java
@@ -34,7 +34,7 @@ import org.chromium.net.RequestFinishedInfo;
 import org.chromium.net.RequestFinishedInfo.Metrics;
 import org.chromium.net.UploadDataProvider;
 
-/** UrlRequest, backed by Envoy-Mobile, a.k.a Cronvoy */
+/** UrlRequest, backed by Envoy-Mobile. */
 public final class CronetUrlRequest extends UrlRequestBase {
 
   /**

--- a/library/java/org/chromium/net/impl/CronetUrlRequest.java
+++ b/library/java/org/chromium/net/impl/CronetUrlRequest.java
@@ -34,7 +34,7 @@ import org.chromium.net.RequestFinishedInfo;
 import org.chromium.net.RequestFinishedInfo.Metrics;
 import org.chromium.net.UploadDataProvider;
 
-/** UrlRequest, backed by Envoy-Mobile. */
+/** UrlRequest, backed by Envoy-Mobile, a.k.a Cronvoy */
 public final class CronetUrlRequest extends UrlRequestBase {
 
   /**

--- a/test/common/integration/BUILD
+++ b/test/common/integration/BUILD
@@ -41,9 +41,9 @@ envoy_cc_test_library(
     ],
     repository = "@envoy",
     deps = [
+        ":autonomous_upstream_lib",
         "@envoy//source/exe:process_wide_lib",
         "@envoy//test/config:utility_lib",
-        "@envoy//test/integration:autonomous_upstream_lib",
         "@envoy//test/mocks/server:transport_socket_factory_context_mocks",
         "@envoy//test/test_common:environment_lib",
     ] + select({
@@ -52,4 +52,18 @@ envoy_cc_test_library(
             "@envoy//source/common/signal:sigaction_lib",
         ],
     }),
+)
+
+envoy_cc_test_library(
+    name = "autonomous_upstream_lib",
+    srcs = [
+        "autonomous_upstream.cc",
+    ],
+    hdrs = [
+        "autonomous_upstream.h",
+    ],
+    repository = "@envoy",
+    deps = [
+        "@envoy//test/integration:fake_upstream_lib",
+    ],
 )

--- a/test/common/integration/autonomous_upstream.cc
+++ b/test/common/integration/autonomous_upstream.cc
@@ -29,7 +29,7 @@ void AutonomousStream::sendResponse() {
              {Http::LowerCaseString("X-Original-Url"),
               "https://test.example.com:6121/simple.txt"}})};
     encodeHeaders(*response_headers, /* headers_only_response= */ false);
-    encodeData("This is a simple text file served by QUIC.", /* end_stream= */ true);
+    encodeData("This is a simple text file served by QUIC.\n", /* end_stream= */ true);
   }
 }
 

--- a/test/common/integration/autonomous_upstream.cc
+++ b/test/common/integration/autonomous_upstream.cc
@@ -1,0 +1,180 @@
+#include "test/common/integration/autonomous_upstream.h"
+
+namespace Envoy {
+namespace {
+
+void HeaderToInt(const char header_name[], int32_t& return_int,
+                 Http::TestResponseHeaderMapImpl& headers) {
+  const std::string header_value(headers.get_(header_name));
+  if (!header_value.empty()) {
+    uint64_t parsed_value;
+    RELEASE_ASSERT(absl::SimpleAtoi(header_value, &parsed_value) &&
+                       parsed_value < static_cast<uint32_t>(std::numeric_limits<int32_t>::max()),
+                   "");
+    return_int = parsed_value;
+  }
+}
+
+} // namespace
+
+const char AutonomousStream::RESPONSE_SIZE_BYTES[] = "response_size_bytes";
+const char AutonomousStream::RESPONSE_DATA_BLOCKS[] = "response_data_blocks";
+const char AutonomousStream::EXPECT_REQUEST_SIZE_BYTES[] = "expect_request_size_bytes";
+const char AutonomousStream::RESET_AFTER_REQUEST[] = "reset_after_request";
+const char AutonomousStream::CLOSE_AFTER_RESPONSE[] = "close_after_response";
+const char AutonomousStream::NO_TRAILERS[] = "no_trailers";
+const char AutonomousStream::NO_END_STREAM[] = "no_end_stream";
+
+AutonomousStream::AutonomousStream(FakeHttpConnection& parent, Http::ResponseEncoder& encoder,
+                                   AutonomousUpstream& upstream, bool allow_incomplete_streams)
+    : FakeStream(parent, encoder, upstream.timeSystem()), upstream_(upstream),
+      allow_incomplete_streams_(allow_incomplete_streams) {}
+
+AutonomousStream::~AutonomousStream() {
+  if (!allow_incomplete_streams_) {
+    RELEASE_ASSERT(complete(), "Found that end_stream is not true");
+  }
+}
+
+// By default, automatically send a response when the request is complete.
+void AutonomousStream::setEndStream(bool end_stream) {
+  FakeStream::setEndStream(end_stream);
+  if (end_stream) {
+    sendResponse();
+  }
+}
+
+// Check all the special headers and send a customized response based on them.
+void AutonomousStream::sendResponse() {
+  Http::TestResponseHeaderMapImpl headers(*headers_);
+  upstream_.setLastRequestHeaders(*headers_);
+
+  int32_t request_body_length = -1;
+  HeaderToInt(EXPECT_REQUEST_SIZE_BYTES, request_body_length, headers);
+  if (request_body_length >= 0) {
+    EXPECT_EQ(request_body_length, body_.length());
+  }
+
+  if (!headers.get_(RESET_AFTER_REQUEST).empty()) {
+    encodeResetStream();
+    return;
+  }
+
+  int32_t response_body_length = 10;
+  HeaderToInt(RESPONSE_SIZE_BYTES, response_body_length, headers);
+
+  int32_t response_data_blocks = 1;
+  HeaderToInt(RESPONSE_DATA_BLOCKS, response_data_blocks, headers);
+
+  pre_response_headers_metadata_ = upstream_.preResponseHeadersMetadata();
+  if (pre_response_headers_metadata_) {
+    encodeMetadata(*pre_response_headers_metadata_);
+  }
+
+  Envoy::Http::ResponseHeaderMapPtr response_headers{
+      Envoy::Http::createHeaderMap<Envoy::Http::ResponseHeaderMapImpl>(
+          {{Envoy::Http::Headers::get().Status, "200"}, {Http::LowerCaseString("Foo"), "bar"}, {Http::LowerCaseString("connection"), "close"}})};
+  encodeHeaders(*response_headers, /* headers_only_response= */ false);
+
+  if (headers_->Path()->value() == "/echo_method") {
+    encodeData(headers_->Method()->value().getStringView(), /* end_stream= */ true);
+  }
+
+    parent_.connection().dispatcher().post(
+        [this]() -> void { parent_.connection().close(Network::ConnectionCloseType::FlushWrite); });
+}
+
+AutonomousHttpConnection::AutonomousHttpConnection(AutonomousUpstream& autonomous_upstream,
+                                                   SharedConnectionWrapper& shared_connection,
+                                                   Http::CodecType type,
+                                                   AutonomousUpstream& upstream)
+    : FakeHttpConnection(autonomous_upstream, shared_connection, type, upstream.timeSystem(),
+                         Http::DEFAULT_MAX_REQUEST_HEADERS_KB, Http::DEFAULT_MAX_HEADERS_COUNT,
+                         envoy::config::core::v3::HttpProtocolOptions::ALLOW),
+      upstream_(upstream) {}
+
+Http::RequestDecoder& AutonomousHttpConnection::newStream(Http::ResponseEncoder& response_encoder,
+                                                          bool) {
+  auto stream =
+      new AutonomousStream(*this, response_encoder, upstream_, upstream_.allow_incomplete_streams_);
+  streams_.push_back(FakeStreamPtr{stream});
+  return *(stream);
+}
+
+AutonomousUpstream::~AutonomousUpstream() {
+  // Make sure the dispatcher is stopped before the connections are destroyed.
+  cleanUp();
+  http_connections_.clear();
+}
+
+bool AutonomousUpstream::createNetworkFilterChain(Network::Connection& connection,
+                                                  const std::vector<Network::FilterFactoryCb>&) {
+  shared_connections_.emplace_back(new SharedConnectionWrapper(connection));
+  AutonomousHttpConnectionPtr http_connection(
+      new AutonomousHttpConnection(*this, *shared_connections_.back(), http_type_, *this));
+  http_connection->initialize();
+  http_connections_.push_back(std::move(http_connection));
+  return true;
+}
+
+bool AutonomousUpstream::createListenerFilterChain(Network::ListenerFilterManager&) { return true; }
+
+void AutonomousUpstream::createUdpListenerFilterChain(Network::UdpListenerFilterManager&,
+                                                      Network::UdpReadFilterCallbacks&) {}
+
+void AutonomousUpstream::setLastRequestHeaders(const Http::HeaderMap& headers) {
+  Thread::LockGuard lock(headers_lock_);
+  last_request_headers_ = std::make_unique<Http::TestRequestHeaderMapImpl>(headers);
+}
+
+std::unique_ptr<Http::TestRequestHeaderMapImpl> AutonomousUpstream::lastRequestHeaders() {
+  Thread::LockGuard lock(headers_lock_);
+  return std::move(last_request_headers_);
+}
+
+void AutonomousUpstream::setResponseTrailers(
+    std::unique_ptr<Http::TestResponseTrailerMapImpl>&& response_trailers) {
+  Thread::LockGuard lock(headers_lock_);
+  response_trailers_ = std::move(response_trailers);
+}
+
+void AutonomousUpstream::setResponseHeaders(
+    std::unique_ptr<Http::TestResponseHeaderMapImpl>&& response_headers) {
+  Thread::LockGuard lock(headers_lock_);
+  response_headers_ = std::move(response_headers);
+}
+
+void AutonomousUpstream::setPreResponseHeadersMetadata(
+    std::unique_ptr<Http::MetadataMapVector>&& metadata) {
+  Thread::LockGuard lock(headers_lock_);
+  pre_response_headers_metadata_ = std::move(metadata);
+}
+
+Http::TestResponseTrailerMapImpl AutonomousUpstream::responseTrailers() {
+  Thread::LockGuard lock(headers_lock_);
+  Http::TestResponseTrailerMapImpl return_trailers = *response_trailers_;
+  return return_trailers;
+}
+
+Http::TestResponseHeaderMapImpl AutonomousUpstream::responseHeaders() {
+  Thread::LockGuard lock(headers_lock_);
+  Http::TestResponseHeaderMapImpl return_headers = *response_headers_;
+  return return_headers;
+}
+
+std::unique_ptr<Http::MetadataMapVector> AutonomousUpstream::preResponseHeadersMetadata() {
+  Thread::LockGuard lock(headers_lock_);
+  return std::move(pre_response_headers_metadata_);
+}
+
+AssertionResult AutonomousUpstream::closeConnection(uint32_t index,
+                                                    std::chrono::milliseconds timeout) {
+  return shared_connections_[index]->executeOnDispatcher(
+      [](Network::Connection& connection) {
+        ASSERT(connection.state() == Network::Connection::State::Open);
+        connection.close(Network::ConnectionCloseType::FlushWrite);
+      },
+      timeout);
+}
+
+} // namespace Envoy

--- a/test/common/integration/autonomous_upstream.cc
+++ b/test/common/integration/autonomous_upstream.cc
@@ -18,7 +18,7 @@ void AutonomousStream::setEndStream(bool end_stream) {
   }
 }
 
-// Check all the special headers and send a customized response based on them.
+// Reply with the canned response if the URI is /simple.txt. Otherwise this is a 503.
 void AutonomousStream::sendResponse() {
   if (headers_->Path()->value() == "/simple.txt") {
     Envoy::Http::ResponseHeaderMapPtr response_headers{

--- a/test/common/integration/autonomous_upstream.h
+++ b/test/common/integration/autonomous_upstream.h
@@ -1,0 +1,111 @@
+#pragma once
+
+#include "test/integration/fake_upstream.h"
+
+namespace Envoy {
+
+class AutonomousUpstream;
+
+// A stream which automatically responds when the downstream request is
+// completely read. By default the response is 200: OK with 10 bytes of
+// payload. This behavior can be overridden with custom request headers defined below.
+class AutonomousStream : public FakeStream {
+public:
+  // The number of response bytes to send. Payload is randomized.
+  static const char RESPONSE_SIZE_BYTES[];
+  // The number of data blocks send.
+  static const char RESPONSE_DATA_BLOCKS[];
+  // If set to an integer, the AutonomousStream will expect the response body to
+  // be this large.
+  static const char EXPECT_REQUEST_SIZE_BYTES[];
+  // If set, the stream will reset when the request is complete, rather than
+  // sending a response.
+  static const char RESET_AFTER_REQUEST[];
+  // Prevents upstream from sending trailers.
+  static const char NO_TRAILERS[];
+  // Prevents upstream from finishing response.
+  static const char NO_END_STREAM[];
+  // Closes the underlying connection after a given response is sent.
+  static const char CLOSE_AFTER_RESPONSE[];
+
+  AutonomousStream(FakeHttpConnection& parent, Http::ResponseEncoder& encoder,
+                   AutonomousUpstream& upstream, bool allow_incomplete_streams);
+  ~AutonomousStream() override;
+
+  void setEndStream(bool set) ABSL_EXCLUSIVE_LOCKS_REQUIRED(lock_) override;
+
+private:
+  AutonomousUpstream& upstream_;
+  void sendResponse() ABSL_EXCLUSIVE_LOCKS_REQUIRED(lock_);
+  const bool allow_incomplete_streams_{false};
+  std::unique_ptr<Http::MetadataMapVector> pre_response_headers_metadata_;
+};
+
+// An upstream which creates AutonomousStreams for new incoming streams.
+class AutonomousHttpConnection : public FakeHttpConnection {
+public:
+  AutonomousHttpConnection(AutonomousUpstream& autonomous_upstream,
+                           SharedConnectionWrapper& shared_connection, Http::CodecType type,
+                           AutonomousUpstream& upstream);
+
+  Http::RequestDecoder& newStream(Http::ResponseEncoder& response_encoder, bool) override;
+
+private:
+  AutonomousUpstream& upstream_;
+  std::vector<FakeStreamPtr> streams_;
+};
+
+using AutonomousHttpConnectionPtr = std::unique_ptr<AutonomousHttpConnection>;
+
+// An upstream which creates AutonomousHttpConnection for new incoming connections.
+class AutonomousUpstream : public FakeUpstream {
+public:
+  AutonomousUpstream(Network::TransportSocketFactoryPtr&& transport_socket_factory,
+                     const Network::Address::InstanceConstSharedPtr& address,
+                     const FakeUpstreamConfig& config, bool allow_incomplete_streams)
+      : FakeUpstream(std::move(transport_socket_factory), address, config),
+        allow_incomplete_streams_(allow_incomplete_streams),
+        response_trailers_(std::make_unique<Http::TestResponseTrailerMapImpl>()),
+        response_headers_(std::make_unique<Http::TestResponseHeaderMapImpl>(
+            Http::TestResponseHeaderMapImpl({{":status", "200"}}))) {}
+
+  AutonomousUpstream(Network::TransportSocketFactoryPtr&& transport_socket_factory, uint32_t port,
+                     Network::Address::IpVersion version, const FakeUpstreamConfig& config,
+                     bool allow_incomplete_streams)
+      : FakeUpstream(std::move(transport_socket_factory), port, version, config),
+        allow_incomplete_streams_(allow_incomplete_streams),
+        response_trailers_(std::make_unique<Http::TestResponseTrailerMapImpl>()),
+        response_headers_(std::make_unique<Http::TestResponseHeaderMapImpl>(
+            Http::TestResponseHeaderMapImpl({{":status", "200"}}))) {}
+
+  ~AutonomousUpstream() override;
+  bool
+  createNetworkFilterChain(Network::Connection& connection,
+                           const std::vector<Network::FilterFactoryCb>& filter_factories) override;
+  bool createListenerFilterChain(Network::ListenerFilterManager& listener) override;
+  void createUdpListenerFilterChain(Network::UdpListenerFilterManager& listener,
+                                    Network::UdpReadFilterCallbacks& callbacks) override;
+  AssertionResult closeConnection(uint32_t index,
+                                  std::chrono::milliseconds timeout = TestUtility::DefaultTimeout);
+
+  void setLastRequestHeaders(const Http::HeaderMap& headers);
+  std::unique_ptr<Http::TestRequestHeaderMapImpl> lastRequestHeaders();
+  void setResponseTrailers(std::unique_ptr<Http::TestResponseTrailerMapImpl>&& response_trailers);
+  void setResponseHeaders(std::unique_ptr<Http::TestResponseHeaderMapImpl>&& response_headers);
+  void setPreResponseHeadersMetadata(std::unique_ptr<Http::MetadataMapVector>&& metadata);
+  Http::TestResponseTrailerMapImpl responseTrailers();
+  Http::TestResponseHeaderMapImpl responseHeaders();
+  std::unique_ptr<Http::MetadataMapVector> preResponseHeadersMetadata();
+  const bool allow_incomplete_streams_{false};
+
+private:
+  Thread::MutexBasicLockable headers_lock_;
+  std::unique_ptr<Http::TestRequestHeaderMapImpl> last_request_headers_;
+  std::unique_ptr<Http::TestResponseTrailerMapImpl> response_trailers_;
+  std::unique_ptr<Http::TestResponseHeaderMapImpl> response_headers_;
+  std::unique_ptr<Http::MetadataMapVector> pre_response_headers_metadata_;
+  std::vector<AutonomousHttpConnectionPtr> http_connections_;
+  std::vector<SharedConnectionWrapperPtr> shared_connections_;
+};
+
+} // namespace Envoy

--- a/test/common/integration/autonomous_upstream.h
+++ b/test/common/integration/autonomous_upstream.h
@@ -6,39 +6,18 @@ namespace Envoy {
 
 class AutonomousUpstream;
 
-// A stream which automatically responds when the downstream request is
-// completely read. By default the response is 200: OK with 10 bytes of
-// payload. This behavior can be overridden with custom request headers defined below.
+// A stream which automatically responds when the downstream request is completely read.
+// However, it supports only only request: https://test.example.com/simple.txt
 class AutonomousStream : public FakeStream {
 public:
-  // The number of response bytes to send. Payload is randomized.
-  static const char RESPONSE_SIZE_BYTES[];
-  // The number of data blocks send.
-  static const char RESPONSE_DATA_BLOCKS[];
-  // If set to an integer, the AutonomousStream will expect the response body to
-  // be this large.
-  static const char EXPECT_REQUEST_SIZE_BYTES[];
-  // If set, the stream will reset when the request is complete, rather than
-  // sending a response.
-  static const char RESET_AFTER_REQUEST[];
-  // Prevents upstream from sending trailers.
-  static const char NO_TRAILERS[];
-  // Prevents upstream from finishing response.
-  static const char NO_END_STREAM[];
-  // Closes the underlying connection after a given response is sent.
-  static const char CLOSE_AFTER_RESPONSE[];
-
   AutonomousStream(FakeHttpConnection& parent, Http::ResponseEncoder& encoder,
-                   AutonomousUpstream& upstream, bool allow_incomplete_streams);
+                   AutonomousUpstream& upstream);
   ~AutonomousStream() override;
 
   void setEndStream(bool set) ABSL_EXCLUSIVE_LOCKS_REQUIRED(lock_) override;
 
 private:
-  AutonomousUpstream& upstream_;
   void sendResponse() ABSL_EXCLUSIVE_LOCKS_REQUIRED(lock_);
-  const bool allow_incomplete_streams_{false};
-  std::unique_ptr<Http::MetadataMapVector> pre_response_headers_metadata_;
 };
 
 // An upstream which creates AutonomousStreams for new incoming streams.
@@ -62,21 +41,12 @@ class AutonomousUpstream : public FakeUpstream {
 public:
   AutonomousUpstream(Network::TransportSocketFactoryPtr&& transport_socket_factory,
                      const Network::Address::InstanceConstSharedPtr& address,
-                     const FakeUpstreamConfig& config, bool allow_incomplete_streams)
-      : FakeUpstream(std::move(transport_socket_factory), address, config),
-        allow_incomplete_streams_(allow_incomplete_streams),
-        response_trailers_(std::make_unique<Http::TestResponseTrailerMapImpl>()),
-        response_headers_(std::make_unique<Http::TestResponseHeaderMapImpl>(
-            Http::TestResponseHeaderMapImpl({{":status", "200"}}))) {}
+                     const FakeUpstreamConfig& config)
+      : FakeUpstream(std::move(transport_socket_factory), address, config) {}
 
   AutonomousUpstream(Network::TransportSocketFactoryPtr&& transport_socket_factory, uint32_t port,
-                     Network::Address::IpVersion version, const FakeUpstreamConfig& config,
-                     bool allow_incomplete_streams)
-      : FakeUpstream(std::move(transport_socket_factory), port, version, config),
-        allow_incomplete_streams_(allow_incomplete_streams),
-        response_trailers_(std::make_unique<Http::TestResponseTrailerMapImpl>()),
-        response_headers_(std::make_unique<Http::TestResponseHeaderMapImpl>(
-            Http::TestResponseHeaderMapImpl({{":status", "200"}}))) {}
+                     Network::Address::IpVersion version, const FakeUpstreamConfig& config)
+      : FakeUpstream(std::move(transport_socket_factory), port, version, config) {}
 
   ~AutonomousUpstream() override;
   bool
@@ -85,25 +55,8 @@ public:
   bool createListenerFilterChain(Network::ListenerFilterManager& listener) override;
   void createUdpListenerFilterChain(Network::UdpListenerFilterManager& listener,
                                     Network::UdpReadFilterCallbacks& callbacks) override;
-  AssertionResult closeConnection(uint32_t index,
-                                  std::chrono::milliseconds timeout = TestUtility::DefaultTimeout);
-
-  void setLastRequestHeaders(const Http::HeaderMap& headers);
-  std::unique_ptr<Http::TestRequestHeaderMapImpl> lastRequestHeaders();
-  void setResponseTrailers(std::unique_ptr<Http::TestResponseTrailerMapImpl>&& response_trailers);
-  void setResponseHeaders(std::unique_ptr<Http::TestResponseHeaderMapImpl>&& response_headers);
-  void setPreResponseHeadersMetadata(std::unique_ptr<Http::MetadataMapVector>&& metadata);
-  Http::TestResponseTrailerMapImpl responseTrailers();
-  Http::TestResponseHeaderMapImpl responseHeaders();
-  std::unique_ptr<Http::MetadataMapVector> preResponseHeadersMetadata();
-  const bool allow_incomplete_streams_{false};
 
 private:
-  Thread::MutexBasicLockable headers_lock_;
-  std::unique_ptr<Http::TestRequestHeaderMapImpl> last_request_headers_;
-  std::unique_ptr<Http::TestResponseTrailerMapImpl> response_trailers_;
-  std::unique_ptr<Http::TestResponseHeaderMapImpl> response_headers_;
-  std::unique_ptr<Http::MetadataMapVector> pre_response_headers_metadata_;
   std::vector<AutonomousHttpConnectionPtr> http_connections_;
   std::vector<SharedConnectionWrapperPtr> shared_connections_;
 };

--- a/test/common/integration/quic_test_server.cc
+++ b/test/common/integration/quic_test_server.cc
@@ -49,8 +49,8 @@ void QuicTestServer::startQuicTestServer() {
 
   Network::TransportSocketFactoryPtr factory = createUpstreamTlsContext(factory_context_);
 
-  upstream_ = std::make_unique<AutonomousUpstream>(std::move(factory), port_, version_,
-                                                   upstream_config_, false);
+  upstream_ =
+      std::make_unique<AutonomousUpstream>(std::move(factory), port_, version_, upstream_config_);
 
   // see upstream address
   ENVOY_LOG_MISC(debug, "Upstream now listening on {}", upstream_->localAddress()->asString());

--- a/test/common/integration/quic_test_server.h
+++ b/test/common/integration/quic_test_server.h
@@ -6,8 +6,8 @@
 #include "source/exe/process_wide.h"
 
 #include "envoy/extensions/transport_sockets/quic/v3/quic_transport.pb.h"
+#include "test/common/integration/autonomous_upstream.h"
 #include "test/mocks/server/transport_socket_factory_context.h"
-#include "test/integration/autonomous_upstream.h"
 #include "test/config/utility.h"
 
 namespace Envoy {

--- a/test/java/io/envoyproxy/envoymobile/engine/testing/QuicTestServer.java
+++ b/test/java/io/envoyproxy/envoymobile/engine/testing/QuicTestServer.java
@@ -7,12 +7,6 @@ import java.util.concurrent.atomic.AtomicBoolean;
  */
 public final class QuicTestServer {
 
-  private static final String ECHO_HEADER_PATH = "/echo_header";
-  private static final String ECHO_METHOD_PATH = "/echo_method";
-  private static final String ECHO_ALL_HEADERS_PATH = "/echo_all_headers";
-  private static final String REDIRECT_TO_ECHO_BODY_PATH = "/redirect_to_echo_body";
-  private static final String ECHO_BODY_PATH = "/echo_body";
-
   private static final AtomicBoolean sServerRunning = new AtomicBoolean();
 
   /*
@@ -50,20 +44,6 @@ public final class QuicTestServer {
     }
     return nativeGetServerPort();
   }
-
-  public static String getEchoBodyURL() { return getUrl(ECHO_BODY_PATH); }
-
-  public static String getEchoHeaderURL(String header) {
-    return getUrl(ECHO_HEADER_PATH + "?" + header);
-  }
-
-  public static String getEchoAllHeadersURL() { return getUrl(ECHO_ALL_HEADERS_PATH); }
-
-  public static String getEchoMethodURL() { return getUrl(ECHO_METHOD_PATH); }
-
-  public static String getRedirectToEchoBody() { return getUrl(REDIRECT_TO_ECHO_BODY_PATH); }
-
-  private static String getUrl(String path) { return getServerURL() + path; }
 
   private static native void nativeStartQuicTestServer();
 

--- a/test/java/io/envoyproxy/envoymobile/engine/testing/QuicTestServer.java
+++ b/test/java/io/envoyproxy/envoymobile/engine/testing/QuicTestServer.java
@@ -7,6 +7,12 @@ import java.util.concurrent.atomic.AtomicBoolean;
  */
 public final class QuicTestServer {
 
+  private static final String ECHO_HEADER_PATH = "/echo_header";
+  private static final String ECHO_METHOD_PATH = "/echo_method";
+  private static final String ECHO_ALL_HEADERS_PATH = "/echo_all_headers";
+  private static final String REDIRECT_TO_ECHO_BODY_PATH = "/redirect_to_echo_body";
+  private static final String ECHO_BODY_PATH = "/echo_body";
+
   private static final AtomicBoolean sServerRunning = new AtomicBoolean();
 
   /*
@@ -30,7 +36,7 @@ public final class QuicTestServer {
   }
 
   public static String getServerURL() {
-    return "https://" + getServerHost() + ":" + getServerPort() + "/";
+    return "https://" + getServerHost() + ":" + getServerPort();
   }
 
   public static String getServerHost() { return "test.example.com"; }
@@ -44,6 +50,20 @@ public final class QuicTestServer {
     }
     return nativeGetServerPort();
   }
+
+  public static String getEchoBodyURL() { return getUrl(ECHO_BODY_PATH); }
+
+  public static String getEchoHeaderURL(String header) {
+    return getUrl(ECHO_HEADER_PATH + "?" + header);
+  }
+
+  public static String getEchoAllHeadersURL() { return getUrl(ECHO_ALL_HEADERS_PATH); }
+
+  public static String getEchoMethodURL() { return getUrl(ECHO_METHOD_PATH); }
+
+  public static String getRedirectToEchoBody() { return getUrl(REDIRECT_TO_ECHO_BODY_PATH); }
+
+  private static String getUrl(String path) { return getServerURL() + path; }
 
   private static native void nativeStartQuicTestServer();
 

--- a/test/java/io/envoyproxy/envoymobile/engine/testing/QuicTestServerTest.java
+++ b/test/java/io/envoyproxy/envoymobile/engine/testing/QuicTestServerTest.java
@@ -134,7 +134,7 @@ public class QuicTestServerTest {
     QuicTestServerTest.Response response = sendRequest(requestScenario);
 
     assertThat(response.getHeaders().getHttpStatus()).isEqualTo(200);
-    assertThat(response.getBodyAsString()).isEqualTo("This is a simple text file served by QUIC.");
+    assertThat(response.getBodyAsString()).isEqualTo("This is a simple text file served by QUIC.\n");
     assertThat(response.getEnvoyError()).isNull();
   }
 

--- a/test/java/io/envoyproxy/envoymobile/engine/testing/QuicTestServerTest.java
+++ b/test/java/io/envoyproxy/envoymobile/engine/testing/QuicTestServerTest.java
@@ -134,7 +134,8 @@ public class QuicTestServerTest {
     QuicTestServerTest.Response response = sendRequest(requestScenario);
 
     assertThat(response.getHeaders().getHttpStatus()).isEqualTo(200);
-    assertThat(response.getBodyAsString()).isEqualTo("This is a simple text file served by QUIC.\n");
+    assertThat(response.getBodyAsString())
+        .isEqualTo("This is a simple text file served by QUIC.\n");
     assertThat(response.getEnvoyError()).isNull();
   }
 

--- a/test/java/io/envoyproxy/envoymobile/engine/testing/QuicTestServerTest.java
+++ b/test/java/io/envoyproxy/envoymobile/engine/testing/QuicTestServerTest.java
@@ -125,16 +125,17 @@ public class QuicTestServerTest {
   }
 
   @Test
-  public void get_simple() throws Exception {
+  public void get_echoMethod() throws Exception {
     QuicTestServerTest.RequestScenario requestScenario = new QuicTestServerTest.RequestScenario()
-                                                             .setHttpMethod(RequestMethod.GET)
-                                                             .setUrl(QuicTestServer.getServerURL());
+            .setHttpMethod(RequestMethod.GET)
+            .setUrl(QuicTestServer.getEchoMethodURL());
 
     QuicTestServerTest.Response response = sendRequest(requestScenario);
 
     assertThat(response.getHeaders().getHttpStatus()).isEqualTo(200);
-    assertThat(response.getBodyAsString()).isEqualTo("aaaaaaaaaa");
+    assertThat(response.getBodyAsString()).isEqualTo("GET");
     assertThat(response.getEnvoyError()).isNull();
+    System.err.println(response.getHeaders().allHeaders());
   }
 
   private QuicTestServerTest.Response sendRequest(RequestScenario requestScenario)

--- a/test/java/io/envoyproxy/envoymobile/engine/testing/QuicTestServerTest.java
+++ b/test/java/io/envoyproxy/envoymobile/engine/testing/QuicTestServerTest.java
@@ -44,7 +44,7 @@ public class QuicTestServerTest {
   private static final String QUIC_UPSTREAM_TYPE =
       "type.googleapis.com/envoy.extensions.transport_sockets.quic.v3.QuicUpstreamTransport";
 
-  private static final String config =
+  private static final String CONFIG =
       "static_resources:\n"
       + " listeners:\n"
       + " - name: base_api_listener\n"
@@ -108,8 +108,8 @@ public class QuicTestServerTest {
     QuicTestServer.startQuicTestServer();
     CountDownLatch latch = new CountDownLatch(1);
     engine = new AndroidEngineBuilder(
-                 appContext, new Custom(String.format(config, QuicTestServer.getServerPort())))
-                 .addLogLevel(LogLevel.OFF)
+                 appContext, new Custom(String.format(CONFIG, QuicTestServer.getServerPort())))
+                 .addLogLevel(LogLevel.WARN)
                  .setOnEngineRunning(() -> {
                    latch.countDown();
                    return null;
@@ -126,16 +126,16 @@ public class QuicTestServerTest {
 
   @Test
   public void get_echoMethod() throws Exception {
-    QuicTestServerTest.RequestScenario requestScenario = new QuicTestServerTest.RequestScenario()
+    QuicTestServerTest.RequestScenario requestScenario =
+        new QuicTestServerTest.RequestScenario()
             .setHttpMethod(RequestMethod.GET)
-            .setUrl(QuicTestServer.getEchoMethodURL());
+            .setUrl(QuicTestServer.getServerURL() + "/simple.txt");
 
     QuicTestServerTest.Response response = sendRequest(requestScenario);
 
     assertThat(response.getHeaders().getHttpStatus()).isEqualTo(200);
-    assertThat(response.getBodyAsString()).isEqualTo("GET");
+    assertThat(response.getBodyAsString()).isEqualTo("This is a simple text file served by QUIC.");
     assertThat(response.getEnvoyError()).isNull();
-    System.err.println(response.getHeaders().allHeaders());
   }
 
   private QuicTestServerTest.Response sendRequest(RequestScenario requestScenario)

--- a/test/java/io/envoyproxy/envoymobile/engine/testing/QuicTestServerTest.java
+++ b/test/java/io/envoyproxy/envoymobile/engine/testing/QuicTestServerTest.java
@@ -125,7 +125,7 @@ public class QuicTestServerTest {
   }
 
   @Test
-  public void get_echoMethod() throws Exception {
+  public void get_simpleTxt() throws Exception {
     QuicTestServerTest.RequestScenario requestScenario =
         new QuicTestServerTest.RequestScenario()
             .setHttpMethod(RequestMethod.GET)


### PR DESCRIPTION
Attempts to mimic this: https://source.chromium.org/chromium/chromium/src/+/main:components/cronet/testing/test_server/data/quic_data/simple.txt
The original QuicTestServer reads that file and caches it while booting up, and precomputes the full response out of it.

Description: provide a canned response to a specific request.
Risk Level: N/A - only changes test infrastructure
Testing: CI
Docs Changes: N/A
Release Notes: N/A