### PR TITLE
builds: make bazelw support arm64 builds

### DIFF
--- a/bazelw
+++ b/bazelw
@@ -4,9 +4,8 @@ set -euo pipefail
 
 readonly bazelisk_version="1.10.1"
 
-readonly raw_os="$(uname -s)"
 readonly raw_arch="$(uname -m)"
-if [[ "$raw_os" == "Darwin" ]]; then
+if [[ $OSTYPE == darwin* ]]; then
   readonly bazel_os="darwin"
 else
   readonly bazel_os="linux"
@@ -33,7 +32,7 @@ case "$bazel_platform" in
     ;;
 
   *)
-    echo "Unsupported platform $raw_os $raw_arch" >&2
+    echo "Unsupported platform $OSTYPE $raw_arch" >&2
     exit 1
 esac
 

--- a/bazelw
+++ b/bazelw
@@ -3,14 +3,39 @@
 set -euo pipefail
 
 readonly bazelisk_version="1.10.1"
-if [[ $OSTYPE == darwin* ]]; then
-  # TODO: Support M1 once https://github.com/envoyproxy/envoy/issues/16482
-  readonly bazel_platform="darwin-amd64"
-  readonly bazel_version_sha="e485bbf84532d02a60b0eb23c702610b5408df3a199087a4f2b5e0995bbf2d5a"
+
+readonly raw_os="$(uname -s)"
+readonly raw_arch="$(uname -m)"
+if [[ "$raw_os" == "Darwin" ]]; then
+  readonly bazel_os="darwin"
 else
-  readonly bazel_platform="linux-amd64"
-  readonly bazel_version_sha="4cb534c52cdd47a6223d4596d530e7c9c785438ab3b0a49ff347e991c210b2cd"
+  readonly bazel_os="linux"
 fi
+if [[ "$raw_arch" == "aarch64" || "$raw_arch" == "arm64" ]]; then
+  readonly bazel_arch="arm64"
+else
+  readonly bazel_arch="amd64"
+fi
+
+bazel_platform="$bazel_os-$bazel_arch"
+case "$bazel_platform" in
+  darwin-arm64)
+    readonly bazel_version_sha="c22d48601466d9d3b043ccd74051f2f4230f9b9f4509f097017c97303aa88d13"
+    ;;
+  darwin-amd64)
+    readonly bazel_version_sha="e485bbf84532d02a60b0eb23c702610b5408df3a199087a4f2b5e0995bbf2d5a"
+    ;;
+  linux-arm64)
+    readonly bazel_version_sha="c1de6860dd4f8d5e2ec270097bd46d6a211b971a0b8b38559784bd051ea950a1"
+    ;;
+  linux-amd64)
+    readonly bazel_version_sha="4cb534c52cdd47a6223d4596d530e7c9c785438ab3b0a49ff347e991c210b2cd"
+    ;;
+
+  *)
+    echo "Unsupported platform $raw_os $raw_arch" >&2
+    exit 1
+esac
 
 readonly bazel_version_url="https://github.com/bazelbuild/bazelisk/releases/download/v$bazelisk_version/bazelisk-$bazel_platform"
 script_root="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"

--- a/bazelw
+++ b/bazelw
@@ -4,12 +4,13 @@ set -euo pipefail
 
 readonly bazelisk_version="1.10.1"
 
-readonly raw_arch="$(uname -m)"
 if [[ $OSTYPE == darwin* ]]; then
   readonly bazel_os="darwin"
 else
   readonly bazel_os="linux"
 fi
+
+readonly raw_arch="$(uname -m)"
 if [[ "$raw_arch" == "aarch64" || "$raw_arch" == "arm64" ]]; then
   readonly bazel_arch="arm64"
 else


### PR DESCRIPTION
For an explanation of how to fill out the fields, please see the relevant section
in [PULL_REQUESTS.md](https://github.com/envoyproxy/envoy/blob/master/PULL_REQUESTS.md)

Description: Modifies the `bazelw` shell script to bootstrap `bazelisk` for arm64 on both Darwin and Linux. This unblocks work to re-enable Python builds for py-envoy-mobile internally. Note that this may not work until #2085 is in, as (iirc) it includes fixes to arm64 builds for Envoy.
Risk Level: Low
Testing: No unit testing, but tested on arm64 both on macOS (natively) and Linux (Docker). See below. I don't have an x86_64 laptop on hand at the moment, so if someone wouldn't mind checking that this still works on x86_64, that'd be much appreciated!
Docs Changes: N/A
Release Notes: N/A

<details>
<summary>macOS</summary>
<pre><code>~/src/envoy-mobile$ ./bazelw
Installing bazelisk...
[bazel output omitted]
~/src/envoy-mobile$ ls tmp/bazel/versions/
bazelisk-1.10.1-darwin-arm64</code></pre>

Note that there is no "Extracting Bazel installation..." step as I've been running this already.
</details>

<details>
<summary>Linux</summary>
<pre><code>/code/envoy-mobile$ ./bazelw
Installing bazelisk...
2022/03/14 03:42:12 Downloading https://releases.bazel.build/5.0.0/release/bazel-5.0.0-linux-arm64...
Extracting Bazel installation...
Starting local Bazel server and connecting to it...
[bazel output omitted]
/code/envoy-mobile$ ls tmp/bazel/versions/
bazelisk-1.10.1-linux-arm64</code></pre>
</details>