### PR TITLE
build: set 'local' tag on android_dist builds

### DIFF
--- a/BUILD
+++ b/BUILD
@@ -72,6 +72,9 @@ genrule(
     touch $@
     """,
     stamp = True,
+    # This action writes to a non-hermetic output location, so running it
+    # remotely isn't currently possible.
+    tags = ["local"],
 )
 
 define_kt_toolchain(

--- a/BUILD
+++ b/BUILD
@@ -17,8 +17,8 @@ unzip -o $< -d dist/
 touch $@
 """,
     stamp = True,
-    # This action writes to a non-hermetic output location, so running it
-    # remotely isn't currently possible.
+    # This action writes to a non-hermetic output location, so it needs to run
+    # locally.
     tags = ["local"],
 )
 
@@ -72,8 +72,8 @@ genrule(
     touch $@
     """,
     stamp = True,
-    # This action writes to a non-hermetic output location, so running it
-    # remotely isn't currently possible.
+    # This action writes to a non-hermetic output location, so it needs to run
+    # locally.
     tags = ["local"],
 )
 


### PR DESCRIPTION
Description: a061f3dcdd2cdeec50a171973eabf0660bc9a8c6 caused build failures when attempting to build the android_dist target locally. This ensures the target can write the to the `dist/` directory when built.
Risk Level: Low
Testing: Local & CI

Signed-off-by: Mike Schore <mike.schore@gmail.com>