### PR TITLE
Fix Maven deploy CI job

### DIFF
--- a/.github/workflows/artifacts.yml
+++ b/.github/workflows/artifacts.yml
@@ -28,8 +28,8 @@ jobs:
           current_release_version=$(git describe --tag --abbrev=0)
           ./bazelw build \
               --config=release-android \
-              --fat_apk_cpu=x86 \
-              --define=pom_version=$current_release_version \
+              --fat_apk_cpu=x86,x86_64,armeabi-v7a,arm64-v8a \
+              --define=pom_version="${current_release_version:1}" \
               --config=remote-ci-macos \
               --remote_header="Authorization=Bearer $GITHUB_TOKEN" \
               //:android_dist_ci


### PR DESCRIPTION
* Drop the "v" prefix from versions in the pom file
* Build Android release for more architectures: `x86` -> `x86,x86_64,armeabi-v7a,arm64-v8a`

Fixes https://github.com/envoyproxy/envoy-mobile/issues/2109

Risk Level: Low, we haven't published Maven releases in two years
Testing: Ran the GitHub Actions, verified pulling the release from Maven
Central in an Android app project in Android Studio.
Docs Changes: N/A
Release Notes: Pending...