### PR TITLE
Fix race condition when saving FinalStreamIntel

### DIFF
--- a/library/common/http/client.cc
+++ b/library/common/http/client.cc
@@ -269,9 +269,6 @@ void Client::DirectStreamCallbacks::onCancel() {
 
   ENVOY_LOG(debug, "[S{}] dispatching to platform cancel stream", direct_stream_.stream_handle_);
   http_client_.stats().stream_cancel_.inc();
-  // Attempt to latch the latest stream info. This will be a no-op if the stream
-  // is already complete.
-  direct_stream_.saveFinalStreamIntel();
   bridge_callbacks_.on_cancel(streamIntel(), finalStreamIntel(), bridge_callbacks_.context);
 }
 
@@ -515,6 +512,9 @@ void Client::cancelStream(envoy_stream_t stream) {
     bool stream_was_open =
         getStream(stream, GetStreamFilters::ALLOW_ONLY_FOR_OPEN_STREAMS) != nullptr;
     ScopeTrackerScopeState scope(direct_stream.get(), scopeTracker());
+    // Attempt to latch the latest stream info. This will be a no-op if the stream
+    // is already complete.
+    direct_stream->saveFinalStreamIntel();
     removeStream(direct_stream->stream_handle_);
 
     ENVOY_LOG(debug, "[S{}] application cancelled stream", stream);


### PR DESCRIPTION

Description:  Solves more CI test flakiness: unexpected java_tests_mac failure: test/java/org/chromium/net:net_tests
Risk Level: Small
Testing: CI, multiple local runs
Docs Changes: N/A
Release Notes: N/A
Fixes #2192 
Signed-off-by: Charles Le Borgne <cleborgne@google.com>

