### PR TITLE
extract jni lib out of cc_binary 

### DIFF
--- a/library/common/jni/BUILD
+++ b/library/common/jni/BUILD
@@ -119,17 +119,27 @@ envoy_mobile_so_to_jni_lib(
     native_dep = "libjava_jni_lib.so",
 )
 
+cc_library(
+    name = "java_jni_lib",
+    srcs = [
+        "jni_interface.cc",
+    ],
+    deps = [
+        "base_java_jni_lib",
+    ]
+    alwayslink = True,
+)
+
 # Base binary (.so) for JVM testing
 cc_binary(
     name = "libjava_jni_lib.so",
-    srcs = ["jni_interface.cc"],
     copts = ["-std=c++17"],
     linkopts = [
         "-lm",
     ],
     linkshared = True,
     deps = [
-        "base_java_jni_lib",
+        ":java_jni_lib",
         "@envoy_mobile_extra_jni_deps//:extra_jni_dep",
     ],
 )

--- a/library/common/jni/BUILD
+++ b/library/common/jni/BUILD
@@ -120,7 +120,7 @@ envoy_mobile_so_to_jni_lib(
 )
 
 cc_library(
-    name = "java_jni_lib",
+    name = "java_jni_base_lib",
     srcs = [
         "jni_interface.cc",
     ],
@@ -139,7 +139,7 @@ cc_binary(
     ],
     linkshared = True,
     deps = [
-        ":java_jni_lib",
+        ":java_jni_base_lib",
         "@envoy_mobile_extra_jni_deps//:extra_jni_dep",
     ],
 )

--- a/library/common/jni/BUILD
+++ b/library/common/jni/BUILD
@@ -126,7 +126,7 @@ cc_library(
     ],
     deps = [
         "base_java_jni_lib",
-    ]
+    ],
     alwayslink = True,
 )
 


### PR DESCRIPTION
This allows depending on jni_interface.cc as a standard cc library

Risk Level: Low, test only (JVM target)
Testing: Existing tests
Docs Changes: n/a
Release Notes: n/a
