### PR TITLE
bazel: Allow multiple definitions for armeabi android links

### DIFF
--- a/library/common/jni/BUILD
+++ b/library/common/jni/BUILD
@@ -51,6 +51,14 @@ cc_library(
     alwayslink = True,
 )
 
+config_setting(
+    name = "android_armeabi",
+    constraint_values = [
+        "@platforms//cpu:arm",
+        "@platforms//os:android",
+    ],
+)
+
 # Main dynamic library for the Envoy Mobile aar
 cc_binary(
     name = "libenvoy_jni.so",
@@ -60,6 +68,10 @@ cc_binary(
         "-llog",
     ] + select({
         "@envoy//bazel:dbg_build": ["-Wl,--build-id=sha1"],
+        "//conditions:default": [],
+    }) + select({
+        # TODO(keith): https://github.com/rust-lang/compiler-builtins/issues/353
+        ":android_armeabi": ["-Wl,--allow-multiple-definition"],
         "//conditions:default": [],
     }),
     linkshared = True,


### PR DESCRIPTION
When working on rust support we hit this issue
https://github.com/rust-lang/compiler-builtins/issues/353 which seems to
still be persistent even in the case you have the nightly version
mentioned there. I haven't been able to reproduce the issue in a
separate project, but the core seems to be that both libgcc and rust's
compiler builtins module vendor some float math symbols and both are
included. This change is as scoped as possible so that no real issues
could sneak in with this disabled, which should mostly be covered by
only passing this for the single arch.

Signed-off-by: Keith Smiley <keithbsmiley@gmail.com>