### PR TITLE
bump envoy to 5181d2355f208061688922572727fe06ba8b3a07

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -2,6 +2,7 @@
 try-import ./envoy/.bazelrc
 
 # Common flags for all builds
+build --platform_mappings=envoy/bazel/platform_mappings
 build --define=google_grpc=disabled
 build --define=hot_restart=disabled
 build --define=tcmalloc=disabled

--- a/library/common/config/config.cc
+++ b/library/common/config/config.cc
@@ -351,7 +351,10 @@ R"(
     connect_timeout: *connect_timeout
     lb_policy: CLUSTER_PROVIDED
     cluster_type: *base_cluster_type
-    transport_socket: { name: envoy.transport_sockets.raw_buffer }
+    transport_socket:
+      name: envoy.transport_sockets.raw_buffer
+      typed_config:
+        "@type": type.googleapis.com/envoy.extensions.transport_sockets.raw_buffer.v3.RawBuffer
     upstream_connection_options: *upstream_opts
     circuit_breakers: *circuit_breakers_settings
     typed_extension_protocol_options: *h1_protocol_options

--- a/library/common/extensions/key_value/platform/config.cc
+++ b/library/common/extensions/key_value/platform/config.cc
@@ -11,11 +11,11 @@ namespace KeyValue {
 PlatformKeyValueStore::PlatformKeyValueStore(Event::Dispatcher& dispatcher,
                                              std::chrono::milliseconds save_interval,
                                              PlatformInterface& platform_interface,
-                                             const std::string& key)
-    : KeyValueStoreBase(dispatcher, save_interval), platform_interface_(platform_interface),
-      key_(key) {
+                                             uint64_t max_entries, const std::string& key)
+    : KeyValueStoreBase(dispatcher, save_interval, max_entries),
+      platform_interface_(platform_interface), key_(key) {
   const std::string contents = platform_interface.read(key);
-  if (!parseContents(contents, store_)) {
+  if (!parseContents(contents)) {
     ENVOY_LOG(warn, "Failed to parse key value store contents {}", key);
   }
 }
@@ -41,8 +41,9 @@ PlatformKeyValueStoreFactory::createStore(const Protobuf::Message& config,
       typed_config.config().typed_config(), validation_visitor);
   auto milliseconds =
       std::chrono::milliseconds(DurationUtil::durationToMilliseconds(file_config.save_interval()));
-  return std::make_unique<PlatformKeyValueStore>(
-      dispatcher, milliseconds, platform_interface_.value().get(), file_config.key());
+  return std::make_unique<PlatformKeyValueStore>(dispatcher, milliseconds,
+                                                 platform_interface_.value().get(),
+                                                 file_config.max_entries(), file_config.key());
 }
 
 REGISTER_FACTORY(PlatformKeyValueStoreFactory, KeyValueStoreFactory);

--- a/library/common/extensions/key_value/platform/config.h
+++ b/library/common/extensions/key_value/platform/config.h
@@ -26,7 +26,8 @@ public:
 class PlatformKeyValueStore : public KeyValueStoreBase {
 public:
   PlatformKeyValueStore(Event::Dispatcher& dispatcher, std::chrono::milliseconds save_interval,
-                        PlatformInterface& platform_interface, const std::string& key);
+                        PlatformInterface& platform_interface, uint64_t max_entries,
+                        const std::string& key);
   // KeyValueStore
   void flush() override;
 

--- a/library/common/extensions/key_value/platform/platform.proto
+++ b/library/common/extensions/key_value/platform/platform.proto
@@ -12,4 +12,7 @@ message PlatformKeyValueStoreConfig {
 
   // The interval at which the key value store should be saved.
   google.protobuf.Duration save_interval = 2;
+
+  // The maximum number of entries that can be stored in the cache.
+  uint64 max_entries = 3;
 }

--- a/test/common/extensions/key_value/platform/platform_store_test.cc
+++ b/test/common/extensions/key_value/platform/platform_store_test.cc
@@ -37,8 +37,8 @@ protected:
 
   void createStore() {
     flush_timer_ = new NiceMock<Event::MockTimer>(&dispatcher_);
-    store_ =
-        std::make_unique<PlatformKeyValueStore>(dispatcher_, save_interval_, mock_platform_, key_);
+    store_ = std::make_unique<PlatformKeyValueStore>(dispatcher_, save_interval_, mock_platform_,
+                                                     std::numeric_limits<uint64_t>::max(), key_);
   }
   NiceMock<Event::MockDispatcher> dispatcher_;
   std::string key_{"key"};

--- a/test/kotlin/integration/SetLoggerTest.kt
+++ b/test/kotlin/integration/SetLoggerTest.kt
@@ -15,6 +15,7 @@ import org.junit.Test
 private const val apiListenerType =
   "type.googleapis.com/envoy.extensions.filters.network.http_connection_manager.v3.EnvoyMobileHttpConnectionManager"
 private const val assertionFilterType = "type.googleapis.com/envoymobile.extensions.filters.http.assertion.Assertion"
+private const val testLoggerFilterType = "type.googleapis.com/envoymobile.extensions.filters.http.test_logger.TestLogger"
 private const val config =
 """
 static_resources:
@@ -44,7 +45,7 @@ static_resources:
           http_filters:
             - name: test_logger
               typed_config:
-                "@type": type.googleapis.com/envoymobile.extensions.filters.http.test_logger.TestLogger
+                "@type": $testLoggerFilterType
             - name: envoy.filters.http.assertion
               typed_config:
                 "@type": $assertionFilterType

--- a/test/kotlin/integration/SetLoggerTest.kt
+++ b/test/kotlin/integration/SetLoggerTest.kt
@@ -43,6 +43,8 @@ static_resources:
                       status: 200
           http_filters:
             - name: test_logger
+              typed_config:
+                "@type": envoymobile.extensions.filters.http.test_logger.TestLogger
             - name: envoy.filters.http.assertion
               typed_config:
                 "@type": $assertionFilterType

--- a/test/kotlin/integration/SetLoggerTest.kt
+++ b/test/kotlin/integration/SetLoggerTest.kt
@@ -44,7 +44,7 @@ static_resources:
           http_filters:
             - name: test_logger
               typed_config:
-                "@type": envoymobile.extensions.filters.http.test_logger.TestLogger
+                "@type": type.googleapis.com/envoymobile.extensions.filters.http.test_logger.TestLogger
             - name: envoy.filters.http.assertion
               typed_config:
                 "@type": $assertionFilterType

--- a/test/swift/integration/SetLoggerTest.swift
+++ b/test/swift/integration/SetLoggerTest.swift
@@ -12,6 +12,8 @@ final class LoggerTests: XCTestCase {
     let emhcmType = "type.googleapis.com/envoy.extensions.filters.network.http_connection_manager.v3.EnvoyMobileHttpConnectionManager"
     // swiftlint:disable:next line_length
     let assertionFilterType = "type.googleapis.com/envoymobile.extensions.filters.http.assertion.Assertion"
+    // swiftlint:disable:next line_length
+    let testLoggerFilterType = "type.googleapis.com/envoymobile.extensions.filters.http.test_logger.TestLogger"
     let config =
 """
 static_resources:
@@ -41,7 +43,7 @@ static_resources:
           http_filters:
             - name: test_logger
               typed_config:
-                "@type": type.googleapis.com/envoymobile.extensions.filters.http.test_logger.TestLogger
+                "@type": \(testLoggerFilterType)
             - name: envoy.filters.http.assertion
               typed_config:
                 "@type": \(assertionFilterType)

--- a/test/swift/integration/SetLoggerTest.swift
+++ b/test/swift/integration/SetLoggerTest.swift
@@ -40,6 +40,8 @@ static_resources:
                       status: 200
           http_filters:
             - name: test_logger
+              typed_config:
+                "@type": envoymobile.extensions.filters.http.test_logger.TestLogger
             - name: envoy.filters.http.assertion
               typed_config:
                 "@type": \(assertionFilterType)

--- a/test/swift/integration/SetLoggerTest.swift
+++ b/test/swift/integration/SetLoggerTest.swift
@@ -41,7 +41,7 @@ static_resources:
           http_filters:
             - name: test_logger
               typed_config:
-                "@type": envoymobile.extensions.filters.http.test_logger.TestLogger
+                "@type": type.googleapis.com/envoymobile.extensions.filters.http.test_logger.TestLogger
             - name: envoy.filters.http.assertion
               typed_config:
                 "@type": \(assertionFilterType)


### PR DESCRIPTION
Propagates the new platform mappings command, fixes the platform k-v store and updates the config now that a typed_config is required

Signed-off-by: Snow Pettersen <snowp@lyft.com>

Risk Level: Medium
Testing: Existing tests
Docs Changes: n/a
Release Notes: n/a
