### PR TITLE
stats: enable more metrics

### DIFF
--- a/library/common/config/config.cc
+++ b/library/common/config/config.cc
@@ -389,6 +389,12 @@ stats_config:
             regex: '^cluster\.[\w]+?\.upstream_rq_[\w]+'
         - safe_regex:
             google_re2: {}
+            regex: '^cluster\.[\w]+?\.update_(attempt|success|failure)'
+        - safe_regex:
+            google_re2: {}
+            regex: '^cluster\.[\w]+?\.http2.keepalive_timeout'
+        - safe_regex:
+            google_re2: {}
             regex: '^dns.apple.*'
         - safe_regex:
             google_re2: {}
@@ -398,7 +404,7 @@ stats_config:
             regex: '^http.hcm.decompressor.*'
         - safe_regex:
             google_re2: {}
-            regex: '^http.hcm.downstream_rq_(?:[12345]xx|total|completed)'
+            regex: '^http.hcm.downstream_rq_[\w]+'
         - safe_regex:
             google_re2: {}
             regex: '^pulse.*'


### PR DESCRIPTION
Signed-off-by: Rafal Augustyniak <raugustyniak@lyft.com>

Description: Modify config to enable more metrics. Mainly focused on downstream requests, DNS updates and h2 ping timeouts. The changes add around 44 new metrics (a move from around 250 to around 290).
Risk Level: Low
Testing: N/A
Docs Changes: N/A
Release Notes: N/A

