### PR TITLE
routing/cluster changes: move cluster selection to Envoy's routing table

### DIFF
--- a/library/common/config/config.cc
+++ b/library/common/config/config.cc
@@ -46,7 +46,7 @@ const std::string config_header = R"(
 - &enable_interface_binding false
 - &h2_connection_keepalive_idle_interval 100000s
 - &h2_connection_keepalive_timeout 10s
-- &h2_hostnames []
+- &h2_hostnames ["api.foo.bar"]
 - &metadata {}
 - &stats_domain 127.0.0.1
 - &stats_flush_interval 60s
@@ -239,13 +239,15 @@ static_resources:
               routes:
 #{custom_routes}
               - match:
+                  prefix: "/"
                   headers:
                   - name: ":scheme"
-                    value: http
+                    string_match:
+                      exact: http
                 request_headers_to_remove:
                 - x-forwarded-proto
                 route:
-                  cluster: base
+                  cluster: base_clear
                   timeout: 0s
                   retry_policy:
                     per_try_idle_timeout: *per_try_idle_timeout

--- a/library/common/config/config.cc
+++ b/library/common/config/config.cc
@@ -167,7 +167,6 @@ const char* config_template = R"(
                 direct_response: { status: 404, body: { inline_string: "not found" } }
                 request_headers_to_remove:
                 - x-forwarded-proto
-                - x-envoy-mobile-cluster
           http_filters:
           - name: envoy.router
             typed_config:

--- a/library/common/config/config.cc
+++ b/library/common/config/config.cc
@@ -46,6 +46,7 @@ const std::string config_header = R"(
 - &enable_interface_binding false
 - &h2_connection_keepalive_idle_interval 100000s
 - &h2_connection_keepalive_timeout 10s
+- &h2_hostnames []
 - &metadata {}
 - &stats_domain 127.0.0.1
 - &stats_flush_interval 60s
@@ -214,18 +215,48 @@ static_resources:
           route_config:
             name: api_router
             virtual_hosts:
-            - name: api
+            - name: h2
               include_attempt_count_in_response: true
               virtual_clusters: *virtual_clusters
-              domains: ["*"]
+              domains: *h2_hostnames
               routes:
 #{custom_routes}
               - match: { prefix: "/" }
                 request_headers_to_remove:
                 - x-forwarded-proto
-                - x-envoy-mobile-cluster
                 route:
-                  cluster_header: x-envoy-mobile-cluster
+                  cluster: base_h2
+                  timeout: 0s
+                  retry_policy:
+                    per_try_idle_timeout: *per_try_idle_timeout
+                    retry_back_off:
+                      base_interval: 0.25s
+                      max_interval: 60s
+            - name: catchall
+              include_attempt_count_in_response: true
+              virtual_clusters: *virtual_clusters
+              domains: ["*"]
+              routes:
+#{custom_routes}
+              - match:
+                  headers:
+                  - name: ":scheme"
+                    value: http
+                request_headers_to_remove:
+                - x-forwarded-proto
+                route:
+                  cluster: base
+                  timeout: 0s
+                  retry_policy:
+                    per_try_idle_timeout: *per_try_idle_timeout
+                    retry_back_off:
+                      base_interval: 0.25s
+                      max_interval: 60s
+              - match: { prefix: "/" }
+                request_headers_to_remove:
+                - x-forwarded-proto
+                route:
+                  cluster: base
                   timeout: 0s
                   retry_policy:
                     per_try_idle_timeout: *per_try_idle_timeout
@@ -321,7 +352,7 @@ R"(
     // Therefore, the ejection time is short and the interval for unejection is tight, but not too
     // tight to cause unnecessary churn.
 R"(
-    typed_extension_protocol_options: *http1_protocol_options_defs
+    typed_extension_protocol_options: *base_protocol_options
   - name: base_clear
     connect_timeout: *connect_timeout
     lb_policy: CLUSTER_PROVIDED
@@ -347,14 +378,6 @@ R"(
             trusted_ca:
               inline_string: *tls_root_certs
             trust_chain_verification: *trust_chain_verification
-    upstream_connection_options: *upstream_opts
-    circuit_breakers: *circuit_breakers_settings
-    typed_extension_protocol_options: *base_protocol_options
-  - name: base_alpn
-    connect_timeout: *connect_timeout
-    lb_policy: CLUSTER_PROVIDED
-    cluster_type: *base_cluster_type
-    transport_socket: *base_tls_socket
     upstream_connection_options: *upstream_opts
     circuit_breakers: *circuit_breakers_settings
     typed_extension_protocol_options: *base_protocol_options

--- a/library/common/config/config.cc
+++ b/library/common/config/config.cc
@@ -235,6 +235,7 @@ static_resources:
               - match: { prefix: "/" }
                 request_headers_to_remove:
                 - x-forwarded-proto
+                - x-envoy-mobile-upstream-protocol
                 route:
                   cluster: base_h2
                   timeout: 0s
@@ -257,6 +258,7 @@ static_resources:
                       exact: http
                 request_headers_to_remove:
                 - x-forwarded-proto
+                - x-envoy-mobile-upstream-protocol
                 route:
                   cluster: base_clear
                   timeout: 0s
@@ -268,6 +270,7 @@ static_resources:
               - match: { prefix: "/" }
                 request_headers_to_remove:
                 - x-forwarded-proto
+                - x-envoy-mobile-upstream-protocol
                 route:
                   cluster: base
                   timeout: 0s

--- a/library/common/config/config.cc
+++ b/library/common/config/config.cc
@@ -76,7 +76,7 @@ const std::string config_header = R"(
       address:
         socket_address: { address: *statsd_host, port_value: *statsd_port }
 
-!ignore protocol_defs: &http1_protocol_options_defs
+!ignore http1_protocol_options_defs: &http1_protocol_options
     envoy.extensions.upstreams.http.v3.HttpProtocolOptions:
       "@type": type.googleapis.com/envoy.extensions.upstreams.http.v3.HttpProtocolOptions
       explicit_http_config:
@@ -90,7 +90,7 @@ const std::string config_header = R"(
         auto_sni: true
         auto_san_validation: true
 
-!ignore protocol_defs: &http2_protocol_options_defs
+!ignore http2_protocol_options_defs: &http2_protocol_options
     envoy.extensions.upstreams.http.v3.HttpProtocolOptions:
       "@type": type.googleapis.com/envoy.extensions.upstreams.http.v3.HttpProtocolOptions
       explicit_http_config:
@@ -374,7 +374,7 @@ R"(
     transport_socket: { name: envoy.transport_sockets.raw_buffer }
     upstream_connection_options: *upstream_opts
     circuit_breakers: *circuit_breakers_settings
-    typed_extension_protocol_options: *http1_protocol_options_defs
+    typed_extension_protocol_options: *http1_protocol_options
   - name: base_h2
     http2_protocol_options: {}
     connect_timeout: *connect_timeout
@@ -394,7 +394,7 @@ R"(
             trust_chain_verification: *trust_chain_verification
     upstream_connection_options: *upstream_opts
     circuit_breakers: *circuit_breakers_settings
-    typed_extension_protocol_options: *http2_protocol_options_defs
+    typed_extension_protocol_options: *http2_protocol_options
 stats_flush_interval: *stats_flush_interval
 stats_sinks: *stats_sinks
 stats_config:

--- a/library/common/config/config.cc
+++ b/library/common/config/config.cc
@@ -90,6 +90,18 @@ const std::string config_header = R"(
         auto_sni: true
         auto_san_validation: true
 
+!ignore protocol_defs: &http2_protocol_options_defs
+    envoy.extensions.upstreams.http.v3.HttpProtocolOptions:
+      "@type": type.googleapis.com/envoy.extensions.upstreams.http.v3.HttpProtocolOptions
+      explicit_http_config:
+        http2_protocol_options:
+          connection_keepalive:
+            connection_idle_interval: *h2_connection_keepalive_idle_interval
+            timeout: *h2_connection_keepalive_timeout
+      upstream_http_protocol_options:
+        auto_sni: true
+        auto_san_validation: true
+
 !ignore admin_interface_defs: &admin_interface
     address:
       socket_address:
@@ -115,7 +127,7 @@ R"(
 )";
 
 const char* config_template = R"(
-!ignore base_protocol_options_defs: &base_protocol_options
+!ignore alpn_protocol_options_defs: &alpn_protocol_options
   envoy.extensions.upstreams.http.v3.HttpProtocolOptions:
     "@type": type.googleapis.com/envoy.extensions.upstreams.http.v3.HttpProtocolOptions
     auto_config:
@@ -354,7 +366,7 @@ R"(
     // Therefore, the ejection time is short and the interval for unejection is tight, but not too
     // tight to cause unnecessary churn.
 R"(
-    typed_extension_protocol_options: *base_protocol_options
+    typed_extension_protocol_options: *alpn_protocol_options
   - name: base_clear
     connect_timeout: *connect_timeout
     lb_policy: CLUSTER_PROVIDED
@@ -382,7 +394,7 @@ R"(
             trust_chain_verification: *trust_chain_verification
     upstream_connection_options: *upstream_opts
     circuit_breakers: *circuit_breakers_settings
-    typed_extension_protocol_options: *base_protocol_options
+    typed_extension_protocol_options: *http2_protocol_options_defs
 stats_flush_interval: *stats_flush_interval
 stats_sinks: *stats_sinks
 stats_config:

--- a/library/common/http/client.h
+++ b/library/common/http/client.h
@@ -317,7 +317,6 @@ private:
   };
   DirectStreamSharedPtr getStream(envoy_stream_t stream_handle, GetStreamFilters filters);
   void removeStream(envoy_stream_t stream_handle);
-  void setDestinationCluster(RequestHeaderMap& headers);
 
   ApiListener& api_listener_;
   Event::ProvisionalDispatcher& dispatcher_;

--- a/library/kotlin/io/envoyproxy/envoymobile/EngineBuilder.kt
+++ b/library/kotlin/io/envoyproxy/envoymobile/EngineBuilder.kt
@@ -42,6 +42,7 @@ open class EngineBuilder(
   private var enableInterfaceBinding = false
   private var h2ConnectionKeepaliveIdleIntervalMilliseconds = 100000000
   private var h2ConnectionKeepaliveTimeoutSeconds = 10
+  private var h2Hostnames = listOf<String>()
   private var statsFlushSeconds = 60
   private var streamIdleTimeoutSeconds = 15
   private var perTryIdleTimeoutSeconds = 15
@@ -228,6 +229,18 @@ open class EngineBuilder(
    */
   fun addH2ConnectionKeepaliveTimeoutSeconds(timeoutSeconds: Int): EngineBuilder {
     this.h2ConnectionKeepaliveTimeoutSeconds = timeoutSeconds
+    return this
+  }
+
+  /**
+   * Add a list of hostnames to force h2 connections for.
+   *
+   * @param h2Hostnames addresses to use.
+   *
+   * @return this builder.
+   */
+  fun addDNSFallbackNameservers(h2Hostnames: List<String>): EngineBuilder {
+    this.h2Hostnames = h2Hostnames
     return this
   }
 
@@ -442,6 +455,7 @@ open class EngineBuilder(
             enableInterfaceBinding,
             h2ConnectionKeepaliveIdleIntervalMilliseconds,
             h2ConnectionKeepaliveTimeoutSeconds,
+            h2Hostnames,
             statsFlushSeconds,
             streamIdleTimeoutSeconds,
             perTryIdleTimeoutSeconds,
@@ -476,6 +490,7 @@ open class EngineBuilder(
             enableInterfaceBinding,
             h2ConnectionKeepaliveIdleIntervalMilliseconds,
             h2ConnectionKeepaliveTimeoutSeconds,
+            h2Hostnames,
             statsFlushSeconds,
             streamIdleTimeoutSeconds,
             perTryIdleTimeoutSeconds,

--- a/library/objective-c/EnvoyConfiguration.m
+++ b/library/objective-c/EnvoyConfiguration.m
@@ -152,7 +152,7 @@
                             (double)self.h2ConnectionKeepaliveIdleIntervalMilliseconds / 1000.0];
   [definitions appendFormat:@"- &h2_connection_keepalive_timeout %lus\n",
                             (unsigned long)self.h2ConnectionKeepaliveTimeoutSeconds];
-  [definitions appendFormat:@"- &h2_hostnames %@\n", hasH2Hostnames ? @"[]" : @"[]"];
+  [definitions appendFormat:@"- &h2_hostnames %@\n", hasH2Hostnames ? @"[\"host.name\"]" : @"[\"host.name\"]"];
   [definitions
       appendFormat:@"- &stream_idle_timeout %lus\n", (unsigned long)self.streamIdleTimeoutSeconds];
   [definitions

--- a/library/objective-c/EnvoyConfiguration.m
+++ b/library/objective-c/EnvoyConfiguration.m
@@ -104,14 +104,7 @@
 
   BOOL hasH2Hostnames = self.h2Hostnames.count > 0;
   if (hasH2Hostnames) {
-    templateYAML = [templateYAML stringByReplacingOccurrencesOfString:@"#{fake_remote_responses}"
-                                                           withString:self.directResponses];
-    [customClusters appendString:[[NSString alloc] initWithUTF8String:fake_remote_cluster_insert]];
-    [customListeners
-        appendString:[[NSString alloc] initWithUTF8String:fake_remote_listener_insert]];
-    [customRoutes appendString:self.directResponseMatchers];
-    [customFilters
-        appendString:[[NSString alloc] initWithUTF8String:route_cache_reset_filter_insert]];
+    // FIXME: build string.
   }
 
   templateYAML = [templateYAML stringByReplacingOccurrencesOfString:@"#{custom_clusters}"

--- a/library/objective-c/EnvoyConfiguration.m
+++ b/library/objective-c/EnvoyConfiguration.m
@@ -17,6 +17,7 @@
     h2ConnectionKeepaliveIdleIntervalMilliseconds:
         (UInt32)h2ConnectionKeepaliveIdleIntervalMilliseconds
               h2ConnectionKeepaliveTimeoutSeconds:(UInt32)h2ConnectionKeepaliveTimeoutSeconds
+                                      h2Hostnames:(NSArray<NSString *> *)h2Hostnames
                                 statsFlushSeconds:(UInt32)statsFlushSeconds
                          streamIdleTimeoutSeconds:(UInt32)streamIdleTimeoutSeconds
                          perTryIdleTimeoutSeconds:(UInt32)perTryIdleTimeoutSeconds
@@ -50,6 +51,7 @@
   self.h2ConnectionKeepaliveIdleIntervalMilliseconds =
       h2ConnectionKeepaliveIdleIntervalMilliseconds;
   self.h2ConnectionKeepaliveTimeoutSeconds = h2ConnectionKeepaliveTimeoutSeconds;
+  self.h2Hostnames = h2Hostnames;
   self.statsFlushSeconds = statsFlushSeconds;
   self.streamIdleTimeoutSeconds = streamIdleTimeoutSeconds;
   self.perTryIdleTimeoutSeconds = perTryIdleTimeoutSeconds;
@@ -100,6 +102,18 @@
         appendString:[[NSString alloc] initWithUTF8String:route_cache_reset_filter_insert]];
   }
 
+  BOOL hasH2Hostnames = self.h2Hostnames.count > 0;
+  if (hasH2Hostnames) {
+    templateYAML = [templateYAML stringByReplacingOccurrencesOfString:@"#{fake_remote_responses}"
+                                                           withString:self.directResponses];
+    [customClusters appendString:[[NSString alloc] initWithUTF8String:fake_remote_cluster_insert]];
+    [customListeners
+        appendString:[[NSString alloc] initWithUTF8String:fake_remote_listener_insert]];
+    [customRoutes appendString:self.directResponseMatchers];
+    [customFilters
+        appendString:[[NSString alloc] initWithUTF8String:route_cache_reset_filter_insert]];
+  }
+
   templateYAML = [templateYAML stringByReplacingOccurrencesOfString:@"#{custom_clusters}"
                                                          withString:customClusters];
   templateYAML = [templateYAML stringByReplacingOccurrencesOfString:@"#{custom_listeners}"
@@ -138,6 +152,7 @@
                             (double)self.h2ConnectionKeepaliveIdleIntervalMilliseconds / 1000.0];
   [definitions appendFormat:@"- &h2_connection_keepalive_timeout %lus\n",
                             (unsigned long)self.h2ConnectionKeepaliveTimeoutSeconds];
+  [definitions appendFormat:@"- &h2_hostnames %@\n", hasH2Hostnames ? @"[]" : @"[]"];
   [definitions
       appendFormat:@"- &stream_idle_timeout %lus\n", (unsigned long)self.streamIdleTimeoutSeconds];
   [definitions

--- a/library/objective-c/EnvoyEngine.h
+++ b/library/objective-c/EnvoyEngine.h
@@ -341,6 +341,7 @@ extern const int kEnvoyFilterResumeStatusResumeIteration;
 @property (nonatomic, assign) BOOL enableInterfaceBinding;
 @property (nonatomic, assign) UInt32 h2ConnectionKeepaliveIdleIntervalMilliseconds;
 @property (nonatomic, assign) UInt32 h2ConnectionKeepaliveTimeoutSeconds;
+@property (nonatomic, strong) NSArray<NSString *> *h2Hostnames;
 @property (nonatomic, assign) UInt32 statsFlushSeconds;
 @property (nonatomic, assign) UInt32 streamIdleTimeoutSeconds;
 @property (nonatomic, assign) UInt32 perTryIdleTimeoutSeconds;
@@ -369,6 +370,7 @@ extern const int kEnvoyFilterResumeStatusResumeIteration;
     h2ConnectionKeepaliveIdleIntervalMilliseconds:
         (UInt32)h2ConnectionKeepaliveIdleIntervalMilliseconds
               h2ConnectionKeepaliveTimeoutSeconds:(UInt32)h2ConnectionKeepaliveTimeoutSeconds
+                                      h2Hostnames:(NSArray<NSString *> *)h2Hostnames
                                 statsFlushSeconds:(UInt32)statsFlushSeconds
                          streamIdleTimeoutSeconds:(UInt32)streamIdleTimeoutSeconds
                          perTryIdleTimeoutSeconds:(UInt32)perTryIdleTimeoutSeconds

--- a/library/swift/EngineBuilder.swift
+++ b/library/swift/EngineBuilder.swift
@@ -25,6 +25,7 @@ open class EngineBuilder: NSObject {
   private var enableInterfaceBinding: Bool = false
   private var h2ConnectionKeepaliveIdleIntervalMilliseconds: UInt32 = 100000000
   private var h2ConnectionKeepaliveTimeoutSeconds: UInt32 = 10
+  private var h2Hostnames: [String] = []
   private var statsFlushSeconds: UInt32 = 60
   private var streamIdleTimeoutSeconds: UInt32 = 15
   private var perTryIdleTimeoutSeconds: UInt32 = 15
@@ -182,6 +183,18 @@ open class EngineBuilder: NSObject {
   public func addH2ConnectionKeepaliveTimeoutSeconds(
     _ h2ConnectionKeepaliveTimeoutSeconds: UInt32) -> Self {
     self.h2ConnectionKeepaliveTimeoutSeconds = h2ConnectionKeepaliveTimeoutSeconds
+    return self
+  }
+
+  /// Add a list of hostnames to force h2 connections for.
+  ///
+  /// - parameter h2Hostnames: Hostnames to use.
+  ///
+  /// - returns: This builder.
+  @discardableResult
+  public func addH2Hostnames(
+    _ h2Hostnames: [String]) -> Self {
+    self.h2Hostnames = h2Hostnames
     return self
   }
 
@@ -381,6 +394,7 @@ open class EngineBuilder: NSObject {
       h2ConnectionKeepaliveIdleIntervalMilliseconds:
         self.h2ConnectionKeepaliveIdleIntervalMilliseconds,
       h2ConnectionKeepaliveTimeoutSeconds: self.h2ConnectionKeepaliveTimeoutSeconds,
+      h2Hostnames: self.h2Hostnames,
       statsFlushSeconds: self.statsFlushSeconds,
       streamIdleTimeoutSeconds: self.streamIdleTimeoutSeconds,
       perTryIdleTimeoutSeconds: self.perTryIdleTimeoutSeconds,

--- a/test/common/engine_test.cc
+++ b/test/common/engine_test.cc
@@ -28,7 +28,6 @@ static_resources:
               routes:
               - match: { prefix: "/" }
                 route:
-                  cluster_header: x-envoy-mobile-cluster
                   retry_policy:
                     retry_back_off: { base_interval: 0.25s, max_interval: 60s }
           http_filters:

--- a/test/common/http/client_test.cc
+++ b/test/common/http/client_test.cc
@@ -177,7 +177,6 @@ TEST_P(ClientTest, SetDestinationClusterUpstreamProtocol) {
       {":method", "GET"},
       {":authority", "host"},
       {":path", "/"},
-      {"x-envoy-mobile-cluster", "base_h2"},
       {"x-forwarded-proto", "https"},
   };
   EXPECT_CALL(dispatcher_, pushTrackedObject(_));
@@ -196,7 +195,6 @@ TEST_P(ClientTest, SetDestinationClusterUpstreamProtocol) {
       {":method", "GET"},
       {":authority", "host"},
       {":path", "/"},
-      {"x-envoy-mobile-cluster", "base_alpn"},
       {"x-forwarded-proto", "https"},
   };
   EXPECT_CALL(dispatcher_, pushTrackedObject(_));
@@ -215,7 +213,6 @@ TEST_P(ClientTest, SetDestinationClusterUpstreamProtocol) {
       {":method", "GET"},
       {":authority", "host"},
       {":path", "/"},
-      {"x-envoy-mobile-cluster", "base"},
       {"x-forwarded-proto", "https"},
   };
   EXPECT_CALL(dispatcher_, pushTrackedObject(_));

--- a/test/common/main_interface_test.cc
+++ b/test/common/main_interface_test.cc
@@ -45,7 +45,6 @@ static_resources:
               routes:
               - match: { prefix: "/" }
                 route:
-                  cluster_header: x-envoy-mobile-cluster
                   retry_policy:
                     retry_back_off: { base_interval: 0.25s, max_interval: 60s }
           http_filters:

--- a/test/java/io/envoyproxy/envoymobile/engine/EnvoyConfigurationTest.kt
+++ b/test/java/io/envoyproxy/envoymobile/engine/EnvoyConfigurationTest.kt
@@ -30,7 +30,7 @@ class EnvoyConfigurationTest {
   fun `resolving with default configuration resolves with values`() {
     val envoyConfiguration = EnvoyConfiguration(
       false, "stats.foo.com", null, 123, 234, 345, 456, 321, "[hostname]", listOf("8.8.8.8"), true,
-      true, true, 222, 333, 567, 678, 910, "v1.2.3", "com.mydomain.myapp",
+      true, true, 222, 333, listOf("host.name"), 567, 678, 910, "v1.2.3", "com.mydomain.myapp",
       TrustChainVerification.ACCEPT_UNTRUSTED, "[test]",
       listOf(EnvoyNativeFilterConfig("filter_name", "test_config")), emptyList(), emptyMap()
     )
@@ -60,6 +60,9 @@ class EnvoyConfigurationTest {
     assertThat(resolvedTemplate).contains("&h2_connection_keepalive_idle_interval 0.222s")
     assertThat(resolvedTemplate).contains("&h2_connection_keepalive_timeout 333s")
 
+    // H2 Hostnames
+    assertThat(resolvedTemplate).contains("&h2_hostnames [\"host.name\"]")
+
     // Metadata
     assertThat(resolvedTemplate).contains("os: Android")
     assertThat(resolvedTemplate).contains("app_version: v1.2.3")
@@ -87,7 +90,7 @@ class EnvoyConfigurationTest {
   fun `resolving with alternate values also sets appropriate config`() {
     val envoyConfiguration = EnvoyConfiguration(
       false, "stats.foo.com", null, 123, 234, 345, 456, 321, "[hostname]", emptyList(), false,
-      false, false, 222, 333, 567, 678, 910, "v1.2.3", "com.mydomain.myapp",
+      false, false, 222, 333, emptyList(), 567, 678, 910, "v1.2.3", "com.mydomain.myapp",
       TrustChainVerification.ACCEPT_UNTRUSTED, "[test]",
       listOf(EnvoyNativeFilterConfig("filter_name", "test_config")), emptyList(), emptyMap()
     )
@@ -109,7 +112,7 @@ class EnvoyConfigurationTest {
   fun `resolve templates with invalid templates will throw on build`() {
     val envoyConfiguration = EnvoyConfiguration(
       false, "stats.foo.com", null, 123, 234, 345, 456, 321, "[hostname]", emptyList(), false,
-      false, false, 123, 123, 567, 678, 910, "v1.2.3", "com.mydomain.myapp",
+      false, false, 123, 123, emptyList(), 567, 678, 910, "v1.2.3", "com.mydomain.myapp",
       TrustChainVerification.ACCEPT_UNTRUSTED, "[test]", emptyList(), emptyList(), emptyMap()
     )
 
@@ -125,7 +128,7 @@ class EnvoyConfigurationTest {
   fun `cannot configure both statsD and gRPC stat sink`() {
     val envoyConfiguration = EnvoyConfiguration(
       false, "stats.foo.com", 5050, 123, 234, 345, 456, 321, "[hostname]", emptyList(), false,
-      false, false, 123, 123, 567, 678, 910, "v1.2.3", "com.mydomain.myapp",
+      false, false, 123, 123, emptyList(), 567, 678, 910, "v1.2.3", "com.mydomain.myapp",
       TrustChainVerification.ACCEPT_UNTRUSTED, "[test]", emptyList(), emptyList(), emptyMap()
     )
 

--- a/test/kotlin/io/envoyproxy/envoymobile/EngineBuilderTest.kt
+++ b/test/kotlin/io/envoyproxy/envoymobile/EngineBuilderTest.kt
@@ -141,6 +141,16 @@ class EngineBuilderTest {
   }
 
   @Test
+  fun `specifying h2 hostnames overrides default`() {
+    engineBuilder = EngineBuilder(Standard())
+    engineBuilder.addEngineType { envoyEngine }
+    engineBuilder.addDNSFallbackNameservers(listOf<String>("api.foo.bar"))
+
+    val engine = engineBuilder.build() as EngineImpl
+    assertThat(engine.envoyConfiguration!!.h2Hostnames.size).isEqualTo(1)
+  }
+
+  @Test
   fun `specifying stats flush overrides default`() {
     engineBuilder = EngineBuilder(Standard())
     engineBuilder.addEngineType { envoyEngine }

--- a/test/swift/EngineBuilderTests.swift
+++ b/test/swift/EngineBuilderTests.swift
@@ -223,6 +223,20 @@ final class EngineBuilderTests: XCTestCase {
     self.waitForExpectations(timeout: 0.01)
   }
 
+  func testAddingH2HostnamesAddsToConfigurationWhenRunningEnvoy() {
+    let expectation = self.expectation(description: "Run called with expected data")
+    MockEnvoyEngine.onRunWithConfig = { config, _ in
+      XCTAssertEqual(1, config.h2Hostnames.count)
+      expectation.fulfill()
+    }
+
+    _ = EngineBuilder()
+      .addEngineType(MockEnvoyEngine.self)
+      .addH2Hostnames(["host.name"])
+      .build()
+    self.waitForExpectations(timeout: 0.01)
+  }
+
   func testAddingPlatformFiltersToConfigurationWhenRunningEnvoy() {
     let expectation = self.expectation(description: "Run called with expected data")
     MockEnvoyEngine.onRunWithConfig = { config, _ in
@@ -363,6 +377,7 @@ final class EngineBuilderTests: XCTestCase {
       enableInterfaceBinding: true,
       h2ConnectionKeepaliveIdleIntervalMilliseconds: 1,
       h2ConnectionKeepaliveTimeoutSeconds: 333,
+      h2Hostnames: ["host.name"],
       statsFlushSeconds: 600,
       streamIdleTimeoutSeconds: 700,
       perTryIdleTimeoutSeconds: 777,
@@ -392,6 +407,8 @@ final class EngineBuilderTests: XCTestCase {
 
     XCTAssertTrue(resolvedYAML.contains("&h2_connection_keepalive_idle_interval 0.001s"))
     XCTAssertTrue(resolvedYAML.contains("&h2_connection_keepalive_timeout 333s"))
+
+    XCTAssertTrue(resolvedYAML.contains("&h2_hostnames [\"host.name\"]"))
 
     XCTAssertTrue(resolvedYAML.contains("&stream_idle_timeout 700s"))
     XCTAssertTrue(resolvedYAML.contains("&per_try_idle_timeout 777s"))
@@ -429,6 +446,7 @@ final class EngineBuilderTests: XCTestCase {
       enableInterfaceBinding: false,
       h2ConnectionKeepaliveIdleIntervalMilliseconds: 1,
       h2ConnectionKeepaliveTimeoutSeconds: 333,
+      h2Hostnames: [],
       statsFlushSeconds: 600,
       streamIdleTimeoutSeconds: 700,
       perTryIdleTimeoutSeconds: 777,
@@ -465,6 +483,7 @@ final class EngineBuilderTests: XCTestCase {
       enableInterfaceBinding: false,
       h2ConnectionKeepaliveIdleIntervalMilliseconds: 222,
       h2ConnectionKeepaliveTimeoutSeconds: 333,
+      h2Hostnames: [],
       statsFlushSeconds: 600,
       streamIdleTimeoutSeconds: 700,
       perTryIdleTimeoutSeconds: 700,


### PR DESCRIPTION
For an explanation of how to fill out the fields, please see the relevant section
in [PULL_REQUESTS.md](https://github.com/envoyproxy/envoy/blob/master/PULL_REQUESTS.md)

Description:
Risk Level:
Testing:
Docs Changes:
Release Notes:
[Optional Fixes #Issue]
[Optional Deprecated:]
