### PR TITLE
update envoy@e4eaf1b97

### DIFF
--- a/envoy_build_config/extension_registry.cc
+++ b/envoy_build_config/extension_registry.cc
@@ -1,5 +1,6 @@
 #include "extension_registry.h"
 
+#include "source/common/network/default_client_connection_factory.h"
 #include "source/common/network/socket_interface_impl.h"
 #include "source/common/upstream/logical_dns_cluster.h"
 #include "source/extensions/clusters/dynamic_forward_proxy/cluster.h"
@@ -64,8 +65,9 @@ void ExtensionRegistry::registerFactories() {
   // https://github.com/envoyproxy/envoy/pull/11380/files#diff-8a5c90e5a39b2ea975170edc4434345bR138.
   // For now force the compilation unit to run by creating an instance of the class declared in
   // socket_interface_impl.h and immediately destroy.
-  auto ptr = std::make_unique<Network::SocketInterfaceImpl>();
-  ptr.reset(nullptr);
+  { auto ptr = std::make_unique<Network::SocketInterfaceImpl>(); }
+
+  { auto ptr = std::make_unique<Network::DefaultClientConnectionFactory>(); }
 }
 
 } // namespace Envoy

--- a/library/common/network/synthetic_address_impl.h
+++ b/library/common/network/synthetic_address_impl.h
@@ -20,35 +20,39 @@ class SyntheticAddressImpl : public Instance {
 public:
   SyntheticAddressImpl() {}
 
-  bool operator==(const Instance&) const {
+  bool operator==(const Instance&) const override {
     // Every synthetic address is different from one another and other address types. In reality,
     // whatever object owns a synthetic address can't rely on address equality for any logic as the
     // address is just a stub.
     return false;
   }
 
-  const std::string& asString() const { return address_; }
+  const std::string& asString() const override { return address_; }
 
-  absl::string_view asStringView() const { return address_; }
+  absl::string_view asStringView() const override { return address_; }
 
-  const std::string& logicalName() const { return address_; }
+  const std::string& logicalName() const override { return address_; }
 
-  const Ip* ip() const { return nullptr; }
+  const Ip* ip() const override { return nullptr; }
 
-  const Pipe* pipe() const { return nullptr; }
+  const Pipe* pipe() const override { return nullptr; }
 
-  const EnvoyInternalAddress* envoyInternalAddress() const { return nullptr; }
+  const EnvoyInternalAddress* envoyInternalAddress() const override { return nullptr; }
 
-  const sockaddr* sockAddr() const { return nullptr; }
+  const sockaddr* sockAddr() const override { return nullptr; }
 
-  socklen_t sockAddrLen() const { return 0; }
+  socklen_t sockAddrLen() const override { return 0; }
 
-  Type type() const {
+  Type type() const override {
     // TODO(junr03): consider adding another type of address.
     return Type::Ip;
   }
 
-  const SocketInterface& socketInterface() const { return SocketInterfaceSingleton::get(); }
+  absl::string_view addressType() const override {
+    return "";
+  }
+
+  const SocketInterface& socketInterface() const override { return SocketInterfaceSingleton::get(); }
 
 private:
   const std::string address_{"synthetic"};

--- a/library/common/network/synthetic_address_impl.h
+++ b/library/common/network/synthetic_address_impl.h
@@ -48,11 +48,11 @@ public:
     return Type::Ip;
   }
 
-  absl::string_view addressType() const override {
-    return "";
-  }
+  absl::string_view addressType() const override { return ""; }
 
-  const SocketInterface& socketInterface() const override { return SocketInterfaceSingleton::get(); }
+  const SocketInterface& socketInterface() const override {
+    return SocketInterfaceSingleton::get();
+  }
 
 private:
   const std::string address_{"synthetic"};

--- a/library/common/network/synthetic_address_impl.h
+++ b/library/common/network/synthetic_address_impl.h
@@ -48,7 +48,7 @@ public:
     return Type::Ip;
   }
 
-  absl::string_view addressType() const override { return ""; }
+  absl::string_view addressType() const override { return "default"; }
 
   const SocketInterface& socketInterface() const override {
     return SocketInterfaceSingleton::get();

--- a/test/kotlin/integration/StatFlushIntegrationTest.kt
+++ b/test/kotlin/integration/StatFlushIntegrationTest.kt
@@ -72,6 +72,6 @@ class StatFlushIntegrationTest {
 
     engine!!.flushStats()
 
-    statsdServer.awaitStatMatching("envoy.pulse.foo.bar:1|c");
+    statsdServer.awaitStatMatching { s -> s == "envoy.pulse.foo.bar:1|c" }
   }
 }

--- a/test/kotlin/integration/StatFlushIntegrationTest.kt
+++ b/test/kotlin/integration/StatFlushIntegrationTest.kt
@@ -72,7 +72,6 @@ class StatFlushIntegrationTest {
 
     engine!!.flushStats()
 
-    statsdServer.awaitNextStat()
-    assertThat(statsdServer.mostRecentlyReceivedStat()).contains("envoy.pulse.foo.bar:1|c")
+    statsdServer.awaitStatMatching("envoy.pulse.foo.bar:1|c");
   }
 }


### PR DESCRIPTION
Updates to the latest version of Envoy upstream

Fixes a flaky stats test that got worse with the bump
Forces the registration of the new client channel factory extension that is part of core
Implements a new method for the synthetic address

Signed-off-by: Snow Pettersen <snowp@lyft.com>

Risk Level: Medium
Testing: Existing tests
Docs Changes: n/a
Release Notes: n/a
