### PR TITLE
Revert "CI: Re-enable engflow for kotlin tests (#2071)"

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -119,11 +119,6 @@ build:remote-ci-common --spawn_strategy=remote,sandboxed,local
 # sends a keepalive if we don't receive any messages (server updates every 60s).
 build:remote-ci-common --grpc_keepalive_time=61s
 #############################################################################
-# remote-ci-local-java8: Use a local Java 8 (JDK)
-#############################################################################
-build:remote-ci-local-java8 --java_runtime_version=local_jdk
-build:remote-ci-local-java8 --java_language_version=8
-#############################################################################
 # remote-ci-linux: These options are linux-only using GCC by default
 #############################################################################
 # Common Engflow flags
@@ -179,6 +174,13 @@ build:remote-ci-linux-tsan --extra_toolchains=//third_party/rbe_configs/config:c
 build:remote-ci-linux-tsan --host_platform=//third_party/rbe_configs/config:platform
 build:remote-ci-linux-tsan --platforms=//third_party/rbe_configs/config:platform
 build:remote-ci-linux-tsan --config=remote-ci-common
+#############################################################################
+# remote-ci-linux-local-java8: These options are linux-only using a local Java 8 (JDK)
+#############################################################################
+build:remote-ci-linux-local-java8 --extra_toolchains=@local_jdk//:all
+build:remote-ci-linux-local-java8 --host_java_toolchain=@bazel_tools//tools/jdk:toolchain_java8
+build:remote-ci-linux-local-java8 --java_toolchain=@bazel_tools//tools/jdk:toolchain_java8
+build:remote-ci-linux-local-java8 --config=remote-ci-common
 #############################################################################
 # remote-ci-linux-coverage: These options are Linux-only using Clang and LLVM coverage
 #############################################################################

--- a/.github/workflows/android_tests.yml
+++ b/.github/workflows/android_tests.yml
@@ -45,9 +45,6 @@ jobs:
           ./bazelw test \
             --test_output=all \
             --build_tests_only \
-            --config=remote-ci-macos \
-            --config=remote-ci-local-java8 \
-            --remote_header="Authorization=Bearer $GITHUB_TOKEN" \
             //test/kotlin/io/...
   javatestsmac:
     name: java_tests_mac
@@ -86,7 +83,6 @@ jobs:
             --test_output=all \
             --build_tests_only \
             --config=remote-ci-macos \
-            --config=remote-ci-local-java8 \
             --remote_header="Authorization=Bearer $GITHUB_TOKEN" \
             --define=signal_trace=disabled \
             //test/java/...
@@ -131,6 +127,6 @@ jobs:
             --test_output=all \
             --build_tests_only \
             --config=remote-ci-linux-clang \
-            --config=remote-ci-local-java8 \
+            --config=remote-ci-linux-local-java8 \
             --remote_header="Authorization=Bearer $GITHUB_TOKEN" \
             //test/kotlin/...

--- a/bazel/kotlin_test.bzl
+++ b/bazel/kotlin_test.bzl
@@ -61,8 +61,8 @@ def envoy_mobile_jni_kt_test(name, srcs, native_deps = [], deps = [], library_pa
 #         "ExampleTest.kt",
 #     ],
 # )
-def envoy_mobile_kt_test(name, srcs, deps = [], repository = "", exec_properties = {}):
-    _internal_kt_test(name, srcs, deps, repository = repository, exec_properties = exec_properties)
+def envoy_mobile_kt_test(name, srcs, deps = [], repository = ""):
+    _internal_kt_test(name, srcs, deps, repository = repository)
 
 # A basic macro to run android based (robolectric) tests with native dependencies
 def envoy_mobile_android_test(name, srcs, deps = [], native_deps = [], repository = "", library_path = "library/common/jni", exec_properties = {}):

--- a/test/kotlin/io/envoyproxy/envoymobile/BUILD
+++ b/test/kotlin/io/envoyproxy/envoymobile/BUILD
@@ -7,10 +7,6 @@ envoy_mobile_kt_test(
     srcs = [
         "EngineBuilderTest.kt",
     ],
-    exec_properties = {
-        # TODO(lfpino): Remove this once the JVM paths are allow-listed in the sandbox.
-        "sandboxAllowed": "False",
-    },
     deps = [
         "//library/kotlin/io/envoyproxy/envoymobile:envoy_interfaces_lib",
     ],
@@ -51,10 +47,6 @@ envoy_mobile_kt_test(
     srcs = [
         "PulseClientImplTest.kt",
     ],
-    exec_properties = {
-        # TODO(lfpino): Remove this once the JVM paths are allow-listed in the sandbox.
-        "sandboxAllowed": "False",
-    },
     deps = [
         "//library/kotlin/io/envoyproxy/envoymobile:envoy_interfaces_lib",
     ],


### PR DESCRIPTION
Description: This reverts commit 66ce0b5d5db57ed3fc1bfcb63ca7d75157e5b22b. Reverting temporarily due to remote exec issues.
Risk Level: Low
Testing: CI

Signed-off-by: Mike Schore <mike.schore@gmail.com>