### PR TITLE
Fix `bump_support_rotation` GitHub Action

### DIFF
--- a/.github/workflows/bump_support_rotation.yml
+++ b/.github/workflows/bump_support_rotation.yml
@@ -27,7 +27,7 @@ jobs:
           git config --global user.name "${GITHUB_ACTOR}@users.noreply.github.com"
           git add .github/lyft_maintainers.yml
           git commit -am "Bump Lyft Support Rotation"
-          git push
+          git push "${{ steps.branch.outputs.BRANCH_NAME }}"
       - name: Submit Pull Request
         run: |
           curl \


### PR DESCRIPTION
Failed with the following error when I ran it manually a few minutes ago:

```
fatal: The current branch support-bump-1854030781 has no upstream branch.
To push the current branch and set the remote as upstream, use

    git push --set-upstream origin support-bump-1854030781
```

https://github.com/envoyproxy/envoy-mobile/runs/5219745723?check_suite_focus=true

Signed-off-by: JP Simard <jp@jpsim.com>