### PR TITLE
bazel: make test swift_library testonly

### DIFF
--- a/bazel/apple_test.bzl
+++ b/bazel/apple_test.bzl
@@ -28,6 +28,7 @@ def envoy_mobile_swift_test(name, srcs, data = [], deps = [], tags = [], reposit
             repository + "//library/swift:ios_lib",
         ] + deps,
         linkopts = ["-lresolv.9"],
+        testonly = True,
         visibility = ["//visibility:private"],
     )
 


### PR DESCRIPTION
These should only ever be used by tests, so if they depend on testonly
libraries this is required.

Signed-off-by: Keith Smiley <keithbsmiley@gmail.com>