### PR TITLE
Add test support for H2

### DIFF
--- a/library/common/config/config.cc
+++ b/library/common/config/config.cc
@@ -53,6 +53,7 @@ const std::string config_header = R"(
 - &statsd_port 8125
 - &stream_idle_timeout 15s
 - &per_try_idle_timeout 15s
+- &trust_chain_verification VERIFY_TRUST_CHAIN
 - &virtual_clusters []
 
 !ignore stats_defs:
@@ -104,17 +105,6 @@ R"(
   typed_config:
     "@type": type.googleapis.com/envoy.extensions.transport_sockets.tls.v3.UpstreamTlsContext
     common_tls_context:
-      tls_params:
-        tls_maximum_protocol_version: TLSv1_3
-      validation_context:
-        trusted_ca:
-          inline_string: *tls_root_certs
-- &base_tls_h2_socket
-  name: envoy.transport_sockets.tls
-  typed_config:
-    "@type": type.googleapis.com/envoy.extensions.transport_sockets.tls.v3.UpstreamTlsContext
-    common_tls_context:
-      alpn_protocols: [h2]
       tls_params:
         tls_maximum_protocol_version: TLSv1_3
       validation_context:
@@ -344,7 +334,18 @@ R"(
     connect_timeout: *connect_timeout
     lb_policy: CLUSTER_PROVIDED
     cluster_type: *base_cluster_type
-    transport_socket: *base_tls_h2_socket
+    transport_socket:
+      name: envoy.transport_sockets.tls
+      typed_config:
+        "@type": type.googleapis.com/envoy.extensions.transport_sockets.tls.v3.UpstreamTlsContext
+        common_tls_context:
+          alpn_protocols: [h2]
+          tls_params:
+            tls_maximum_protocol_version: TLSv1_3
+          validation_context:
+            trusted_ca:
+              inline_string: *tls_root_certs
+            trust_chain_verification: *trust_chain_verification
     upstream_connection_options: *upstream_opts
     circuit_breakers: *circuit_breakers_settings
     typed_extension_protocol_options: *base_protocol_options

--- a/library/java/io/envoyproxy/envoymobile/engine/EnvoyConfiguration.java
+++ b/library/java/io/envoyproxy/envoymobile/engine/EnvoyConfiguration.java
@@ -19,7 +19,7 @@ public class EnvoyConfiguration {
     VERIFY_TRUST_CHAIN,
     // Connections where the certificate fails verification will be permitted.
     // For HTTP connections, the result of certificate verification can be used in route matching.
-    // Mostly used for testing.
+    // Used for testing.
     ACCEPT_UNTRUSTED;
   }
 
@@ -75,7 +75,7 @@ public class EnvoyConfiguration {
    * @param perTryIdleTimeoutSeconds     per try idle timeout for HTTP streams.
    * @param appVersion                   the App Version of the App using this Envoy Client.
    * @param appId                        the App ID of the App using this Envoy Client.
-   * @param trustChainVerification       wether or not to make TLS verification a passthrough.
+   * @param trustChainVerification       wether to mute TLS Cert verification - for tests only.
    * @param virtualClusters              the JSON list of virtual cluster configs.
    * @param nativeFilterChain            the configuration for native filters.
    * @param httpPlatformFilterFactories  the configuration for platform filters.
@@ -135,7 +135,6 @@ public class EnvoyConfiguration {
   String resolveTemplate(final String templateYAML, final String platformFilterTemplateYAML,
                          final String nativeFilterTemplateYAML) {
     final StringBuilder customFiltersBuilder = new StringBuilder();
-    System.err.println("nativeFilterTemplateYAML\n" +nativeFilterTemplateYAML);
 
     for (EnvoyHTTPFilterFactory filterFactory : httpPlatformFilterFactories) {
       String filterConfig = platformFilterTemplateYAML.replace("{{ platform_filter_name }}",

--- a/library/java/io/envoyproxy/envoymobile/engine/EnvoyConfiguration.java
+++ b/library/java/io/envoyproxy/envoymobile/engine/EnvoyConfiguration.java
@@ -75,7 +75,7 @@ public class EnvoyConfiguration {
    * @param perTryIdleTimeoutSeconds     per try idle timeout for HTTP streams.
    * @param appVersion                   the App Version of the App using this Envoy Client.
    * @param appId                        the App ID of the App using this Envoy Client.
-   * @param trustChainVerification       wether to mute TLS Cert verification - for tests only.
+   * @param trustChainVerification       whether to mute TLS Cert verification - for tests.
    * @param virtualClusters              the JSON list of virtual cluster configs.
    * @param nativeFilterChain            the configuration for native filters.
    * @param httpPlatformFilterFactories  the configuration for platform filters.

--- a/library/java/io/envoyproxy/envoymobile/engine/EnvoyConfiguration.java
+++ b/library/java/io/envoyproxy/envoymobile/engine/EnvoyConfiguration.java
@@ -12,6 +12,17 @@ import io.envoyproxy.envoymobile.engine.types.EnvoyStringAccessor;
 
 /* Typed configuration that may be used for starting Envoy. */
 public class EnvoyConfiguration {
+  // Peer certificate verification mode.
+  // Must match the CertificateValidationContext.TrustChainVerification proto enum.
+  public enum TrustChainVerification {
+    // Perform default certificate verification (e.g., against CA / verification lists)
+    VERIFY_TRUST_CHAIN,
+    // Connections where the certificate fails verification will be permitted.
+    // For HTTP connections, the result of certificate verification can be used in route matching.
+    // Mostly used for testing.
+    ACCEPT_UNTRUSTED;
+  }
+
   public final Boolean adminInterfaceEnabled;
   public final String grpcStatsDomain;
   public final Integer statsdPort;
@@ -33,6 +44,7 @@ public class EnvoyConfiguration {
   public final Integer perTryIdleTimeoutSeconds;
   public final String appVersion;
   public final String appId;
+  public final TrustChainVerification trustChainVerification;
   public final String virtualClusters;
   public final List<EnvoyNativeFilterConfig> nativeFilterChain;
   public final Map<String, EnvoyStringAccessor> stringAccessors;
@@ -63,25 +75,24 @@ public class EnvoyConfiguration {
    * @param perTryIdleTimeoutSeconds     per try idle timeout for HTTP streams.
    * @param appVersion                   the App Version of the App using this Envoy Client.
    * @param appId                        the App ID of the App using this Envoy Client.
+   * @param trustChainVerification       wether or not to make TLS verification a passthrough.
    * @param virtualClusters              the JSON list of virtual cluster configs.
    * @param nativeFilterChain            the configuration for native filters.
    * @param httpPlatformFilterFactories  the configuration for platform filters.
    * @param stringAccessors              platform string accessors to register.
    */
-  public EnvoyConfiguration(Boolean adminInterfaceEnabled, String grpcStatsDomain,
-                            @Nullable Integer statsdPort, int connectTimeoutSeconds,
-                            int dnsRefreshSeconds, int dnsFailureRefreshSecondsBase,
-                            int dnsFailureRefreshSecondsMax, int dnsQueryTimeoutSeconds,
-                            String dnsPreresolveHostnames, List<String> dnsFallbackNameservers,
-                            Boolean dnsFilterUnroutableFamilies, boolean enableHappyEyeballs,
-                            boolean enableInterfaceBinding,
-                            int h2ConnectionKeepaliveIdleIntervalMilliseconds,
-                            int h2ConnectionKeepaliveTimeoutSeconds, int statsFlushSeconds,
-                            int streamIdleTimeoutSeconds, int perTryIdleTimeoutSeconds,
-                            String appVersion, String appId, String virtualClusters,
-                            List<EnvoyNativeFilterConfig> nativeFilterChain,
-                            List<EnvoyHTTPFilterFactory> httpPlatformFilterFactories,
-                            Map<String, EnvoyStringAccessor> stringAccessors) {
+  public EnvoyConfiguration(
+      Boolean adminInterfaceEnabled, String grpcStatsDomain, @Nullable Integer statsdPort,
+      int connectTimeoutSeconds, int dnsRefreshSeconds, int dnsFailureRefreshSecondsBase,
+      int dnsFailureRefreshSecondsMax, int dnsQueryTimeoutSeconds, String dnsPreresolveHostnames,
+      List<String> dnsFallbackNameservers, Boolean dnsFilterUnroutableFamilies,
+      boolean enableHappyEyeballs, boolean enableInterfaceBinding,
+      int h2ConnectionKeepaliveIdleIntervalMilliseconds, int h2ConnectionKeepaliveTimeoutSeconds,
+      int statsFlushSeconds, int streamIdleTimeoutSeconds, int perTryIdleTimeoutSeconds,
+      String appVersion, String appId, TrustChainVerification trustChainVerification,
+      String virtualClusters, List<EnvoyNativeFilterConfig> nativeFilterChain,
+      List<EnvoyHTTPFilterFactory> httpPlatformFilterFactories,
+      Map<String, EnvoyStringAccessor> stringAccessors) {
     this.adminInterfaceEnabled = adminInterfaceEnabled;
     this.grpcStatsDomain = grpcStatsDomain;
     this.statsdPort = statsdPort;
@@ -103,6 +114,7 @@ public class EnvoyConfiguration {
     this.perTryIdleTimeoutSeconds = perTryIdleTimeoutSeconds;
     this.appVersion = appVersion;
     this.appId = appId;
+    this.trustChainVerification = trustChainVerification;
     this.virtualClusters = virtualClusters;
     this.nativeFilterChain = nativeFilterChain;
     this.httpPlatformFilterFactories = httpPlatformFilterFactories;
@@ -123,6 +135,7 @@ public class EnvoyConfiguration {
   String resolveTemplate(final String templateYAML, final String platformFilterTemplateYAML,
                          final String nativeFilterTemplateYAML) {
     final StringBuilder customFiltersBuilder = new StringBuilder();
+    System.err.println("nativeFilterTemplateYAML\n" +nativeFilterTemplateYAML);
 
     for (EnvoyHTTPFilterFactory filterFactory : httpPlatformFilterFactories) {
       String filterConfig = platformFilterTemplateYAML.replace("{{ platform_filter_name }}",
@@ -175,6 +188,7 @@ public class EnvoyConfiguration {
         .append(String.format("- &per_try_idle_timeout %ss\n", perTryIdleTimeoutSeconds))
         .append(String.format("- &metadata { device_os: %s, app_version: %s, app_id: %s }\n",
                               "Android", appVersion, appId))
+        .append(String.format("- &trust_chain_verification %s\n", trustChainVerification.name()))
         .append("- &virtual_clusters ")
         .append(virtualClusters)
         .append("\n");

--- a/library/java/org/chromium/net/impl/NativeCronetEngineBuilderImpl.java
+++ b/library/java/org/chromium/net/impl/NativeCronetEngineBuilderImpl.java
@@ -1,10 +1,13 @@
 package org.chromium.net.impl;
 
+import static io.envoyproxy.envoymobile.engine.EnvoyConfiguration.TrustChainVerification.VERIFY_TRUST_CHAIN;
+
 import android.content.Context;
 import io.envoyproxy.envoymobile.engine.AndroidEngineImpl;
 import io.envoyproxy.envoymobile.engine.AndroidJniLibrary;
 import io.envoyproxy.envoymobile.engine.AndroidNetworkMonitor;
 import io.envoyproxy.envoymobile.engine.EnvoyConfiguration;
+import io.envoyproxy.envoymobile.engine.EnvoyConfiguration.TrustChainVerification;
 import io.envoyproxy.envoymobile.engine.EnvoyEngine;
 import io.envoyproxy.envoymobile.engine.EnvoyNativeFilterConfig;
 import io.envoyproxy.envoymobile.engine.types.EnvoyEventTracker;
@@ -45,6 +48,7 @@ public class NativeCronetEngineBuilderImpl extends CronetEngineBuilderImpl {
   private int mPerTryIdleTimeoutSeconds = 15;
   private String mAppVersion = "unspecified";
   private String mAppId = "unspecified";
+  private TrustChainVerification mTrustChainVerification = VERIFY_TRUST_CHAIN;
   private String mVirtualClusters = "[]";
   private List<EnvoyHTTPFilterFactory> mPlatformFilterChain = Collections.emptyList();
   private List<EnvoyNativeFilterConfig> mNativeFilterChain = Collections.emptyList();
@@ -82,6 +86,7 @@ public class NativeCronetEngineBuilderImpl extends CronetEngineBuilderImpl {
         mEnableDnsFilterUnroutableFamilies, mEnableHappyEyeballs, mEnableInterfaceBinding,
         mH2ConnectionKeepaliveIdleIntervalMilliseconds, mH2ConnectionKeepaliveTimeoutSeconds,
         mStatsFlushSeconds, mStreamIdleTimeoutSeconds, mPerTryIdleTimeoutSeconds, mAppVersion,
-        mAppId, mVirtualClusters, mNativeFilterChain, mPlatformFilterChain, mStringAccessors);
+        mAppId, mTrustChainVerification, mVirtualClusters, mNativeFilterChain, mPlatformFilterChain,
+        mStringAccessors);
   }
 }

--- a/library/kotlin/io/envoyproxy/envoymobile/EngineBuilder.kt
+++ b/library/kotlin/io/envoyproxy/envoymobile/EngineBuilder.kt
@@ -382,7 +382,7 @@ open class EngineBuilder(
   /**
    * Set how the TrustChainVerification must be handled.
    *
-   * @param trustChainVerification wether to mute TLS Cert verification - for tests only
+   * @param trustChainVerification whether to mute TLS Cert verification - intended for testing
    *
    * @return this builder.
    */

--- a/library/kotlin/io/envoyproxy/envoymobile/EngineBuilder.kt
+++ b/library/kotlin/io/envoyproxy/envoymobile/EngineBuilder.kt
@@ -1,6 +1,7 @@
 package io.envoyproxy.envoymobile
 
 import io.envoyproxy.envoymobile.engine.EnvoyConfiguration
+import io.envoyproxy.envoymobile.engine.EnvoyConfiguration.TrustChainVerification
 import io.envoyproxy.envoymobile.engine.EnvoyEngine
 import io.envoyproxy.envoymobile.engine.EnvoyEngineImpl
 import io.envoyproxy.envoymobile.engine.EnvoyNativeFilterConfig
@@ -46,6 +47,7 @@ open class EngineBuilder(
   private var perTryIdleTimeoutSeconds = 15
   private var appVersion = "unspecified"
   private var appId = "unspecified"
+  private var trustChainVerification = TrustChainVerification.VERIFY_TRUST_CHAIN
   private var virtualClusters = "[]"
   private var platformFilterChain = mutableListOf<EnvoyHTTPFilterFactory>()
   private var nativeFilterChain = mutableListOf<EnvoyNativeFilterConfig>()
@@ -378,6 +380,18 @@ open class EngineBuilder(
   }
 
   /**
+   * Set how the TrustChainVerification must be done.
+   *
+   * @param trustChainVerification wether or not to make TLS verification a passthrough.
+   *
+   * @return this builder.
+   */
+  fun setTrustChainVerification(trustChainVerification: TrustChainVerification): EngineBuilder {
+    this.trustChainVerification = trustChainVerification
+    return this
+  }
+
+  /**
    * Add virtual cluster configuration.
    *
    * @param virtualClusters the JSON configuration string for virtual clusters.
@@ -433,6 +447,7 @@ open class EngineBuilder(
             perTryIdleTimeoutSeconds,
             appVersion,
             appId,
+            trustChainVerification,
             virtualClusters,
             nativeFilterChain,
             platformFilterChain,
@@ -466,6 +481,7 @@ open class EngineBuilder(
             perTryIdleTimeoutSeconds,
             appVersion,
             appId,
+            trustChainVerification,
             virtualClusters,
             nativeFilterChain,
             platformFilterChain,

--- a/library/kotlin/io/envoyproxy/envoymobile/EngineBuilder.kt
+++ b/library/kotlin/io/envoyproxy/envoymobile/EngineBuilder.kt
@@ -380,9 +380,9 @@ open class EngineBuilder(
   }
 
   /**
-   * Set how the TrustChainVerification must be done.
+   * Set how the TrustChainVerification must be handled.
    *
-   * @param trustChainVerification wether or not to make TLS verification a passthrough.
+   * @param trustChainVerification wether to mute TLS Cert verification - for tests only
    *
    * @return this builder.
    */

--- a/test/java/io/envoyproxy/envoymobile/engine/EnvoyConfigurationTest.kt
+++ b/test/java/io/envoyproxy/envoymobile/engine/EnvoyConfigurationTest.kt
@@ -86,7 +86,7 @@ class EnvoyConfigurationTest {
     val envoyConfiguration = EnvoyConfiguration(
       false, "stats.foo.com", null, 123, 234, 345, 456, 321, "[hostname]", emptyList(), false,
       false, false, 222, 333, 567, 678, 910, "v1.2.3", "com.mydomain.myapp",
-      TrustChainVerification.ACCEPT_UNTRUSTED,"[test]", listOf(EnvoyNativeFilterConfig("filter_name", "test_config")), emptyList(), emptyMap()
+      TrustChainVerification.ACCEPT_UNTRUSTED, "[test]", listOf(EnvoyNativeFilterConfig("filter_name", "test_config")), emptyList(), emptyMap()
     )
 
     val resolvedTemplate = envoyConfiguration.resolveTemplate(
@@ -106,7 +106,7 @@ class EnvoyConfigurationTest {
     val envoyConfiguration = EnvoyConfiguration(
       false, "stats.foo.com", null, 123, 234, 345, 456, 321, "[hostname]", emptyList(), false,
       false, false, 123, 123, 567, 678, 910, "v1.2.3", "com.mydomain.myapp",
-      TrustChainVerification.ACCEPT_UNTRUSTED,"[test]", emptyList(), emptyList(), emptyMap()
+      TrustChainVerification.ACCEPT_UNTRUSTED, "[test]", emptyList(), emptyList(), emptyMap()
     )
 
     try {
@@ -122,7 +122,7 @@ class EnvoyConfigurationTest {
     val envoyConfiguration = EnvoyConfiguration(
       false, "stats.foo.com", 5050, 123, 234, 345, 456, 321, "[hostname]", emptyList(), false,
       false, false, 123, 123, 567, 678, 910, "v1.2.3", "com.mydomain.myapp",
-      TrustChainVerification.ACCEPT_UNTRUSTED,"[test]", emptyList(), emptyList(), emptyMap()
+      TrustChainVerification.ACCEPT_UNTRUSTED, "[test]", emptyList(), emptyList(), emptyMap()
     )
 
     try {

--- a/test/java/io/envoyproxy/envoymobile/engine/EnvoyConfigurationTest.kt
+++ b/test/java/io/envoyproxy/envoymobile/engine/EnvoyConfigurationTest.kt
@@ -31,7 +31,8 @@ class EnvoyConfigurationTest {
     val envoyConfiguration = EnvoyConfiguration(
       false, "stats.foo.com", null, 123, 234, 345, 456, 321, "[hostname]", listOf("8.8.8.8"), true,
       true, true, 222, 333, 567, 678, 910, "v1.2.3", "com.mydomain.myapp",
-      TrustChainVerification.ACCEPT_UNTRUSTED, "[test]", listOf(EnvoyNativeFilterConfig("filter_name", "test_config")), emptyList(), emptyMap()
+      TrustChainVerification.ACCEPT_UNTRUSTED, "[test]",
+      listOf(EnvoyNativeFilterConfig("filter_name", "test_config")), emptyList(), emptyMap()
     )
 
     val resolvedTemplate = envoyConfiguration.resolveTemplate(
@@ -86,7 +87,8 @@ class EnvoyConfigurationTest {
     val envoyConfiguration = EnvoyConfiguration(
       false, "stats.foo.com", null, 123, 234, 345, 456, 321, "[hostname]", emptyList(), false,
       false, false, 222, 333, 567, 678, 910, "v1.2.3", "com.mydomain.myapp",
-      TrustChainVerification.ACCEPT_UNTRUSTED, "[test]", listOf(EnvoyNativeFilterConfig("filter_name", "test_config")), emptyList(), emptyMap()
+      TrustChainVerification.ACCEPT_UNTRUSTED, "[test]",
+      listOf(EnvoyNativeFilterConfig("filter_name", "test_config")), emptyList(), emptyMap()
     )
 
     val resolvedTemplate = envoyConfiguration.resolveTemplate(

--- a/test/java/io/envoyproxy/envoymobile/engine/EnvoyConfigurationTest.kt
+++ b/test/java/io/envoyproxy/envoymobile/engine/EnvoyConfigurationTest.kt
@@ -1,5 +1,6 @@
 package io.envoyproxy.envoymobile.engine
 
+import io.envoyproxy.envoymobile.engine.EnvoyConfiguration.TrustChainVerification
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.Assert.fail
 import org.junit.Test
@@ -28,9 +29,9 @@ class EnvoyConfigurationTest {
   @Test
   fun `resolving with default configuration resolves with values`() {
     val envoyConfiguration = EnvoyConfiguration(
-      false, "stats.foo.com", null, 123, 234, 345, 456, 321, "[hostname]", listOf("8.8.8.8"), true, true, true, 222, 333, 567, 678, 910, "v1.2.3", "com.mydomain.myapp", "[test]",
-      listOf(EnvoyNativeFilterConfig("filter_name", "test_config")),
-      emptyList(), emptyMap()
+      false, "stats.foo.com", null, 123, 234, 345, 456, 321, "[hostname]", listOf("8.8.8.8"), true,
+      true, true, 222, 333, 567, 678, 910, "v1.2.3", "com.mydomain.myapp",
+      TrustChainVerification.ACCEPT_UNTRUSTED, "[test]", listOf(EnvoyNativeFilterConfig("filter_name", "test_config")), emptyList(), emptyMap()
     )
 
     val resolvedTemplate = envoyConfiguration.resolveTemplate(
@@ -72,6 +73,9 @@ class EnvoyConfigurationTest {
     assertThat(resolvedTemplate).contains("&stream_idle_timeout 678s")
     assertThat(resolvedTemplate).contains("&per_try_idle_timeout 910s")
 
+    // TlS Verification
+    assertThat(resolvedTemplate).contains("&trust_chain_verification ACCEPT_UNTRUSTED")
+
     // Filters
     assertThat(resolvedTemplate).contains("filter_name")
     assertThat(resolvedTemplate).contains("test_config")
@@ -80,9 +84,9 @@ class EnvoyConfigurationTest {
   @Test
   fun `resolving with alternate values also sets appropriate config`() {
     val envoyConfiguration = EnvoyConfiguration(
-      false, "stats.foo.com", null, 123, 234, 345, 456, 321, "[hostname]", emptyList(), false, false, false, 222, 333, 567, 678, 910, "v1.2.3", "com.mydomain.myapp", "[test]",
-      listOf(EnvoyNativeFilterConfig("filter_name", "test_config")),
-      emptyList(), emptyMap()
+      false, "stats.foo.com", null, 123, 234, 345, 456, 321, "[hostname]", emptyList(), false,
+      false, false, 222, 333, 567, 678, 910, "v1.2.3", "com.mydomain.myapp",
+      TrustChainVerification.ACCEPT_UNTRUSTED,"[test]", listOf(EnvoyNativeFilterConfig("filter_name", "test_config")), emptyList(), emptyMap()
     )
 
     val resolvedTemplate = envoyConfiguration.resolveTemplate(
@@ -100,8 +104,9 @@ class EnvoyConfigurationTest {
   @Test
   fun `resolve templates with invalid templates will throw on build`() {
     val envoyConfiguration = EnvoyConfiguration(
-      false, "stats.foo.com", null, 123, 234, 345, 456, 321, "[hostname]", emptyList(), false, false, false, 123, 123, 567, 678, 910, "v1.2.3", "com.mydomain.myapp", "[test]",
-      emptyList(), emptyList(), emptyMap()
+      false, "stats.foo.com", null, 123, 234, 345, 456, 321, "[hostname]", emptyList(), false,
+      false, false, 123, 123, 567, 678, 910, "v1.2.3", "com.mydomain.myapp",
+      TrustChainVerification.ACCEPT_UNTRUSTED,"[test]", emptyList(), emptyList(), emptyMap()
     )
 
     try {
@@ -115,8 +120,9 @@ class EnvoyConfigurationTest {
   @Test
   fun `cannot configure both statsD and gRPC stat sink`() {
     val envoyConfiguration = EnvoyConfiguration(
-      false, "stats.foo.com", 5050, 123, 234, 345, 456, 321, "[hostname]", emptyList(), false, false, false, 123, 123, 567, 678, 910, "v1.2.3", "com.mydomain.myapp", "[test]",
-      emptyList(), emptyList(), emptyMap()
+      false, "stats.foo.com", 5050, 123, 234, 345, 456, 321, "[hostname]", emptyList(), false,
+      false, false, 123, 123, 567, 678, 910, "v1.2.3", "com.mydomain.myapp",
+      TrustChainVerification.ACCEPT_UNTRUSTED,"[test]", emptyList(), emptyList(), emptyMap()
     )
 
     try {

--- a/test/java/org/chromium/net/testing/BUILD
+++ b/test/java/org/chromium/net/testing/BUILD
@@ -29,7 +29,7 @@ android_library(
         "TestUrlRequestCallback.java",
         "UrlUtils.java",
     ],
-    data = glob(["data/*"]),
+    data = glob(["data/*"]) + ["@envoy//test/config/integration/certs"],
     visibility = ["//test:__subpackages__"],
     deps = [
         "//library/java/io/envoyproxy/envoymobile/engine:envoy_base_engine_lib",
@@ -67,6 +67,25 @@ envoy_mobile_android_test(
         "//library/java/io/envoyproxy/envoymobile/engine:envoy_engine_lib",
         "//library/java/org/chromium/net/impl:cronvoy",
         "//library/kotlin/io/envoyproxy/envoymobile:envoy_interfaces_lib",
+        "//library/kotlin/io/envoyproxy/envoymobile:envoy_lib",
+    ],
+)
+
+envoy_mobile_android_test(
+    name = "http2_test_server_test",
+    srcs = [
+        "Http2TestServerTest.java",
+    ],
+    exec_properties = {
+        # TODO(lfpino): Remove this once the sandboxNetwork=off works for ipv4 localhost addresses.
+        "sandboxNetwork": "standard",
+    },
+    native_deps = [
+        "//library/common/jni:libndk_envoy_jni.so",
+        "//library/common/jni:libndk_envoy_jni.jnilib",
+    ],
+    deps = [
+        ":testing",
         "//library/kotlin/io/envoyproxy/envoymobile:envoy_lib",
     ],
 )

--- a/test/java/org/chromium/net/testing/CronetTestRule.java
+++ b/test/java/org/chromium/net/testing/CronetTestRule.java
@@ -49,12 +49,14 @@ public final class CronetTestRule implements TestRule {
   /**
    * Name of the file that contains the test server certificate in PEM format.
    */
-  public static final String SERVER_CERT_PEM = "quic-chain.pem";
+  public static final String SERVER_CERT_PEM =
+      "../envoy/test/config/integration/certs/upstreamcert.pem";
 
   /**
    * Name of the file that contains the test server private key in PKCS8 PEM format.
    */
-  public static final String SERVER_KEY_PKCS8_PEM = "quic-leaf-cert.key.pkcs8.pem";
+  public static final String SERVER_KEY_PKCS8_PEM =
+      "../envoy/test/config/integration/certs/upstreamkey.pem";
 
   private static final String TAG = CronetTestRule.class.getSimpleName();
 

--- a/test/java/org/chromium/net/testing/Http2TestServer.java
+++ b/test/java/org/chromium/net/testing/Http2TestServer.java
@@ -16,7 +16,6 @@ import io.netty.channel.EventLoopGroup;
 import io.netty.channel.nio.NioEventLoopGroup;
 import io.netty.channel.socket.SocketChannel;
 import io.netty.channel.socket.nio.NioServerSocketChannel;
-import io.netty.handler.codec.http2.Http2SecurityUtil;
 import io.netty.handler.logging.LogLevel;
 import io.netty.handler.logging.LoggingHandler;
 import io.netty.handler.ssl.ApplicationProtocolConfig;
@@ -25,9 +24,8 @@ import io.netty.handler.ssl.ApplicationProtocolConfig.SelectedListenerFailureBeh
 import io.netty.handler.ssl.ApplicationProtocolConfig.SelectorFailureBehavior;
 import io.netty.handler.ssl.ApplicationProtocolNames;
 import io.netty.handler.ssl.ApplicationProtocolNegotiationHandler;
-import io.netty.handler.ssl.OpenSslServerContext;
+import io.netty.handler.ssl.SslContextBuilder;
 import io.netty.handler.ssl.SslContext;
-import io.netty.handler.ssl.SupportedCipherSuiteFilter;
 
 /**
  * Wrapper class to start a HTTP/2 test server.
@@ -157,9 +155,9 @@ public final class Http2TestServer {
       // exist. Just avoid a KeyManagerFactory as it's unnecessary for our testing.
       System.setProperty("io.netty.handler.ssl.openssl.useKeyManagerFactory", "false");
 
-      mSslCtx = new OpenSslServerContext(certFile, keyFile, null, null, Http2SecurityUtil.CIPHERS,
-                                         SupportedCipherSuiteFilter.INSTANCE,
-                                         applicationProtocolConfig, 0, 0);
+      mSslCtx = SslContextBuilder.forServer(certFile, keyFile)
+                    .applicationProtocolConfig(applicationProtocolConfig)
+                    .build();
 
       mHangingUrlLatch = hangingUrlLatch;
     }

--- a/test/java/org/chromium/net/testing/Http2TestServerTest.java
+++ b/test/java/org/chromium/net/testing/Http2TestServerTest.java
@@ -1,0 +1,201 @@
+package org.chromium.net.testing;
+
+import static io.envoyproxy.envoymobile.engine.EnvoyConfiguration.TrustChainVerification.ACCEPT_UNTRUSTED;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.chromium.net.testing.CronetTestRule.SERVER_CERT_PEM;
+import static org.chromium.net.testing.CronetTestRule.SERVER_KEY_PKCS8_PEM;
+
+import android.content.Context;
+import androidx.test.core.app.ApplicationProvider;
+import androidx.test.ext.junit.runners.AndroidJUnit4;
+import io.envoyproxy.envoymobile.AndroidEngineBuilder;
+import io.envoyproxy.envoymobile.Engine;
+import io.envoyproxy.envoymobile.EnvoyError;
+import io.envoyproxy.envoymobile.RequestHeaders;
+import io.envoyproxy.envoymobile.RequestHeadersBuilder;
+import io.envoyproxy.envoymobile.RequestMethod;
+import io.envoyproxy.envoymobile.ResponseHeaders;
+import io.envoyproxy.envoymobile.ResponseTrailers;
+import io.envoyproxy.envoymobile.UpstreamHttpProtocol;
+import io.envoyproxy.envoymobile.engine.AndroidJniLibrary;
+import java.net.MalformedURLException;
+import java.net.URL;
+import java.nio.ByteBuffer;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.Executors;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicReference;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+@RunWith(AndroidJUnit4.class)
+public class Http2TestServerTest {
+
+  private Engine engine;
+
+  @BeforeClass
+  public static void loadJniLibrary() {
+    AndroidJniLibrary.loadTestLibrary();
+  }
+
+  @Before
+  public void setUpEngine() throws Exception {
+    CountDownLatch latch = new CountDownLatch(1);
+    Context appContext = ApplicationProvider.getApplicationContext();
+    engine = new AndroidEngineBuilder(appContext)
+                 .setTrustChainVerification(ACCEPT_UNTRUSTED)
+                 .setOnEngineRunning(() -> {
+                   latch.countDown();
+                   return null;
+                 })
+                 .build();
+    Http2TestServer.startHttp2TestServer(appContext, SERVER_CERT_PEM, SERVER_KEY_PKCS8_PEM);
+    latch.await(); // Don't launch a request before initialization has completed.
+  }
+
+  @After
+  public void shutdown() throws Exception {
+    engine.terminate();
+    Http2TestServer.shutdownHttp2TestServer();
+  }
+
+  @Test
+  public void get_schemeIsHttps() throws Exception {
+    RequestScenario requestScenario = new RequestScenario()
+                                          .setHttpMethod(RequestMethod.GET)
+                                          .setUrl(Http2TestServer.getEchoAllHeadersUrl());
+
+    Response response = sendRequest(requestScenario);
+
+    assertThat(response.getHeaders().getHttpStatus()).isEqualTo(200);
+    assertThat(response.getBodyAsString()).contains(":scheme: https");
+    assertThat(response.getEnvoyError()).isNull();
+  }
+
+  private Response sendRequest(RequestScenario requestScenario) throws Exception {
+    final CountDownLatch latch = new CountDownLatch(1);
+    final AtomicReference<Response> response = new AtomicReference<>(new Response());
+
+    engine.streamClient()
+        .newStreamPrototype()
+        .setOnResponseHeaders((responseHeaders, endStream, ignored) -> {
+          response.get().setHeaders(responseHeaders);
+          return null;
+        })
+        .setOnResponseData((data, endStream, ignored) -> {
+          response.get().addBody(data);
+          return null;
+        })
+        .setOnResponseTrailers((trailers, ignored) -> {
+          response.get().setTrailers(trailers);
+          return null;
+        })
+        .setOnError((error, ignored) -> {
+          response.get().setEnvoyError(error);
+          latch.countDown();
+          return null;
+        })
+        .setOnCancel((ignored) -> {
+          response.get().setCancelled();
+          latch.countDown();
+          return null;
+        })
+        .setOnComplete((ignore) -> {
+          latch.countDown();
+          return null;
+        })
+        .start(Executors.newSingleThreadExecutor())
+        .sendHeaders(requestScenario.getHeaders(), /* hasRequestBody= */ false);
+
+    latch.await();
+    response.get().throwAssertionErrorIfAny();
+    return response.get();
+  }
+
+  private static class RequestScenario {
+
+    private URL url;
+    private RequestMethod method = null;
+
+    RequestHeaders getHeaders() {
+      RequestHeadersBuilder requestHeadersBuilder =
+          new RequestHeadersBuilder(method, url.getProtocol(), url.getAuthority(), url.getPath());
+      return requestHeadersBuilder.addUpstreamHttpProtocol(UpstreamHttpProtocol.HTTP2).build();
+    }
+
+    RequestScenario setHttpMethod(RequestMethod requestMethod) {
+      this.method = requestMethod;
+      return this;
+    }
+
+    RequestScenario setUrl(String url) throws MalformedURLException {
+      this.url = new URL(url);
+      return this;
+    }
+  }
+
+  private static class Response {
+    private final AtomicReference<ResponseHeaders> headers = new AtomicReference<>();
+    private final AtomicReference<ResponseTrailers> trailers = new AtomicReference<>();
+    private final AtomicReference<EnvoyError> envoyError = new AtomicReference<>();
+    private final List<ByteBuffer> bodies = new ArrayList<>();
+    private final AtomicBoolean cancelled = new AtomicBoolean(false);
+    private final AtomicReference<AssertionError> assertionError = new AtomicReference<>();
+
+    void setHeaders(ResponseHeaders headers) {
+      if (!this.headers.compareAndSet(null, headers)) {
+        assertionError.compareAndSet(
+            null, new AssertionError("setOnResponseHeaders called more than once."));
+      }
+    }
+
+    void addBody(ByteBuffer body) { bodies.add(body); }
+
+    void setTrailers(ResponseTrailers trailers) {
+      if (!this.trailers.compareAndSet(null, trailers)) {
+        assertionError.compareAndSet(
+            null, new AssertionError("setOnResponseTrailers called more than once."));
+      }
+    }
+
+    void setEnvoyError(EnvoyError envoyError) {
+      if (!this.envoyError.compareAndSet(null, envoyError)) {
+        assertionError.compareAndSet(null, new AssertionError("setOnError called more than once."));
+      }
+    }
+
+    void setCancelled() {
+      if (!cancelled.compareAndSet(false, true)) {
+        assertionError.compareAndSet(null,
+                                     new AssertionError("setOnCancel called more than once."));
+      }
+    }
+
+    EnvoyError getEnvoyError() { return envoyError.get(); }
+
+    ResponseHeaders getHeaders() { return headers.get(); }
+
+    String getBodyAsString() {
+      int totalSize = bodies.stream().mapToInt(ByteBuffer::limit).sum();
+      byte[] body = new byte[totalSize];
+      int pos = 0;
+      for (ByteBuffer buffer : bodies) {
+        int bytesToRead = buffer.limit();
+        buffer.get(body, pos, bytesToRead);
+        pos += bytesToRead;
+      }
+      return new String(body);
+    }
+
+    void throwAssertionErrorIfAny() {
+      if (assertionError.get() != null) {
+        throw assertionError.get();
+      }
+    }
+  }
+}

--- a/test/java/org/chromium/net/testing/Http2TestServerTest.java
+++ b/test/java/org/chromium/net/testing/Http2TestServerTest.java
@@ -74,6 +74,7 @@ public class Http2TestServerTest {
 
     assertThat(response.getHeaders().getHttpStatus()).isEqualTo(200);
     assertThat(response.getBodyAsString()).contains(":scheme: https");
+    assertThat(response.getHeaders().value("x-envoy-upstream-alpn")).containsExactly("h2");
     assertThat(response.getEnvoyError()).isNull();
   }
 

--- a/test/java/org/chromium/net/testing/Http2TestServerTest.java
+++ b/test/java/org/chromium/net/testing/Http2TestServerTest.java
@@ -65,7 +65,7 @@ public class Http2TestServerTest {
   }
 
   @Test
-  public void get_schemeIsHttps() throws Exception {
+  public void getSchemeIsHttps() throws Exception {
     RequestScenario requestScenario = new RequestScenario()
                                           .setHttpMethod(RequestMethod.GET)
                                           .setUrl(Http2TestServer.getEchoAllHeadersUrl());


### PR DESCRIPTION
PLEASE READ

- With this PR, only one `UpstreamTlsContext` supports the configurable `trust_chain_verification`:  [`&base_tls_h2_socket`](https://github.com/envoyproxy/envoy-mobile/blob/v0.4.5.02082022/library/common/config/config.cc#L112). The other one, `&base_tls_socket`, does not.

- `&base_tls_h2_socket` has been inlined. Consequently, `&base_tls_h2_socket` does not exist anymore. Unfortunately, when a config variable is assigned in the Java code, it won't get substituted when encountered inside another config variable.

- Swift/objective-c/c++ configuration classes were not updated. Only Java and Kotlin were.

Description: Allow tests to avoid TLS Cert Verification
Risk Level: Small
Testing: New test and CI
Docs Changes: N/A
Release Notes: N/A
Signed-off-by: Charles Le Borgne <cleborgne@google.com>