### PR TITLE
Fix race condition when posting CronetMetrics

### DIFF
--- a/library/java/org/chromium/net/impl/AtomicCombinatoryState.java
+++ b/library/java/org/chromium/net/impl/AtomicCombinatoryState.java
@@ -1,0 +1,38 @@
+package org.chromium.net.impl;
+
+import java.util.concurrent.atomic.AtomicInteger;
+
+/**
+ * CAS logic based class providing a mean to ensure that the last awaited "stateEvent" will be
+ * identified as so. Typically a "stateEvent" is a single bit flip.
+ *
+ * <p>This class is Thread Safe.
+ */
+final class AtomicCombinatoryState {
+
+  private final int mFinalState;
+  private final AtomicInteger mState = new AtomicInteger(0);
+
+  /**
+   * finalState must be a power of two minus one: 1, 3, 7, 15, ...
+   */
+  AtomicCombinatoryState(int finalState) {
+    assert finalState > 0 && ((finalState + 1) & finalState) == 0;
+    this.mFinalState = finalState;
+  }
+
+  /**
+   * Returns true is the state reaches, for the first time, the final state. The provided stateEvent
+   * is atmomically ORed with the current state - the outcome is saved as the new state.
+   */
+  boolean hasReachedFinalState(int stateEvent) {
+    assert stateEvent <= mFinalState;
+    while (true) {
+      int originalState = mState.get();
+      int updatedState = originalState | stateEvent;
+      if (mState.compareAndSet(originalState, updatedState)) {
+        return originalState != mFinalState && updatedState == mFinalState;
+      }
+    }
+  }
+}

--- a/library/java/org/chromium/net/impl/AtomicCombinatoryState.java
+++ b/library/java/org/chromium/net/impl/AtomicCombinatoryState.java
@@ -3,8 +3,8 @@ package org.chromium.net.impl;
 import java.util.concurrent.atomic.AtomicInteger;
 
 /**
- * "CAS" logic based class providing a mean to ensure that the last awaited "stateEvent" will be
- * identified as so. Typically a "stateEvent" is a single bit flip.
+ * "Compare And Swap" logic based class providing a mean to ensure that the last awaited
+ * "stateEvent" will be identified as so. Typically a "stateEvent" is a single bit flip.
  *
  * <p>This class is Thread Safe.
  */
@@ -22,7 +22,7 @@ final class AtomicCombinatoryState {
   }
 
   /**
-   * Returns true is the state reaches, for the first time, the final state. The provided stateEvent
+   * Returns true if the state reaches, for the first time, the final state. The provided stateEvent
    * is atmomically ORed with the current state - the outcome is saved as the new state.
    */
   boolean hasReachedFinalState(int stateEvent) {

--- a/library/java/org/chromium/net/impl/AtomicCombinatoryState.java
+++ b/library/java/org/chromium/net/impl/AtomicCombinatoryState.java
@@ -3,7 +3,7 @@ package org.chromium.net.impl;
 import java.util.concurrent.atomic.AtomicInteger;
 
 /**
- * CAS logic based class providing a mean to ensure that the last awaited "stateEvent" will be
+ * "CAS" logic based class providing a mean to ensure that the last awaited "stateEvent" will be
  * identified as so. Typically a "stateEvent" is a single bit flip.
  *
  * <p>This class is Thread Safe.

--- a/library/java/org/chromium/net/impl/BUILD
+++ b/library/java/org/chromium/net/impl/BUILD
@@ -10,6 +10,7 @@ android_library(
     name = "cronvoy",
     srcs = [
         "Annotations.java",
+        "AtomicCombinatoryState.java",
         "BidirectionalStreamBuilderImpl.java",
         "CallbackExceptionImpl.java",
         "CronetEngineBase.java",

--- a/library/java/org/chromium/net/impl/CronetUrlRequest.java
+++ b/library/java/org/chromium/net/impl/CronetUrlRequest.java
@@ -121,7 +121,7 @@ public final class CronetUrlRequest extends UrlRequestBase {
    * At the end of a request, mRequestFinishedListener is used to post the CronetMetrics. Before
    * doing so, two events must have occurred first: the "final user callback" and the "final
    * Network callback". The Thread involved with the last of these two events is in charge of the
-   * posting - this is intinsically racy. So this AtomicInteger ensures that the CronetMetrics will
+   * posting - this is intrinsically racy. So this AtomicInteger ensures that the CronetMetrics will
    * be posted no more than once.
    */
   private final AtomicInteger mReportState = new AtomicInteger(ReportState.UNDETERMINED);
@@ -713,7 +713,7 @@ public final class CronetUrlRequest extends UrlRequestBase {
     }
   }
 
-  // Can the called from any Thread, but it is guaranteed that the network final calback has been
+  // Can be called from any Thread, but it is guaranteed that the network final callback has been
   // invoked. mEnvoyFinalStreamIntel is set, otherwise there is a bug.
   private void reportMetrics() {
     Metrics metrics = getMetrics(mEnvoyFinalStreamIntel, mBytesReceivedFromRedirects);
@@ -833,7 +833,7 @@ public final class CronetUrlRequest extends UrlRequestBase {
           checkCallingThread();
           try {
             if (locationField != null) {
-              // This CronvoyHttpCallbacks instance is already in an abandonned state at this point:
+              // This CronvoyHttpCallbacks instance is already in an abandoned state at this point:
               // mState == State.AWAITING_FOLLOW_REDIRECT. But mState will change soon, so this line
               // puts the final nail in the coffin. isAbandoned() can only keep returning true.
               mCronvoyCallbacks = null;

--- a/library/java/org/chromium/net/impl/CronetUrlRequest.java
+++ b/library/java/org/chromium/net/impl/CronetUrlRequest.java
@@ -906,6 +906,10 @@ public final class CronetUrlRequest extends UrlRequestBase {
       if (completeAbandonIfAny(originalState, updatedState)) {
         return;
       }
+      if (mState.compareAndSet(State.READING, State.COMPLETE)) {
+        // onComplete still needs to be called - this always returns false.
+        mSucceededState.hasReachedFinalState(SucceededState.FINAL_READ_DONE);
+      }
     }
 
     @Override

--- a/library/java/org/chromium/net/impl/CronetUrlRequest.java
+++ b/library/java/org/chromium/net/impl/CronetUrlRequest.java
@@ -124,7 +124,7 @@ public final class CronetUrlRequest extends UrlRequestBase {
    * events, and that it will be done only once.
    *
    * <p>At the end of a successful request, "mCallback.onSucceeded" is invoked. Before doing so,
-   * doing so, two events must have occurred first: the "final user read" and the "onComplete
+   * two events must have occurred first: the "completion of the final read" and the "onComplete
    * Network callback". The Thread involved with the last of these two events is in charge of the
    * registering the task to execute "mCallback.onSucceeded" - this is intrinsically racy.
    */

--- a/test/java/org/chromium/net/impl/AtomicCombinatoryStateTest.java
+++ b/test/java/org/chromium/net/impl/AtomicCombinatoryStateTest.java
@@ -1,0 +1,71 @@
+package org.chromium.net.impl;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import androidx.test.ext.junit.runners.AndroidJUnit4;
+import java.util.concurrent.atomic.AtomicInteger;
+import org.chromium.net.testing.ConditionVariable;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+@RunWith(AndroidJUnit4.class)
+public class AtomicCombinatoryStateTest {
+
+  @Test
+  public void trivialCase_false() {
+    assertThat(new AtomicCombinatoryState(1).hasReachedFinalState(0)).isFalse();
+  }
+
+  @Test
+  public void trivialCase_true() {
+    assertThat(new AtomicCombinatoryState(1).hasReachedFinalState(1)).isTrue();
+  }
+
+  @Test
+  public void partialState() {
+    assertThat(new AtomicCombinatoryState(3).hasReachedFinalState(1)).isFalse();
+  }
+
+  @Test
+  public void finalState() {
+    AtomicCombinatoryState atomicCombinatoryState = new AtomicCombinatoryState(3);
+    atomicCombinatoryState.hasReachedFinalState(2);
+    assertThat(atomicCombinatoryState.hasReachedFinalState(1)).isTrue();
+  }
+
+  @Test
+  public void finalState_twice() {
+    AtomicCombinatoryState atomicCombinatoryState = new AtomicCombinatoryState(3);
+    atomicCombinatoryState.hasReachedFinalState(2);
+    atomicCombinatoryState.hasReachedFinalState(1);
+    assertThat(atomicCombinatoryState.hasReachedFinalState(1)).isFalse();
+  }
+
+  @Test
+  public void finalState_multiThread() throws Exception {
+    ConditionVariable startBlock = new ConditionVariable();
+    AtomicCombinatoryState atomicCombinatoryState = new AtomicCombinatoryState(3);
+    AtomicInteger trueCount = new AtomicInteger(0);
+    AtomicInteger eventStatePurveyor = new AtomicInteger(0);
+    Thread[] threads = new Thread[10];
+    for (int i = 0; i < threads.length; i++) {
+      threads[i] = new Thread() {
+        @Override
+        public void run() {
+          int eventState = (eventStatePurveyor.incrementAndGet() & 1) + 1; // 1 and 2 only
+          startBlock.block();
+          if (atomicCombinatoryState.hasReachedFinalState(eventState)) {
+            trueCount.incrementAndGet(); // Should be executed only once.
+          }
+        }
+      };
+      threads[i].start();
+    }
+    Thread.sleep(100); // Should be good enough so all 10 Threads are currently blocking.
+    startBlock.open(); // Most threads will unblock simultaneously on a "multi-threading" CPU.
+    for (Thread thread : threads) {
+      thread.join(); // Wait for each Thread to die.
+    }
+    assertThat(trueCount.get()).isEqualTo(1);
+  }
+}

--- a/test/java/org/chromium/net/impl/BUILD
+++ b/test/java/org/chromium/net/impl/BUILD
@@ -8,6 +8,7 @@ envoy_package()
 envoy_mobile_android_test(
     name = "cronvoy_test",
     srcs = [
+        "AtomicCombinatoryStateTest.java",
         "CronvoyEngineTest.java",
         "UrlRequestCallbackTester.java",
     ],
@@ -26,5 +27,6 @@ envoy_mobile_android_test(
         "//library/java/org/chromium/net/impl:cronvoy",
         "//library/kotlin/io/envoyproxy/envoymobile:envoy_interfaces_lib",
         "//library/kotlin/io/envoyproxy/envoymobile:envoy_lib",
+        "//test/java/org/chromium/net/testing",
     ],
 )

--- a/test/java/org/chromium/net/testing/Http2TestServer.java
+++ b/test/java/org/chromium/net/testing/Http2TestServer.java
@@ -32,11 +32,10 @@ import io.netty.handler.ssl.SslContext;
  */
 public final class Http2TestServer {
   private static Channel sServerChannel;
+  private static int sPort = -1;
   private static final String TAG = Http2TestServer.class.getSimpleName();
 
   private static final String HOST = "127.0.0.1";
-  // Server port.
-  private static final int PORT = 8443;
 
   private static ReportingCollector sReportingCollector;
 
@@ -45,6 +44,7 @@ public final class Http2TestServer {
       sServerChannel.close().sync();
       sServerChannel = null;
       sReportingCollector = null;
+      sPort = -1;
       return true;
     }
     return false;
@@ -52,9 +52,9 @@ public final class Http2TestServer {
 
   public static String getServerHost() { return HOST; }
 
-  public static int getServerPort() { return PORT; }
+  public static int getServerPort() { return sPort; }
 
-  public static String getServerUrl() { return "https://" + HOST + ":" + PORT; }
+  public static String getServerUrl() { return "https://" + HOST + ":" + sPort; }
 
   public static ReportingCollector getReportingCollector() { return sReportingCollector; }
 
@@ -179,7 +179,9 @@ public final class Http2TestServer {
                 .handler(new LoggingHandler(LogLevel.INFO))
                 .childHandler(new Http2ServerInitializer(mSslCtx, mHangingUrlLatch));
 
-            sServerChannel = b.bind(PORT).sync().channel();
+            sServerChannel = b.bind(0).sync().channel();
+            String localAddress = sServerChannel.localAddress().toString();
+            sPort = Integer.parseInt(localAddress.substring(localAddress.lastIndexOf(':') + 1));
             Log.i(TAG, "Netty HTTP/2 server started on " + getServerUrl());
             mBlock.open();
             sServerChannel.closeFuture().sync();


### PR DESCRIPTION
At the end of a request, mRequestFinishedListener is used to post the CronetMetrics. Before doing so, two events must have occurred first: the "final user callback" and the "final Network callback". The Thread involved with the last of these two events is in charge of the posting the CronetMetrics - this is intrinsically racy. This PR ensures a proper behaviour.

Description: Solves CI test flakiness: unexpected java_tests_mac failure: test/java/org/chromium/net:net_tests 
Risk Level: N/A (Cronet is still in development)
Testing: CI, and local multi runs
Docs Changes: N/A
Release Notes: N/A
Fixes #2136
Signed-off-by: Charles Le Borgne <cleborgne@google.com>
