### PR TITLE
config: temporarily hardcode h2 max concurrent streams to 100

### DIFF
--- a/library/common/config/config.cc
+++ b/library/common/config/config.cc
@@ -123,6 +123,7 @@ const char* config_template = R"(
         connection_keepalive:
           connection_idle_interval: *h2_connection_keepalive_idle_interval
           timeout: *h2_connection_keepalive_timeout
+        max_concurrent_streams: 100
     upstream_http_protocol_options:
       auto_sni: true
       auto_san_validation: true


### PR DESCRIPTION
Description: This plays nicer with some upstreams that have this commonly configured as default because it preemptively allows for local queueing to occur and/or additional  connections to be utilized. However we should iterate and consider the following improvements:
1. make globally configurable
2. make configurable per-host
3. remember server settings for next time

Risk: Low
Testing: Local

Signed-off-by: Mike Schore <mike.schore@gmail.com>
