### PR TITLE
bazel: Add constant for minimum iOS version

### DIFF
--- a/bazel/apple_test.bzl
+++ b/bazel/apple_test.bzl
@@ -1,6 +1,7 @@
 load("@build_bazel_rules_apple//apple:ios.bzl", "ios_unit_test")
 load("@build_bazel_rules_swift//swift:swift.bzl", "swift_library")
 load("@rules_cc//cc:defs.bzl", "objc_library")
+load("//bazel:config.bzl", "MINIMUM_IOS_VERSION")
 
 # Macro providing a way to easily/consistently define Swift unit test targets.
 #
@@ -35,7 +36,7 @@ def envoy_mobile_swift_test(name, srcs, data = [], deps = [], tags = [], reposit
         name = name,
         data = data,
         deps = [test_lib_name],
-        minimum_os_version = "12.0",
+        minimum_os_version = MINIMUM_IOS_VERSION,
         tags = tags,
     )
 
@@ -53,6 +54,6 @@ def envoy_mobile_objc_test(name, srcs, data = [], deps = [], tags = []):
         name = name,
         data = data,
         deps = [test_lib_name],
-        minimum_os_version = "12.0",
+        minimum_os_version = MINIMUM_IOS_VERSION,
         tags = tags,
     )

--- a/bazel/config.bzl
+++ b/bazel/config.bzl
@@ -1,0 +1,3 @@
+"""Shared configuration for things we don't want to duplicate"""
+
+MINIMUM_IOS_VERSION = "12.0"

--- a/examples/objective-c/hello_world/BUILD
+++ b/examples/objective-c/hello_world/BUILD
@@ -1,3 +1,4 @@
+load("//bazel:config.bzl", "MINIMUM_IOS_VERSION")
 load("@rules_cc//cc:defs.bzl", "objc_library")
 load("@build_bazel_rules_apple//apple:ios.bzl", "ios_application")
 
@@ -17,7 +18,7 @@ ios_application(
     bundle_id = "io.envoyproxy.envoymobile.helloworld",
     families = ["iphone"],
     infoplists = ["Info.plist"],
-    minimum_os_version = "12.0",
+    minimum_os_version = MINIMUM_IOS_VERSION,
     deps = [
         "appmain",
     ],

--- a/examples/swift/hello_world/BUILD
+++ b/examples/swift/hello_world/BUILD
@@ -1,3 +1,4 @@
+load("//bazel:config.bzl", "MINIMUM_IOS_VERSION")
 load("@build_bazel_rules_apple//apple:ios.bzl", "ios_application")
 load("@build_bazel_rules_swift//swift:swift.bzl", "swift_library")
 
@@ -14,6 +15,6 @@ ios_application(
     bundle_id = "io.envoyproxy.envoymobile.helloworld",
     families = ["iphone"],
     infoplists = ["Info.plist"],
-    minimum_os_version = "12.0",
+    minimum_os_version = MINIMUM_IOS_VERSION,
     deps = ["appmain"],
 )

--- a/library/swift/BUILD
+++ b/library/swift/BUILD
@@ -1,3 +1,4 @@
+load("//bazel:config.bzl", "MINIMUM_IOS_VERSION")
 load("@build_bazel_rules_apple//apple:ios.bzl", "ios_static_framework")
 load("@build_bazel_rules_swift//swift:swift.bzl", "swift_library")
 load("//bazel:swift_header_collector.bzl", "swift_header_collector")
@@ -64,7 +65,7 @@ ios_static_framework(
     name = "ios_framework",
     hdrs = ["ios_lib_headers"],
     bundle_name = "Envoy",
-    minimum_os_version = "12.0",
+    minimum_os_version = MINIMUM_IOS_VERSION,
     # Currently the framework is over 2GB, and is not worth caching
     tags = [
         "no-cache",

--- a/test/swift/apps/baseline/BUILD
+++ b/test/swift/apps/baseline/BUILD
@@ -1,5 +1,6 @@
 load("@build_bazel_rules_apple//apple:ios.bzl", "ios_application")
 load("@build_bazel_rules_swift//swift:swift.bzl", "swift_library")
+load("//bazel:config.bzl", "MINIMUM_IOS_VERSION")
 
 licenses(["notice"])  # Apache 2
 
@@ -14,6 +15,6 @@ ios_application(
     bundle_id = "io.envoyproxy.envoymobile.helloworld",
     families = ["iphone"],
     infoplists = ["Info.plist"],
-    minimum_os_version = "11.0",
+    minimum_os_version = MINIMUM_IOS_VERSION,
     deps = ["appmain"],
 )

--- a/test/swift/apps/experimental/BUILD
+++ b/test/swift/apps/experimental/BUILD
@@ -1,3 +1,4 @@
+load("//bazel:config.bzl", "MINIMUM_IOS_VERSION")
 load("@build_bazel_rules_apple//apple:ios.bzl", "ios_application")
 load("@build_bazel_rules_swift//swift:swift.bzl", "swift_library")
 
@@ -14,6 +15,6 @@ ios_application(
     bundle_id = "io.envoyproxy.envoymobile.helloworld",
     families = ["iphone"],
     infoplists = ["Info.plist"],
-    minimum_os_version = "11.0",
+    minimum_os_version = MINIMUM_IOS_VERSION,
     deps = ["appmain"],
 )


### PR DESCRIPTION
This way we make sure the examples stay in sync with the framework

Signed-off-by: Keith Smiley <keithbsmiley@gmail.com>