### PR TITLE
[iOS/macOS] Remove `EngineBuilder.enableNetworkPathMonitor(_:)`

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -9,6 +9,7 @@ build --features=debug_prefix_map_pwd_is_dot
 build --features=swift.cacheable_swiftmodules
 build --features=swift.debug_prefix_map
 build --host_force_python=PY3
+build --macos_minimum_os=10.14
 build --ios_minimum_os=12.0
 build --ios_simulator_device="iPhone 13"
 build --ios_simulator_version=15.2

--- a/docs/root/api/starting_envoy.rst
+++ b/docs/root/api/starting_envoy.rst
@@ -369,25 +369,6 @@ Specify a closure to be called by Envoy to access arbitrary strings from Platfor
   // Swift
   builder.addStringAccessor(name: "demo-accessor", accessor: { return "PlatformString" })
 
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-``enableNetworkPathMonitor``
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-
-Configure the engine to use ``NWPathMonitor`` rather than ``SCNetworkReachability``
-on supported platforms (iOS 12+) to update the preferred Envoy network cluster (e.g. WLAN vs WWAN).
-
-.. attention::
-
-    Only available on iOS 12 or later.
-
-**Example**::
-
-  // Kotlin
-  // N/A
-
-  // Swift
-  builder.enableNetworkPathMonitor()
-
 ~~~~~~~~~~~~~~~~~~~~~~~
 ``enableHappyEyeballs``
 ~~~~~~~~~~~~~~~~~~~~~~~

--- a/docs/root/intro/version_history.rst
+++ b/docs/root/intro/version_history.rst
@@ -13,6 +13,8 @@ Features:
 
 - API: added Envoy's response flags to final stream intel (:issue:`#2009 <2009>`)
 - size: The size of the dynamic library was reduced by ~46% (:issue:`#2053 <2053>`)
+- iOS: Removed ``EngineBuilder.enableNetworkPathMonitor(_:)``, now ``NWPathMonitor`` is always
+  used to observe network reachability state.
 
 0.4.5 (January 13, 2022)
 ========================

--- a/library/objective-c/BUILD
+++ b/library/objective-c/BUILD
@@ -20,14 +20,9 @@ objc_library(
         "EnvoyHTTPStreamImpl.m",
         "EnvoyLogger.m",
         "EnvoyNativeFilterConfig.m",
+        "EnvoyNetworkMonitor.m",
         "EnvoyStringAccessor.m",
-    ] + select({
-        "@platforms//os:macos": [
-        ],
-        "//conditions:default": [
-            "EnvoyNetworkMonitor.m",
-        ],
-    }),
+    ],
     hdrs = [
         "EnvoyEngine.h",
     ],

--- a/library/objective-c/EnvoyEngine.h
+++ b/library/objective-c/EnvoyEngine.h
@@ -425,13 +425,10 @@ extern const int kEnvoyFailure;
  running.
  @param logger Logging interface.
  @param eventTracker Event tracking interface.
- @param enableNetworkPathMonitor Configure the engine to use `NWPathMonitor` to observe network
- reachability.
  */
 - (instancetype)initWithRunningCallback:(nullable void (^)())onEngineRunning
                                  logger:(nullable void (^)(NSString *))logger
-                           eventTracker:(nullable void (^)(EnvoyEvent *))eventTracker
-               enableNetworkPathMonitor:(BOOL)enableNetworkPathMonitor;
+                           eventTracker:(nullable void (^)(EnvoyEvent *))eventTracker;
 /**
  Run the Envoy engine with the provided configuration and log level.
 
@@ -560,11 +557,6 @@ extern const int kEnvoyFailure;
 
 // Monitors network changes in order to update Envoy network cluster preferences.
 @interface EnvoyNetworkMonitor : NSObject
-
-// Start monitoring reachability using `SCNetworkReachability`, updating the
-// preferred Envoy network cluster on changes.
-// This is typically called by `EnvoyEngine` automatically on startup.
-+ (void)startReachabilityIfNeeded;
 
 // Start monitoring reachability using `NWPathMonitor`, updating the
 // preferred Envoy network cluster on changes.

--- a/library/objective-c/EnvoyEngineImpl.m
+++ b/library/objective-c/EnvoyEngineImpl.m
@@ -409,8 +409,7 @@ static void ios_track_event(envoy_map map, const void *context) {
 
 - (instancetype)initWithRunningCallback:(nullable void (^)())onEngineRunning
                                  logger:(nullable void (^)(NSString *))logger
-                           eventTracker:(nullable void (^)(EnvoyEvent *))eventTracker
-               enableNetworkPathMonitor:(BOOL)enableNetworkPathMonitor {
+                           eventTracker:(nullable void (^)(EnvoyEvent *))eventTracker {
   self = [super init];
   if (!self) {
     return nil;
@@ -440,13 +439,7 @@ static void ios_track_event(envoy_map map, const void *context) {
 
   _engineHandle = init_engine(native_callbacks, native_logger, native_event_tracker);
 
-#ifndef TARGET_OS_MAC
-  if (enableNetworkPathMonitor) {
-    [EnvoyNetworkMonitor startPathMonitorIfNeeded];
-  } else {
-    [EnvoyNetworkMonitor startReachabilityIfNeeded];
-  }
-#endif
+  [EnvoyNetworkMonitor startPathMonitorIfNeeded];
 
   return self;
 }

--- a/library/swift/EngineBuilder.swift
+++ b/library/swift/EngineBuilder.swift
@@ -35,7 +35,6 @@ open class EngineBuilder: NSObject {
   private var onEngineRunning: (() -> Void)?
   private var logger: ((String) -> Void)?
   private var eventTracker: (([String: String]) -> Void)?
-  private(set) var enableNetworkPathMonitor = false
   private var nativeFilterChain: [EnvoyNativeFilterConfig] = []
   private var platformFilterChain: [EnvoyHTTPFilterFactory] = []
   private var stringAccessors: [String: EnvoyStringAccessor] = [:]
@@ -321,15 +320,6 @@ open class EngineBuilder: NSObject {
     return self
   }
 
-  /// Configure the engine to use `NWPathMonitor` to observe network reachability.
-  ///
-  /// - returns: This builder.
-  @discardableResult
-  public func enableNetworkPathMonitor(_ enableNetworkPathMonitor: Bool) -> Self {
-    self.enableNetworkPathMonitor = enableNetworkPathMonitor
-    return self
-  }
-
   /// Add the App Version of the App using this Envoy Client.
   ///
   /// - parameter appVersion: The version.
@@ -378,8 +368,7 @@ open class EngineBuilder: NSObject {
   ///
   public func build() -> Engine {
     let engine = self.engineType.init(runningCallback: self.onEngineRunning, logger: self.logger,
-                                      eventTracker: self.eventTracker,
-                                      enableNetworkPathMonitor: self.enableNetworkPathMonitor)
+                                      eventTracker: self.eventTracker)
     let config = EnvoyConfiguration(
       adminInterfaceEnabled: self.adminInterfaceEnabled,
       grpcStatsDomain: self.grpcStatsDomain,

--- a/library/swift/mocks/MockEnvoyEngine.swift
+++ b/library/swift/mocks/MockEnvoyEngine.swift
@@ -4,7 +4,7 @@ import Foundation
 /// Mock implementation of `EnvoyEngine`. Used internally for testing the bridging layer & mocking.
 final class MockEnvoyEngine: NSObject {
   init(runningCallback onEngineRunning: (() -> Void)? = nil, logger: ((String) -> Void)? = nil,
-       eventTracker: (([String: String]) -> Void)? = nil, enableNetworkPathMonitor: Bool = true) {}
+       eventTracker: (([String: String]) -> Void)? = nil) {}
 
   /// Closure called when `run(withConfig:)` is called.
   static var onRunWithConfig: ((_ config: EnvoyConfiguration, _ logLevel: String?) -> Void)?

--- a/test/swift/EngineBuilderTests.swift
+++ b/test/swift/EngineBuilderTests.swift
@@ -28,19 +28,6 @@ final class EngineBuilderTests: XCTestCase {
     MockEnvoyEngine.onRunWithTemplate = nil
   }
 
-  func testEnableNetworkPathMonitorDefaultsToFalse() {
-    let builder = EngineBuilder()
-    XCTAssertFalse(builder.enableNetworkPathMonitor)
-  }
-
-  func testEnableNetworkPathMonitorSetsToValue() {
-    let builder = EngineBuilder()
-      .enableNetworkPathMonitor(true)
-    XCTAssertTrue(builder.enableNetworkPathMonitor)
-    builder.enableNetworkPathMonitor(false)
-    XCTAssertFalse(builder.enableNetworkPathMonitor)
-  }
-
   func testCustomConfigTemplateUsesSpecifiedYAMLWhenRunningEnvoy() {
     let expectation = self.expectation(description: "Run called with expected data")
     MockEnvoyEngine.onRunWithTemplate = { yaml, _, _ in


### PR DESCRIPTION
**Description**

We ran some experiments in the Lyft apps and found no regressions with this enabled, so we believe it's safe to remove the legacy `SCNetworkReachability` implementation and always use the `NWPathMonitor` code path.

Also enable path monitor reachability state observation on macOS while I'm in there.

It was disabled in https://github.com/envoyproxy/envoy-mobile/pull/2052 because we didn't have a minimum macOS version set but this API is available as of 10.14.

**Risk Level:** Medium. It's possible the previous `SCNetworkReachability` implementation performs better under some circumstances but if that's the case we weren't able to find them.
**Testing:** Ran pre-release and release experiments in Lyft's production environments
**Docs Changes:** Updated
**Release Notes:** Updated

Signed-off-by: JP Simard <jp@jpsim.com>