### PR TITLE
bazel: remove sandbox disable

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -13,7 +13,6 @@ build --macos_minimum_os=10.14
 build --ios_minimum_os=12.0
 build --ios_simulator_device="iPhone 13"
 build --ios_simulator_version=15.2
-build --spawn_strategy=local
 build --verbose_failures
 build --workspace_status_command=envoy/bazel/get_workspace_status
 build --xcode_version=13.2.1


### PR DESCRIPTION
This was added ages ago for local build performance. This breaks
rules_rust currently because of https://github.com/bazelbuild/rules_rust/issues/1244

I did a test and the clean build time of `ios_dist` was 687s with
sandboxing disabled, and 705s with it enabled on my M1 Max MBP. I think
this is small enough that we can remove this for now to enable using
rust, and revisit in the future if that issue is fixed.