### PR TITLE
[iOS] Fix macOS/iOS compiler conditionals

### DIFF
--- a/library/objective-c/EnvoyEngineImpl.m
+++ b/library/objective-c/EnvoyEngineImpl.m
@@ -7,7 +7,7 @@
 #import "library/common/main_interface.h"
 #import "library/common/types/c_types.h"
 
-#ifndef TARGET_OS_MAC
+#if TARGET_OS_IPHONE
 #import <UIKit/UIKit.h>
 #endif
 
@@ -594,7 +594,7 @@ static void ios_track_event(envoy_map map, const void *context) {
 #pragma mark - Private
 
 - (void)startObservingLifecycleNotifications {
-#ifndef TARGET_OS_MAC
+#if TARGET_OS_IPHONE
   // re-enable lifecycle-based stat flushing when
   // https://github.com/envoyproxy/envoy-mobile/issues/748 gets fixed.
   NSNotificationCenter *notificationCenter = [NSNotificationCenter defaultCenter];

--- a/library/objective-c/EnvoyNetworkMonitor.m
+++ b/library/objective-c/EnvoyNetworkMonitor.m
@@ -90,10 +90,10 @@ static void _reachability_callback(SCNetworkReachabilityRef target,
     return;
   }
 
-#ifdef TARGET_OS_MAC
-  BOOL isUsingWWAN = NO; // Macs don't have WWAN interfaces
-#else
+#if TARGET_OS_IPHONE
   BOOL isUsingWWAN = flags & kSCNetworkReachabilityFlagsIsWWAN;
+#else
+  BOOL isUsingWWAN = NO; // Macs don't have WWAN interfaces
 #endif
 
   NSLog(@"[Envoy] setting preferred network to %@", isUsingWWAN ? @"WWAN" : @"WLAN");


### PR DESCRIPTION
Description: `TARGET_OS_MAC` is defined on iOS, but is not truth-y, so the previous checks were not sufficient.
Risk Level: Low, re-enabling something that used to be enabled on iOS.
Testing: Verified in our sample apps that WLAN/WWAN interfaces are properly logged when reachability changes.
Docs Changes:
Release Notes:
[Optional Fixes #Issue]
[Optional Deprecated:]

Signed-off-by: JP Simard <jp@jpsim.com>