### PR TITLE
bazel: set inmemory remote exec flags globally

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -5,6 +5,8 @@ try-import ./envoy/.bazelrc
 build --define=google_grpc=disabled
 build --define=hot_restart=disabled
 build --define=tcmalloc=disabled
+build --experimental_inmemory_dotd_files
+build --experimental_inmemory_jdeps_files
 build --features=debug_prefix_map_pwd_is_dot
 build --features=swift.cacheable_swiftmodules
 build --features=swift.debug_prefix_map
@@ -132,8 +134,6 @@ build:remote-ci-local-java8 --java_language_version=8
 # Common Engflow flags
 build:remote-ci-linux --define=EXECUTOR=remote
 build:remote-ci-linux --disk_cache=
-build:remote-ci-linux --experimental_inmemory_dotd_files
-build:remote-ci-linux --experimental_inmemory_jdeps_files
 build:remote-ci-linux --incompatible_strict_action_env=true
 build:remote-ci-linux --remote_timeout=600
 # GCC toolchain options


### PR DESCRIPTION
I asked around and it sounds like these flags have no downside, but when
we only set them for remote exec, if you swapped between using remote
exec and then not using it, it would invalidate your build and you'd
rebuild the world. I'm hoping we can fix this rough edge in bazel but in
the meantime it should be safe to set them globally.

https://github.com/bazelbuild/bazel/pull/15203
https://github.com/bazelbuild/bazel/pull/15204