### PR TITLE
internal: pass engine handles throughout API

### DIFF
--- a/library/cc/stream.cc
+++ b/library/cc/stream.cc
@@ -7,27 +7,30 @@
 namespace Envoy {
 namespace Platform {
 
-Stream::Stream(envoy_stream_t handle) : handle_(handle) {}
+Stream::Stream(envoy_engine_t engine_handle, envoy_stream_t handle)
+    : engine_handle_(engine_handle), handle_(handle) {}
 
 Stream& Stream::sendHeaders(RequestHeadersSharedPtr headers, bool end_stream) {
   envoy_headers raw_headers = rawHeaderMapAsEnvoyHeaders(headers->allHeaders());
-  ::send_headers(this->handle_, raw_headers, end_stream);
+  ::send_headers(this->engine_handle_, this->handle_, raw_headers, end_stream);
   return *this;
 }
 
 Stream& Stream::sendData(envoy_data data) {
-  ::send_data(this->handle_, data, false);
+  ::send_data(this->engine_handle_, this->handle_, data, false);
   return *this;
 }
 
 void Stream::close(RequestTrailersSharedPtr trailers) {
   envoy_headers raw_headers = rawHeaderMapAsEnvoyHeaders(trailers->allHeaders());
-  ::send_trailers(this->handle_, raw_headers);
+  ::send_trailers(this->engine_handle_, this->handle_, raw_headers);
 }
 
-void Stream::close(envoy_data data) { ::send_data(this->handle_, data, true); }
+void Stream::close(envoy_data data) {
+  ::send_data(this->engine_handle_, this->handle_, data, true);
+}
 
-void Stream::cancel() { reset_stream(this->handle_); }
+void Stream::cancel() { reset_stream(this->engine_handle_, this->handle_); }
 
 } // namespace Platform
 } // namespace Envoy

--- a/library/cc/stream.h
+++ b/library/cc/stream.h
@@ -15,7 +15,7 @@ using EngineSharedPtr = std::shared_ptr<Engine>;
 
 class Stream {
 public:
-  Stream(envoy_stream_t handle);
+  Stream(envoy_engine_t engine_handle, envoy_stream_t handle);
 
   Stream& sendHeaders(RequestHeadersSharedPtr headers, bool end_stream);
   Stream& sendData(envoy_data data);
@@ -24,6 +24,7 @@ public:
   void cancel();
 
 private:
+  envoy_engine_t engine_handle_;
   envoy_stream_t handle_;
 };
 

--- a/library/cc/stream_prototype.cc
+++ b/library/cc/stream_prototype.cc
@@ -11,8 +11,9 @@ StreamPrototype::StreamPrototype(EngineSharedPtr engine) : engine_(engine) {
 
 StreamSharedPtr StreamPrototype::start() {
   auto envoy_stream = init_stream(this->engine_->engine_);
-  start_stream(envoy_stream, this->callbacks_->asEnvoyHttpCallbacks(), false);
-  return std::make_shared<Stream>(envoy_stream);
+  start_stream(this->engine_->engine_, envoy_stream, this->callbacks_->asEnvoyHttpCallbacks(),
+               false);
+  return std::make_shared<Stream>(this->engine_->engine_, envoy_stream);
 }
 
 StreamPrototype& StreamPrototype::setOnHeaders(OnHeadersCallback closure) {

--- a/library/common/jni/android_jni_interface.cc
+++ b/library/common/jni/android_jni_interface.cc
@@ -25,7 +25,9 @@ Java_io_envoyproxy_envoymobile_engine_AndroidJniLibrary_initialize(JNIEnv* env,
 extern "C" JNIEXPORT jint JNICALL
 Java_io_envoyproxy_envoymobile_engine_AndroidJniLibrary_setPreferredNetwork(JNIEnv* env,
                                                                             jclass, // class
+                                                                            jlong engine,
                                                                             jint network) {
   jni_log("[Envoy]", "setting preferred network");
-  return set_preferred_network(static_cast<envoy_network_t>(network));
+  return set_preferred_network(static_cast<envoy_engine_t>(engine),
+                               static_cast<envoy_network_t>(network));
 }

--- a/library/common/jni/android_jni_interface.cc
+++ b/library/common/jni/android_jni_interface.cc
@@ -21,13 +21,3 @@ Java_io_envoyproxy_envoymobile_engine_AndroidJniLibrary_initialize(JNIEnv* env,
 
   return ares_library_init_android(connectivity_manager);
 }
-
-extern "C" JNIEXPORT jint JNICALL
-Java_io_envoyproxy_envoymobile_engine_AndroidJniLibrary_setPreferredNetwork(JNIEnv* env,
-                                                                            jclass, // class
-                                                                            jlong engine,
-                                                                            jint network) {
-  jni_log("[Envoy]", "setting preferred network");
-  return set_preferred_network(static_cast<envoy_engine_t>(engine),
-                               static_cast<envoy_network_t>(network));
-}

--- a/library/common/jni/android_test_jni_interface.cc
+++ b/library/common/jni/android_test_jni_interface.cc
@@ -18,7 +18,9 @@ Java_io_envoyproxy_envoymobile_engine_AndroidJniLibrary_initialize(JNIEnv* env,
 extern "C" JNIEXPORT jint JNICALL
 Java_io_envoyproxy_envoymobile_engine_AndroidJniLibrary_setPreferredNetwork(JNIEnv* env,
                                                                             jclass, // class
+                                                                            jlong engine,
                                                                             jint network) {
   jni_log("[Envoy]", "setting preferred network");
-  return set_preferred_network(static_cast<envoy_network_t>(network));
+  return set_preferred_network(static_cast<envoy_engine_t>(engine),
+                               static_cast<envoy_network_t>(network));
 }

--- a/library/common/jni/android_test_jni_interface.cc
+++ b/library/common/jni/android_test_jni_interface.cc
@@ -14,13 +14,3 @@ Java_io_envoyproxy_envoymobile_engine_AndroidJniLibrary_initialize(JNIEnv* env,
 
   return 0;
 }
-
-extern "C" JNIEXPORT jint JNICALL
-Java_io_envoyproxy_envoymobile_engine_AndroidJniLibrary_setPreferredNetwork(JNIEnv* env,
-                                                                            jclass, // class
-                                                                            jlong engine,
-                                                                            jint network) {
-  jni_log("[Envoy]", "setting preferred network");
-  return set_preferred_network(static_cast<envoy_engine_t>(engine),
-                               static_cast<envoy_network_t>(network));
-}

--- a/library/common/jni/jni_interface.cc
+++ b/library/common/jni/jni_interface.cc
@@ -1022,3 +1022,12 @@ Java_io_envoyproxy_envoymobile_engine_JniLibrary_drainConnections(JNIEnv* env,
   jni_log("[Envoy]", "drainConnections");
   drain_connections(engine);
 }
+
+extern "C" JNIEXPORT jint JNICALL
+Java_io_envoyproxy_envoymobile_engine_JniLibrary_setPreferredNetwork(JNIEnv* env,
+                                                                     jclass, // class
+                                                                     jlong engine, jint network) {
+  jni_log("[Envoy]", "setting preferred network");
+  return set_preferred_network(static_cast<envoy_engine_t>(engine),
+                               static_cast<envoy_network_t>(network));
+}

--- a/library/common/jni/jni_interface.cc
+++ b/library/common/jni/jni_interface.cc
@@ -839,7 +839,8 @@ extern "C" JNIEXPORT jlong JNICALL Java_io_envoyproxy_envoymobile_engine_JniLibr
 }
 
 extern "C" JNIEXPORT jint JNICALL Java_io_envoyproxy_envoymobile_engine_JniLibrary_startStream(
-    JNIEnv* env, jclass, jlong stream_handle, jobject j_context, jboolean explicit_flow_control) {
+    JNIEnv* env, jclass, jlong engine_handle, jlong stream_handle, jobject j_context,
+    jboolean explicit_flow_control) {
 
   // TODO: To be truly safe we may need stronger guarantees of operation ordering on this ref.
   jobject retained_context = env->NewGlobalRef(j_context);
@@ -852,7 +853,8 @@ extern "C" JNIEXPORT jint JNICALL Java_io_envoyproxy_envoymobile_engine_JniLibra
                                            jvm_on_cancel,
                                            jvm_on_send_window_available,
                                            retained_context};
-  envoy_status_t result = start_stream(static_cast<envoy_stream_t>(stream_handle), native_callbacks,
+  envoy_status_t result = start_stream(static_cast<envoy_engine_t>(engine_handle),
+                                       static_cast<envoy_stream_t>(stream_handle), native_callbacks,
                                        explicit_flow_control);
   if (result != ENVOY_SUCCESS) {
     env->DeleteGlobalRef(retained_context); // No callbacks are fired and we need to release
@@ -934,60 +936,62 @@ Java_io_envoyproxy_envoymobile_engine_EnvoyHTTPFilterCallbacksImpl_callReleaseCa
 // EnvoyHTTPStream
 
 extern "C" JNIEXPORT jint JNICALL Java_io_envoyproxy_envoymobile_engine_JniLibrary_readData(
-    JNIEnv* env, jclass, jlong stream_handle, jlong byte_count) {
-
-  return read_data(static_cast<envoy_stream_t>(stream_handle), byte_count);
+    JNIEnv* env, jclass, jlong engine_handle, jlong stream_handle, jlong byte_count) {
+  return read_data(static_cast<envoy_engine_t>(engine_handle),
+                   static_cast<envoy_stream_t>(stream_handle), byte_count);
 }
 
-// Note: JLjava_nio_ByteBuffer_2IZ is the mangled signature of the java method.
-// https://docs.oracle.com/javase/7/docs/technotes/guides/jni/spec/design.html
 // The Java counterpart guarantees to invoke this method with a non-null direct ByteBuffer where the
 // provided length is between 0 and ByteBuffer.capacity(), inclusively.
-extern "C" JNIEXPORT jint JNICALL
-Java_io_envoyproxy_envoymobile_engine_JniLibrary_sendData__JLjava_nio_ByteBuffer_2IZ(
-    JNIEnv* env, jclass, jlong stream_handle, jobject data, jint length, jboolean end_stream) {
+extern "C" JNIEXPORT jint JNICALL Java_io_envoyproxy_envoymobile_engine_JniLibrary_sendData(
+    JNIEnv* env, jclass, jlong engine_handle, jlong stream_handle, jobject data, jint length,
+    jboolean end_stream) {
   if (end_stream) {
     jni_log("[Envoy]", "jvm_send_data_end_stream");
   }
-
-  return send_data(static_cast<envoy_stream_t>(stream_handle),
+  return send_data(static_cast<envoy_engine_t>(engine_handle),
+                   static_cast<envoy_stream_t>(stream_handle),
                    buffer_to_native_data(env, data, length), end_stream);
 }
 
-// Note: J_3BIZ is the mangled signature of the java method.
-// https://docs.oracle.com/javase/7/docs/technotes/guides/jni/spec/design.html
 // The Java counterpart guarantees to invoke this method with a non-null jbyteArray where the
 // provided length is between 0 and the size of the jbyteArray, inclusively. And given that this
 // jbyteArray comes from a ByteBuffer, it is also guaranteed that its length will not be greater
 // than 2^31 - this is why the length type is jint.
-extern "C" JNIEXPORT jint JNICALL Java_io_envoyproxy_envoymobile_engine_JniLibrary_sendData__J_3BIZ(
-    JNIEnv* env, jclass, jlong stream_handle, jbyteArray data, jint length, jboolean end_stream) {
+extern "C" JNIEXPORT jint JNICALL
+Java_io_envoyproxy_envoymobile_engine_JniLibrary_sendDataByteArray(JNIEnv* env, jclass,
+                                                                   jlong engine_handle,
+                                                                   jlong stream_handle,
+                                                                   jbyteArray data, jint length,
+                                                                   jboolean end_stream) {
   if (end_stream) {
     jni_log("[Envoy]", "jvm_send_data_end_stream");
   }
-
-  return send_data(static_cast<envoy_stream_t>(stream_handle),
+  return send_data(static_cast<envoy_engine_t>(engine_handle),
+                   static_cast<envoy_stream_t>(stream_handle),
                    array_to_native_data(env, data, length), end_stream);
 }
 
 extern "C" JNIEXPORT jint JNICALL Java_io_envoyproxy_envoymobile_engine_JniLibrary_sendHeaders(
-    JNIEnv* env, jclass, jlong stream_handle, jobjectArray headers, jboolean end_stream) {
-
-  return send_headers(static_cast<envoy_stream_t>(stream_handle), to_native_headers(env, headers),
+    JNIEnv* env, jclass, jlong engine_handle, jlong stream_handle, jobjectArray headers,
+    jboolean end_stream) {
+  return send_headers(static_cast<envoy_engine_t>(engine_handle),
+                      static_cast<envoy_stream_t>(stream_handle), to_native_headers(env, headers),
                       end_stream);
 }
 
 extern "C" JNIEXPORT jint JNICALL Java_io_envoyproxy_envoymobile_engine_JniLibrary_sendTrailers(
-    JNIEnv* env, jclass, jlong stream_handle, jobjectArray trailers) {
+    JNIEnv* env, jclass, jlong engine_handle, jlong stream_handle, jobjectArray trailers) {
   jni_log("[Envoy]", "jvm_send_trailers");
-  return send_trailers(static_cast<envoy_stream_t>(stream_handle),
+  return send_trailers(static_cast<envoy_engine_t>(engine_handle),
+                       static_cast<envoy_stream_t>(stream_handle),
                        to_native_headers(env, trailers));
 }
 
 extern "C" JNIEXPORT jint JNICALL Java_io_envoyproxy_envoymobile_engine_JniLibrary_resetStream(
-    JNIEnv* env, jclass, jlong stream_handle) {
-
-  return reset_stream(static_cast<envoy_stream_t>(stream_handle));
+    JNIEnv* env, jclass, jlong engine_handle, jlong stream_handle) {
+  return reset_stream(static_cast<envoy_engine_t>(engine_handle),
+                      static_cast<envoy_stream_t>(stream_handle));
 }
 
 // EnvoyStringAccessor

--- a/library/common/main_interface.h
+++ b/library/common/main_interface.h
@@ -23,71 +23,80 @@ envoy_stream_t init_stream(envoy_engine_t engine);
 /**
  * Open an underlying HTTP stream. Note: Streams must be started before other other interaction can
  * can occur.
+ * @param engine, handle to the engine associated with this stream.
  * @param stream, handle to the stream to be started.
  * @param callbacks, the callbacks that will run the stream callbacks.
  * @param explicit_flow_control, whether to enable explicit flow control on the response stream.
  * @return envoy_stream, with a stream handle and a success status, or a failure status.
  */
-envoy_status_t start_stream(envoy_stream_t stream, envoy_http_callbacks callbacks,
-                            bool explicit_flow_control);
+envoy_status_t start_stream(envoy_engine_t engine, envoy_stream_t stream,
+                            envoy_http_callbacks callbacks, bool explicit_flow_control);
 
 /**
  * Send headers over an open HTTP stream. This method can be invoked once and needs to be called
  * before send_data.
+ * @param engine, the engine associated with this stream.
  * @param stream, the stream to send headers over.
  * @param headers, the headers to send.
  * @param end_stream, supplies whether this is headers only.
  * @return envoy_status_t, the resulting status of the operation.
  */
-envoy_status_t send_headers(envoy_stream_t stream, envoy_headers headers, bool end_stream);
+envoy_status_t send_headers(envoy_engine_t engine, envoy_stream_t stream, envoy_headers headers,
+                            bool end_stream);
 
 /**
  * Notify the stream that the caller is ready to receive more data from the response stream. Only
  * used in explicit flow control mode.
  * @param bytes_to_read, the quantity of data the caller is prepared to process.
  */
-envoy_status_t read_data(envoy_stream_t stream, size_t bytes_to_read);
+envoy_status_t read_data(envoy_engine_t engine, envoy_stream_t stream, size_t bytes_to_read);
 
 /**
  * Send data over an open HTTP stream. This method can be invoked multiple times.
+ * @param engine, the engine associated with this stream.
  * @param stream, the stream to send data over.
  * @param data, the data to send.
  * @param end_stream, supplies whether this is the last data in the stream.
  * @return envoy_status_t, the resulting status of the operation.
  */
-envoy_status_t send_data(envoy_stream_t stream, envoy_data data, bool end_stream);
+envoy_status_t send_data(envoy_engine_t engine, envoy_stream_t stream, envoy_data data,
+                         bool end_stream);
 
 /**
  * Send metadata over an HTTP stream. This method can be invoked multiple times.
+ * @param engine, the engine associated with this stream.
  * @param stream, the stream to send metadata over.
  * @param metadata, the metadata to send.
  * @return envoy_status_t, the resulting status of the operation.
  */
-envoy_status_t send_metadata(envoy_stream_t stream, envoy_headers metadata);
+envoy_status_t send_metadata(envoy_engine_t engine, envoy_stream_t stream, envoy_headers metadata);
 
 /**
  * Send trailers over an open HTTP stream. This method can only be invoked once per stream.
  * Note that this method implicitly ends the stream.
+ * @param engine, the engine associated with this stream.
  * @param stream, the stream to send trailers over.
  * @param trailers, the trailers to send.
  * @return envoy_status_t, the resulting status of the operation.
  */
-envoy_status_t send_trailers(envoy_stream_t stream, envoy_headers trailers);
+envoy_status_t send_trailers(envoy_engine_t engine, envoy_stream_t stream, envoy_headers trailers);
 
 /**
  * Detach all callbacks from a stream and send an interrupt upstream if supported by transport.
+ * @param engine, the engine associated with this stream.
  * @param stream, the stream to evict.
  * @return envoy_status_t, the resulting status of the operation.
  */
-envoy_status_t reset_stream(envoy_stream_t stream);
+envoy_status_t reset_stream(envoy_engine_t engine, envoy_stream_t stream);
 
 /**
  * Update the network interface to the preferred network for opening new streams.
  * Note that this state is shared by all engines.
+ * @param engine, the engine whose preferred network should be set.
  * @param network, the network to be preferred for new streams.
  * @return envoy_status_t, the resulting status of the operation.
  */
-envoy_status_t set_preferred_network(envoy_network_t network);
+envoy_status_t set_preferred_network(envoy_engine_t engine, envoy_network_t network);
 
 /**
  * Increment a counter with the given elements and by the given count.

--- a/library/java/io/envoyproxy/envoymobile/engine/AndroidEngineImpl.java
+++ b/library/java/io/envoyproxy/envoymobile/engine/AndroidEngineImpl.java
@@ -4,6 +4,7 @@ import android.content.Context;
 import io.envoyproxy.envoymobile.engine.types.EnvoyEventTracker;
 import io.envoyproxy.envoymobile.engine.types.EnvoyHTTPCallbacks;
 import io.envoyproxy.envoymobile.engine.types.EnvoyLogger;
+import io.envoyproxy.envoymobile.engine.types.EnvoyNetworkType;
 import io.envoyproxy.envoymobile.engine.types.EnvoyOnEngineRunning;
 import io.envoyproxy.envoymobile.engine.types.EnvoyStringAccessor;
 

--- a/library/java/io/envoyproxy/envoymobile/engine/AndroidEngineImpl.java
+++ b/library/java/io/envoyproxy/envoymobile/engine/AndroidEngineImpl.java
@@ -24,11 +24,6 @@ public class AndroidEngineImpl implements EnvoyEngine {
   }
 
   @Override
-  public long getHandle() {
-    return envoyEngine.getHandle();
-  }
-
-  @Override
   public EnvoyHTTPStream startStream(EnvoyHTTPCallbacks callbacks, boolean explicitFlowControl) {
     return envoyEngine.startStream(callbacks, explicitFlowControl);
   }
@@ -96,5 +91,10 @@ public class AndroidEngineImpl implements EnvoyEngine {
   @Override
   public void drainConnections() {
     envoyEngine.drainConnections();
+  }
+
+  @Override
+  public void setPreferredNetwork(EnvoyNetworkType network) {
+    envoyEngine.setPreferredNetwork(network);
   }
 }

--- a/library/java/io/envoyproxy/envoymobile/engine/AndroidEngineImpl.java
+++ b/library/java/io/envoyproxy/envoymobile/engine/AndroidEngineImpl.java
@@ -24,6 +24,11 @@ public class AndroidEngineImpl implements EnvoyEngine {
   }
 
   @Override
+  public long getHandle() {
+    return envoyEngine.getHandle();
+  }
+
+  @Override
   public EnvoyHTTPStream startStream(EnvoyHTTPCallbacks callbacks, boolean explicitFlowControl) {
     return envoyEngine.startStream(callbacks, explicitFlowControl);
   }

--- a/library/java/io/envoyproxy/envoymobile/engine/AndroidJniLibrary.java
+++ b/library/java/io/envoyproxy/envoymobile/engine/AndroidJniLibrary.java
@@ -44,13 +44,4 @@ public class AndroidJniLibrary {
    * @return The resulting status of the initialization.
    */
   protected static native int initialize(ConnectivityManager connectivityManager);
-
-  /**
-   * Update the network interface to the preferred network for opening new
-   * streams. Note that this state is shared by all engines.
-   *
-   * @param network, the network to be preferred for new streams.
-   * @return The resulting status of the operation.
-   */
-  protected static native int setPreferredNetwork(long engine, int network);
 }

--- a/library/java/io/envoyproxy/envoymobile/engine/AndroidJniLibrary.java
+++ b/library/java/io/envoyproxy/envoymobile/engine/AndroidJniLibrary.java
@@ -52,5 +52,5 @@ public class AndroidJniLibrary {
    * @param network, the network to be preferred for new streams.
    * @return The resulting status of the operation.
    */
-  protected static native int setPreferredNetwork(int network);
+  protected static native int setPreferredNetwork(long engine, int network);
 }

--- a/library/java/io/envoyproxy/envoymobile/engine/AndroidNetworkMonitor.java
+++ b/library/java/io/envoyproxy/envoymobile/engine/AndroidNetworkMonitor.java
@@ -34,7 +34,7 @@ public class AndroidNetworkMonitor extends BroadcastReceiver {
   private static volatile AndroidNetworkMonitor instance = null;
 
   private int previousNetworkType = ConnectivityManager.TYPE_DUMMY;
-  private long engineHandle;
+  private EnvoyEngine envoyEngine;
   private ConnectivityManager connectivityManager;
   private NetworkCallback networkCallback;
   private NetworkRequest networkRequest;
@@ -64,7 +64,7 @@ public class AndroidNetworkMonitor extends BroadcastReceiver {
       return;
     }
 
-    engineHandle = envoyEngine.getHandle();
+    this.envoyEngine = envoyEngine;
 
     connectivityManager =
         (ConnectivityManager)context.getSystemService(Context.CONNECTIVITY_SERVICE);
@@ -117,13 +117,13 @@ public class AndroidNetworkMonitor extends BroadcastReceiver {
 
     switch (networkType) {
     case ConnectivityManager.TYPE_MOBILE:
-      AndroidJniLibrary.setPreferredNetwork(engineHandle, ENVOY_NET_WWAN);
+      envoyEngine.setPreferredNetwork(ENVOY_NETWORK_TYPE_WWAN);
       return;
     case ConnectivityManager.TYPE_WIFI:
-      AndroidJniLibrary.setPreferredNetwork(engineHandle, ENVOY_NET_WLAN);
+      envoyEngine.setPreferredNetwork(ENVOY_NETWORK_TYPE_WLAN);
       return;
     default:
-      AndroidJniLibrary.setPreferredNetwork(engineHandle, ENVOY_NET_GENERIC);
+      envoyEngine.setPreferredNetwork(ENVOY_NETWORK_TYPE_GENERIC);
     }
   }
 }

--- a/library/java/io/envoyproxy/envoymobile/engine/AndroidNetworkMonitor.java
+++ b/library/java/io/envoyproxy/envoymobile/engine/AndroidNetworkMonitor.java
@@ -34,6 +34,7 @@ public class AndroidNetworkMonitor extends BroadcastReceiver {
   private static volatile AndroidNetworkMonitor instance = null;
 
   private int previousNetworkType = ConnectivityManager.TYPE_DUMMY;
+  private long engineHandle;
   private ConnectivityManager connectivityManager;
   private NetworkCallback networkCallback;
   private NetworkRequest networkRequest;
@@ -62,6 +63,8 @@ public class AndroidNetworkMonitor extends BroadcastReceiver {
       }
       return;
     }
+
+    engineHandle = envoyEngine.getHandle();
 
     connectivityManager =
         (ConnectivityManager)context.getSystemService(Context.CONNECTIVITY_SERVICE);
@@ -114,13 +117,13 @@ public class AndroidNetworkMonitor extends BroadcastReceiver {
 
     switch (networkType) {
     case ConnectivityManager.TYPE_MOBILE:
-      AndroidJniLibrary.setPreferredNetwork(ENVOY_NET_WWAN);
+      AndroidJniLibrary.setPreferredNetwork(engineHandle, ENVOY_NET_WWAN);
       return;
     case ConnectivityManager.TYPE_WIFI:
-      AndroidJniLibrary.setPreferredNetwork(ENVOY_NET_WLAN);
+      AndroidJniLibrary.setPreferredNetwork(engineHandle, ENVOY_NET_WLAN);
       return;
     default:
-      AndroidJniLibrary.setPreferredNetwork(ENVOY_NET_GENERIC);
+      AndroidJniLibrary.setPreferredNetwork(engineHandle, ENVOY_NET_GENERIC);
     }
   }
 }

--- a/library/java/io/envoyproxy/envoymobile/engine/AndroidNetworkMonitor.java
+++ b/library/java/io/envoyproxy/envoymobile/engine/AndroidNetworkMonitor.java
@@ -1,5 +1,7 @@
 package io.envoyproxy.envoymobile.engine;
 
+import io.envoyproxy.envoymobile.engine.types.EnvoyNetworkType;
+
 import android.Manifest;
 import android.annotation.TargetApi;
 import android.content.BroadcastReceiver;
@@ -117,13 +119,13 @@ public class AndroidNetworkMonitor extends BroadcastReceiver {
 
     switch (networkType) {
     case ConnectivityManager.TYPE_MOBILE:
-      envoyEngine.setPreferredNetwork(ENVOY_NETWORK_TYPE_WWAN);
+      envoyEngine.setPreferredNetwork(EnvoyNetworkType.ENVOY_NETWORK_TYPE_WWAN);
       return;
     case ConnectivityManager.TYPE_WIFI:
-      envoyEngine.setPreferredNetwork(ENVOY_NETWORK_TYPE_WLAN);
+      envoyEngine.setPreferredNetwork(EnvoyNetworkType.ENVOY_NETWORK_TYPE_WLAN);
       return;
     default:
-      envoyEngine.setPreferredNetwork(ENVOY_NETWORK_TYPE_GENERIC);
+      envoyEngine.setPreferredNetwork(EnvoyNetworkType.ENVOY_NETWORK_TYPE_GENERIC);
     }
   }
 }

--- a/library/java/io/envoyproxy/envoymobile/engine/EnvoyEngine.java
+++ b/library/java/io/envoyproxy/envoymobile/engine/EnvoyEngine.java
@@ -22,6 +22,11 @@ public interface EnvoyEngine {
   void terminate();
 
   /**
+   * Gets the engine's handle.
+   */
+  long getHandle();
+
+  /**
    * Run the Envoy engine with the provided yaml string and log level.
    *
    * The envoyConfiguration is used to resolve the configurationYAML.

--- a/library/java/io/envoyproxy/envoymobile/engine/EnvoyEngine.java
+++ b/library/java/io/envoyproxy/envoymobile/engine/EnvoyEngine.java
@@ -1,6 +1,7 @@
 package io.envoyproxy.envoymobile.engine;
 
 import io.envoyproxy.envoymobile.engine.types.EnvoyHTTPCallbacks;
+import io.envoyproxy.envoymobile.engine.types.EnvoyNetworkType;
 import io.envoyproxy.envoymobile.engine.types.EnvoyStringAccessor;
 
 import java.util.Map;
@@ -20,11 +21,6 @@ public interface EnvoyEngine {
    * Terminates the running engine.
    */
   void terminate();
-
-  /**
-   * Gets the engine's handle.
-   */
-  long getHandle();
 
   /**
    * Run the Envoy engine with the provided yaml string and log level.
@@ -123,4 +119,12 @@ public interface EnvoyEngine {
    * Drain all connections owned by this Engine.
    */
   void drainConnections();
+
+  /**
+   * Update the network interface to the preferred network for opening new
+   * streams.
+   *
+   * @param network The network to be preferred for new streams.
+   */
+  void setPreferredNetwork(EnvoyNetworkType network);
 }

--- a/library/java/io/envoyproxy/envoymobile/engine/EnvoyEngineImpl.java
+++ b/library/java/io/envoyproxy/envoymobile/engine/EnvoyEngineImpl.java
@@ -27,6 +27,11 @@ public class EnvoyEngineImpl implements EnvoyEngine {
     this.engineHandle = JniLibrary.initEngine(runningCallback, logger, eventTracker);
   }
 
+  @Override
+  public long getHandle() {
+    return engineHandle;
+  }
+
   /**
    * Creates a new stream with the provided callbacks.
    *
@@ -37,7 +42,8 @@ public class EnvoyEngineImpl implements EnvoyEngine {
   @Override
   public EnvoyHTTPStream startStream(EnvoyHTTPCallbacks callbacks, boolean explicitFlowControl) {
     long streamHandle = JniLibrary.initStream(engineHandle);
-    EnvoyHTTPStream stream = new EnvoyHTTPStream(streamHandle, callbacks, explicitFlowControl);
+    EnvoyHTTPStream stream =
+        new EnvoyHTTPStream(engineHandle, streamHandle, callbacks, explicitFlowControl);
     stream.start();
     return stream;
   }

--- a/library/java/io/envoyproxy/envoymobile/engine/EnvoyEngineImpl.java
+++ b/library/java/io/envoyproxy/envoymobile/engine/EnvoyEngineImpl.java
@@ -4,6 +4,7 @@ import io.envoyproxy.envoymobile.engine.types.EnvoyEventTracker;
 import io.envoyproxy.envoymobile.engine.types.EnvoyHTTPCallbacks;
 import io.envoyproxy.envoymobile.engine.types.EnvoyHTTPFilterFactory;
 import io.envoyproxy.envoymobile.engine.types.EnvoyLogger;
+import io.envoyproxy.envoymobile.engine.types.EnvoyNetworkType;
 import io.envoyproxy.envoymobile.engine.types.EnvoyOnEngineRunning;
 import io.envoyproxy.envoymobile.engine.types.EnvoyStringAccessor;
 import java.util.Map;
@@ -13,6 +14,10 @@ public class EnvoyEngineImpl implements EnvoyEngine {
   // TODO(goaway): enforce agreement values in /library/common/types/c_types.h.
   private static final int ENVOY_SUCCESS = 0;
   private static final int ENVOY_FAILURE = 1;
+
+  private static final int ENVOY_NET_GENERIC = 0;
+  private static final int ENVOY_NET_WWAN = 1;
+  private static final int ENVOY_NET_WLAN = 2;
 
   private final long engineHandle;
 
@@ -25,11 +30,6 @@ public class EnvoyEngineImpl implements EnvoyEngine {
                          EnvoyEventTracker eventTracker) {
     JniLibrary.load();
     this.engineHandle = JniLibrary.initEngine(runningCallback, logger, eventTracker);
-  }
-
-  @Override
-  public long getHandle() {
-    return engineHandle;
   }
 
   /**
@@ -204,5 +204,23 @@ public class EnvoyEngineImpl implements EnvoyEngine {
   @Override
   public void drainConnections() {
     JniLibrary.drainConnections(engineHandle);
+  }
+
+  @Override
+  public void setPreferredNetwork(EnvoyNetworkType network) {
+    switch (network) {
+    case ENVOY_NETWORK_TYPE_WWAN:
+      JniLibrary.setPreferredNetwork(engineHandle, ENVOY_NET_WWAN);
+      return;
+    case ENVOY_NETWORK_TYPE_WLAN:
+      JniLibrary.setPreferredNetwork(engineHandle, ENVOY_NET_WLAN);
+      return;
+    case ENVOY_NETWORK_TYPE_GENERIC:
+      JniLibrary.setPreferredNetwork(engineHandle, ENVOY_NET_GENERIC);
+      return;
+    default:
+      JniLibrary.setPreferredNetwork(engineHandle, ENVOY_NET_GENERIC);
+      return;
+    }
   }
 }

--- a/library/java/io/envoyproxy/envoymobile/engine/EnvoyHTTPStream.java
+++ b/library/java/io/envoyproxy/envoymobile/engine/EnvoyHTTPStream.java
@@ -9,6 +9,7 @@ import java.util.List;
 import java.util.Map;
 
 public class EnvoyHTTPStream {
+  private final long engineHandle;
   private final long streamHandle;
   private final boolean explicitFlowControl;
   private final JvmCallbackContext callbacksContext;
@@ -16,7 +17,9 @@ public class EnvoyHTTPStream {
   /**
    * Start the stream via the JNI library.
    */
-  void start() { JniLibrary.startStream(streamHandle, callbacksContext, explicitFlowControl); }
+  void start() {
+    JniLibrary.startStream(engineHandle, streamHandle, callbacksContext, explicitFlowControl);
+  }
 
   /**
    * Initialize a new stream.
@@ -24,8 +27,9 @@ public class EnvoyHTTPStream {
    * @param callbacks The callbacks for the stream.
    * @param explicitFlowControl Whether explicit flow control will be enabled for this stream.
    */
-  public EnvoyHTTPStream(long streamHandle, EnvoyHTTPCallbacks callbacks,
+  public EnvoyHTTPStream(long engineHandle, long streamHandle, EnvoyHTTPCallbacks callbacks,
                          boolean explicitFlowControl) {
+    this.engineHandle = engineHandle;
     this.streamHandle = streamHandle;
     this.explicitFlowControl = explicitFlowControl;
     callbacksContext = new JvmCallbackContext(callbacks);
@@ -39,7 +43,8 @@ public class EnvoyHTTPStream {
    * @param endStream, supplies whether this is headers only.
    */
   public void sendHeaders(Map<String, List<String>> headers, boolean endStream) {
-    JniLibrary.sendHeaders(streamHandle, JniBridgeUtility.toJniHeaders(headers), endStream);
+    JniLibrary.sendHeaders(engineHandle, streamHandle, JniBridgeUtility.toJniHeaders(headers),
+                           endStream);
   }
 
   /**
@@ -72,9 +77,9 @@ public class EnvoyHTTPStream {
       throw new IllegalArgumentException("Length out of bound");
     }
     if (data.isDirect()) {
-      JniLibrary.sendData(streamHandle, data, length, endStream);
+      JniLibrary.sendData(engineHandle, streamHandle, data, length, endStream);
     } else if (data.hasArray()) {
-      JniLibrary.sendData(streamHandle, data.array(), length, endStream);
+      JniLibrary.sendDataByteArray(engineHandle, streamHandle, data.array(), length, endStream);
     } else {
       throw new UnsupportedOperationException("Unsupported ByteBuffer implementation.");
     }
@@ -90,7 +95,7 @@ public class EnvoyHTTPStream {
     if (!explicitFlowControl) {
       throw new UnsupportedOperationException("Called readData without explicit flow control.");
     }
-    JniLibrary.readData(streamHandle, byteCount);
+    JniLibrary.readData(engineHandle, streamHandle, byteCount);
   }
 
   /**
@@ -101,7 +106,7 @@ public class EnvoyHTTPStream {
    * @param trailers, the trailers to send.
    */
   public void sendTrailers(Map<String, List<String>> trailers) {
-    JniLibrary.sendTrailers(streamHandle, JniBridgeUtility.toJniHeaders(trailers));
+    JniLibrary.sendTrailers(engineHandle, streamHandle, JniBridgeUtility.toJniHeaders(trailers));
   }
 
   /**
@@ -110,5 +115,5 @@ public class EnvoyHTTPStream {
    *
    * @return int, success unless the stream has already been canceled.
    */
-  public int cancel() { return JniLibrary.resetStream(streamHandle); }
+  public int cancel() { return JniLibrary.resetStream(engineHandle, streamHandle); }
 }

--- a/library/java/io/envoyproxy/envoymobile/engine/EnvoyHTTPStream.java
+++ b/library/java/io/envoyproxy/envoymobile/engine/EnvoyHTTPStream.java
@@ -23,6 +23,7 @@ public class EnvoyHTTPStream {
 
   /**
    * Initialize a new stream.
+   * @param engineHandle Underlying handle of the Envoy engine.
    * @param streamHandle Underlying handle of the HTTP stream owned by an Envoy engine.
    * @param callbacks The callbacks for the stream.
    * @param explicitFlowControl Whether explicit flow control will be enabled for this stream.

--- a/library/java/io/envoyproxy/envoymobile/engine/JniLibrary.java
+++ b/library/java/io/envoyproxy/envoymobile/engine/JniLibrary.java
@@ -57,6 +57,7 @@ public class JniLibrary {
    * Open an underlying HTTP stream. Note: Streams must be started before other
    * other interaction can can occur.
    *
+   * @param engine,  handle to the stream's associated engine.
    * @param stream,  handle to the stream to be started.
    * @param context, context that contains dispatch logic to fire callbacks
    *                 callbacks.
@@ -72,6 +73,7 @@ public class JniLibrary {
    * Send headers over an open HTTP stream. This method can be invoked once and
    * needs to be called before send_data.
    *
+   * @param engine,    the stream's associated engine.
    * @param stream,    the stream to send headers over.
    * @param headers,   the headers to send.
    * @param endStream, supplies whether this is headers only.
@@ -84,6 +86,7 @@ public class JniLibrary {
    * Send data over an open HTTP stream. This method can be invoked multiple
    * times.
    *
+   * @param engine,    the stream's associated engine.
    * @param stream,    the stream to send data over.
    * @param data,      the data to send.
    * @param length,    the size in bytes of the data to send. 0 <= length <= data.length
@@ -97,6 +100,7 @@ public class JniLibrary {
    * Send data over an open HTTP stream. This method can be invoked multiple
    * times.
    *
+   * @param engine,    the stream's associated engine.
    * @param stream,    the stream to send data over.
    * @param data,      the data to send; must be a <b>direct</b> ByteBuffer.
    * @param length,    the size in bytes of the data to send. 0 <= length <= data.capacity()
@@ -110,6 +114,7 @@ public class JniLibrary {
    * Read data from the response stream. Returns immediately.
    * Has no effect if explicit flow control is not enabled.
    *
+   * @param engine,    the stream's associated engine.
    * @param stream,    the stream.
    * @param byteCount, Maximum number of bytes that may be be passed by the next data callback.
    * @return int, the resulting status of the operation.
@@ -120,6 +125,7 @@ public class JniLibrary {
    * Send trailers over an open HTTP stream. This method can only be invoked once
    * per stream. Note that this method implicitly ends the stream.
    *
+   * @param engine,   the stream's associated engine.
    * @param stream,   the stream to send trailers over.
    * @param trailers, the trailers to send.
    * @return int, the resulting status of the operation.
@@ -130,6 +136,7 @@ public class JniLibrary {
    * Detach all callbacks from a stream and send an interrupt upstream if
    * supported by transport.
    *
+   * @param engine, the stream's associated engine.
    * @param stream, the stream to evict.
    * @return int, the resulting status of the operation.
    */
@@ -237,6 +244,7 @@ public class JniLibrary {
   /**
    * Add another recorded duration in ms to the timer histogram with the given string of elements.
    *
+   * @param engine   Handle to the engine that owns the histogram.
    * @param elements Elements of the histogram stat.
    * @param tags Tags of the histogram.
    * @param durationMs Duration value to record in the histogram timer distribution.
@@ -249,6 +257,8 @@ public class JniLibrary {
    * Flush the stats sinks outside of a flushing interval.
    * Note: stat flushing is done asynchronously, this function will never block.
    * This is a noop if called before the underlying EnvoyEngine has started.
+   *
+   * @param engine engine whose stats should be flushed.
    */
   protected static native int flushStats(long engine);
 
@@ -261,6 +271,7 @@ public class JniLibrary {
   /**
    * Add another recorded value to the generic histogram with the given string of elements.
    *
+   * @param engine   Handle to the engine that owns the histogram.
    * @param elements Elements of the histogram stat.
    * @param tags Tags of the histogram.
    * @param value Amount to record as a new value for the histogram distribution.
@@ -299,6 +310,8 @@ public class JniLibrary {
 
   /**
    * Drain all connections owned by this Engine.
+   *
+   * @param engine Handle to the engine for which to drain connections.
    */
   protected static native int drainConnections(long engine);
 
@@ -306,6 +319,7 @@ public class JniLibrary {
    * Update the network interface to the preferred network for opening new
    * streams. Note that this state is shared by all engines.
    *
+   * @param engine  Handle to the engine whose preferred network will be set.
    * @param network the network to be preferred for new streams.
    * @return The resulting status of the operation.
    */

--- a/library/java/io/envoyproxy/envoymobile/engine/JniLibrary.java
+++ b/library/java/io/envoyproxy/envoymobile/engine/JniLibrary.java
@@ -302,11 +302,11 @@ public class JniLibrary {
    */
   protected static native int drainConnections(long engine);
 
-    /**
+  /**
    * Update the network interface to the preferred network for opening new
    * streams. Note that this state is shared by all engines.
    *
-   * @param network, the network to be preferred for new streams.
+   * @param network the network to be preferred for new streams.
    * @return The resulting status of the operation.
    */
   protected static native int setPreferredNetwork(long engine, int network);

--- a/library/java/io/envoyproxy/envoymobile/engine/JniLibrary.java
+++ b/library/java/io/envoyproxy/envoymobile/engine/JniLibrary.java
@@ -65,7 +65,7 @@ public class JniLibrary {
    * @return envoy_stream, with a stream handle and a success status, or a failure
    * status.
    */
-  protected static native int startStream(long stream, JvmCallbackContext context,
+  protected static native int startStream(long engine, long stream, JvmCallbackContext context,
                                           boolean explicitFlowControl);
 
   /**
@@ -77,7 +77,8 @@ public class JniLibrary {
    * @param endStream, supplies whether this is headers only.
    * @return int, the resulting status of the operation.
    */
-  protected static native int sendHeaders(long stream, byte[][] headers, boolean endStream);
+  protected static native int sendHeaders(long engine, long stream, byte[][] headers,
+                                          boolean endStream);
 
   /**
    * Send data over an open HTTP stream. This method can be invoked multiple
@@ -89,7 +90,8 @@ public class JniLibrary {
    * @param endStream, supplies whether this is the last data in the stream.
    * @return int,      the resulting status of the operation.
    */
-  protected static native int sendData(long stream, byte[] data, int length, boolean endStream);
+  protected static native int sendDataByteArray(long engine, long stream, byte[] data, int length,
+                                                boolean endStream);
 
   /**
    * Send data over an open HTTP stream. This method can be invoked multiple
@@ -101,7 +103,8 @@ public class JniLibrary {
    * @param endStream, supplies whether this is the last data in the stream.
    * @return int,      the resulting status of the operation.
    */
-  protected static native int sendData(long stream, ByteBuffer data, int length, boolean endStream);
+  protected static native int sendData(long engine, long stream, ByteBuffer data, int length,
+                                       boolean endStream);
 
   /**
    * Read data from the response stream. Returns immediately.
@@ -111,7 +114,7 @@ public class JniLibrary {
    * @param byteCount, Maximum number of bytes that may be be passed by the next data callback.
    * @return int, the resulting status of the operation.
    */
-  protected static native int readData(long stream, long byteCount);
+  protected static native int readData(long engine, long stream, long byteCount);
 
   /**
    * Send trailers over an open HTTP stream. This method can only be invoked once
@@ -121,7 +124,7 @@ public class JniLibrary {
    * @param trailers, the trailers to send.
    * @return int, the resulting status of the operation.
    */
-  protected static native int sendTrailers(long stream, byte[][] trailers);
+  protected static native int sendTrailers(long engine, long stream, byte[][] trailers);
 
   /**
    * Detach all callbacks from a stream and send an interrupt upstream if
@@ -130,7 +133,7 @@ public class JniLibrary {
    * @param stream, the stream to evict.
    * @return int, the resulting status of the operation.
    */
-  protected static native int resetStream(long stream);
+  protected static native int resetStream(long engine, long stream);
 
   /**
    * Register a factory for creating platform filter instances for each HTTP stream.

--- a/library/java/io/envoyproxy/envoymobile/engine/JniLibrary.java
+++ b/library/java/io/envoyproxy/envoymobile/engine/JniLibrary.java
@@ -301,4 +301,13 @@ public class JniLibrary {
    * Drain all connections owned by this Engine.
    */
   protected static native int drainConnections(long engine);
+
+    /**
+   * Update the network interface to the preferred network for opening new
+   * streams. Note that this state is shared by all engines.
+   *
+   * @param network, the network to be preferred for new streams.
+   * @return The resulting status of the operation.
+   */
+  protected static native int setPreferredNetwork(long engine, int network);
 }

--- a/library/java/io/envoyproxy/envoymobile/engine/types/BUILD
+++ b/library/java/io/envoyproxy/envoymobile/engine/types/BUILD
@@ -12,6 +12,7 @@ java_library(
         "EnvoyHTTPFilterCallbacks.java",
         "EnvoyHTTPFilterFactory.java",
         "EnvoyLogger.java",
+        "EnvoyNetworkType.java",
         "EnvoyOnEngineRunning.java",
         "EnvoyStatus.java",
         "EnvoyStreamIntel.java",

--- a/library/java/io/envoyproxy/envoymobile/engine/types/EnvoyNetworkType.java
+++ b/library/java/io/envoyproxy/envoymobile/engine/types/EnvoyNetworkType.java
@@ -1,0 +1,11 @@
+package io.envoyproxy.envoymobile.engine.types;
+
+// Network interface type
+public enum EnvoyNetworkType {
+  // WWAN
+  ENVOY_NETWORK_TYPE_WWAN,
+  // WLAN
+  ENVOY_NETWORK_TYPE_WLAN,
+  // GENERIC
+  ENVOY_NETWORK_TYPE_GENERIC;
+}

--- a/library/kotlin/io/envoyproxy/envoymobile/mocks/MockEnvoyEngine.kt
+++ b/library/kotlin/io/envoyproxy/envoymobile/mocks/MockEnvoyEngine.kt
@@ -10,6 +10,8 @@ import io.envoyproxy.envoymobile.engine.types.EnvoyStringAccessor
  * Mock implementation of `EnvoyEngine`. Used internally for testing the bridging layer & mocking.
  */
 internal class MockEnvoyEngine : EnvoyEngine {
+  override fun getHandle(): Long = 0
+
   override fun runWithConfig(envoyConfiguration: EnvoyConfiguration?, logLevel: String?): Int = 0
 
   override fun runWithTemplate(

--- a/library/kotlin/io/envoyproxy/envoymobile/mocks/MockEnvoyEngine.kt
+++ b/library/kotlin/io/envoyproxy/envoymobile/mocks/MockEnvoyEngine.kt
@@ -4,14 +4,13 @@ import io.envoyproxy.envoymobile.engine.EnvoyConfiguration
 import io.envoyproxy.envoymobile.engine.EnvoyEngine
 import io.envoyproxy.envoymobile.engine.EnvoyHTTPStream
 import io.envoyproxy.envoymobile.engine.types.EnvoyHTTPCallbacks
+import io.envoyproxy.envoymobile.engine.types.EnvoyNetworkType
 import io.envoyproxy.envoymobile.engine.types.EnvoyStringAccessor
 
 /**
  * Mock implementation of `EnvoyEngine`. Used internally for testing the bridging layer & mocking.
  */
 internal class MockEnvoyEngine : EnvoyEngine {
-  override fun getHandle(): Long = 0
-
   override fun runWithConfig(envoyConfiguration: EnvoyConfiguration?, logLevel: String?): Int = 0
 
   override fun runWithTemplate(
@@ -48,4 +47,6 @@ internal class MockEnvoyEngine : EnvoyEngine {
   override fun dumpStats(): String = ""
 
   override fun drainConnections() = Unit
+
+  override fun setPreferredNetwork(network: EnvoyNetworkType) = Unit
 }

--- a/library/kotlin/io/envoyproxy/envoymobile/mocks/MockEnvoyHTTPStream.kt
+++ b/library/kotlin/io/envoyproxy/envoymobile/mocks/MockEnvoyHTTPStream.kt
@@ -12,7 +12,7 @@ import java.nio.ByteBuffer
 internal class MockEnvoyHTTPStream(
   val callbacks: EnvoyHTTPCallbacks,
   val explicitFlowControl: Boolean
-) : EnvoyHTTPStream(0, callbacks, explicitFlowControl) {
+) : EnvoyHTTPStream(0, 0, callbacks, explicitFlowControl) {
   override fun sendHeaders(headers: MutableMap<String, MutableList<String>>?, endStream: Boolean) {}
 
   override fun sendData(data: ByteBuffer?, endStream: Boolean) {}

--- a/library/objective-c/EnvoyEngine.h
+++ b/library/objective-c/EnvoyEngine.h
@@ -243,10 +243,12 @@ extern const int kEnvoyFilterResumeStatusResumeIteration;
  Open an underlying HTTP stream.
 
  @param handle Underlying handle of the HTTP stream owned by an Envoy engine.
+ @param engine Underlying handle of the Envoy engine.
  @param callbacks The callbacks for the stream.
  @param explicitFlowControl Whether explicit flow control will be enabled for this stream.
  */
 - (instancetype)initWithHandle:(intptr_t)handle
+                        engine:(intptr_t)engineHandle
                      callbacks:(EnvoyHTTPCallbacks *)callbacks
            explicitFlowControl:(BOOL)explicitFlowControl;
 
@@ -567,15 +569,20 @@ extern const int kEnvoyFailure;
 // Monitors network changes in order to update Envoy network cluster preferences.
 @interface EnvoyNetworkMonitor : NSObject
 
+/**
+ Create a new instance of the network monitor.
+ */
+- (instancetype)initWithEngine:(envoy_engine_t)engineHandle;
+
 // Start monitoring reachability using `SCNetworkReachability`, updating the
 // preferred Envoy network cluster on changes.
 // This is typically called by `EnvoyEngine` automatically on startup.
-+ (void)startReachabilityIfNeeded;
+- (void)startReachability;
 
 // Start monitoring reachability using `NWPathMonitor`, updating the
 // preferred Envoy network cluster on changes.
 // This is typically called by `EnvoyEngine` automatically on startup.
-+ (void)startPathMonitorIfNeeded;
+- (void)startPathMonitor;
 
 @end
 

--- a/library/objective-c/EnvoyEngineImpl.m
+++ b/library/objective-c/EnvoyEngineImpl.m
@@ -405,6 +405,7 @@ static void ios_track_event(envoy_map map, const void *context) {
 
 @implementation EnvoyEngineImpl {
   envoy_engine_t _engineHandle;
+  EnvoyNetworkMonitor *_networkMonitor;
 }
 
 - (instancetype)initWithRunningCallback:(nullable void (^)())onEngineRunning
@@ -439,11 +440,12 @@ static void ios_track_event(envoy_map map, const void *context) {
   }
 
   _engineHandle = init_engine(native_callbacks, native_logger, native_event_tracker);
+  _networkMonitor = [[EnvoyNetworkMonitor alloc] initWithEngine:_engineHandle];
 
   if (enableNetworkPathMonitor) {
-    [EnvoyNetworkMonitor startPathMonitorIfNeeded];
+    [_networkMonitor startPathMonitor];
   } else {
-    [EnvoyNetworkMonitor startReachabilityIfNeeded];
+    [_networkMonitor startReachability];
   }
 
   return self;
@@ -532,6 +534,7 @@ static void ios_track_event(envoy_map map, const void *context) {
 - (id<EnvoyHTTPStream>)startStreamWithCallbacks:(EnvoyHTTPCallbacks *)callbacks
                             explicitFlowControl:(BOOL)explicitFlowControl {
   return [[EnvoyHTTPStreamImpl alloc] initWithHandle:init_stream(_engineHandle)
+                                              engine:_engineHandle
                                            callbacks:callbacks
                                  explicitFlowControl:explicitFlowControl];
 }

--- a/library/swift/mocks/MockEnvoyEngine.swift
+++ b/library/swift/mocks/MockEnvoyEngine.swift
@@ -51,7 +51,7 @@ extension MockEnvoyEngine: EnvoyEngine {
     with callbacks: EnvoyHTTPCallbacks,
     explicitFlowControl: Bool
   ) -> EnvoyHTTPStream {
-    return MockEnvoyHTTPStream(handle: 0, callbacks: callbacks,
+    return MockEnvoyHTTPStream(handle: 0, engine: 0, callbacks: callbacks,
                                explicitFlowControl: explicitFlowControl)
   }
 

--- a/library/swift/mocks/MockEnvoyHTTPStream.swift
+++ b/library/swift/mocks/MockEnvoyHTTPStream.swift
@@ -7,7 +7,7 @@ final class MockEnvoyHTTPStream: EnvoyHTTPStream {
   let callbacks: EnvoyHTTPCallbacks
   let explicitFlowControl: Bool
 
-  init(handle: Int, callbacks: EnvoyHTTPCallbacks, explicitFlowControl: Bool) {
+  init(handle: Int, engine: Int, callbacks: EnvoyHTTPCallbacks, explicitFlowControl: Bool) {
     self.callbacks = callbacks
     self.explicitFlowControl = explicitFlowControl
   }

--- a/library/swift/mocks/MockStreamPrototype.swift
+++ b/library/swift/mocks/MockStreamPrototype.swift
@@ -18,7 +18,7 @@ public final class MockStreamPrototype: StreamPrototype {
 
   public override func start(queue: DispatchQueue = .main) -> Stream {
     let callbacks = self.createCallbacks(queue: queue)
-    let underlyingStream = MockEnvoyHTTPStream(handle: 0, callbacks: callbacks,
+    let underlyingStream = MockEnvoyHTTPStream(handle: 0, engine: 0, callbacks: callbacks,
                                                explicitFlowControl: false)
     let stream = MockStream(mockStream: underlyingStream)
     self.onStart?(stream)

--- a/test/common/main_interface_test.cc
+++ b/test/common/main_interface_test.cc
@@ -136,8 +136,8 @@ TEST(MainInterfaceTest, BasicStream) {
                                       exit->on_exit.Notify();
                                     } /*on_exit*/,
                                     &engine_cbs_context /*context*/};
-  init_engine(engine_cbs, {}, {});
-  run_engine(0, BUFFERED_TEST_CONFIG.c_str(), level.c_str());
+  envoy_engine_t engine_handle = init_engine(engine_cbs, {}, {});
+  run_engine(engine_handle, BUFFERED_TEST_CONFIG.c_str(), level.c_str());
 
   ASSERT_TRUE(
       engine_cbs_context.on_engine_running.WaitForNotificationWithTimeout(absl::Seconds(10)));
@@ -172,17 +172,17 @@ TEST(MainInterfaceTest, BasicStream) {
   Http::TestRequestTrailerMapImpl trailers;
   envoy_headers c_trailers = Http::Utility::toBridgeHeaders(trailers);
 
-  envoy_stream_t stream = init_stream(0);
+  envoy_stream_t stream = init_stream(engine_handle);
 
-  start_stream(stream, stream_cbs, false);
+  start_stream(engine_handle, stream, stream_cbs, false);
 
-  send_headers(stream, c_headers, false);
-  send_data(stream, c_data, false);
-  send_trailers(stream, c_trailers);
+  send_headers(engine_handle, stream, c_headers, false);
+  send_data(engine_handle, stream, c_data, false);
+  send_trailers(engine_handle, stream, c_trailers);
 
   ASSERT_TRUE(on_complete_notification.WaitForNotificationWithTimeout(absl::Seconds(10)));
 
-  terminate_engine(0);
+  terminate_engine(engine_handle);
 
   ASSERT_TRUE(engine_cbs_context.on_exit.WaitForNotificationWithTimeout(absl::Seconds(10)));
 }
@@ -202,8 +202,8 @@ TEST(MainInterfaceTest, SendMetadata) {
 
   // There is nothing functional about the config used to run the engine, as the created stream is
   // only used for send_metadata.
-  init_engine(engine_cbs, {}, {});
-  run_engine(0, MINIMAL_TEST_CONFIG.c_str(), LEVEL_DEBUG.c_str());
+  envoy_engine_t engine_handle = init_engine(engine_cbs, {}, {});
+  run_engine(engine_handle, MINIMAL_TEST_CONFIG.c_str(), LEVEL_DEBUG.c_str());
 
   ASSERT_TRUE(
       engine_cbs_context.on_engine_running.WaitForNotificationWithTimeout(absl::Seconds(10)));
@@ -216,13 +216,13 @@ TEST(MainInterfaceTest, SendMetadata) {
       nullptr /* context */,
   };
 
-  envoy_stream_t stream = init_stream(0);
+  envoy_stream_t stream = init_stream(engine_handle);
 
-  start_stream(stream, stream_cbs, false);
+  start_stream(engine_handle, stream, stream_cbs, false);
 
-  EXPECT_EQ(ENVOY_FAILURE, send_metadata(stream, {}));
+  EXPECT_EQ(ENVOY_FAILURE, send_metadata(engine_handle, stream, {}));
 
-  terminate_engine(0);
+  terminate_engine(engine_handle);
 
   ASSERT_TRUE(engine_cbs_context.on_exit.WaitForNotificationWithTimeout(absl::Seconds(10)));
 }
@@ -242,8 +242,8 @@ TEST(MainInterfaceTest, ResetStream) {
 
   // There is nothing functional about the config used to run the engine, as the created stream is
   // immediately reset.
-  init_engine(engine_cbs, {}, {});
-  run_engine(0, MINIMAL_TEST_CONFIG.c_str(), LEVEL_DEBUG.c_str());
+  envoy_engine_t engine_handle = init_engine(engine_cbs, {}, {});
+  run_engine(engine_handle, MINIMAL_TEST_CONFIG.c_str(), LEVEL_DEBUG.c_str());
 
   ASSERT_TRUE(
       engine_cbs_context.on_engine_running.WaitForNotificationWithTimeout(absl::Seconds(10)));
@@ -264,15 +264,15 @@ TEST(MainInterfaceTest, ResetStream) {
       nullptr /* on_send_window_available */,
       &on_cancel_notification /* context */};
 
-  envoy_stream_t stream = init_stream(0);
+  envoy_stream_t stream = init_stream(engine_handle);
 
-  start_stream(stream, stream_cbs, false);
+  start_stream(engine_handle, stream, stream_cbs, false);
 
-  reset_stream(stream);
+  reset_stream(engine_handle, stream);
 
   ASSERT_TRUE(on_cancel_notification.WaitForNotificationWithTimeout(absl::Seconds(10)));
 
-  terminate_engine(0);
+  terminate_engine(engine_handle);
 
   ASSERT_TRUE(engine_cbs_context.on_exit.WaitForNotificationWithTimeout(absl::Seconds(10)));
 }
@@ -288,10 +288,10 @@ TEST(MainInterfaceTest, UsingMainInterfaceWithoutARunningEngine) {
   Http::TestRequestTrailerMapImpl trailers;
   envoy_headers c_trailers = Http::Utility::toBridgeHeaders(trailers);
 
-  EXPECT_EQ(ENVOY_FAILURE, send_headers(0, c_headers, false));
-  EXPECT_EQ(ENVOY_FAILURE, send_data(0, c_data, false));
-  EXPECT_EQ(ENVOY_FAILURE, send_trailers(0, c_trailers));
-  EXPECT_EQ(ENVOY_FAILURE, reset_stream(0));
+  EXPECT_EQ(ENVOY_FAILURE, send_headers(1, 0, c_headers, false));
+  EXPECT_EQ(ENVOY_FAILURE, send_data(1, 0, c_data, false));
+  EXPECT_EQ(ENVOY_FAILURE, send_trailers(1, 0, c_trailers));
+  EXPECT_EQ(ENVOY_FAILURE, reset_stream(1, 0));
 
   // Release memory
   release_envoy_headers(c_headers);
@@ -313,8 +313,8 @@ TEST(MainInterfaceTest, RegisterPlatformApi) {
                                     &engine_cbs_context /*context*/};
 
   // Using the minimal envoy mobile config that allows for running the engine.
-  init_engine(engine_cbs, {}, {});
-  run_engine(0, MINIMAL_TEST_CONFIG.c_str(), LEVEL_DEBUG.c_str());
+  envoy_engine_t engine_handle = init_engine(engine_cbs, {}, {});
+  run_engine(engine_handle, MINIMAL_TEST_CONFIG.c_str(), LEVEL_DEBUG.c_str());
 
   ASSERT_TRUE(
       engine_cbs_context.on_engine_running.WaitForNotificationWithTimeout(absl::Seconds(10)));
@@ -322,7 +322,7 @@ TEST(MainInterfaceTest, RegisterPlatformApi) {
   uint64_t fake_api;
   EXPECT_EQ(ENVOY_SUCCESS, register_platform_api("api", &fake_api));
 
-  terminate_engine(0);
+  terminate_engine(engine_handle);
 
   ASSERT_TRUE(engine_cbs_context.on_exit.WaitForNotificationWithTimeout(absl::Seconds(10)));
 }
@@ -342,14 +342,14 @@ TEST(MainInterfaceTest, InitEngineReturns1) {
                                     } /*on_exit*/,
                                     &test_context /*context*/};
   ASSERT_EQ(1, init_engine(engine_cbs, {}, {}));
-  run_engine(0, MINIMAL_TEST_CONFIG.c_str(), LEVEL_DEBUG.c_str());
+  run_engine(1, MINIMAL_TEST_CONFIG.c_str(), LEVEL_DEBUG.c_str());
   ASSERT_TRUE(test_context.on_engine_running.WaitForNotificationWithTimeout(absl::Seconds(3)));
-  terminate_engine(0);
+  terminate_engine(1);
   ASSERT_TRUE(test_context.on_exit.WaitForNotificationWithTimeout(absl::Seconds(3)));
 }
 
 TEST(MainInterfaceTest, PreferredNetwork) {
-  EXPECT_EQ(ENVOY_SUCCESS, set_preferred_network(ENVOY_NET_WLAN));
+  EXPECT_EQ(ENVOY_SUCCESS, set_preferred_network(1, ENVOY_NET_WLAN));
 }
 
 TEST(EngineTest, RecordCounter) {
@@ -364,13 +364,13 @@ TEST(EngineTest, RecordCounter) {
                                       exit->on_exit.Notify();
                                     } /*on_exit*/,
                                     &test_context /*context*/};
-  EXPECT_EQ(ENVOY_FAILURE, record_counter_inc(0, "counter", envoy_stats_notags, 1));
-  init_engine(engine_cbs, {}, {});
-  run_engine(0, MINIMAL_TEST_CONFIG.c_str(), LEVEL_DEBUG.c_str());
+  EXPECT_EQ(ENVOY_FAILURE, record_counter_inc(1, "counter", envoy_stats_notags, 1));
+  envoy_engine_t engine_handle = init_engine(engine_cbs, {}, {});
+  run_engine(engine_handle, MINIMAL_TEST_CONFIG.c_str(), LEVEL_DEBUG.c_str());
   ASSERT_TRUE(test_context.on_engine_running.WaitForNotificationWithTimeout(absl::Seconds(3)));
-  EXPECT_EQ(ENVOY_SUCCESS, record_counter_inc(0, "counter", envoy_stats_notags, 1));
+  EXPECT_EQ(ENVOY_SUCCESS, record_counter_inc(engine_handle, "counter", envoy_stats_notags, 1));
 
-  terminate_engine(0);
+  terminate_engine(engine_handle);
   ASSERT_TRUE(test_context.on_exit.WaitForNotificationWithTimeout(absl::Seconds(3)));
 }
 
@@ -386,15 +386,15 @@ TEST(EngineTest, SetGauge) {
                                       exit->on_exit.Notify();
                                     } /*on_exit*/,
                                     &test_context /*context*/};
-  EXPECT_EQ(ENVOY_FAILURE, record_gauge_set(0, "gauge", envoy_stats_notags, 1));
-  init_engine(engine_cbs, {}, {});
-  run_engine(0, MINIMAL_TEST_CONFIG.c_str(), LEVEL_DEBUG.c_str());
+  EXPECT_EQ(ENVOY_FAILURE, record_gauge_set(1, "gauge", envoy_stats_notags, 1));
+  envoy_engine_t engine_handle = init_engine(engine_cbs, {}, {});
+  run_engine(engine_handle, MINIMAL_TEST_CONFIG.c_str(), LEVEL_DEBUG.c_str());
 
   ASSERT_TRUE(test_context.on_engine_running.WaitForNotificationWithTimeout(absl::Seconds(3)));
 
-  EXPECT_EQ(ENVOY_SUCCESS, record_gauge_set(0, "gauge", envoy_stats_notags, 1));
+  EXPECT_EQ(ENVOY_SUCCESS, record_gauge_set(engine_handle, "gauge", envoy_stats_notags, 1));
 
-  terminate_engine(0);
+  terminate_engine(engine_handle);
   ASSERT_TRUE(test_context.on_exit.WaitForNotificationWithTimeout(absl::Seconds(3)));
 }
 
@@ -410,15 +410,15 @@ TEST(EngineTest, AddToGauge) {
                                       exit->on_exit.Notify();
                                     } /*on_exit*/,
                                     &test_context /*context*/};
-  EXPECT_EQ(ENVOY_FAILURE, record_gauge_add(0, "gauge", envoy_stats_notags, 30));
+  EXPECT_EQ(ENVOY_FAILURE, record_gauge_add(1, "gauge", envoy_stats_notags, 30));
 
-  init_engine(engine_cbs, {}, {});
-  run_engine(0, MINIMAL_TEST_CONFIG.c_str(), LEVEL_DEBUG.c_str());
+  envoy_engine_t engine_handle = init_engine(engine_cbs, {}, {});
+  run_engine(engine_handle, MINIMAL_TEST_CONFIG.c_str(), LEVEL_DEBUG.c_str());
   ASSERT_TRUE(test_context.on_engine_running.WaitForNotificationWithTimeout(absl::Seconds(3)));
 
-  EXPECT_EQ(ENVOY_SUCCESS, record_gauge_add(0, "gauge", envoy_stats_notags, 30));
+  EXPECT_EQ(ENVOY_SUCCESS, record_gauge_add(engine_handle, "gauge", envoy_stats_notags, 30));
 
-  terminate_engine(0);
+  terminate_engine(engine_handle);
   ASSERT_TRUE(test_context.on_exit.WaitForNotificationWithTimeout(absl::Seconds(3)));
 }
 
@@ -434,17 +434,17 @@ TEST(EngineTest, SubFromGauge) {
                                       exit->on_exit.Notify();
                                     } /*on_exit*/,
                                     &test_context /*context*/};
-  EXPECT_EQ(ENVOY_FAILURE, record_gauge_sub(0, "gauge", envoy_stats_notags, 30));
+  EXPECT_EQ(ENVOY_FAILURE, record_gauge_sub(1, "gauge", envoy_stats_notags, 30));
 
-  init_engine(engine_cbs, {}, {});
-  run_engine(0, MINIMAL_TEST_CONFIG.c_str(), LEVEL_DEBUG.c_str());
+  envoy_engine_t engine_handle = init_engine(engine_cbs, {}, {});
+  run_engine(engine_handle, MINIMAL_TEST_CONFIG.c_str(), LEVEL_DEBUG.c_str());
   ASSERT_TRUE(test_context.on_engine_running.WaitForNotificationWithTimeout(absl::Seconds(3)));
 
-  record_gauge_add(0, "gauge", envoy_stats_notags, 30);
+  record_gauge_add(engine_handle, "gauge", envoy_stats_notags, 30);
 
-  EXPECT_EQ(ENVOY_SUCCESS, record_gauge_sub(0, "gauge", envoy_stats_notags, 30));
+  EXPECT_EQ(ENVOY_SUCCESS, record_gauge_sub(engine_handle, "gauge", envoy_stats_notags, 30));
 
-  terminate_engine(0);
+  terminate_engine(engine_handle);
   ASSERT_TRUE(test_context.on_exit.WaitForNotificationWithTimeout(absl::Seconds(3)));
 }
 
@@ -461,18 +461,18 @@ TEST(EngineTest, RecordHistogramValue) {
                                     } /*on_exit*/,
                                     &test_context /*context*/};
   EXPECT_EQ(ENVOY_FAILURE,
-            record_histogram_value(0, "histogram", envoy_stats_notags, 99, MILLISECONDS));
+            record_histogram_value(1, "histogram", envoy_stats_notags, 99, MILLISECONDS));
 
-  init_engine(engine_cbs, {}, {});
-  run_engine(0, MINIMAL_TEST_CONFIG.c_str(), LEVEL_DEBUG.c_str());
+  envoy_engine_t engine_handle = init_engine(engine_cbs, {}, {});
+  run_engine(engine_handle, MINIMAL_TEST_CONFIG.c_str(), LEVEL_DEBUG.c_str());
   ASSERT_TRUE(test_context.on_engine_running.WaitForNotificationWithTimeout(absl::Seconds(3)));
 
-  record_histogram_value(0, "histogram", envoy_stats_notags, 99, MILLISECONDS);
+  record_histogram_value(engine_handle, "histogram", envoy_stats_notags, 99, MILLISECONDS);
 
-  EXPECT_EQ(ENVOY_SUCCESS,
-            record_histogram_value(0, "histogram", envoy_stats_notags, 99, MILLISECONDS));
+  EXPECT_EQ(ENVOY_SUCCESS, record_histogram_value(engine_handle, "histogram", envoy_stats_notags,
+                                                  99, MILLISECONDS));
 
-  terminate_engine(0);
+  terminate_engine(engine_handle);
   ASSERT_TRUE(test_context.on_exit.WaitForNotificationWithTimeout(absl::Seconds(3)));
 }
 
@@ -505,13 +505,13 @@ TEST(EngineTest, Logger) {
                       } /* release */,
                       &test_context};
 
-  init_engine(engine_cbs, logger, {});
-  run_engine(0, MINIMAL_TEST_CONFIG.c_str(), LEVEL_DEBUG.c_str());
+  envoy_engine_t engine_handle = init_engine(engine_cbs, logger, {});
+  run_engine(engine_handle, MINIMAL_TEST_CONFIG.c_str(), LEVEL_DEBUG.c_str());
   ASSERT_TRUE(test_context.on_engine_running.WaitForNotificationWithTimeout(absl::Seconds(3)));
 
   ASSERT_TRUE(test_context.on_log.WaitForNotificationWithTimeout(absl::Seconds(3)));
 
-  terminate_engine(0);
+  terminate_engine(engine_handle);
   ASSERT_TRUE(test_context.on_logger_release.WaitForNotificationWithTimeout(absl::Seconds(3)));
   ASSERT_TRUE(test_context.on_exit.WaitForNotificationWithTimeout(absl::Seconds(3)));
 }
@@ -530,8 +530,8 @@ TEST(EngineTest, EventTrackerRegistersDefaultAPI) {
                                     } /*on_exit*/,
                                     &test_context /*context*/};
 
-  init_engine(engine_cbs, {}, {});
-  run_engine(0, MINIMAL_TEST_CONFIG.c_str(), LEVEL_DEBUG.c_str());
+  envoy_engine_t engine_handle = init_engine(engine_cbs, {}, {});
+  run_engine(engine_handle, MINIMAL_TEST_CONFIG.c_str(), LEVEL_DEBUG.c_str());
 
   // A default event tracker is registered in external API registry.
   const auto registered_event_tracker =
@@ -547,7 +547,7 @@ TEST(EngineTest, EventTrackerRegistersDefaultAPI) {
   // tracker is passed at engine's initialization time.
   Assert::invokeDebugAssertionFailureRecordActionForAssertMacroUseOnly("foo_location");
 
-  terminate_engine(0);
+  terminate_engine(engine_handle);
   ASSERT_TRUE(test_context.on_exit.WaitForNotificationWithTimeout(absl::Seconds(3)));
 }
 
@@ -574,8 +574,8 @@ TEST(EngineTest, EventTrackerRegistersAPI) {
                                     } /*track*/,
                                     &test_context /*context*/};
 
-  init_engine(engine_cbs, {}, event_tracker);
-  run_engine(0, MINIMAL_TEST_CONFIG.c_str(), LEVEL_DEBUG.c_str());
+  envoy_engine_t engine_handle = init_engine(engine_cbs, {}, event_tracker);
+  run_engine(engine_handle, MINIMAL_TEST_CONFIG.c_str(), LEVEL_DEBUG.c_str());
 
   ASSERT_TRUE(test_context.on_engine_running.WaitForNotificationWithTimeout(absl::Seconds(3)));
   const auto registered_event_tracker =
@@ -588,7 +588,7 @@ TEST(EngineTest, EventTrackerRegistersAPI) {
                       registered_event_tracker->context);
 
   ASSERT_TRUE(test_context.on_event.WaitForNotificationWithTimeout(absl::Seconds(3)));
-  terminate_engine(0);
+  terminate_engine(engine_handle);
   ASSERT_TRUE(test_context.on_exit.WaitForNotificationWithTimeout(absl::Seconds(3)));
 }
 
@@ -617,8 +617,8 @@ TEST(EngineTest, EventTrackerRegistersAssertionFailureRecordAction) {
       } /*track*/,
       &test_context /*context*/};
 
-  init_engine(engine_cbs, {}, event_tracker);
-  run_engine(0, MINIMAL_TEST_CONFIG.c_str(), LEVEL_DEBUG.c_str());
+  envoy_engine_t engine_handle = init_engine(engine_cbs, {}, event_tracker);
+  run_engine(engine_handle, MINIMAL_TEST_CONFIG.c_str(), LEVEL_DEBUG.c_str());
 
   ASSERT_TRUE(test_context.on_engine_running.WaitForNotificationWithTimeout(absl::Seconds(3)));
   // Simulate a failed assertion by invoking a debug assertion failure
@@ -628,7 +628,7 @@ TEST(EngineTest, EventTrackerRegistersAssertionFailureRecordAction) {
   Assert::invokeDebugAssertionFailureRecordActionForAssertMacroUseOnly("foo_location");
 
   ASSERT_TRUE(test_context.on_event.WaitForNotificationWithTimeout(absl::Seconds(3)));
-  terminate_engine(0);
+  terminate_engine(engine_handle);
   ASSERT_TRUE(test_context.on_exit.WaitForNotificationWithTimeout(absl::Seconds(3)));
 }
 
@@ -657,8 +657,8 @@ TEST(EngineTest, EventTrackerRegistersEnvoyBugRecordAction) {
                                     } /*track*/,
                                     &test_context /*context*/};
 
-  init_engine(engine_cbs, {}, event_tracker);
-  run_engine(0, MINIMAL_TEST_CONFIG.c_str(), LEVEL_DEBUG.c_str());
+  envoy_engine_t engine_handle = init_engine(engine_cbs, {}, event_tracker);
+  run_engine(engine_handle, MINIMAL_TEST_CONFIG.c_str(), LEVEL_DEBUG.c_str());
 
   ASSERT_TRUE(test_context.on_engine_running.WaitForNotificationWithTimeout(absl::Seconds(3)));
   // Simulate an envoy bug by invoking an Envoy bug failure
@@ -668,7 +668,7 @@ TEST(EngineTest, EventTrackerRegistersEnvoyBugRecordAction) {
   Assert::invokeEnvoyBugFailureRecordActionForEnvoyBugMacroUseOnly("foo_location");
 
   ASSERT_TRUE(test_context.on_event.WaitForNotificationWithTimeout(absl::Seconds(3)));
-  terminate_engine(0);
+  terminate_engine(engine_handle);
   ASSERT_TRUE(test_context.on_exit.WaitForNotificationWithTimeout(absl::Seconds(3)));
 }
 


### PR DESCRIPTION
In preparation for removing the singleton. This is split off into its own independent change to minimize the scope of the main singleton removal work.

We were already doing this in many places, this just adds more instances of passing the engine handle so we do so comprehensively.

Description: Pass engine handles throughout API
Risk Level: Medium, changing some JNI interfaces, removing some static state
Testing: Unit tests and sample apps
Docs Changes: N/A internal only
Release Notes: N/A internal only
[Optional Fixes #Issue]
[Optional Deprecated:]

Signed-off-by: JP Simard <jp@jpsim.com>