### PR TITLE
build: export flatbuffer jvm dep

### DIFF
--- a/bazel/flatbuffers.bzl
+++ b/bazel/flatbuffers.bzl
@@ -21,6 +21,7 @@ def envoy_mobile_flatbuffers_library(name, srcs, namespace, types):
         name = "{}_fb_kt_lib".format(name),
         srcs = [":{}_fb_kt_srcs".format(name)],
         deps = ["@maven//:com_google_flatbuffers_flatbuffers_java"],
+        exports = ["@maven//:com_google_flatbuffers_flatbuffers_java"],
     )
 
     swift_intermediate_outputs = ["{}_generated.swift".format(f.replace(".fbs", "")) for f in srcs]

--- a/bazel/kotlin_lib.bzl
+++ b/bazel/kotlin_lib.bzl
@@ -19,7 +19,7 @@ def native_lib_name(native_dep):
         lib_name = native_dep.split(".so")[0]
     return lib_name
 
-def envoy_mobile_kt_library(name, visibility = None, srcs = [], deps = []):
+def envoy_mobile_kt_library(name, visibility = None, srcs = [], deps = [], exports = []):
     # These source files must be re-exported to the kotlin custom library rule to ensure their
     # inclusion. This is used to work around testing visibility.
     native.filegroup(
@@ -32,6 +32,7 @@ def envoy_mobile_kt_library(name, visibility = None, srcs = [], deps = []):
         name = name,
         srcs = srcs,
         deps = deps,
+        exports = exports,
         visibility = visibility,
     )
 


### PR DESCRIPTION
This allows the pom rule to pick up the dependency, ensuring that it gets included in the <dependency> stanza of the final Envoy POM file. 

Signed-off-by: Snow Pettersen <snowp@lyft.com>

Risk Level: Low, build only
Testing: Generated the POM file and verified flatbuffers-java now appear
Docs Changes: n/a
Release Notes: n/a
