### PR TITLE
[Android] Replace uses of `StringJoiner` with `StringBuilder`

### DIFF
--- a/docs/root/intro/version_history.rst
+++ b/docs/root/intro/version_history.rst
@@ -6,6 +6,9 @@ Pending Release
 
 Bugfixes:
 
+- Android: Fix `NoClassDefFoundError` errors when using `addDNSFallbackNameservers`
+  or `addH2RawDomains` with Android versions older than API level 24.
+
 Features:
 
 - API: added Envoy's response flags to final stream intel (:issue:`#2009 <2009>`)

--- a/library/java/io/envoyproxy/envoymobile/engine/EnvoyConfiguration.java
+++ b/library/java/io/envoyproxy/envoymobile/engine/EnvoyConfiguration.java
@@ -4,7 +4,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.regex.Pattern;
 import java.util.regex.Matcher;
-import java.util.StringBuilder;
+import java.lang.StringBuilder;
 import javax.annotation.Nullable;
 
 import io.envoyproxy.envoymobile.engine.types.EnvoyHTTPFilterFactory;

--- a/library/java/io/envoyproxy/envoymobile/engine/EnvoyConfiguration.java
+++ b/library/java/io/envoyproxy/envoymobile/engine/EnvoyConfiguration.java
@@ -163,11 +163,11 @@ public class EnvoyConfiguration {
       StringBuilder sb = new StringBuilder("[");
       String separator = "";
       for (String nameserver : dnsFallbackNameservers) {
-        sb.add(separator);
+        sb.append(separator);
         separator = ",";
-        sb.add(String.format("{\"socket_address\":{\"address\":\"%s\"}},", nameserver));
+        sb.append(String.format("{\"socket_address\":{\"address\":\"%s\"}},", nameserver));
       }
-      sb.add("]");
+      sb.append("]");
       dnsFallbackNameserversAsString = sb.toString();
     }
 
@@ -176,11 +176,11 @@ public class EnvoyConfiguration {
       StringBuilder sb = new StringBuilder("[");
       String separator = "";
       for (String hostname : h2RawDomains) {
-        sb.add(separator);
+        sb.append(separator);
         separator = ",";
-        sb.add(String.format("\"%s\"", hostname));
+        sb.append(String.format("\"%s\"", hostname));
       }
-      sb.add("]");
+      sb.append("]");
       h2RawDomainsAsString = sb.toString();
     }
 

--- a/library/java/io/envoyproxy/envoymobile/engine/EnvoyConfiguration.java
+++ b/library/java/io/envoyproxy/envoymobile/engine/EnvoyConfiguration.java
@@ -4,7 +4,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.regex.Pattern;
 import java.util.regex.Matcher;
-import java.util.StringJoiner;
+import java.util.StringBuilder;
 import javax.annotation.Nullable;
 
 import io.envoyproxy.envoymobile.engine.types.EnvoyHTTPFilterFactory;
@@ -160,20 +160,28 @@ public class EnvoyConfiguration {
 
     String dnsFallbackNameserversAsString = "[]";
     if (!dnsFallbackNameservers.isEmpty()) {
-      StringJoiner sj = new StringJoiner(",", "[", "]");
+      StringBuilder sb = new StringBuilder("[");
+      String separator = "";
       for (String nameserver : dnsFallbackNameservers) {
-        sj.add(String.format("{\"socket_address\":{\"address\":\"%s\"}}", nameserver));
+        sb.add(separator);
+        separator = ",";
+        sb.add(String.format("{\"socket_address\":{\"address\":\"%s\"}},", nameserver));
       }
-      dnsFallbackNameserversAsString = sj.toString();
+      sb.add("]");
+      dnsFallbackNameserversAsString = sb.toString();
     }
 
     String h2RawDomainsAsString = "[]";
     if (!h2RawDomains.isEmpty()) {
-      StringJoiner sj = new StringJoiner(",", "[", "]");
+      StringBuilder sb = new StringBuilder("[");
+      String separator = "";
       for (String hostname : h2RawDomains) {
-        sj.add(String.format("\"%s\"", hostname));
+        sb.add(separator);
+        separator = ",";
+        sb.add(String.format("\"%s\"", hostname));
       }
-      h2RawDomainsAsString = sj.toString();
+      sb.add("]");
+      h2RawDomainsAsString = sb.toString();
     }
 
     String dnsResolverConfig = String.format(

--- a/library/java/io/envoyproxy/envoymobile/engine/EnvoyConfiguration.java
+++ b/library/java/io/envoyproxy/envoymobile/engine/EnvoyConfiguration.java
@@ -165,7 +165,7 @@ public class EnvoyConfiguration {
       for (String nameserver : dnsFallbackNameservers) {
         sb.append(separator);
         separator = ",";
-        sb.append(String.format("{\"socket_address\":{\"address\":\"%s\"}},", nameserver));
+        sb.append(String.format("{\"socket_address\":{\"address\":\"%s\"}}", nameserver));
       }
       sb.append("]");
       dnsFallbackNameserversAsString = sb.toString();


### PR DESCRIPTION
Description: [StringJoiner](https://developer.android.com/reference/java/util/StringJoiner) was added in Android API level 24 but we still support back to API level 21, so this results in `NoClassDefFoundError` errors on devices running older Android versions.

Risk Level: Medium, this code is simple and unit tested.
Testing: Existing unit tests
Docs Changes: None
Release Notes: Added

Signed-off-by: JP Simard <jp@jpsim.com>