### PR TITLE
h3/quic: add experimental option to the Android/JVM EngineBuilder

### DIFF
--- a/.github/workflows/ios_tests.yml
+++ b/.github/workflows/ios_tests.yml
@@ -31,7 +31,7 @@ jobs:
         if: steps.check_context.outputs.run_tests == 'true'
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: ./bazelw test --test_output=all --config=ios --build_tests_only --config=remote-ci-macos --remote_header="Authorization=Bearer $GITHUB_TOKEN" //test/swift/...
+        run: ./bazelw test --experimental_ui_max_stdouterr_bytes=10485760 --test_output=all --config=ios --build_tests_only --config=remote-ci-macos --remote_header="Authorization=Bearer $GITHUB_TOKEN" //test/swift/...
   objctests:
     name: objc_tests
     runs-on: macos-11

--- a/envoy_build_config/extensions_build_config.bzl
+++ b/envoy_build_config/extensions_build_config.bzl
@@ -4,6 +4,7 @@ EXTENSION_PACKAGE_VISIBILITY = ["//visibility:public"]
 EXTENSIONS = {
     "envoy.clusters.dynamic_forward_proxy":                "//source/extensions/clusters/dynamic_forward_proxy:cluster",
     "envoy.filters.connection_pools.http.generic":         "//source/extensions/upstreams/http/generic:config",
+    "envoy.filters.http.alternate_protocols_cache":        "//source/extensions/filters/http/alternate_protocols_cache:config",
     "envoy.filters.http.assertion":                        "@envoy_mobile//library/common/extensions/filters/http/assertion:config",
     "envoy.filters.http.buffer":                           "//source/extensions/filters/http/buffer:config",
     "envoy.filters.http.decompressor":                     "//source/extensions/filters/http/decompressor:config",

--- a/library/common/config/config.cc
+++ b/library/common/config/config.cc
@@ -30,6 +30,14 @@ const char* route_cache_reset_filter_insert = R"(
               "@type": type.googleapis.com/envoymobile.extensions.filters.http.route_cache_reset.RouteCacheReset
 )";
 
+const char* alternate_protocols_cache_filter_insert = R"(
+          - name: alternate_protocols_cache
+            typed_config:
+              "@type": type.googleapis.com/envoy.extensions.filters.http.alternate_protocols_cache.v3.FilterConfig
+              alternate_protocols_cache_options:
+                name: default_alternate_protocols_cache
+)";
+
 // clang-format off
 const std::string config_header = R"(
 !ignore default_defs:
@@ -100,6 +108,18 @@ R"(
       validation_context:
         trusted_ca:
           inline_string: *tls_root_certs
+- &base_h3_socket
+  name: envoy.transport_sockets.quic
+  typed_config:
+    "@type": type.googleapis.com/envoy.extensions.transport_sockets.quic.v3.QuicUpstreamTransport
+    upstream_tls_context:
+      common_tls_context:
+        tls_params:
+          tls_maximum_protocol_version: TLSv1_3
+        validation_context:
+          trusted_ca:
+             inline_string: *tls_root_certs
+- &default_upstream_socket *base_tls_socket
 )";
 
 const char* config_template = R"(
@@ -336,17 +356,7 @@ R"(
       typed_config:
         "@type": type.googleapis.com/envoy.extensions.clusters.dynamic_forward_proxy.v3.ClusterConfig
         dns_cache_config: *dns_cache_config
-    transport_socket:
-      name: envoy.transport_sockets.quic
-      typed_config:
-        "@type": type.googleapis.com/envoy.extensions.transport_sockets.quic.v3.QuicUpstreamTransport
-        upstream_tls_context:
-          common_tls_context:
-            tls_params:
-              tls_maximum_protocol_version: TLSv1_3
-            validation_context:
-              trusted_ca:
-                 inline_string: *tls_root_certs
+    transport_socket: *default_upstream_socket
     upstream_connection_options: &upstream_opts
       set_local_interface_name_on_upstream_connections: true
       tcp_keepalive:

--- a/library/common/config/templates.h
+++ b/library/common/config/templates.h
@@ -60,6 +60,12 @@ extern const char* fake_remote_cluster_insert;
 extern const char* fake_remote_route_insert;
 
 /**
+ * Insert that enables the alternate protocols cache filter in teh filter chain.
+ * This is only needed for (currently experimental) QUIC/H3 support.
+ */
+const char* alternate_protocols_cache_filter_insert = R"(
+
+/**
  * Insert that enables the route cache reset filter in the filter chain.
  * Should only be added when the route cache should be cleared on every request
  * going through the filter chain between initial route resolution and the router

--- a/library/common/config/templates.h
+++ b/library/common/config/templates.h
@@ -63,7 +63,7 @@ extern const char* fake_remote_route_insert;
  * Insert that enables the alternate protocols cache filter in teh filter chain.
  * This is only needed for (currently experimental) QUIC/H3 support.
  */
-const char* alternate_protocols_cache_filter_insert = R"(
+extern const char* alternate_protocols_cache_filter_insert;
 
 /**
  * Insert that enables the route cache reset filter in the filter chain.

--- a/library/common/config/templates.h
+++ b/library/common/config/templates.h
@@ -60,7 +60,7 @@ extern const char* fake_remote_cluster_insert;
 extern const char* fake_remote_route_insert;
 
 /**
- * Insert that enables the alternate protocols cache filter in teh filter chain.
+ * Insert that enables the alternate protocols cache filter in the filter chain.
  * This is only needed for (currently experimental) QUIC/H3 support.
  */
 extern const char* alternate_protocols_cache_filter_insert;

--- a/library/common/http/client.cc
+++ b/library/common/http/client.cc
@@ -617,10 +617,10 @@ void Client::setDestinationCluster(Http::RequestHeaderMap& headers) {
     // NOTE: This cluster *forces* H2-Raw and does not use ALPN.
     if (value == "http2") {
       cluster = H2Cluster;
-    // NOTE: This cluster will attempt to negotiate H3, but defaults to ALPN over TCP.
+      // NOTE: This cluster will attempt to negotiate H3, but defaults to ALPN over TCP.
     } else if (value == "http3") {
       cluster = H3Cluster;
-    // FIXME(goaway): No cluster actually forces H1 today except cleartext!
+      // FIXME(goaway): No cluster actually forces H1 today except cleartext!
     } else if (value == "alpn" || value == "http1") {
       cluster = BaseCluster;
     } else {

--- a/library/common/http/client.cc
+++ b/library/common/http/client.cc
@@ -587,7 +587,7 @@ void Client::removeStream(envoy_stream_t stream_handle) {
 namespace {
 
 const LowerCaseString ClusterHeader{"x-envoy-mobile-cluster"};
-const LowerCaseString H2UpstreamHeader{"x-envoy-mobile-upstream-protocol"};
+const LowerCaseString ProtocolHeader{"x-envoy-mobile-upstream-protocol"};
 
 // Alternate clusters included here are a stopgap to make it less likely for a given connection
 // class to suffer "catastrophic" failure of all outbound requests due to a network blip, by
@@ -597,6 +597,7 @@ const LowerCaseString H2UpstreamHeader{"x-envoy-mobile-upstream-protocol"};
 
 const char* BaseCluster = "base";
 const char* H2Cluster = "base_h2";
+const char* H3Cluster = "base_h3";
 const char* ClearTextCluster = "base_clear";
 
 } // namespace
@@ -607,15 +608,19 @@ void Client::setDestinationCluster(Http::RequestHeaderMap& headers) {
   // - Use http/2 or ALPN if requested explicitly via x-envoy-mobile-upstream-protocol.
   // - Force http/1.1 if request scheme is http (cleartext).
   const char* cluster{};
-  auto h2_header = headers.get(H2UpstreamHeader);
+  auto protocol_header = headers.get(ProtocolHeader);
   if (headers.getSchemeValue() == Headers::get().SchemeValues.Http) {
     cluster = ClearTextCluster;
-  } else if (!h2_header.empty()) {
-    ASSERT(h2_header.size() == 1);
-    const auto value = h2_header[0]->value().getStringView();
+  } else if (!protocol_header.empty()) {
+    ASSERT(protocol_header.size() == 1);
+    const auto value = protocol_header[0]->value().getStringView();
+    // NOTE: This cluster *forces* H2-Raw and does not use ALPN.
     if (value == "http2") {
       cluster = H2Cluster;
-      // FIXME(goaway): No cluster actually forces H1 today except cleartext!
+    // NOTE: This cluster will attempt to negotiate H3, but defaults to ALPN over TCP.
+    } else if (value == "http3") {
+      cluster = H3Cluster;
+    // FIXME(goaway): No cluster actually forces H1 today except cleartext!
     } else if (value == "alpn" || value == "http1") {
       cluster = BaseCluster;
     } else {
@@ -625,8 +630,8 @@ void Client::setDestinationCluster(Http::RequestHeaderMap& headers) {
     cluster = BaseCluster;
   }
 
-  if (!h2_header.empty()) {
-    headers.remove(H2UpstreamHeader);
+  if (!protocol_header.empty()) {
+    headers.remove(ProtocolHeader);
   }
 
   headers.addCopy(ClusterHeader, std::string{cluster});

--- a/library/common/jni/jni_interface.cc
+++ b/library/common/jni/jni_interface.cc
@@ -145,8 +145,8 @@ Java_io_envoyproxy_envoymobile_engine_JniLibrary_nativeFilterTemplate(JNIEnv* en
 }
 
 extern "C" JNIEXPORT jstring JNICALL
-Java_io_envoyproxy_envoymobile_engine_JniLibrary altProtocolCacheFilterInsert(JNIEnv* env, jclass) {
-  jstring result = env->NewStringUTF(alternate_protocols_filter_cache_insert);
+Java_io_envoyproxy_envoymobile_engine_JniLibrary_altProtocolCacheFilterInsert(JNIEnv* env, jclass) {
+  jstring result = env->NewStringUTF(alternate_protocols_cache_filter_insert);
   return result;
 }
 

--- a/library/common/jni/jni_interface.cc
+++ b/library/common/jni/jni_interface.cc
@@ -127,26 +127,26 @@ extern "C" JNIEXPORT void JNICALL Java_io_envoyproxy_envoymobile_engine_JniLibra
 }
 
 extern "C" JNIEXPORT jstring JNICALL
-Java_io_envoyproxy_envoymobile_engine_JniLibrary_templateString(JNIEnv* env,
-                                                                jclass // class
-) {
+Java_io_envoyproxy_envoymobile_engine_JniLibrary_configTemplate(JNIEnv* env, jclass) {
   jstring result = env->NewStringUTF(config_template);
   return result;
 }
 
 extern "C" JNIEXPORT jstring JNICALL
-Java_io_envoyproxy_envoymobile_engine_JniLibrary_platformFilterTemplateString(JNIEnv* env,
-                                                                              jclass // class
-) {
+Java_io_envoyproxy_envoymobile_engine_JniLibrary_platformFilterTemplate(JNIEnv* env, jclass) {
   jstring result = env->NewStringUTF(platform_filter_template);
   return result;
 }
 
 extern "C" JNIEXPORT jstring JNICALL
-Java_io_envoyproxy_envoymobile_engine_JniLibrary_nativeFilterTemplateString(JNIEnv* env,
-                                                                            jclass // class
-) {
+Java_io_envoyproxy_envoymobile_engine_JniLibrary_nativeFilterTemplate(JNIEnv* env, jclass) {
   jstring result = env->NewStringUTF(native_filter_template);
+  return result;
+}
+
+extern "C" JNIEXPORT jstring JNICALL
+Java_io_envoyproxy_envoymobile_engine_JniLibrary altProtocolCacheFilterInsert(JNIEnv* env, jclass) {
+  jstring result = env->NewStringUTF(alternate_protocols_filter_cache_insert);
   return result;
 }
 

--- a/library/java/io/envoyproxy/envoymobile/engine/EnvoyConfiguration.java
+++ b/library/java/io/envoyproxy/envoymobile/engine/EnvoyConfiguration.java
@@ -147,7 +147,8 @@ public class EnvoyConfiguration {
    *                                 resolved.
    */
   String resolveTemplate(final String configTemplate, final String platformFilterTemplate,
-                         final String nativeFilterTemplate) {
+                         final String nativeFilterTemplate,
+                         final String altProtocolCacheFilterInsert) {
     final StringBuilder customFiltersBuilder = new StringBuilder();
 
     for (EnvoyHTTPFilterFactory filterFactory : httpPlatformFilterFactories) {

--- a/library/java/io/envoyproxy/envoymobile/engine/EnvoyConfiguration.java
+++ b/library/java/io/envoyproxy/envoymobile/engine/EnvoyConfiguration.java
@@ -153,14 +153,13 @@ public class EnvoyConfiguration {
 
     for (EnvoyHTTPFilterFactory filterFactory : httpPlatformFilterFactories) {
       String filterConfig = platformFilterTemplate.replace("{{ platform_filter_name }}",
-                                                               filterFactory.getFilterName());
+                                                           filterFactory.getFilterName());
       customFiltersBuilder.append(filterConfig);
     }
 
     for (EnvoyNativeFilterConfig filter : nativeFilterChain) {
-      String filterConfig =
-          nativeFilterTemplate.replace("{{ native_filter_name }}", filter.name)
-              .replace("{{ native_filter_typed_config }}", filter.typedConfig);
+      String filterConfig = nativeFilterTemplate.replace("{{ native_filter_name }}", filter.name)
+                                .replace("{{ native_filter_typed_config }}", filter.typedConfig);
       customFiltersBuilder.append(filterConfig);
     }
 

--- a/library/java/io/envoyproxy/envoymobile/engine/EnvoyConfiguration.java
+++ b/library/java/io/envoyproxy/envoymobile/engine/EnvoyConfiguration.java
@@ -35,6 +35,7 @@ public class EnvoyConfiguration {
   public final String dnsPreresolveHostnames;
   public final List<String> dnsFallbackNameservers;
   public final Boolean dnsFilterUnroutableFamilies;
+  public final Boolean enableHttp3;
   public final Boolean enableHappyEyeballs;
   public final Boolean enableInterfaceBinding;
   public final Integer h2ConnectionKeepaliveIdleIntervalMilliseconds;
@@ -69,6 +70,7 @@ public class EnvoyConfiguration {
    * @param dnsPreresolveHostnames       hostnames to preresolve on Envoy Client construction.
    * @param dnsFallbackNameservers       addresses to use as DNS name server fallback.
    * @param dnsFilterUnroutableFamilies  whether to filter unroutable IP families or not.
+   * @param enableHttp3                  whether to enable experimental support for HTTP/3 (QUIC).
    * @param enableHappyEyeballs          whether to enable RFC 6555 handling for IPv4/IPv6.
    * @param enableInterfaceBinding       whether to allow interface binding.
    * @param h2ConnectionKeepaliveIdleIntervalMilliseconds rate in milliseconds seconds to send h2
@@ -92,7 +94,7 @@ public class EnvoyConfiguration {
       int connectTimeoutSeconds, int dnsRefreshSeconds, int dnsFailureRefreshSecondsBase,
       int dnsFailureRefreshSecondsMax, int dnsQueryTimeoutSeconds, int dnsMinRefreshSeconds,
       String dnsPreresolveHostnames, List<String> dnsFallbackNameservers,
-      Boolean dnsFilterUnroutableFamilies, boolean enableHappyEyeballs,
+      Boolean dnsFilterUnroutableFamilies, boolean enableHttp3, boolean enableHappyEyeballs,
       boolean enableInterfaceBinding, int h2ConnectionKeepaliveIdleIntervalMilliseconds,
       int h2ConnectionKeepaliveTimeoutSeconds, List<String> h2RawDomains, int maxConnectionsPerHost,
       int statsFlushSeconds, int streamIdleTimeoutSeconds, int perTryIdleTimeoutSeconds,
@@ -112,6 +114,7 @@ public class EnvoyConfiguration {
     this.dnsPreresolveHostnames = dnsPreresolveHostnames;
     this.dnsFallbackNameservers = dnsFallbackNameservers;
     this.dnsFilterUnroutableFamilies = dnsFilterUnroutableFamilies;
+    this.enableHttp3 = enableHttp3;
     this.enableHappyEyeballs = enableHappyEyeballs;
     this.enableInterfaceBinding = enableInterfaceBinding;
     this.h2ConnectionKeepaliveIdleIntervalMilliseconds =
@@ -135,32 +138,37 @@ public class EnvoyConfiguration {
    * Resolves the provided configuration template using properties on this
    * configuration.
    *
-   * @param templateYAML the template configuration to resolve.
-   * @param platformFilterTemplateYAML helper template to build platform http filters.
-   * @param nativeFilterTemplateYAML helper template to build native http filters.
+   * @param configTemplate the template configuration to resolve.
+   * @param platformFilterTemplate helper template to build platform http filters.
+   * @param nativeFilterTemplate helper template to build native http filters.
+   * @param altProtocolCacheFilterInsert helper insert to include the alt protocol cache filter.
    * @return String, the resolved template.
    * @throws ConfigurationException, when the template provided is not fully
    *                                 resolved.
    */
-  String resolveTemplate(final String templateYAML, final String platformFilterTemplateYAML,
-                         final String nativeFilterTemplateYAML) {
+  String resolveTemplate(final String configTemplate, final String platformFilterTemplate,
+                         final String nativeFilterTemplate) {
     final StringBuilder customFiltersBuilder = new StringBuilder();
 
     for (EnvoyHTTPFilterFactory filterFactory : httpPlatformFilterFactories) {
-      String filterConfig = platformFilterTemplateYAML.replace("{{ platform_filter_name }}",
+      String filterConfig = platformFilterTemplate.replace("{{ platform_filter_name }}",
                                                                filterFactory.getFilterName());
       customFiltersBuilder.append(filterConfig);
     }
 
     for (EnvoyNativeFilterConfig filter : nativeFilterChain) {
       String filterConfig =
-          nativeFilterTemplateYAML.replace("{{ native_filter_name }}", filter.name)
+          nativeFilterTemplate.replace("{{ native_filter_name }}", filter.name)
               .replace("{{ native_filter_typed_config }}", filter.typedConfig);
       customFiltersBuilder.append(filterConfig);
     }
 
+    if (enableHttp3) {
+      customFiltersBuilder.append(altProtocolCacheFilterInsert);
+    }
+
     String processedTemplate =
-        templateYAML.replace("#{custom_filters}", customFiltersBuilder.toString());
+        configTemplate.replace("#{custom_filters}", customFiltersBuilder.toString());
 
     String dnsFallbackNameserversAsString = "[]";
     if (!dnsFallbackNameservers.isEmpty()) {

--- a/library/java/io/envoyproxy/envoymobile/engine/EnvoyEngineImpl.java
+++ b/library/java/io/envoyproxy/envoymobile/engine/EnvoyEngineImpl.java
@@ -87,11 +87,11 @@ public class EnvoyEngineImpl implements EnvoyEngine {
                                         new JvmStringAccessorContext(entry.getValue()));
     }
 
-    return runWithResolvedYAML(envoyConfiguration.resolveTemplate(
-                                   configurationYAML, JniLibrary.platformFilterTemplate(),
-                                   JniLibrary.nativeFilterTemplate(),
-                                   JniLibrary.altProtocolCacheFilterInsert()),
-                               logLevel);
+    return runWithResolvedYAML(
+        envoyConfiguration.resolveTemplate(configurationYAML, JniLibrary.platformFilterTemplate(),
+                                           JniLibrary.nativeFilterTemplate(),
+                                           JniLibrary.altProtocolCacheFilterInsert()),
+        logLevel);
   }
 
   /**

--- a/library/java/io/envoyproxy/envoymobile/engine/EnvoyEngineImpl.java
+++ b/library/java/io/envoyproxy/envoymobile/engine/EnvoyEngineImpl.java
@@ -88,8 +88,9 @@ public class EnvoyEngineImpl implements EnvoyEngine {
     }
 
     return runWithResolvedYAML(envoyConfiguration.resolveTemplate(
-                                   configurationYAML, JniLibrary.platformFilterTemplateString(),
-                                   JniLibrary.nativeFilterTemplateString()),
+                                   configurationYAML, JniLibrary.platformFilterTemplate(),
+                                   JniLibrary.nativeFilterTemplate(),
+                                   JniLibrary.altProtocolCacheFilterInsert()),
                                logLevel);
   }
 

--- a/library/java/io/envoyproxy/envoymobile/engine/EnvoyEngineImpl.java
+++ b/library/java/io/envoyproxy/envoymobile/engine/EnvoyEngineImpl.java
@@ -103,7 +103,7 @@ public class EnvoyEngineImpl implements EnvoyEngine {
    */
   @Override
   public int runWithConfig(EnvoyConfiguration envoyConfiguration, String logLevel) {
-    return runWithTemplate(JniLibrary.templateString(), envoyConfiguration, logLevel);
+    return runWithTemplate(JniLibrary.configTemplate(), envoyConfiguration, logLevel);
   }
 
   private int runWithResolvedYAML(String configurationYAML, String logLevel) {

--- a/library/java/io/envoyproxy/envoymobile/engine/JniLibrary.java
+++ b/library/java/io/envoyproxy/envoymobile/engine/JniLibrary.java
@@ -191,7 +191,7 @@ public class JniLibrary {
    * @return A template that may be used as a starting point for constructing
    * configurations.
    */
-  public static native String templateString();
+  public static native String configTemplate();
 
   /**
    * Increment a counter with the given count.

--- a/library/java/io/envoyproxy/envoymobile/engine/JniLibrary.java
+++ b/library/java/io/envoyproxy/envoymobile/engine/JniLibrary.java
@@ -287,7 +287,7 @@ public class JniLibrary {
    * @return A template that may be used as a starting point for constructing
    * platform filter configuration.
    */
-  public static native String platformFilterTemplateString();
+  public static native String platformFilterTemplate();
 
   /**
    * Provides a configuration template that may be used for building native
@@ -296,7 +296,14 @@ public class JniLibrary {
    * @return A template that may be used as a starting point for constructing
    * native filter configuration.
    */
-  public static native String nativeFilterTemplateString();
+  public static native String nativeFilterTemplate();
+
+  /**
+   * Provides a configruation insert that may be used to include an instance
+   * of ther AlternateProtocolsCacheFilter in the filter chain. Needed only
+   * when (experimental) QUIC/H3 support is enabled.
+   */
+  public static native String altProtocolCacheFilterInsert();
 
   /**
    * Register a string accessor to get strings from the platform.

--- a/library/java/io/envoyproxy/envoymobile/engine/JniLibrary.java
+++ b/library/java/io/envoyproxy/envoymobile/engine/JniLibrary.java
@@ -299,8 +299,8 @@ public class JniLibrary {
   public static native String nativeFilterTemplate();
 
   /**
-   * Provides a configruation insert that may be used to include an instance
-   * of ther AlternateProtocolsCacheFilter in the filter chain. Needed only
+   * Provides a configuration insert that may be used to include an instance
+   * of the AlternateProtocolsCacheFilter in the filter chain. Needed only
    * when (experimental) QUIC/H3 support is enabled.
    */
   public static native String altProtocolCacheFilterInsert();

--- a/library/java/org/chromium/net/impl/NativeCronetEngineBuilderImpl.java
+++ b/library/java/org/chromium/net/impl/NativeCronetEngineBuilderImpl.java
@@ -60,6 +60,7 @@ public class NativeCronetEngineBuilderImpl extends CronetEngineBuilderImpl {
   private String mDnsPreresolveHostnames = "[]";
   private List<String> mDnsFallbackNameservers = Collections.emptyList();
   private boolean mEnableDnsFilterUnroutableFamilies = false;
+  private boolean mEnableHttp3 = false;
   private boolean mEnableHappyEyeballs = false;
   private boolean mEnableInterfaceBinding = false;
   private int mH2ConnectionKeepaliveIdleIntervalMilliseconds = 100000000;
@@ -121,11 +122,11 @@ public class NativeCronetEngineBuilderImpl extends CronetEngineBuilderImpl {
         mAdminInterfaceEnabled, mGrpcStatsDomain, mStatsDPort, mConnectTimeoutSeconds,
         mDnsRefreshSeconds, mDnsFailureRefreshSecondsBase, mDnsFailureRefreshSecondsMax,
         mDnsQueryTimeoutSeconds, mDnsMinRefreshSeconds, mDnsPreresolveHostnames,
-        mDnsFallbackNameservers, mEnableDnsFilterUnroutableFamilies, mEnableHappyEyeballs,
-        mEnableInterfaceBinding, mH2ConnectionKeepaliveIdleIntervalMilliseconds,
-        mH2ConnectionKeepaliveTimeoutSeconds, mH2RawDomains, mMaxConnectionsPerHost,
-        mStatsFlushSeconds, mStreamIdleTimeoutSeconds, mPerTryIdleTimeoutSeconds, mAppVersion,
-        mAppId, mTrustChainVerification, mVirtualClusters, nativeFilterChain, platformFilterChain,
-        stringAccessors);
+        mDnsFallbackNameservers, mEnableDnsFilterUnroutableFamilies, mEnableHttp3,
+        mEnableHappyEyeballs, mEnableInterfaceBinding,
+        mH2ConnectionKeepaliveIdleIntervalMilliseconds, mH2ConnectionKeepaliveTimeoutSeconds,
+        mH2RawDomains, mMaxConnectionsPerHost, mStatsFlushSeconds, mStreamIdleTimeoutSeconds,
+        mPerTryIdleTimeoutSeconds, mAppVersion, mAppId, mTrustChainVerification, mVirtualClusters,
+        nativeFilterChain, platformFilterChain, stringAccessors);
   }
 }

--- a/library/kotlin/io/envoyproxy/envoymobile/EngineBuilder.kt
+++ b/library/kotlin/io/envoyproxy/envoymobile/EngineBuilder.kt
@@ -39,6 +39,7 @@ open class EngineBuilder(
   private var dnsQueryTimeoutSeconds = 25
   private var dnsMinRefreshSeconds = 60
   private var dnsPreresolveHostnames = "[]"
+  private var enableHttp3 = false
   private var enableHappyEyeballs = false
   private var enableInterfaceBinding = false
   private var h2ConnectionKeepaliveIdleIntervalMilliseconds = 100000000
@@ -194,6 +195,20 @@ open class EngineBuilder(
    */
   fun enableDNSFilterUnroutableFamilies(dnsFilterUnroutableFamilies: Boolean): EngineBuilder {
     this.dnsFilterUnroutableFamilies = dnsFilterUnroutableFamilies
+    return this
+  }
+
+  /**
+   * Specify whether to enable experimental HTTP/3 (QUIC) support. Note the actual protocol will
+   * be negotiated with the upstream endpoint and so upstream support is still required for HTTP/3
+   * to be utilized.
+   *
+   * @param enableHttp3 whether to enable HTTP/3.
+   *
+   * @return This builder.
+   */
+  fun enableHttp3(enableHttp3: Boolean): EngineBuilder {
+    this.enableHttp3 = enableHttp3
     return this
   }
 
@@ -475,6 +490,7 @@ open class EngineBuilder(
       dnsPreresolveHostnames,
       dnsFallbackNameservers,
       dnsFilterUnroutableFamilies,
+      enableHttp3,
       enableHappyEyeballs,
       enableInterfaceBinding,
       h2ConnectionKeepaliveIdleIntervalMilliseconds,

--- a/test/java/io/envoyproxy/envoymobile/engine/EnvoyConfigurationTest.kt
+++ b/test/java/io/envoyproxy/envoymobile/engine/EnvoyConfigurationTest.kt
@@ -24,19 +24,80 @@ private const val NATIVE_FILTER_CONFIG =
     typed_config: {{ native_filter_typed_config }}
 """
 
+private const val APLF_INSERT =
+"""
+  - name: AlternateProtocolsCacheFilter
+"""
+
 class EnvoyConfigurationTest {
 
-  @Test
-  fun `resolving with default configuration resolves with values`() {
-    val envoyConfiguration = EnvoyConfiguration(
-      false, "stats.foo.com", null, 123, 234, 345, 456, 321, 12, "[hostname]", listOf("8.8.8.8"),
-      true, true, true, 222, 333, listOf("h2-raw.domain"), 543, 567, 678, 910, "v1.2.3",
-      "com.mydomain.myapp", TrustChainVerification.ACCEPT_UNTRUSTED, "[test]",
-      listOf(EnvoyNativeFilterConfig("filter_name", "test_config")), emptyList(), emptyMap()
+  fun buildTestEnvoyConfiguration(
+    adminInterfaceEnabled: Boolean = false,
+    grpcStatsDomain: String = "stats.example.com",
+    statsDPort: Int? = null,
+    connectTimeoutSeconds: Int = 123,
+    dnsRefreshSeconds: Int = 234,
+    dnsFailureRefreshSecondsBase: Int = 345,
+    dnsFailureRefreshSecondsMax: Int = 456,
+    dnsQueryTimeoutSeconds: Int = 321,
+    dnsMinRefreshSeconds: Int = 12,
+    dnsPreresolveHostnames: String = "[hostname]",
+    dnsFallbackNameservers: List<String> = emptyList(),
+    enableDnsFilterUnroutableFamilies: Boolean = false,
+    enableHttp3: Boolean = false,
+    enableHappyEyeballs: Boolean = false,
+    enableInterfaceBinding: Boolean = false,
+    h2ConnectionKeepaliveIdleIntervalMilliseconds: Int = 222,
+    h2ConnectionKeepaliveTimeoutSeconds: Int = 333,
+    h2RawDomains: List<String> = listOf("h2-raw.example.com"),
+    maxConnectionsPerHost: Int = 543,
+    statsFlushSeconds: Int = 567,
+    streamIdleTimeoutSeconds: Int = 678,
+    perTryIdleTimeoutSeconds: Int = 910,
+    appVersion: String = "v1.2.3",
+    appId: String = "com.example.myapp",
+    trustChainVerification: TrustChainVerification = TrustChainVerification.VERIFY_TRUST_CHAIN,
+    virtualClusters: String = "[test]"
+  ): EnvoyConfiguration {
+    return EnvoyConfiguration(
+      adminInterfaceEnabled,
+      grpcStatsDomain,
+      statsDPort,
+      connectTimeoutSeconds,
+      dnsRefreshSeconds,
+      dnsFailureRefreshSecondsBase,
+      dnsFailureRefreshSecondsMax,
+      dnsQueryTimeoutSeconds,
+      dnsMinRefreshSeconds,
+      dnsPreresolveHostnames,
+      dnsFallbackNameservers,
+      enableDnsFilterUnroutableFamilies,
+      enableHttp3,
+      enableHappyEyeballs,
+      enableInterfaceBinding,
+      h2ConnectionKeepaliveIdleIntervalMilliseconds,
+      h2ConnectionKeepaliveTimeoutSeconds,
+      h2RawDomains,
+      maxConnectionsPerHost,
+      statsFlushSeconds,
+      streamIdleTimeoutSeconds,
+      perTryIdleTimeoutSeconds,
+      appVersion,
+      appId,
+      trustChainVerification,
+      virtualClusters,
+      listOf(EnvoyNativeFilterConfig("filter_name", "test_config")),
+      emptyList(),
+      emptyMap()
     )
+  }
+
+  @Test
+  fun `configuration resolves with values`() {
+    val envoyConfiguration = buildTestEnvoyConfiguration()
 
     val resolvedTemplate = envoyConfiguration.resolveTemplate(
-      TEST_CONFIG, PLATFORM_FILTER_CONFIG, NATIVE_FILTER_CONFIG
+      TEST_CONFIG, PLATFORM_FILTER_CONFIG, NATIVE_FILTER_CONFIG, APLF_INSERT
     )
     assertThat(resolvedTemplate).contains("&connect_timeout 123s")
 
@@ -47,22 +108,22 @@ class EnvoyConfigurationTest {
     assertThat(resolvedTemplate).contains("&dns_fail_base_interval 345s")
     assertThat(resolvedTemplate).contains("&dns_fail_max_interval 456s")
     assertThat(resolvedTemplate).contains("&dns_query_timeout 321s")
-    assertThat(resolvedTemplate).contains("&dns_lookup_family ALL")
-    assertThat(resolvedTemplate).contains("&dns_multiple_addresses true")
+    assertThat(resolvedTemplate).contains("&dns_lookup_family V4_PREFERRED")
+    assertThat(resolvedTemplate).contains("&dns_multiple_addresses false")
     assertThat(resolvedTemplate).contains("&dns_min_refresh_rate 12s")
     assertThat(resolvedTemplate).contains("&dns_preresolve_hostnames [hostname]")
     assertThat(resolvedTemplate).contains("&dns_resolver_name envoy.network.dns_resolver.cares")
-    assertThat(resolvedTemplate).contains("&dns_resolver_config {\"@type\":\"type.googleapis.com/envoy.extensions.network.dns_resolver.cares.v3.CaresDnsResolverConfig\",\"resolvers\":[{\"socket_address\":{\"address\":\"8.8.8.8\"}}],\"use_resolvers_as_fallback\": true, \"filter_unroutable_families\": true}")
+    assertThat(resolvedTemplate).contains("&dns_resolver_config {\"@type\":\"type.googleapis.com/envoy.extensions.network.dns_resolver.cares.v3.CaresDnsResolverConfig\",\"resolvers\":[],\"use_resolvers_as_fallback\": false, \"filter_unroutable_families\": false}")
 
     // Interface Binding
-    assertThat(resolvedTemplate).contains("&enable_interface_binding true")
+    assertThat(resolvedTemplate).contains("&enable_interface_binding false")
 
     // H2 Ping
     assertThat(resolvedTemplate).contains("&h2_connection_keepalive_idle_interval 0.222s")
     assertThat(resolvedTemplate).contains("&h2_connection_keepalive_timeout 333s")
 
     // H2 Hostnames
-    assertThat(resolvedTemplate).contains("&h2_raw_domains [\"h2-raw.domain\"]")
+    assertThat(resolvedTemplate).contains("&h2_raw_domains [\"h2-raw.example.com\"]")
 
     // Per Host Limits
     assertThat(resolvedTemplate).contains("&max_connections_per_host 543")
@@ -70,12 +131,12 @@ class EnvoyConfigurationTest {
     // Metadata
     assertThat(resolvedTemplate).contains("os: Android")
     assertThat(resolvedTemplate).contains("app_version: v1.2.3")
-    assertThat(resolvedTemplate).contains("app_id: com.mydomain.myapp")
+    assertThat(resolvedTemplate).contains("app_id: com.example.myapp")
 
     assertThat(resolvedTemplate).contains("&virtual_clusters [test]")
 
     // Stats
-    assertThat(resolvedTemplate).contains("&stats_domain stats.foo.com")
+    assertThat(resolvedTemplate).contains("&stats_domain stats.example.com")
     assertThat(resolvedTemplate).contains("&stats_flush_interval 567s")
 
     // Idle timeouts
@@ -83,7 +144,7 @@ class EnvoyConfigurationTest {
     assertThat(resolvedTemplate).contains("&per_try_idle_timeout 910s")
 
     // TlS Verification
-    assertThat(resolvedTemplate).contains("&trust_chain_verification ACCEPT_UNTRUSTED")
+    assertThat(resolvedTemplate).contains("&trust_chain_verification VERIFY_TRUST_CHAIN")
 
     // Filters
     assertThat(resolvedTemplate).contains("filter_name")
@@ -91,37 +152,33 @@ class EnvoyConfigurationTest {
   }
 
   @Test
-  fun `resolving with alternate values also sets appropriate config`() {
-    val envoyConfiguration = EnvoyConfiguration(
-      false, "stats.foo.com", null, 123, 234, 345, 456, 321, 12, "[hostname]", emptyList(), false,
-      false, false, 222, 333, emptyList(), 543, 567, 678, 910, "v1.2.3", "com.mydomain.myapp",
-      TrustChainVerification.ACCEPT_UNTRUSTED, "[test]",
-      listOf(EnvoyNativeFilterConfig("filter_name", "test_config")), emptyList(), emptyMap()
+  fun `configuration resolves with alternate values`() {
+    val envoyConfiguration = buildTestEnvoyConfiguration(
+      dnsFallbackNameservers = listOf("8.8.8.8"),
+      enableDnsFilterUnroutableFamilies = true,
+      enableHappyEyeballs = true,
+      enableInterfaceBinding = true
     )
 
     val resolvedTemplate = envoyConfiguration.resolveTemplate(
-      TEST_CONFIG, PLATFORM_FILTER_CONFIG, NATIVE_FILTER_CONFIG
+      TEST_CONFIG, PLATFORM_FILTER_CONFIG, NATIVE_FILTER_CONFIG, APLF_INSERT
     )
 
     // DNS
-    assertThat(resolvedTemplate).contains("&dns_resolver_config {\"@type\":\"type.googleapis.com/envoy.extensions.network.dns_resolver.cares.v3.CaresDnsResolverConfig\",\"resolvers\":[],\"use_resolvers_as_fallback\": false, \"filter_unroutable_families\": false}")
-    assertThat(resolvedTemplate).contains("&dns_lookup_family V4_PREFERRED")
-    assertThat(resolvedTemplate).contains("&dns_multiple_addresses false")
+    assertThat(resolvedTemplate).contains("&dns_resolver_config {\"@type\":\"type.googleapis.com/envoy.extensions.network.dns_resolver.cares.v3.CaresDnsResolverConfig\",\"resolvers\":[{\"socket_address\":{\"address\":\"8.8.8.8\"}}],\"use_resolvers_as_fallback\": true, \"filter_unroutable_families\": true}")
+    assertThat(resolvedTemplate).contains("&dns_lookup_family ALL")
+    assertThat(resolvedTemplate).contains("&dns_multiple_addresses true")
 
     // Interface Binding
-    assertThat(resolvedTemplate).contains("&enable_interface_binding false")
+    assertThat(resolvedTemplate).contains("&enable_interface_binding true")
   }
 
   @Test
   fun `resolve templates with invalid templates will throw on build`() {
-    val envoyConfiguration = EnvoyConfiguration(
-      false, "stats.foo.com", null, 123, 234, 345, 456, 321, 12, "[hostname]", emptyList(), false,
-      false, false, 123, 123, emptyList(), 543, 567, 678, 910, "v1.2.3", "com.mydomain.myapp",
-      TrustChainVerification.ACCEPT_UNTRUSTED, "[test]", emptyList(), emptyList(), emptyMap()
-    )
+    val envoyConfiguration = buildTestEnvoyConfiguration()
 
     try {
-      envoyConfiguration.resolveTemplate("{{ missing }}", "", "")
+      envoyConfiguration.resolveTemplate("{{ missing }}", "", "", "")
       fail("Unresolved configuration keys should trigger exception.")
     } catch (e: EnvoyConfiguration.ConfigurationException) {
       assertThat(e.message).contains("missing")
@@ -130,14 +187,13 @@ class EnvoyConfigurationTest {
 
   @Test
   fun `cannot configure both statsD and gRPC stat sink`() {
-    val envoyConfiguration = EnvoyConfiguration(
-      false, "stats.foo.com", 5050, 123, 234, 345, 456, 321, 12, "[hostname]", emptyList(), false,
-      false, false, 123, 123, emptyList(), 543, 567, 678, 910, "v1.2.3", "com.mydomain.myapp",
-      TrustChainVerification.ACCEPT_UNTRUSTED, "[test]", emptyList(), emptyList(), emptyMap()
+    val envoyConfiguration = buildTestEnvoyConfiguration(
+      grpcStatsDomain = "stats.example.com",
+      statsDPort = 5050
     )
 
     try {
-      envoyConfiguration.resolveTemplate("", "", "")
+      envoyConfiguration.resolveTemplate("", "", "", "")
       fail("Conflicting stats keys should trigger exception.")
     } catch (e: EnvoyConfiguration.ConfigurationException) {
       assertThat(e.message).contains("cannot enable both statsD and gRPC metrics sink")
@@ -146,34 +202,27 @@ class EnvoyConfigurationTest {
 
   @Test
   fun `resolving multiple h2 raw domains`() {
-    val envoyConfiguration = EnvoyConfiguration(
-      false, "stats.foo.com", null, 123, 234, 345, 456, 321, 12, "[hostname]", listOf("8.8.8.8"), true,
-      true, true, 222, 333, listOf("h2-raw.domain", "h2-raw.domain2"), 543, 567, 678, 910, "v1.2.3",
-      "com.mydomain.myapp", TrustChainVerification.ACCEPT_UNTRUSTED, "[test]",
-      listOf(EnvoyNativeFilterConfig("filter_name", "test_config")), emptyList(), emptyMap()
+    val envoyConfiguration = buildTestEnvoyConfiguration(
+      h2RawDomains = listOf("h2-raw.example.com", "h2-raw.example.com2")
     )
 
     val resolvedTemplate = envoyConfiguration.resolveTemplate(
-      TEST_CONFIG, PLATFORM_FILTER_CONFIG, NATIVE_FILTER_CONFIG
+      TEST_CONFIG, PLATFORM_FILTER_CONFIG, NATIVE_FILTER_CONFIG, APLF_INSERT
     )
 
-    assertThat(resolvedTemplate).contains("&h2_raw_domains [\"h2-raw.domain\",\"h2-raw.domain2\"]")
+    assertThat(resolvedTemplate).contains("&h2_raw_domains [\"h2-raw.example.com\",\"h2-raw.example.com2\"]")
   }
 
   @Test
   fun `resolving multiple dns fallback nameservers`() {
-    val envoyConfiguration = EnvoyConfiguration(
-      false, "stats.foo.com", null, 123, 234, 345, 456, 321, 12, "[hostname]",
-      listOf("8.8.8.8", "1.1.1.1"), true, true, true, 222, 333,
-      listOf("h2-raw.domain", "h2-raw.domain2"), 543, 567, 678, 910, "v1.2.3", "com.mydomain.myapp",
-      TrustChainVerification.ACCEPT_UNTRUSTED, "[test]",
-      listOf(EnvoyNativeFilterConfig("filter_name", "test_config")), emptyList(), emptyMap()
+    val envoyConfiguration = buildTestEnvoyConfiguration(
+      dnsFallbackNameservers = listOf("8.8.8.8", "1.1.1.1")
     )
 
     val resolvedTemplate = envoyConfiguration.resolveTemplate(
-      TEST_CONFIG, PLATFORM_FILTER_CONFIG, NATIVE_FILTER_CONFIG
+      TEST_CONFIG, PLATFORM_FILTER_CONFIG, NATIVE_FILTER_CONFIG, APLF_INSERT
     )
 
-    assertThat(resolvedTemplate).contains("&dns_resolver_config {\"@type\":\"type.googleapis.com/envoy.extensions.network.dns_resolver.cares.v3.CaresDnsResolverConfig\",\"resolvers\":[{\"socket_address\":{\"address\":\"8.8.8.8\"}},{\"socket_address\":{\"address\":\"1.1.1.1\"}}],\"use_resolvers_as_fallback\": true, \"filter_unroutable_families\": true}")
+    assertThat(resolvedTemplate).contains("&dns_resolver_config {\"@type\":\"type.googleapis.com/envoy.extensions.network.dns_resolver.cares.v3.CaresDnsResolverConfig\",\"resolvers\":[{\"socket_address\":{\"address\":\"8.8.8.8\"}},{\"socket_address\":{\"address\":\"1.1.1.1\"}}],\"use_resolvers_as_fallback\": true, \"filter_unroutable_families\": false}")
   }
 }

--- a/test/java/io/envoyproxy/envoymobile/engine/EnvoyConfigurationTest.kt
+++ b/test/java/io/envoyproxy/envoymobile/engine/EnvoyConfigurationTest.kt
@@ -24,7 +24,7 @@ private const val NATIVE_FILTER_CONFIG =
     typed_config: {{ native_filter_typed_config }}
 """
 
-private const val APLF_INSERT =
+private const val APCF_INSERT =
 """
   - name: AlternateProtocolsCacheFilter
 """
@@ -97,7 +97,7 @@ class EnvoyConfigurationTest {
     val envoyConfiguration = buildTestEnvoyConfiguration()
 
     val resolvedTemplate = envoyConfiguration.resolveTemplate(
-      TEST_CONFIG, PLATFORM_FILTER_CONFIG, NATIVE_FILTER_CONFIG, APLF_INSERT
+      TEST_CONFIG, PLATFORM_FILTER_CONFIG, NATIVE_FILTER_CONFIG, APCF_INSERT
     )
     assertThat(resolvedTemplate).contains("&connect_timeout 123s")
 
@@ -124,6 +124,9 @@ class EnvoyConfigurationTest {
 
     // H2 Hostnames
     assertThat(resolvedTemplate).contains("&h2_raw_domains [\"h2-raw.example.com\"]")
+
+    // H3
+    assertThat(resolvedTemplate).doesNotContain(APCF_INSERT);
 
     // Per Host Limits
     assertThat(resolvedTemplate).contains("&max_connections_per_host 543")
@@ -157,17 +160,21 @@ class EnvoyConfigurationTest {
       dnsFallbackNameservers = listOf("8.8.8.8"),
       enableDnsFilterUnroutableFamilies = true,
       enableHappyEyeballs = true,
+      enableHttp3 = true,
       enableInterfaceBinding = true
     )
 
     val resolvedTemplate = envoyConfiguration.resolveTemplate(
-      TEST_CONFIG, PLATFORM_FILTER_CONFIG, NATIVE_FILTER_CONFIG, APLF_INSERT
+      TEST_CONFIG, PLATFORM_FILTER_CONFIG, NATIVE_FILTER_CONFIG, APCF_INSERT
     )
 
     // DNS
     assertThat(resolvedTemplate).contains("&dns_resolver_config {\"@type\":\"type.googleapis.com/envoy.extensions.network.dns_resolver.cares.v3.CaresDnsResolverConfig\",\"resolvers\":[{\"socket_address\":{\"address\":\"8.8.8.8\"}}],\"use_resolvers_as_fallback\": true, \"filter_unroutable_families\": true}")
     assertThat(resolvedTemplate).contains("&dns_lookup_family ALL")
     assertThat(resolvedTemplate).contains("&dns_multiple_addresses true")
+
+    // H3
+    assertThat(resolvedTemplate).contains(APCF_INSERT);
 
     // Interface Binding
     assertThat(resolvedTemplate).contains("&enable_interface_binding true")
@@ -207,7 +214,7 @@ class EnvoyConfigurationTest {
     )
 
     val resolvedTemplate = envoyConfiguration.resolveTemplate(
-      TEST_CONFIG, PLATFORM_FILTER_CONFIG, NATIVE_FILTER_CONFIG, APLF_INSERT
+      TEST_CONFIG, PLATFORM_FILTER_CONFIG, NATIVE_FILTER_CONFIG, APCF_INSERT
     )
 
     assertThat(resolvedTemplate).contains("&h2_raw_domains [\"h2-raw.example.com\",\"h2-raw.example.com2\"]")
@@ -220,7 +227,7 @@ class EnvoyConfigurationTest {
     )
 
     val resolvedTemplate = envoyConfiguration.resolveTemplate(
-      TEST_CONFIG, PLATFORM_FILTER_CONFIG, NATIVE_FILTER_CONFIG, APLF_INSERT
+      TEST_CONFIG, PLATFORM_FILTER_CONFIG, NATIVE_FILTER_CONFIG, APCF_INSERT
     )
 
     assertThat(resolvedTemplate).contains("&dns_resolver_config {\"@type\":\"type.googleapis.com/envoy.extensions.network.dns_resolver.cares.v3.CaresDnsResolverConfig\",\"resolvers\":[{\"socket_address\":{\"address\":\"8.8.8.8\"}},{\"socket_address\":{\"address\":\"1.1.1.1\"}}],\"use_resolvers_as_fallback\": true, \"filter_unroutable_families\": false}")


### PR DESCRIPTION
Description: Adds *experimental* support for negotiating H3/QUIC connections. To enable this, `enableHttp3` must be set to true on the EngineBuilder AND the header "x-envoy-mobile-upstream-protocol" must be set to "http3" on the request. If the upstream does not support H3, the standard ALPN over TCP configuration will still be used by default.
Risk Level: Moderate
Testing: Updated Unit Coverage

Co-authored-by: Alyssa Wilk <alyssar@chromium.org>
Signed-off-by: Mike Schore <mike.schore@gmail.com>