### PR TITLE
Fix CI setup command for `main_android_dist_ci` GitHub Action

### DIFF
--- a/.github/workflows/artifacts.yml
+++ b/.github/workflows/artifacts.yml
@@ -19,7 +19,7 @@ jobs:
           java-version: '8'
           java-package: jdk
           architecture: x64
-      - run: ./ci/mac_ci_setup.sh
+      - run: ./ci/mac_ci_setup.sh --android
         name: 'Install dependencies'
       - name: 'Build envoy.aar distributable'
         env:


### PR DESCRIPTION
I missed this one in #2095.