### PR TITLE
ci: create symbol mapping file

### DIFF
--- a/bazel/android_debug_info.bzl
+++ b/bazel/android_debug_info.bzl
@@ -25,9 +25,9 @@ def _impl(ctx):
         ctx.actions.run_shell(
             inputs = [lib],
             outputs = [objdump_output],
-            command = cc_toolchain.objdump_executable + " --syms " + lib.path + "| gzip -c >" + objdump_output.path,
+            command = cc_toolchain.objdump_executable + " --dwarf=info --dwarf=rawline " + lib.path + "| gzip -c >" + objdump_output.path,
             tools = [cc_toolchain.all_files],
-            progress_message = "Generating symbol map " + platform_name,
+            progress_message = "Generating symbol mapping file " + platform_name,
         )
 
         strip_output = ctx.actions.declare_file(platform_name + "/" + lib.basename)


### PR DESCRIPTION
Signed-off-by: Rafal Augustyniak <raugustyniak@lyft.com>

Description: Generate symbol mapping file as opposed to symbol table mapping file as it contains more information. Bugsnag's guide explaining the difference between symbol table mapping files and symbol mapping files and how  to generate the latter can be found at https://docs.bugsnag.com/api/ndk-symbol-mapping-upload/#uploading-mapping-files. 

See this Bugsnag Android Github issue https://github.com/bugsnag/bugsnag-android/issues/1609.

Risk Level: Low, affects debugging features only, not production code
Testing: N/A
Docs Changes: N/A
Release Notes: N/A
