### PR TITLE
http client: add cancel log and limit callback to open streams

### DIFF
--- a/library/common/http/client.cc
+++ b/library/common/http/client.cc
@@ -517,16 +517,15 @@ void Client::cancelStream(envoy_stream_t stream) {
     ScopeTrackerScopeState scope(direct_stream.get(), scopeTracker());
     removeStream(direct_stream->stream_handle_);
 
+    ENVOY_LOG(debug, "[S{}] application cancelled stream", stream);
+    direct_stream->callbacks_->onCancel();
+
     // Since https://github.com/envoyproxy/envoy/pull/13052, the connection manager expects that
     // response code details are set on all possible paths for streams.
     direct_stream->setResponseDetails(getCancelDetails());
 
     // Only run the reset callback if the stream is still open.
     if (stream_was_open) {
-      ENVOY_LOG(debug, "[S{}] application cancelled stream", stream);
-
-      direct_stream->callbacks_->onCancel();
-
       // The runResetCallbacks call synchronously causes Envoy to defer delete the HCM's
       // ActiveStream. We have some concern that this could potentially race a terminal callback
       // scheduled on the same iteration of the event loop. If we see violations in the callback

--- a/library/common/http/client.cc
+++ b/library/common/http/client.cc
@@ -517,14 +517,16 @@ void Client::cancelStream(envoy_stream_t stream) {
     ScopeTrackerScopeState scope(direct_stream.get(), scopeTracker());
     removeStream(direct_stream->stream_handle_);
 
-    direct_stream->callbacks_->onCancel();
-
     // Since https://github.com/envoyproxy/envoy/pull/13052, the connection manager expects that
     // response code details are set on all possible paths for streams.
     direct_stream->setResponseDetails(getCancelDetails());
 
     // Only run the reset callback if the stream is still open.
     if (stream_was_open) {
+      ENVOY_LOG(debug, "[S{}] application cancelled stream", stream);
+
+      direct_stream->callbacks_->onCancel();
+
       // The runResetCallbacks call synchronously causes Envoy to defer delete the HCM's
       // ActiveStream. We have some concern that this could potentially race a terminal callback
       // scheduled on the same iteration of the event loop. If we see violations in the callback


### PR DESCRIPTION
Description: Adds a debug log statement to help more clearly indicate when the a stream has been cancelled via the programmatic API. Additionally, noticed that the cancellation callback could theoretically be called for a manual stream that was not currently open, and moved the call into the guard.
Risk Level: Low
Testing: CI

Signed-off-by: Mike Schore <mike.schore@gmail.com>