### PR TITLE
engine builder: add option to add a list of H2-Raw domain names

### DIFF
--- a/library/common/config/config.cc
+++ b/library/common/config/config.cc
@@ -46,7 +46,7 @@ const std::string config_header = R"(
 - &enable_interface_binding false
 - &h2_connection_keepalive_idle_interval 100000s
 - &h2_connection_keepalive_timeout 10s
-- &h2_hostnames []
+- &h2_raw_domains []
 - &metadata {}
 - &stats_domain 127.0.0.1
 - &stats_flush_interval 60s
@@ -228,10 +228,10 @@ static_resources:
           route_config:
             name: api_router
             virtual_hosts:
-            - name: h2
+            - name: h2_raw
               include_attempt_count_in_response: true
               virtual_clusters: *virtual_clusters
-              domains: *h2_hostnames
+              domains: *h2_raw_domains
               routes:
 #{custom_routes}
               - match: { prefix: "/" }
@@ -246,7 +246,7 @@ static_resources:
                     retry_back_off:
                       base_interval: 0.25s
                       max_interval: 60s
-            - name: catchall
+            - name: primary
               include_attempt_count_in_response: true
               virtual_clusters: *virtual_clusters
               domains: ["*"]

--- a/library/common/http/client.cc
+++ b/library/common/http/client.cc
@@ -598,13 +598,12 @@ const LowerCaseString H2UpstreamHeader{"x-envoy-mobile-upstream-protocol"};
 const char* BaseCluster = "base";
 const char* H2Cluster = "base_h2";
 const char* ClearTextCluster = "base_clear";
-const char* AlpnCluster = "base_alpn";
 
 } // namespace
 
 void Client::setDestinationCluster(Http::RequestHeaderMap& headers) {
   // Determine upstream cluster:
-  // - Use TLS by default.
+  // - Use TLS with ALPN by default.
   // - Use http/2 or ALPN if requested explicitly via x-envoy-mobile-upstream-protocol.
   // - Force http/1.1 if request scheme is http (cleartext).
   const char* cluster{};
@@ -616,11 +615,11 @@ void Client::setDestinationCluster(Http::RequestHeaderMap& headers) {
     const auto value = h2_header[0]->value().getStringView();
     if (value == "http2") {
       cluster = H2Cluster;
-    } else if (value == "alpn") {
-      cluster = AlpnCluster;
-    } else {
-      RELEASE_ASSERT(value == "http1", fmt::format("using unsupported protocol version {}", value));
+    // FIXME(goaway): No cluster actually forces H1 today except cleartext!
+    } else if (value == "alpn" || value == "http1") {
       cluster = BaseCluster;
+    } else {
+      PANIC(fmt::format("using unsupported protocol version {}", value));
     }
   } else {
     cluster = BaseCluster;

--- a/library/common/http/client.cc
+++ b/library/common/http/client.cc
@@ -615,7 +615,7 @@ void Client::setDestinationCluster(Http::RequestHeaderMap& headers) {
     const auto value = h2_header[0]->value().getStringView();
     if (value == "http2") {
       cluster = H2Cluster;
-    // FIXME(goaway): No cluster actually forces H1 today except cleartext!
+      // FIXME(goaway): No cluster actually forces H1 today except cleartext!
     } else if (value == "alpn" || value == "http1") {
       cluster = BaseCluster;
     } else {

--- a/library/java/io/envoyproxy/envoymobile/engine/EnvoyConfiguration.java
+++ b/library/java/io/envoyproxy/envoymobile/engine/EnvoyConfiguration.java
@@ -38,7 +38,7 @@ public class EnvoyConfiguration {
   public final Boolean enableInterfaceBinding;
   public final Integer h2ConnectionKeepaliveIdleIntervalMilliseconds;
   public final Integer h2ConnectionKeepaliveTimeoutSeconds;
-  public final List<String> h2Hostnames;
+  public final List<String> h2RawDomains;
   public final List<EnvoyHTTPFilterFactory> httpPlatformFilterFactories;
   public final Integer statsFlushSeconds;
   public final Integer streamIdleTimeoutSeconds;
@@ -71,7 +71,7 @@ public class EnvoyConfiguration {
    * @param h2ConnectionKeepaliveIdleIntervalMilliseconds rate in milliseconds seconds to send h2
    *     pings on stream creation.
    * @param h2ConnectionKeepaliveTimeoutSeconds rate in seconds to timeout h2 pings.
-   * @param h2Hostnames                  hostnames to force h2 connections for.
+   * @param h2RawDomains                 list of domains to which connections should be raw h2.
    * @param statsFlushSeconds            interval at which to flush Envoy stats.
    * @param streamIdleTimeoutSeconds     idle timeout for HTTP streams.
    * @param perTryIdleTimeoutSeconds     per try idle timeout for HTTP streams.
@@ -91,7 +91,7 @@ public class EnvoyConfiguration {
                             Boolean dnsFilterUnroutableFamilies, boolean enableHappyEyeballs,
                             boolean enableInterfaceBinding,
                             int h2ConnectionKeepaliveIdleIntervalMilliseconds,
-                            int h2ConnectionKeepaliveTimeoutSeconds, List<String> h2Hostnames,
+                            int h2ConnectionKeepaliveTimeoutSeconds, List<String> h2RawDomains,
                             int statsFlushSeconds, int streamIdleTimeoutSeconds,
                             int perTryIdleTimeoutSeconds, String appVersion, String appId,
                             TrustChainVerification trustChainVerification, String virtualClusters,
@@ -114,7 +114,7 @@ public class EnvoyConfiguration {
     this.h2ConnectionKeepaliveIdleIntervalMilliseconds =
         h2ConnectionKeepaliveIdleIntervalMilliseconds;
     this.h2ConnectionKeepaliveTimeoutSeconds = h2ConnectionKeepaliveTimeoutSeconds;
-    this.h2Hostnames = h2Hostnames;
+    this.h2RawDomains = h2RawDomains;
     this.statsFlushSeconds = statsFlushSeconds;
     this.streamIdleTimeoutSeconds = streamIdleTimeoutSeconds;
     this.perTryIdleTimeoutSeconds = perTryIdleTimeoutSeconds;
@@ -167,13 +167,13 @@ public class EnvoyConfiguration {
       dnsFallbackNameserversAsString = sj.toString();
     }
 
-    String h2HostnamesAsString = "[]";
-    if (!h2Hostnames.isEmpty()) {
+    String h2RawDomainsAsString = "[]";
+    if (!h2RawDomains.isEmpty()) {
       StringJoiner sj = new StringJoiner(",", "[", "]");
-      for (String hostname : h2Hostnames) {
+      for (String hostname : h2RawDomains) {
         sj.add(String.format("\"%s\"", hostname));
       }
-      h2HostnamesAsString = sj.toString();
+      h2RawDomainsAsString = sj.toString();
     }
 
     String dnsResolverConfig = String.format(
@@ -200,7 +200,7 @@ public class EnvoyConfiguration {
                               h2ConnectionKeepaliveIdleIntervalMilliseconds / 1000.0))
         .append(String.format("- &h2_connection_keepalive_timeout %ss\n",
                               h2ConnectionKeepaliveTimeoutSeconds))
-        .append(String.format("- &h2_hostnames %s\n", h2HostnamesAsString))
+        .append(String.format("- &h2_raw_domains %s\n", h2RawDomainsAsString))
         .append(String.format("- &stream_idle_timeout %ss\n", streamIdleTimeoutSeconds))
         .append(String.format("- &per_try_idle_timeout %ss\n", perTryIdleTimeoutSeconds))
         .append(String.format("- &metadata { device_os: %s, app_version: %s, app_id: %s }\n",

--- a/library/java/io/envoyproxy/envoymobile/engine/EnvoyConfiguration.java
+++ b/library/java/io/envoyproxy/envoymobile/engine/EnvoyConfiguration.java
@@ -83,19 +83,21 @@ public class EnvoyConfiguration {
    * @param httpPlatformFilterFactories  the configuration for platform filters.
    * @param stringAccessors              platform string accessors to register.
    */
-  public EnvoyConfiguration(
-      Boolean adminInterfaceEnabled, String grpcStatsDomain, @Nullable Integer statsdPort,
-      int connectTimeoutSeconds, int dnsRefreshSeconds, int dnsFailureRefreshSecondsBase,
-      int dnsFailureRefreshSecondsMax, int dnsQueryTimeoutSeconds, String dnsPreresolveHostnames,
-      List<String> dnsFallbackNameservers, Boolean dnsFilterUnroutableFamilies,
-      boolean enableHappyEyeballs, boolean enableInterfaceBinding,
-      int h2ConnectionKeepaliveIdleIntervalMilliseconds, int h2ConnectionKeepaliveTimeoutSeconds,
-      List<String> h2Hostnames,
-      int statsFlushSeconds, int streamIdleTimeoutSeconds, int perTryIdleTimeoutSeconds,
-      String appVersion, String appId, TrustChainVerification trustChainVerification,
-      String virtualClusters, List<EnvoyNativeFilterConfig> nativeFilterChain,
-      List<EnvoyHTTPFilterFactory> httpPlatformFilterFactories,
-      Map<String, EnvoyStringAccessor> stringAccessors) {
+  public EnvoyConfiguration(Boolean adminInterfaceEnabled, String grpcStatsDomain,
+                            @Nullable Integer statsdPort, int connectTimeoutSeconds,
+                            int dnsRefreshSeconds, int dnsFailureRefreshSecondsBase,
+                            int dnsFailureRefreshSecondsMax, int dnsQueryTimeoutSeconds,
+                            String dnsPreresolveHostnames, List<String> dnsFallbackNameservers,
+                            Boolean dnsFilterUnroutableFamilies, boolean enableHappyEyeballs,
+                            boolean enableInterfaceBinding,
+                            int h2ConnectionKeepaliveIdleIntervalMilliseconds,
+                            int h2ConnectionKeepaliveTimeoutSeconds, List<String> h2Hostnames,
+                            int statsFlushSeconds, int streamIdleTimeoutSeconds,
+                            int perTryIdleTimeoutSeconds, String appVersion, String appId,
+                            TrustChainVerification trustChainVerification, String virtualClusters,
+                            List<EnvoyNativeFilterConfig> nativeFilterChain,
+                            List<EnvoyHTTPFilterFactory> httpPlatformFilterFactories,
+                            Map<String, EnvoyStringAccessor> stringAccessors) {
     this.adminInterfaceEnabled = adminInterfaceEnabled;
     this.grpcStatsDomain = grpcStatsDomain;
     this.statsdPort = statsdPort;

--- a/library/java/org/chromium/net/impl/NativeCronetEngineBuilderImpl.java
+++ b/library/java/org/chromium/net/impl/NativeCronetEngineBuilderImpl.java
@@ -43,6 +43,7 @@ public class NativeCronetEngineBuilderImpl extends CronetEngineBuilderImpl {
   private boolean mEnableInterfaceBinding = false;
   private int mH2ConnectionKeepaliveIdleIntervalMilliseconds = 100000000;
   private int mH2ConnectionKeepaliveTimeoutSeconds = 10;
+  private List<String> mH2RawDomains = Collections.emptyList();
   private int mStatsFlushSeconds = 60;
   private int mStreamIdleTimeoutSeconds = 15;
   private int mPerTryIdleTimeoutSeconds = 15;
@@ -85,8 +86,8 @@ public class NativeCronetEngineBuilderImpl extends CronetEngineBuilderImpl {
         mDnsQueryTimeoutSeconds, mDnsPreresolveHostnames, mDnsFallbackNameservers,
         mEnableDnsFilterUnroutableFamilies, mEnableHappyEyeballs, mEnableInterfaceBinding,
         mH2ConnectionKeepaliveIdleIntervalMilliseconds, mH2ConnectionKeepaliveTimeoutSeconds,
-        mStatsFlushSeconds, mStreamIdleTimeoutSeconds, mPerTryIdleTimeoutSeconds, mAppVersion,
-        mAppId, mTrustChainVerification, mVirtualClusters, mNativeFilterChain, mPlatformFilterChain,
-        mStringAccessors);
+        mH2RawDomains, mStatsFlushSeconds, mStreamIdleTimeoutSeconds, mPerTryIdleTimeoutSeconds,
+        mAppVersion, mAppId, mTrustChainVerification, mVirtualClusters, mNativeFilterChain,
+        mPlatformFilterChain, mStringAccessors);
   }
 }

--- a/library/kotlin/io/envoyproxy/envoymobile/EngineBuilder.kt
+++ b/library/kotlin/io/envoyproxy/envoymobile/EngineBuilder.kt
@@ -42,6 +42,7 @@ open class EngineBuilder(
   private var enableInterfaceBinding = false
   private var h2ConnectionKeepaliveIdleIntervalMilliseconds = 100000000
   private var h2ConnectionKeepaliveTimeoutSeconds = 10
+  private var h2Hostnames = listOf<String>()
   private var statsFlushSeconds = 60
   private var streamIdleTimeoutSeconds = 15
   private var perTryIdleTimeoutSeconds = 15
@@ -228,6 +229,18 @@ open class EngineBuilder(
    */
   fun addH2ConnectionKeepaliveTimeoutSeconds(timeoutSeconds: Int): EngineBuilder {
     this.h2ConnectionKeepaliveTimeoutSeconds = timeoutSeconds
+    return this
+  }
+
+  /**
+   * Add a list of hostnames to force h2 connections for.
+   *
+   * @param h2Hostnames addresses to use.
+   *
+   * @return this builder.
+   */
+  fun addDNSFallbackNameservers(h2Hostnames: List<String>): EngineBuilder {
+    this.h2Hostnames = h2Hostnames
     return this
   }
 
@@ -442,6 +455,7 @@ open class EngineBuilder(
             enableInterfaceBinding,
             h2ConnectionKeepaliveIdleIntervalMilliseconds,
             h2ConnectionKeepaliveTimeoutSeconds,
+            h2Hostnames,
             statsFlushSeconds,
             streamIdleTimeoutSeconds,
             perTryIdleTimeoutSeconds,
@@ -476,6 +490,7 @@ open class EngineBuilder(
             enableInterfaceBinding,
             h2ConnectionKeepaliveIdleIntervalMilliseconds,
             h2ConnectionKeepaliveTimeoutSeconds,
+            h2Hostnames,
             statsFlushSeconds,
             streamIdleTimeoutSeconds,
             perTryIdleTimeoutSeconds,

--- a/library/kotlin/io/envoyproxy/envoymobile/EngineBuilder.kt
+++ b/library/kotlin/io/envoyproxy/envoymobile/EngineBuilder.kt
@@ -239,7 +239,7 @@ open class EngineBuilder(
    *
    * @return this builder.
    */
-  fun addDNSFallbackNameservers(h2Hostnames: List<String>): EngineBuilder {
+  fun addH2Hostnames(h2Hostnames: List<String>): EngineBuilder {
     this.h2Hostnames = h2Hostnames
     return this
   }

--- a/library/kotlin/io/envoyproxy/envoymobile/EngineBuilder.kt
+++ b/library/kotlin/io/envoyproxy/envoymobile/EngineBuilder.kt
@@ -42,7 +42,7 @@ open class EngineBuilder(
   private var enableInterfaceBinding = false
   private var h2ConnectionKeepaliveIdleIntervalMilliseconds = 100000000
   private var h2ConnectionKeepaliveTimeoutSeconds = 10
-  private var h2Hostnames = listOf<String>()
+  private var h2RawDomains = listOf<String>()
   private var statsFlushSeconds = 60
   private var streamIdleTimeoutSeconds = 15
   private var perTryIdleTimeoutSeconds = 15
@@ -233,14 +233,14 @@ open class EngineBuilder(
   }
 
   /**
-   * Add a list of hostnames to force h2 connections for.
+   * Add a list of domains to which h2 connections will be established without protocol negotiation.
    *
-   * @param h2Hostnames addresses to use.
+   * @param h2RawDomains list of domains to which connections should be raw h2.
    *
    * @return this builder.
    */
-  fun addH2Hostnames(h2Hostnames: List<String>): EngineBuilder {
-    this.h2Hostnames = h2Hostnames
+  fun addH2RawDomains(h2RawDomains: List<String>): EngineBuilder {
+    this.h2RawDomains = h2RawDomains
     return this
   }
 
@@ -455,7 +455,7 @@ open class EngineBuilder(
             enableInterfaceBinding,
             h2ConnectionKeepaliveIdleIntervalMilliseconds,
             h2ConnectionKeepaliveTimeoutSeconds,
-            h2Hostnames,
+            h2RawDomains,
             statsFlushSeconds,
             streamIdleTimeoutSeconds,
             perTryIdleTimeoutSeconds,
@@ -490,7 +490,7 @@ open class EngineBuilder(
             enableInterfaceBinding,
             h2ConnectionKeepaliveIdleIntervalMilliseconds,
             h2ConnectionKeepaliveTimeoutSeconds,
-            h2Hostnames,
+            h2RawDomains,
             statsFlushSeconds,
             streamIdleTimeoutSeconds,
             perTryIdleTimeoutSeconds,

--- a/library/objective-c/EnvoyConfiguration.m
+++ b/library/objective-c/EnvoyConfiguration.m
@@ -145,7 +145,8 @@
                             (double)self.h2ConnectionKeepaliveIdleIntervalMilliseconds / 1000.0];
   [definitions appendFormat:@"- &h2_connection_keepalive_timeout %lus\n",
                             (unsigned long)self.h2ConnectionKeepaliveTimeoutSeconds];
-  [definitions appendFormat:@"- &h2_hostnames %@\n", hasH2Hostnames ? @"[\"host.name\"]" : @"[\"host.name\"]"];
+  [definitions appendFormat:@"- &h2_hostnames %@\n",
+                            hasH2Hostnames ? @"[\"host.name\"]" : @"[\"host.name\"]"];
   [definitions
       appendFormat:@"- &stream_idle_timeout %lus\n", (unsigned long)self.streamIdleTimeoutSeconds];
   [definitions

--- a/library/objective-c/EnvoyConfiguration.m
+++ b/library/objective-c/EnvoyConfiguration.m
@@ -17,6 +17,7 @@
     h2ConnectionKeepaliveIdleIntervalMilliseconds:
         (UInt32)h2ConnectionKeepaliveIdleIntervalMilliseconds
               h2ConnectionKeepaliveTimeoutSeconds:(UInt32)h2ConnectionKeepaliveTimeoutSeconds
+                                      h2Hostnames:(NSArray<NSString *> *)h2Hostnames
                                 statsFlushSeconds:(UInt32)statsFlushSeconds
                          streamIdleTimeoutSeconds:(UInt32)streamIdleTimeoutSeconds
                          perTryIdleTimeoutSeconds:(UInt32)perTryIdleTimeoutSeconds
@@ -50,6 +51,7 @@
   self.h2ConnectionKeepaliveIdleIntervalMilliseconds =
       h2ConnectionKeepaliveIdleIntervalMilliseconds;
   self.h2ConnectionKeepaliveTimeoutSeconds = h2ConnectionKeepaliveTimeoutSeconds;
+  self.h2Hostnames = h2Hostnames;
   self.statsFlushSeconds = statsFlushSeconds;
   self.streamIdleTimeoutSeconds = streamIdleTimeoutSeconds;
   self.perTryIdleTimeoutSeconds = perTryIdleTimeoutSeconds;
@@ -100,6 +102,11 @@
         appendString:[[NSString alloc] initWithUTF8String:route_cache_reset_filter_insert]];
   }
 
+  BOOL hasH2Hostnames = self.h2Hostnames.count > 0;
+  if (hasH2Hostnames) {
+    // FIXME: build string.
+  }
+
   templateYAML = [templateYAML stringByReplacingOccurrencesOfString:@"#{custom_clusters}"
                                                          withString:customClusters];
   templateYAML = [templateYAML stringByReplacingOccurrencesOfString:@"#{custom_listeners}"
@@ -138,6 +145,7 @@
                             (double)self.h2ConnectionKeepaliveIdleIntervalMilliseconds / 1000.0];
   [definitions appendFormat:@"- &h2_connection_keepalive_timeout %lus\n",
                             (unsigned long)self.h2ConnectionKeepaliveTimeoutSeconds];
+  [definitions appendFormat:@"- &h2_hostnames %@\n", hasH2Hostnames ? @"[\"host.name\"]" : @"[\"host.name\"]"];
   [definitions
       appendFormat:@"- &stream_idle_timeout %lus\n", (unsigned long)self.streamIdleTimeoutSeconds];
   [definitions

--- a/library/objective-c/EnvoyConfiguration.m
+++ b/library/objective-c/EnvoyConfiguration.m
@@ -17,7 +17,7 @@
     h2ConnectionKeepaliveIdleIntervalMilliseconds:
         (UInt32)h2ConnectionKeepaliveIdleIntervalMilliseconds
               h2ConnectionKeepaliveTimeoutSeconds:(UInt32)h2ConnectionKeepaliveTimeoutSeconds
-                                      h2RawDomains:(NSArray<NSString *> *)h2RawDomains
+                                     h2RawDomains:(NSArray<NSString *> *)h2RawDomains
                                 statsFlushSeconds:(UInt32)statsFlushSeconds
                          streamIdleTimeoutSeconds:(UInt32)streamIdleTimeoutSeconds
                          perTryIdleTimeoutSeconds:(UInt32)perTryIdleTimeoutSeconds

--- a/library/objective-c/EnvoyConfiguration.m
+++ b/library/objective-c/EnvoyConfiguration.m
@@ -17,7 +17,7 @@
     h2ConnectionKeepaliveIdleIntervalMilliseconds:
         (UInt32)h2ConnectionKeepaliveIdleIntervalMilliseconds
               h2ConnectionKeepaliveTimeoutSeconds:(UInt32)h2ConnectionKeepaliveTimeoutSeconds
-                                      h2Hostnames:(NSArray<NSString *> *)h2Hostnames
+                                      h2RawDomains:(NSArray<NSString *> *)h2RawDomains
                                 statsFlushSeconds:(UInt32)statsFlushSeconds
                          streamIdleTimeoutSeconds:(UInt32)streamIdleTimeoutSeconds
                          perTryIdleTimeoutSeconds:(UInt32)perTryIdleTimeoutSeconds
@@ -51,7 +51,7 @@
   self.h2ConnectionKeepaliveIdleIntervalMilliseconds =
       h2ConnectionKeepaliveIdleIntervalMilliseconds;
   self.h2ConnectionKeepaliveTimeoutSeconds = h2ConnectionKeepaliveTimeoutSeconds;
-  self.h2Hostnames = h2Hostnames;
+  self.h2RawDomains = h2RawDomains;
   self.statsFlushSeconds = statsFlushSeconds;
   self.streamIdleTimeoutSeconds = streamIdleTimeoutSeconds;
   self.perTryIdleTimeoutSeconds = perTryIdleTimeoutSeconds;
@@ -102,10 +102,13 @@
         appendString:[[NSString alloc] initWithUTF8String:route_cache_reset_filter_insert]];
   }
 
-  BOOL hasH2Hostnames = self.h2Hostnames.count > 0;
-  if (hasH2Hostnames) {
-    // FIXME: build string.
+  NSMutableString *h2RawDomainsString = [[NSMutableString alloc] initWithString:@"["];
+  if (self.h2RawDomains.count > 0) {
+    [h2RawDomainsString appendString:@"\""];
+    [h2RawDomainsString appendString:[self.h2RawDomains componentsJoinedByString:@"\",\""]];
+    [h2RawDomainsString appendString:@"\""];
   }
+  [h2RawDomainsString appendString:@"]"];
 
   templateYAML = [templateYAML stringByReplacingOccurrencesOfString:@"#{custom_clusters}"
                                                          withString:customClusters];
@@ -145,8 +148,7 @@
                             (double)self.h2ConnectionKeepaliveIdleIntervalMilliseconds / 1000.0];
   [definitions appendFormat:@"- &h2_connection_keepalive_timeout %lus\n",
                             (unsigned long)self.h2ConnectionKeepaliveTimeoutSeconds];
-  [definitions appendFormat:@"- &h2_hostnames %@\n",
-                            hasH2Hostnames ? @"[\"host.name\"]" : @"[\"host.name\"]"];
+  [definitions appendFormat:@"- &h2_raw_domains %@\n", h2RawDomainsString];
   [definitions
       appendFormat:@"- &stream_idle_timeout %lus\n", (unsigned long)self.streamIdleTimeoutSeconds];
   [definitions

--- a/library/objective-c/EnvoyEngine.h
+++ b/library/objective-c/EnvoyEngine.h
@@ -370,7 +370,7 @@ extern const int kEnvoyFilterResumeStatusResumeIteration;
     h2ConnectionKeepaliveIdleIntervalMilliseconds:
         (UInt32)h2ConnectionKeepaliveIdleIntervalMilliseconds
               h2ConnectionKeepaliveTimeoutSeconds:(UInt32)h2ConnectionKeepaliveTimeoutSeconds
-                                      h2RawDomains:(NSArray<NSString *> *)h2RawDomains
+                                     h2RawDomains:(NSArray<NSString *> *)h2RawDomains
                                 statsFlushSeconds:(UInt32)statsFlushSeconds
                          streamIdleTimeoutSeconds:(UInt32)streamIdleTimeoutSeconds
                          perTryIdleTimeoutSeconds:(UInt32)perTryIdleTimeoutSeconds

--- a/library/objective-c/EnvoyEngine.h
+++ b/library/objective-c/EnvoyEngine.h
@@ -341,6 +341,7 @@ extern const int kEnvoyFilterResumeStatusResumeIteration;
 @property (nonatomic, assign) BOOL enableInterfaceBinding;
 @property (nonatomic, assign) UInt32 h2ConnectionKeepaliveIdleIntervalMilliseconds;
 @property (nonatomic, assign) UInt32 h2ConnectionKeepaliveTimeoutSeconds;
+@property (nonatomic, strong) NSArray<NSString *> *h2Hostnames;
 @property (nonatomic, assign) UInt32 statsFlushSeconds;
 @property (nonatomic, assign) UInt32 streamIdleTimeoutSeconds;
 @property (nonatomic, assign) UInt32 perTryIdleTimeoutSeconds;
@@ -369,6 +370,7 @@ extern const int kEnvoyFilterResumeStatusResumeIteration;
     h2ConnectionKeepaliveIdleIntervalMilliseconds:
         (UInt32)h2ConnectionKeepaliveIdleIntervalMilliseconds
               h2ConnectionKeepaliveTimeoutSeconds:(UInt32)h2ConnectionKeepaliveTimeoutSeconds
+                                      h2Hostnames:(NSArray<NSString *> *)h2Hostnames
                                 statsFlushSeconds:(UInt32)statsFlushSeconds
                          streamIdleTimeoutSeconds:(UInt32)streamIdleTimeoutSeconds
                          perTryIdleTimeoutSeconds:(UInt32)perTryIdleTimeoutSeconds

--- a/library/objective-c/EnvoyEngine.h
+++ b/library/objective-c/EnvoyEngine.h
@@ -341,7 +341,7 @@ extern const int kEnvoyFilterResumeStatusResumeIteration;
 @property (nonatomic, assign) BOOL enableInterfaceBinding;
 @property (nonatomic, assign) UInt32 h2ConnectionKeepaliveIdleIntervalMilliseconds;
 @property (nonatomic, assign) UInt32 h2ConnectionKeepaliveTimeoutSeconds;
-@property (nonatomic, strong) NSArray<NSString *> *h2Hostnames;
+@property (nonatomic, strong) NSArray<NSString *> *h2RawDomains;
 @property (nonatomic, assign) UInt32 statsFlushSeconds;
 @property (nonatomic, assign) UInt32 streamIdleTimeoutSeconds;
 @property (nonatomic, assign) UInt32 perTryIdleTimeoutSeconds;
@@ -370,7 +370,7 @@ extern const int kEnvoyFilterResumeStatusResumeIteration;
     h2ConnectionKeepaliveIdleIntervalMilliseconds:
         (UInt32)h2ConnectionKeepaliveIdleIntervalMilliseconds
               h2ConnectionKeepaliveTimeoutSeconds:(UInt32)h2ConnectionKeepaliveTimeoutSeconds
-                                      h2Hostnames:(NSArray<NSString *> *)h2Hostnames
+                                      h2RawDomains:(NSArray<NSString *> *)h2RawDomains
                                 statsFlushSeconds:(UInt32)statsFlushSeconds
                          streamIdleTimeoutSeconds:(UInt32)streamIdleTimeoutSeconds
                          perTryIdleTimeoutSeconds:(UInt32)perTryIdleTimeoutSeconds

--- a/library/swift/EngineBuilder.swift
+++ b/library/swift/EngineBuilder.swift
@@ -25,6 +25,7 @@ open class EngineBuilder: NSObject {
   private var enableInterfaceBinding: Bool = false
   private var h2ConnectionKeepaliveIdleIntervalMilliseconds: UInt32 = 100000000
   private var h2ConnectionKeepaliveTimeoutSeconds: UInt32 = 10
+  private var h2Hostnames: [String] = []
   private var statsFlushSeconds: UInt32 = 60
   private var streamIdleTimeoutSeconds: UInt32 = 15
   private var perTryIdleTimeoutSeconds: UInt32 = 15
@@ -182,6 +183,18 @@ open class EngineBuilder: NSObject {
   public func addH2ConnectionKeepaliveTimeoutSeconds(
     _ h2ConnectionKeepaliveTimeoutSeconds: UInt32) -> Self {
     self.h2ConnectionKeepaliveTimeoutSeconds = h2ConnectionKeepaliveTimeoutSeconds
+    return self
+  }
+
+  /// Add a list of hostnames to force h2 connections for.
+  ///
+  /// - parameter h2Hostnames: Hostnames to use.
+  ///
+  /// - returns: This builder.
+  @discardableResult
+  public func addH2Hostnames(
+    _ h2Hostnames: [String]) -> Self {
+    self.h2Hostnames = h2Hostnames
     return self
   }
 
@@ -381,6 +394,7 @@ open class EngineBuilder: NSObject {
       h2ConnectionKeepaliveIdleIntervalMilliseconds:
         self.h2ConnectionKeepaliveIdleIntervalMilliseconds,
       h2ConnectionKeepaliveTimeoutSeconds: self.h2ConnectionKeepaliveTimeoutSeconds,
+      h2Hostnames: self.h2Hostnames,
       statsFlushSeconds: self.statsFlushSeconds,
       streamIdleTimeoutSeconds: self.streamIdleTimeoutSeconds,
       perTryIdleTimeoutSeconds: self.perTryIdleTimeoutSeconds,

--- a/library/swift/EngineBuilder.swift
+++ b/library/swift/EngineBuilder.swift
@@ -25,7 +25,7 @@ open class EngineBuilder: NSObject {
   private var enableInterfaceBinding: Bool = false
   private var h2ConnectionKeepaliveIdleIntervalMilliseconds: UInt32 = 100000000
   private var h2ConnectionKeepaliveTimeoutSeconds: UInt32 = 10
-  private var h2Hostnames: [String] = []
+  private var h2RawDomains: [String] = []
   private var statsFlushSeconds: UInt32 = 60
   private var streamIdleTimeoutSeconds: UInt32 = 15
   private var perTryIdleTimeoutSeconds: UInt32 = 15
@@ -186,15 +186,16 @@ open class EngineBuilder: NSObject {
     return self
   }
 
-  /// Add a list of hostnames to force h2 connections for.
+  /// Add a list of domains to which h2 connections will be established without protocol
+  /// negotiation.
   ///
-  /// - parameter h2Hostnames: Hostnames to use.
+  /// - parameter h2RawDomains: list of domains to which connections should be raw h2.
   ///
   /// - returns: This builder.
   @discardableResult
-  public func addH2Hostnames(
-    _ h2Hostnames: [String]) -> Self {
-    self.h2Hostnames = h2Hostnames
+  public func addH2RawDomains(
+    _ h2RawDomains: [String]) -> Self {
+    self.h2RawDomains = h2RawDomains
     return self
   }
 
@@ -394,7 +395,7 @@ open class EngineBuilder: NSObject {
       h2ConnectionKeepaliveIdleIntervalMilliseconds:
         self.h2ConnectionKeepaliveIdleIntervalMilliseconds,
       h2ConnectionKeepaliveTimeoutSeconds: self.h2ConnectionKeepaliveTimeoutSeconds,
-      h2Hostnames: self.h2Hostnames,
+      h2RawDomains: self.h2RawDomains,
       statsFlushSeconds: self.statsFlushSeconds,
       streamIdleTimeoutSeconds: self.streamIdleTimeoutSeconds,
       perTryIdleTimeoutSeconds: self.perTryIdleTimeoutSeconds,

--- a/test/common/http/client_test.cc
+++ b/test/common/http/client_test.cc
@@ -196,7 +196,7 @@ TEST_P(ClientTest, SetDestinationClusterUpstreamProtocol) {
       {":method", "GET"},
       {":authority", "host"},
       {":path", "/"},
-      {"x-envoy-mobile-cluster", "base_alpn"},
+      {"x-envoy-mobile-cluster", "base"},
       {"x-forwarded-proto", "https"},
   };
   EXPECT_CALL(dispatcher_, pushTrackedObject(_));
@@ -204,6 +204,7 @@ TEST_P(ClientTest, SetDestinationClusterUpstreamProtocol) {
   EXPECT_CALL(*request_decoder_, decodeHeaders_(HeaderMapEqual(&expected_headers_alpn), true));
   http_client_.sendHeaders(stream_, c_headers_alpn, true);
 
+  // FIXME(goaway): This doesn't force H1 and still performs ALPN!
   // Setting http1.
   TestRequestHeaderMapImpl headers4{{"x-envoy-mobile-upstream-protocol", "http1"}};
   HttpTestUtility::addDefaultHeaders(headers4);

--- a/test/java/io/envoyproxy/envoymobile/engine/EnvoyConfigurationTest.kt
+++ b/test/java/io/envoyproxy/envoymobile/engine/EnvoyConfigurationTest.kt
@@ -30,7 +30,7 @@ class EnvoyConfigurationTest {
   fun `resolving with default configuration resolves with values`() {
     val envoyConfiguration = EnvoyConfiguration(
       false, "stats.foo.com", null, 123, 234, 345, 456, 321, "[hostname]", listOf("8.8.8.8"), true,
-      true, true, 222, 333, 567, 678, 910, "v1.2.3", "com.mydomain.myapp",
+      true, true, 222, 333, listOf("host.name"), 567, 678, 910, "v1.2.3", "com.mydomain.myapp",
       TrustChainVerification.ACCEPT_UNTRUSTED, "[test]",
       listOf(EnvoyNativeFilterConfig("filter_name", "test_config")), emptyList(), emptyMap()
     )
@@ -60,6 +60,9 @@ class EnvoyConfigurationTest {
     assertThat(resolvedTemplate).contains("&h2_connection_keepalive_idle_interval 0.222s")
     assertThat(resolvedTemplate).contains("&h2_connection_keepalive_timeout 333s")
 
+    // H2 Hostnames
+    assertThat(resolvedTemplate).contains("&h2_hostnames [\"host.name\"]")
+
     // Metadata
     assertThat(resolvedTemplate).contains("os: Android")
     assertThat(resolvedTemplate).contains("app_version: v1.2.3")
@@ -87,7 +90,7 @@ class EnvoyConfigurationTest {
   fun `resolving with alternate values also sets appropriate config`() {
     val envoyConfiguration = EnvoyConfiguration(
       false, "stats.foo.com", null, 123, 234, 345, 456, 321, "[hostname]", emptyList(), false,
-      false, false, 222, 333, 567, 678, 910, "v1.2.3", "com.mydomain.myapp",
+      false, false, 222, 333, emptyList(), 567, 678, 910, "v1.2.3", "com.mydomain.myapp",
       TrustChainVerification.ACCEPT_UNTRUSTED, "[test]",
       listOf(EnvoyNativeFilterConfig("filter_name", "test_config")), emptyList(), emptyMap()
     )
@@ -109,7 +112,7 @@ class EnvoyConfigurationTest {
   fun `resolve templates with invalid templates will throw on build`() {
     val envoyConfiguration = EnvoyConfiguration(
       false, "stats.foo.com", null, 123, 234, 345, 456, 321, "[hostname]", emptyList(), false,
-      false, false, 123, 123, 567, 678, 910, "v1.2.3", "com.mydomain.myapp",
+      false, false, 123, 123, emptyList(), 567, 678, 910, "v1.2.3", "com.mydomain.myapp",
       TrustChainVerification.ACCEPT_UNTRUSTED, "[test]", emptyList(), emptyList(), emptyMap()
     )
 
@@ -125,7 +128,7 @@ class EnvoyConfigurationTest {
   fun `cannot configure both statsD and gRPC stat sink`() {
     val envoyConfiguration = EnvoyConfiguration(
       false, "stats.foo.com", 5050, 123, 234, 345, 456, 321, "[hostname]", emptyList(), false,
-      false, false, 123, 123, 567, 678, 910, "v1.2.3", "com.mydomain.myapp",
+      false, false, 123, 123, emptyList(), 567, 678, 910, "v1.2.3", "com.mydomain.myapp",
       TrustChainVerification.ACCEPT_UNTRUSTED, "[test]", emptyList(), emptyList(), emptyMap()
     )
 

--- a/test/java/io/envoyproxy/envoymobile/engine/EnvoyConfigurationTest.kt
+++ b/test/java/io/envoyproxy/envoymobile/engine/EnvoyConfigurationTest.kt
@@ -30,7 +30,7 @@ class EnvoyConfigurationTest {
   fun `resolving with default configuration resolves with values`() {
     val envoyConfiguration = EnvoyConfiguration(
       false, "stats.foo.com", null, 123, 234, 345, 456, 321, "[hostname]", listOf("8.8.8.8"), true,
-      true, true, 222, 333, listOf("host.name"), 567, 678, 910, "v1.2.3", "com.mydomain.myapp",
+      true, true, 222, 333, listOf("h2-raw.domain"), 567, 678, 910, "v1.2.3", "com.mydomain.myapp",
       TrustChainVerification.ACCEPT_UNTRUSTED, "[test]",
       listOf(EnvoyNativeFilterConfig("filter_name", "test_config")), emptyList(), emptyMap()
     )
@@ -61,7 +61,7 @@ class EnvoyConfigurationTest {
     assertThat(resolvedTemplate).contains("&h2_connection_keepalive_timeout 333s")
 
     // H2 Hostnames
-    assertThat(resolvedTemplate).contains("&h2_hostnames [\"host.name\"]")
+    assertThat(resolvedTemplate).contains("&h2_raw_domains [\"h2-raw.domain\"]")
 
     // Metadata
     assertThat(resolvedTemplate).contains("os: Android")

--- a/test/kotlin/io/envoyproxy/envoymobile/EngineBuilderTest.kt
+++ b/test/kotlin/io/envoyproxy/envoymobile/EngineBuilderTest.kt
@@ -147,7 +147,7 @@ class EngineBuilderTest {
     engineBuilder.addDNSFallbackNameservers(listOf<String>("api.foo.bar"))
 
     val engine = engineBuilder.build() as EngineImpl
-    assertThat(engine.envoyConfiguration!!.h2Hostnames.size).isEqualTo(1)
+    assertThat(engine.envoyConfiguration!!.h2RawDomains.size).isEqualTo(1)
   }
 
   @Test

--- a/test/kotlin/io/envoyproxy/envoymobile/EngineBuilderTest.kt
+++ b/test/kotlin/io/envoyproxy/envoymobile/EngineBuilderTest.kt
@@ -144,7 +144,7 @@ class EngineBuilderTest {
   fun `specifying h2 hostnames overrides default`() {
     engineBuilder = EngineBuilder(Standard())
     engineBuilder.addEngineType { envoyEngine }
-    engineBuilder.addDNSFallbackNameservers(listOf<String>("api.foo.bar"))
+    engineBuilder.addH2RawDomains(listOf<String>("h2-raw.domain"))
 
     val engine = engineBuilder.build() as EngineImpl
     assertThat(engine.envoyConfiguration!!.h2RawDomains.size).isEqualTo(1)

--- a/test/kotlin/io/envoyproxy/envoymobile/EngineBuilderTest.kt
+++ b/test/kotlin/io/envoyproxy/envoymobile/EngineBuilderTest.kt
@@ -141,6 +141,16 @@ class EngineBuilderTest {
   }
 
   @Test
+  fun `specifying h2 hostnames overrides default`() {
+    engineBuilder = EngineBuilder(Standard())
+    engineBuilder.addEngineType { envoyEngine }
+    engineBuilder.addDNSFallbackNameservers(listOf<String>("api.foo.bar"))
+
+    val engine = engineBuilder.build() as EngineImpl
+    assertThat(engine.envoyConfiguration!!.h2Hostnames.size).isEqualTo(1)
+  }
+
+  @Test
   fun `specifying stats flush overrides default`() {
     engineBuilder = EngineBuilder(Standard())
     engineBuilder.addEngineType { envoyEngine }

--- a/test/swift/EngineBuilderTests.swift
+++ b/test/swift/EngineBuilderTests.swift
@@ -223,6 +223,20 @@ final class EngineBuilderTests: XCTestCase {
     self.waitForExpectations(timeout: 0.01)
   }
 
+  func testAddingH2HostnamesAddsToConfigurationWhenRunningEnvoy() {
+    let expectation = self.expectation(description: "Run called with expected data")
+    MockEnvoyEngine.onRunWithConfig = { config, _ in
+      XCTAssertEqual(1, config.h2Hostnames.count)
+      expectation.fulfill()
+    }
+
+    _ = EngineBuilder()
+      .addEngineType(MockEnvoyEngine.self)
+      .addH2Hostnames(["host.name"])
+      .build()
+    self.waitForExpectations(timeout: 0.01)
+  }
+
   func testAddingPlatformFiltersToConfigurationWhenRunningEnvoy() {
     let expectation = self.expectation(description: "Run called with expected data")
     MockEnvoyEngine.onRunWithConfig = { config, _ in
@@ -363,6 +377,7 @@ final class EngineBuilderTests: XCTestCase {
       enableInterfaceBinding: true,
       h2ConnectionKeepaliveIdleIntervalMilliseconds: 1,
       h2ConnectionKeepaliveTimeoutSeconds: 333,
+      h2Hostnames: ["host.name"],
       statsFlushSeconds: 600,
       streamIdleTimeoutSeconds: 700,
       perTryIdleTimeoutSeconds: 777,
@@ -392,6 +407,8 @@ final class EngineBuilderTests: XCTestCase {
 
     XCTAssertTrue(resolvedYAML.contains("&h2_connection_keepalive_idle_interval 0.001s"))
     XCTAssertTrue(resolvedYAML.contains("&h2_connection_keepalive_timeout 333s"))
+
+    XCTAssertTrue(resolvedYAML.contains("&h2_hostnames [\"host.name\"]"))
 
     XCTAssertTrue(resolvedYAML.contains("&stream_idle_timeout 700s"))
     XCTAssertTrue(resolvedYAML.contains("&per_try_idle_timeout 777s"))
@@ -429,6 +446,7 @@ final class EngineBuilderTests: XCTestCase {
       enableInterfaceBinding: false,
       h2ConnectionKeepaliveIdleIntervalMilliseconds: 1,
       h2ConnectionKeepaliveTimeoutSeconds: 333,
+      h2Hostnames: [],
       statsFlushSeconds: 600,
       streamIdleTimeoutSeconds: 700,
       perTryIdleTimeoutSeconds: 777,
@@ -465,6 +483,7 @@ final class EngineBuilderTests: XCTestCase {
       enableInterfaceBinding: false,
       h2ConnectionKeepaliveIdleIntervalMilliseconds: 222,
       h2ConnectionKeepaliveTimeoutSeconds: 333,
+      h2Hostnames: [],
       statsFlushSeconds: 600,
       streamIdleTimeoutSeconds: 700,
       perTryIdleTimeoutSeconds: 700,

--- a/test/swift/EngineBuilderTests.swift
+++ b/test/swift/EngineBuilderTests.swift
@@ -223,16 +223,16 @@ final class EngineBuilderTests: XCTestCase {
     self.waitForExpectations(timeout: 0.01)
   }
 
-  func testAddingH2HostnamesAddsToConfigurationWhenRunningEnvoy() {
+  func testAddingH2RawDomainsAddsToConfigurationWhenRunningEnvoy() {
     let expectation = self.expectation(description: "Run called with expected data")
     MockEnvoyEngine.onRunWithConfig = { config, _ in
-      XCTAssertEqual(1, config.h2Hostnames.count)
+      XCTAssertEqual(1, config.h2RawDomains.count)
       expectation.fulfill()
     }
 
     _ = EngineBuilder()
       .addEngineType(MockEnvoyEngine.self)
-      .addH2Hostnames(["host.name"])
+      .addH2RawDomains(["h2-raw.domain"])
       .build()
     self.waitForExpectations(timeout: 0.01)
   }
@@ -377,7 +377,7 @@ final class EngineBuilderTests: XCTestCase {
       enableInterfaceBinding: true,
       h2ConnectionKeepaliveIdleIntervalMilliseconds: 1,
       h2ConnectionKeepaliveTimeoutSeconds: 333,
-      h2Hostnames: ["host.name"],
+      h2RawDomains: ["h2-raw.domain"],
       statsFlushSeconds: 600,
       streamIdleTimeoutSeconds: 700,
       perTryIdleTimeoutSeconds: 777,
@@ -408,7 +408,7 @@ final class EngineBuilderTests: XCTestCase {
     XCTAssertTrue(resolvedYAML.contains("&h2_connection_keepalive_idle_interval 0.001s"))
     XCTAssertTrue(resolvedYAML.contains("&h2_connection_keepalive_timeout 333s"))
 
-    XCTAssertTrue(resolvedYAML.contains("&h2_hostnames [\"host.name\"]"))
+    XCTAssertTrue(resolvedYAML.contains("&h2_raw_domains [\"h2-raw.domain\"]"))
 
     XCTAssertTrue(resolvedYAML.contains("&stream_idle_timeout 700s"))
     XCTAssertTrue(resolvedYAML.contains("&per_try_idle_timeout 777s"))
@@ -446,7 +446,7 @@ final class EngineBuilderTests: XCTestCase {
       enableInterfaceBinding: false,
       h2ConnectionKeepaliveIdleIntervalMilliseconds: 1,
       h2ConnectionKeepaliveTimeoutSeconds: 333,
-      h2Hostnames: [],
+      h2RawDomains: [],
       statsFlushSeconds: 600,
       streamIdleTimeoutSeconds: 700,
       perTryIdleTimeoutSeconds: 777,
@@ -483,7 +483,7 @@ final class EngineBuilderTests: XCTestCase {
       enableInterfaceBinding: false,
       h2ConnectionKeepaliveIdleIntervalMilliseconds: 222,
       h2ConnectionKeepaliveTimeoutSeconds: 333,
-      h2Hostnames: [],
+      h2RawDomains: [],
       statsFlushSeconds: 600,
       streamIdleTimeoutSeconds: 700,
       perTryIdleTimeoutSeconds: 700,


### PR DESCRIPTION
Description: Adds public API and support for providing a list of domains to which H2 connections will be established *without* protocol negotiation (i.e. ALPN). See Envoy docs for the domain name patterns supported:
https://www.envoyproxy.io/docs/envoy/latest/api-v3/config/route/v3/route_components.proto#envoy-v3-api-msg-config-route-v3-route

Risk Level: Low
Testing: Unit

Co-authored-by: Mike Schore <mike.schore@gmail.com>
Signed-off-by: Mike Schore <mike.schore@gmail.com>