### PR TITLE
CI: Reinstate sandbox in kotlin tests

### DIFF
--- a/test/kotlin/io/envoyproxy/envoymobile/BUILD
+++ b/test/kotlin/io/envoyproxy/envoymobile/BUILD
@@ -7,10 +7,6 @@ envoy_mobile_kt_test(
     srcs = [
         "EngineBuilderTest.kt",
     ],
-    exec_properties = {
-        # TODO(lfpino): Remove this once the JVM paths are allow-listed in the sandbox.
-        "sandboxAllowed": "False",
-    },
     deps = [
         "//library/kotlin/io/envoyproxy/envoymobile:envoy_interfaces_lib",
     ],
@@ -51,10 +47,6 @@ envoy_mobile_kt_test(
     srcs = [
         "PulseClientImplTest.kt",
     ],
-    exec_properties = {
-        # TODO(lfpino): Remove this once the JVM paths are allow-listed in the sandbox.
-        "sandboxAllowed": "False",
-    },
     deps = [
         "//library/kotlin/io/envoyproxy/envoymobile:envoy_interfaces_lib",
     ],


### PR DESCRIPTION
Signed-off-by: Luis Fernando Pino Duque <luis@engflow.com>

Description:
CI: Reinstate sandbox in kotlin tests now that the low-level JVM paths are allow-listed in the sandbox.

Risk Level: Low
Testing: See android_tests
Docs Changes: N/A
Release Notes: N/A
