### PR TITLE
pin maven dependencies

### DIFF
--- a/bazel/envoy_mobile_dependencies.bzl
+++ b/bazel/envoy_mobile_dependencies.bzl
@@ -64,6 +64,8 @@ def kotlin_dependencies(extra_maven_dependencies = []):
             "com.google.flatbuffers:flatbuffers-java:2.0.3",
             # Kotlin
             "org.jetbrains.kotlin:kotlin-stdlib-jdk8:1.3.11",
+            "org.jetbrains.kotlin:kotlin-stdlib-common:1.3.11",
+            "org.jetbrains.kotlin:kotlin-stdlib:1.3.11",
             "androidx.recyclerview:recyclerview:1.1.0",
             "androidx.core:core:1.3.2",
             # Dokka
@@ -88,6 +90,7 @@ def kotlin_dependencies(extra_maven_dependencies = []):
             "org.hamcrest:hamcrest:2.2",
             "com.google.truth:truth:1.1",
         ] + extra_maven_dependencies,
+        version_conflict_policy = "pinned",
         repositories = [
             "https://repo1.maven.org/maven2",
             "https://jcenter.bintray.com/",


### PR DESCRIPTION
This changes the conflict resolution policy of maven_install to pin, and specifies all the Kotlin libs by default. This ensures that dependent projects that add more deps won't result in Kotlin dependencies that conflict with the ones brought in by the Kotlin rules


Risk Level: Medium
Testing: Existing tests
Docs Changes: n/a
Release Notes: n/a
