### PR TITLE
Add documentation on renewing GPG keys

### DIFF
--- a/docs/root/development/releasing/releasing.rst
+++ b/docs/root/development/releasing/releasing.rst
@@ -45,3 +45,34 @@ Pre-release versioning
 
 Pre-releases are published on a weekly basis. The versioning scheme we use is ``X.Y.Z.{mmddyy}``.
 For example: January 25, 2020: ``0.3.1.012520``.
+
+
+GPG Key
+======================
+
+On 2024-04-20 the GPG key used to sign releases will expire. To extend the key's expiration date,
+follow these steps:
+
+Import the key locally:
+
+    $ echo $GPG_KEY | base64 --decode > signing-key
+    $ gpg --passphrase $GPG_PASSPHRASE --batch --import signing-key
+    $ gpg --list-keys
+
+Follow the instructions here on
+`Dealing with Expired Keys <https://central.sonatype.org/publish/requirements/gpg/#dealing-with-expired-keys>`_
+to extend the key and sub key expiration dates.
+
+Re-distribute the new public key:
+
+    $ gpg --keyserver keyserver.ubuntu.com --send-keys $KEY_ID
+
+Export the public/private keys, store them in a safe place:
+
+    $ gpg -a --export $KEY_ID > envoy.mobile.gpg.public
+    $ gpg -a --export-secret-keys $KEY_ID > envoy.mobile.gpg.private
+
+Update the GitHub Action ``GPG_KEY`` secret with the Base64 encoded value
+of the private key.
+
+    $ cat envoy.mobile.gpg.private | base64

--- a/docs/root/development/releasing/releasing.rst
+++ b/docs/root/development/releasing/releasing.rst
@@ -53,7 +53,7 @@ GPG Key
 On 2024-04-20 the GPG key used to sign releases will expire. To extend the key's expiration date,
 follow these steps:
 
-Import the key locally:
+Import the key locally::
 
     $ echo $GPG_KEY | base64 --decode > signing-key
     $ gpg --passphrase $GPG_PASSPHRASE --batch --import signing-key
@@ -67,7 +67,7 @@ Re-distribute the new public key:
 
     $ gpg --keyserver keyserver.ubuntu.com --send-keys $KEY_ID
 
-Export the public/private keys, store them in a safe place:
+Export the public/private keys, store them in a safe place::
 
     $ gpg -a --export $KEY_ID > envoy.mobile.gpg.public
     $ gpg -a --export-secret-keys $KEY_ID > envoy.mobile.gpg.private


### PR DESCRIPTION
These had expired, and rather than have to hunt around the Internet for how to renew them when this happens again in 2024, document the steps here.