### PR TITLE
ios: add support for toggling trust chain verification

### DIFF
--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -110,6 +110,9 @@ trailing_comma:
   mandatory_comma: true
 line_length:
   - 100
+type_body_length:
+  - 300 # warning
+  - 400 # error
 file_length:
   warning: 300
   ignore_comment_only_lines: true

--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -111,8 +111,8 @@ trailing_comma:
 line_length:
   - 100
 type_body_length:
-  - 300 # warning
-  - 400 # error
+  warning: 300
+  error: 400
 file_length:
   warning: 300
   ignore_comment_only_lines: true

--- a/library/objective-c/EnvoyConfiguration.m
+++ b/library/objective-c/EnvoyConfiguration.m
@@ -146,9 +146,9 @@
                    @"envoy.extensions.network.dns_resolver.apple.v3.AppleDnsResolverConfig\"}\n"];
   [definitions appendFormat:@"- &enable_interface_binding %@\n",
                             self.enableInterfaceBinding ? @"true" : @"false"];
-  [definitions appendFormat:@"- &trust_chain_verification %@\n",
-                            self.enforceTrustChainVerification ? @"VERIFY_TRUST_CHAIN"
-                                                               : @"ACCEPT_UNTRUSTED"];
+  [definitions appendFormat:@"- &trust_chain_verification %@\n", self.enforceTrustChainVerification
+                                                                     ? @"VERIFY_TRUST_CHAIN"
+                                                                     : @"ACCEPT_UNTRUSTED"];
   [definitions appendFormat:@"- &h2_connection_keepalive_idle_interval %.*fs\n", 3,
                             (double)self.h2ConnectionKeepaliveIdleIntervalMilliseconds / 1000.0];
   [definitions appendFormat:@"- &h2_connection_keepalive_timeout %lus\n",

--- a/library/objective-c/EnvoyConfiguration.m
+++ b/library/objective-c/EnvoyConfiguration.m
@@ -14,6 +14,7 @@
                            dnsPreresolveHostnames:(NSString *)dnsPreresolveHostnames
                               enableHappyEyeballs:(BOOL)enableHappyEyeballs
                            enableInterfaceBinding:(BOOL)enableInterfaceBinding
+                    enforceTrustChainVerification:(BOOL)enforceTrustChainVerification
     h2ConnectionKeepaliveIdleIntervalMilliseconds:
         (UInt32)h2ConnectionKeepaliveIdleIntervalMilliseconds
               h2ConnectionKeepaliveTimeoutSeconds:(UInt32)h2ConnectionKeepaliveTimeoutSeconds
@@ -48,6 +49,7 @@
   self.dnsPreresolveHostnames = dnsPreresolveHostnames;
   self.enableHappyEyeballs = enableHappyEyeballs;
   self.enableInterfaceBinding = enableInterfaceBinding;
+  self.enforceTrustChainVerification = enforceTrustChainVerification;
   self.h2ConnectionKeepaliveIdleIntervalMilliseconds =
       h2ConnectionKeepaliveIdleIntervalMilliseconds;
   self.h2ConnectionKeepaliveTimeoutSeconds = h2ConnectionKeepaliveTimeoutSeconds;
@@ -144,6 +146,9 @@
                    @"envoy.extensions.network.dns_resolver.apple.v3.AppleDnsResolverConfig\"}\n"];
   [definitions appendFormat:@"- &enable_interface_binding %@\n",
                             self.enableInterfaceBinding ? @"true" : @"false"];
+  [definitions appendFormat:@"- &trust_chain_verification %@\n",
+                            self.enforceTrustChainVerification ? @"VERIFY_TRUST_CHAIN"
+                                                               : @"ACCEPT_UNTRUSTED"];
   [definitions appendFormat:@"- &h2_connection_keepalive_idle_interval %.*fs\n", 3,
                             (double)self.h2ConnectionKeepaliveIdleIntervalMilliseconds / 1000.0];
   [definitions appendFormat:@"- &h2_connection_keepalive_timeout %lus\n",

--- a/library/objective-c/EnvoyEngine.h
+++ b/library/objective-c/EnvoyEngine.h
@@ -339,6 +339,7 @@ extern const int kEnvoyFilterResumeStatusResumeIteration;
 @property (nonatomic, strong) NSString *dnsPreresolveHostnames;
 @property (nonatomic, assign) BOOL enableHappyEyeballs;
 @property (nonatomic, assign) BOOL enableInterfaceBinding;
+@property (nonatomic, assign) BOOL enforceTrustChainVerification;
 @property (nonatomic, assign) UInt32 h2ConnectionKeepaliveIdleIntervalMilliseconds;
 @property (nonatomic, assign) UInt32 h2ConnectionKeepaliveTimeoutSeconds;
 @property (nonatomic, strong) NSArray<NSString *> *h2RawDomains;
@@ -367,6 +368,7 @@ extern const int kEnvoyFilterResumeStatusResumeIteration;
                            dnsPreresolveHostnames:(NSString *)dnsPreresolveHostnames
                               enableHappyEyeballs:(BOOL)enableHappyEyeballs
                            enableInterfaceBinding:(BOOL)enableInterfaceBinding
+                    enforceTrustChainVerification:(BOOL)enforceTrustChainVerification
     h2ConnectionKeepaliveIdleIntervalMilliseconds:
         (UInt32)h2ConnectionKeepaliveIdleIntervalMilliseconds
               h2ConnectionKeepaliveTimeoutSeconds:(UInt32)h2ConnectionKeepaliveTimeoutSeconds

--- a/library/swift/EngineBuilder.swift
+++ b/library/swift/EngineBuilder.swift
@@ -163,12 +163,12 @@ open class EngineBuilder: NSObject {
 
   /// Specify whether to enforce TLS trust chain verification for secure sockets.
   ///
-  /// - parameter enableTrustChainVerification: whether to enforce trust chain verification.
+  /// - parameter enforceTrustChainVerification: whether to enforce trust chain verification.
   ///
   /// - returns: This builder.
   @discardableResult
-  public func enableTrustChainVerification(_ enableTrustChainVerification: Bool) -> Self {
-    self.enableTrustChainVerification = enableTrustChainVerification
+  public func enforceTrustChainVerification(_ enforceTrustChainVerification: Bool) -> Self {
+    self.enforceTrustChainVerification = enforceTrustChainVerification
     return self
   }
 

--- a/library/swift/EngineBuilder.swift
+++ b/library/swift/EngineBuilder.swift
@@ -23,6 +23,7 @@ open class EngineBuilder: NSObject {
   private var dnsPreresolveHostnames: String = "[]"
   private var enableHappyEyeballs: Bool = false
   private var enableInterfaceBinding: Bool = false
+  private var enforceTrustChainVerification: Bool = true
   private var h2ConnectionKeepaliveIdleIntervalMilliseconds: UInt32 = 100000000
   private var h2ConnectionKeepaliveTimeoutSeconds: UInt32 = 10
   private var h2RawDomains: [String] = []
@@ -157,6 +158,17 @@ open class EngineBuilder: NSObject {
   @discardableResult
   public func enableInterfaceBinding(_ enableInterfaceBinding: Bool) -> Self {
     self.enableInterfaceBinding = enableInterfaceBinding
+    return self
+  }
+
+  /// Specify whether to enforce TLS trust chain verification for secure sockets.
+  ///
+  /// - parameter enableTrustChainVerification: whether to enforce trust chain verification.
+  ///
+  /// - returns: This builder.
+  @discardableResult
+  public func enableTrustChainVerification(_ enableTrustChainVerification: Bool) -> Self {
+    self.enableTrustChainVerification = enableTrustChainVerification
     return self
   }
 
@@ -391,6 +403,7 @@ open class EngineBuilder: NSObject {
       dnsPreresolveHostnames: self.dnsPreresolveHostnames,
       enableHappyEyeballs: self.enableHappyEyeballs,
       enableInterfaceBinding: self.enableInterfaceBinding,
+      enforceTrustChainVerification: self.enforceTrustChainVerification,
       h2ConnectionKeepaliveIdleIntervalMilliseconds:
         self.h2ConnectionKeepaliveIdleIntervalMilliseconds,
       h2ConnectionKeepaliveTimeoutSeconds: self.h2ConnectionKeepaliveTimeoutSeconds,

--- a/test/swift/EngineBuilderTests.swift
+++ b/test/swift/EngineBuilderTests.swift
@@ -123,6 +123,20 @@ final class EngineBuilderTests: XCTestCase {
     self.waitForExpectations(timeout: 0.01)
   }
 
+  func testEnforcingTrustChainVerificationAddsToConfigurationWhenRunningEnvoy() {
+    let expectation = self.expectation(description: "Run called with enabled interface binding")
+    MockEnvoyEngine.onRunWithConfig = { config, _ in
+      XCTAssertTrue(config.enforceTrustChainVerification)
+      expectation.fulfill()
+    }
+
+    _ = EngineBuilder()
+      .addEngineType(MockEnvoyEngine.self)
+      .enforceTrustChainVerification(true)
+      .build()
+    self.waitForExpectations(timeout: 0.01)
+  }
+
   func testAddinggrpcStatsDomainAddsToConfigurationWhenRunningEnvoy() {
     let expectation = self.expectation(description: "Run called with expected data")
     MockEnvoyEngine.onRunWithConfig = { config, _ in
@@ -374,6 +388,7 @@ final class EngineBuilderTests: XCTestCase {
       dnsPreresolveHostnames: "[test]",
       enableHappyEyeballs: true,
       enableInterfaceBinding: true,
+      enforceTrustChainVerification: false,
       h2ConnectionKeepaliveIdleIntervalMilliseconds: 1,
       h2ConnectionKeepaliveTimeoutSeconds: 333,
       h2RawDomains: ["h2-raw.domain"],
@@ -403,6 +418,7 @@ final class EngineBuilderTests: XCTestCase {
     XCTAssertTrue(resolvedYAML.contains("&dns_lookup_family ALL"))
     XCTAssertTrue(resolvedYAML.contains("&dns_multiple_addresses true"))
     XCTAssertTrue(resolvedYAML.contains("&enable_interface_binding true"))
+    XCTAssertTrue(resolvedYAML.contains("&trust_chain_verification ACCEPT_UNTRUSTED"))
 
     XCTAssertTrue(resolvedYAML.contains("&h2_connection_keepalive_idle_interval 0.001s"))
     XCTAssertTrue(resolvedYAML.contains("&h2_connection_keepalive_timeout 333s"))
@@ -443,6 +459,7 @@ final class EngineBuilderTests: XCTestCase {
       dnsPreresolveHostnames: "[test]",
       enableHappyEyeballs: false,
       enableInterfaceBinding: false,
+      enforceTrustChainVerification: true,
       h2ConnectionKeepaliveIdleIntervalMilliseconds: 1,
       h2ConnectionKeepaliveTimeoutSeconds: 333,
       h2RawDomains: [],
@@ -466,6 +483,7 @@ final class EngineBuilderTests: XCTestCase {
     XCTAssertTrue(resolvedYAML.contains("&dns_lookup_family V4_PREFERRED"))
     XCTAssertTrue(resolvedYAML.contains("&dns_multiple_addresses false"))
     XCTAssertTrue(resolvedYAML.contains("&enable_interface_binding false"))
+    XCTAssertTrue(resolvedYAML.contains("&trust_chain_verification VERIFY_TRUST_CHAIN"))
   }
 
   func testReturnsNilWhenUnresolvedValueInTemplate() {
@@ -480,6 +498,7 @@ final class EngineBuilderTests: XCTestCase {
       dnsPreresolveHostnames: "[test]",
       enableHappyEyeballs: false,
       enableInterfaceBinding: false,
+      enforceTrustChainVerification: true,
       h2ConnectionKeepaliveIdleIntervalMilliseconds: 222,
       h2ConnectionKeepaliveTimeoutSeconds: 333,
       h2RawDomains: [],


### PR DESCRIPTION
Description: Adds feature parity to the Android/JVM engine builder, and allows TLS trust chain verification to be bypassed.
Risk Level: Low
Testing: Unit & CI

Signed-off-by: Mike Schore <mike.schore@gmail.com>