### PR TITLE
Remove base_h3 cluster in yaml configuration

### DIFF
--- a/library/common/config/config.cc
+++ b/library/common/config/config.cc
@@ -403,14 +403,6 @@ R"(
     upstream_connection_options: *upstream_opts
     circuit_breakers: *circuit_breakers_settings
     typed_extension_protocol_options: *h2_protocol_options
-  - name: base_h3
-    connect_timeout: *connect_timeout
-    lb_policy: CLUSTER_PROVIDED
-    cluster_type: *base_cluster_type
-    transport_socket: *base_h3_socket
-    upstream_connection_options: *upstream_opts
-    circuit_breakers: *circuit_breakers_settings
-    typed_extension_protocol_options: *h3_protocol_options
 stats_flush_interval: *stats_flush_interval
 stats_sinks: *stats_sinks
 stats_config:


### PR DESCRIPTION
This was causing hangs/crashes in our Lyft apps so I'm reverting this while I continue to investigate.

Here's the crash backtrace I'm seeing on iOS (not very helpful unfortunately):

```
* thread #11, stop reason = signal SIGABRT
  * frame #0: 0x000000013a02300e libsystem_kernel.dylib`__pthread_kill + 10
    frame #1: 0x00000001399a61ff libsystem_pthread.dylib`pthread_kill + 263
    frame #2: 0x0000000138905684 libsystem_c.dylib`abort + 123
    frame #3: 0x00000001024793af Lyft`___lldb_unnamed_symbol4253$$Lyft + 3231
    frame #4: 0x000000010247e0c7 Lyft`___lldb_unnamed_symbol4339$$Lyft + 130
    frame #5: 0x00000001399a64e1 libsystem_pthread.dylib`_pthread_start + 125
    frame #6: 0x00000001399a1f6b libsystem_pthread.dylib`thread_start + 15
```

This breaks h3 functionality, which merged yesterday and is as of yet unused.

Risk Level: Moderate.
Testing: Ran the iOS unit tests for Lyft-iOS that were previously crashing.
Docs Changes:
Release Notes: