### PR TITLE
[bazelw] Use arm64 binary on darwin-arm64

### DIFF
--- a/bazelw
+++ b/bazelw
@@ -20,9 +20,7 @@ fi
 bazel_platform="$bazel_os-$bazel_arch"
 case "$bazel_platform" in
   darwin-arm64)
-    # TODO: Support M1 once this is resolved: https://github.com/envoyproxy/envoy-mobile/issues/2101
-    bazel_platform="darwin-amd64"
-    readonly bazel_version_sha="e485bbf84532d02a60b0eb23c702610b5408df3a199087a4f2b5e0995bbf2d5a"
+    readonly bazel_version_sha="c22d48601466d9d3b043ccd74051f2f4230f9b9f4509f097017c97303aa88d13"
     ;;
   darwin-amd64)
     readonly bazel_version_sha="e485bbf84532d02a60b0eb23c702610b5408df3a199087a4f2b5e0995bbf2d5a"


### PR DESCRIPTION
Now that we've pulled in https://github.com/envoyproxy/envoy/pull/20852, I'm no longer seeing linker errors when running Swift tests for iOS as reported in https://github.com/envoyproxy/envoy-mobile/issues/2101.

Risk Level: Low to the libraries, Moderate to local development on an M1 Mac.
Testing: `./bazelw test //test/swift:test --config=ios` passes
Docs Changes: N/A
Release Notes: N/A