### PR TITLE
bazel: Include debug info in Android release binary

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -76,10 +76,6 @@ build:tsan-dev --copt -DEVENT__DISABLE_DEBUG_MODE
 # https://github.com/google/sanitizers/issues/953
 build:tsan-dev --test_env="TSAN_OPTIONS=report_atomic_races=0"
 
-# Exclude debug info from the release binary since it makes it too large to fit
-# into a zip file. This shouldn't affect crash reports.
-build:release-common --define=no_debug_info=1
-
 # Compile releases optimizing for size (eg -Os, etc).
 build:release-common --config=sizeopt
 
@@ -92,6 +88,11 @@ build:release-ios --config=ios
 build:release-ios --config=release-common
 build:release-ios --copt=-fembed-bitcode
 build:release-ios --compilation_mode=opt
+# Exclude debug info from the release binary since it makes it too large to fit
+# into a zip file. This shouldn't affect iOS crash reports. We do not define it for Android
+# builds as it leads to a removal of relevant symbols from Android binaries (and
+# corresponding objdump files).
+build:release-ios --define=no_debug_info=1
 
 # Flags for release builds targeting Android or the JVM
 # Release does not use the option --define=logger=android


### PR DESCRIPTION
Description: Include debug info in the Android release binary. This allows us to have an objdump file with all of the relevant symbols. The change is needed as we moved from symbol mapping table files to symbol mapping files in https://github.com/envoyproxy/envoy-mobile/commit/f955257e940b7bf3a9f4463fd2f061d3eea6f6ea
Risk Level: low, tooling only
Testing: N/A
Docs Changes: N/A
Release Notes: N/A

Signed-off-by: Rafal Augustyniak <raugustyniak@lyft.com>