### PR TITLE
[iOS/macOS] Fix reachability

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -9,6 +9,7 @@ build --features=debug_prefix_map_pwd_is_dot
 build --features=swift.cacheable_swiftmodules
 build --features=swift.debug_prefix_map
 build --host_force_python=PY3
+build --macos_minimum_os=10.14
 build --ios_minimum_os=12.0
 build --ios_simulator_device="iPhone 13"
 build --ios_simulator_version=15.2

--- a/docs/root/intro/version_history.rst
+++ b/docs/root/intro/version_history.rst
@@ -8,6 +8,7 @@ Bugfixes:
 
 - Android: Fix `NoClassDefFoundError` errors when using `addDNSFallbackNameservers`
   or `addH2RawDomains` with Android versions older than API level 24.
+- iOS: Fix reachability which has been broken since February 11.
 
 Features:
 

--- a/library/objective-c/BUILD
+++ b/library/objective-c/BUILD
@@ -20,14 +20,9 @@ objc_library(
         "EnvoyHTTPStreamImpl.m",
         "EnvoyLogger.m",
         "EnvoyNativeFilterConfig.m",
+        "EnvoyNetworkMonitor.m",
         "EnvoyStringAccessor.m",
-    ] + select({
-        "@platforms//os:macos": [
-        ],
-        "//conditions:default": [
-            "EnvoyNetworkMonitor.m",
-        ],
-    }),
+    ],
     hdrs = [
         "EnvoyEngine.h",
     ],

--- a/library/objective-c/EnvoyEngineImpl.m
+++ b/library/objective-c/EnvoyEngineImpl.m
@@ -440,13 +440,11 @@ static void ios_track_event(envoy_map map, const void *context) {
 
   _engineHandle = init_engine(native_callbacks, native_logger, native_event_tracker);
 
-#ifndef TARGET_OS_MAC
   if (enableNetworkPathMonitor) {
     [EnvoyNetworkMonitor startPathMonitorIfNeeded];
   } else {
     [EnvoyNetworkMonitor startReachabilityIfNeeded];
   }
-#endif
 
   return self;
 }

--- a/library/objective-c/EnvoyNetworkMonitor.m
+++ b/library/objective-c/EnvoyNetworkMonitor.m
@@ -90,7 +90,12 @@ static void _reachability_callback(SCNetworkReachabilityRef target,
     return;
   }
 
+#ifdef TARGET_OS_MAC
+  BOOL isUsingWWAN = NO; // Macs don't have WWAN interfaces
+#else
   BOOL isUsingWWAN = flags & kSCNetworkReachabilityFlagsIsWWAN;
+#endif
+
   NSLog(@"[Envoy] setting preferred network to %@", isUsingWWAN ? @"WWAN" : @"WLAN");
   set_preferred_network(isUsingWWAN ? ENVOY_NET_WWAN : ENVOY_NET_WLAN);
 }


### PR DESCRIPTION
Enable path monitor reachability state observation on both iOS and macOS.

It was disabled in https://github.com/envoyproxy/envoy-mobile/pull/2052 because we didn't have a minimum macOS version set but this API is available as of 10.14.

It seems the `@platforms//os:macos` condition meant that the host was macOS, not that the compilation target was macOS.

Risk Level: Low, re-enabling something that was enabled until fairly recently.
Testing: Validated that preferred network changes are logged when toggling WiFi on/off in the Swift example apps on a physical iPhone. Also confirmed that the library still builds for macOS with `./bazelw build //library/objective-c:envoy_engine_objc_lib --config=macos`.
Release Notes: Added.

Signed-off-by: JP Simard <jp@jpsim.com>