### PR TITLE
ci: Update macOS version to macOS 12

### DIFF
--- a/.github/workflows/android_build.yml
+++ b/.github/workflows/android_build.yml
@@ -9,7 +9,7 @@ on:
 jobs:
   androidbuild:
     name: android_build
-    runs-on: macos-11
+    runs-on: macos-12
     timeout-minutes: 90
     steps:
       - uses: actions/checkout@v1
@@ -46,7 +46,7 @@ jobs:
   javahelloworld:
     name: java_helloworld
     needs: androidbuild
-    runs-on: macos-11
+    runs-on: macos-12
     timeout-minutes: 25
     steps:
       - uses: actions/checkout@v1
@@ -88,7 +88,7 @@ jobs:
   kotlinhelloworld:
     name: kotlin_helloworld
     needs: androidbuild
-    runs-on: macos-11
+    runs-on: macos-12
     timeout-minutes: 25
     steps:
       - uses: actions/checkout@v1
@@ -131,7 +131,7 @@ jobs:
   kotlinbaselineapp:
     name: kotlin_baseline_app
     needs: androidbuild
-    runs-on: macos-11
+    runs-on: macos-12
     timeout-minutes: 25
     steps:
       - uses: actions/checkout@v1
@@ -174,7 +174,7 @@ jobs:
   kotlinexperimentalapp:
     name: kotlin_experimental_app
     needs: androidbuild
-    runs-on: macos-11
+    runs-on: macos-12
     timeout-minutes: 25
     steps:
       - uses: actions/checkout@v1

--- a/.github/workflows/android_tests.yml
+++ b/.github/workflows/android_tests.yml
@@ -11,7 +11,7 @@ jobs:
     # revert to //test/kotlin/... once fixed
     # https://github.com/envoyproxy/envoy-mobile/issues/1932
     name: kotlin_tests_mac
-    runs-on: macos-11
+    runs-on: macos-12
     timeout-minutes: 90
     steps:
       - uses: actions/checkout@v1
@@ -51,7 +51,7 @@ jobs:
             //test/kotlin/io/...
   javatestsmac:
     name: java_tests_mac
-    runs-on: macos-11
+    runs-on: macos-12
     timeout-minutes: 120
     steps:
       - uses: actions/checkout@v1

--- a/.github/workflows/core.yml
+++ b/.github/workflows/core.yml
@@ -9,7 +9,7 @@ on:
 jobs:
   unittests:
     name: unit_tests
-    runs-on: macos-11
+    runs-on: macos-12
     timeout-minutes: 120
     steps:
       - uses: actions/checkout@v1

--- a/.github/workflows/format.yml
+++ b/.github/workflows/format.yml
@@ -26,7 +26,7 @@ jobs:
         run: ./tools/check_format.sh
   precommit:
     name: precommit
-    runs-on: macos-11
+    runs-on: macos-12
     timeout-minutes: 45
     steps:
       - uses: actions/checkout@v1
@@ -46,7 +46,7 @@ jobs:
         run: swiftlint lint --strict
   kotlinlint:
     name: kotlin_lint
-    runs-on: macos-11
+    runs-on: macos-12
     timeout-minutes: 45
     steps:
       - uses: actions/checkout@v1

--- a/.github/workflows/ios_build.yml
+++ b/.github/workflows/ios_build.yml
@@ -9,7 +9,7 @@ on:
 jobs:
   iosbuild:
     name: ios_build
-    runs-on: macos-11
+    runs-on: macos-12
     timeout-minutes: 120
     steps:
       - uses: actions/checkout@v1
@@ -37,7 +37,7 @@ jobs:
   swifthelloworld:
     name: swift_helloworld
     needs: iosbuild
-    runs-on: macos-11
+    runs-on: macos-12
     timeout-minutes: 25
     steps:
       - uses: actions/checkout@v1
@@ -71,7 +71,7 @@ jobs:
   swiftbaselineapp:
     name: swift_baseline_app
     needs: iosbuild
-    runs-on: macos-11
+    runs-on: macos-12
     timeout-minutes: 25
     steps:
       - uses: actions/checkout@v1
@@ -105,7 +105,7 @@ jobs:
   swiftexperimentalapp:
     name: swift_experimental_app
     needs: iosbuild
-    runs-on: macos-11
+    runs-on: macos-12
     timeout-minutes: 25
     steps:
       - uses: actions/checkout@v1
@@ -139,7 +139,7 @@ jobs:
   swiftasyncawait:
     name: swift_async_await
     needs: iosbuild
-    runs-on: macos-11
+    runs-on: macos-12
     timeout-minutes: 25
     steps:
       - uses: actions/checkout@v1
@@ -173,7 +173,7 @@ jobs:
   objchelloworld:
     name: objc_helloworld
     needs: iosbuild
-    runs-on: macos-11
+    runs-on: macos-12
     timeout-minutes: 25
     steps:
       - uses: actions/checkout@v1

--- a/.github/workflows/ios_tests.yml
+++ b/.github/workflows/ios_tests.yml
@@ -9,7 +9,7 @@ on:
 jobs:
   swifttests:
     name: swift_tests
-    runs-on: macos-11
+    runs-on: macos-12
     timeout-minutes: 120
     steps:
       - uses: actions/checkout@v1
@@ -34,7 +34,7 @@ jobs:
         run: ./bazelw test --experimental_ui_max_stdouterr_bytes=10485760 --test_output=all --config=ios --build_tests_only --config=remote-ci-macos --remote_header="Authorization=Bearer $GITHUB_TOKEN" //test/swift/...
   objctests:
     name: objc_tests
-    runs-on: macos-11
+    runs-on: macos-12
     timeout-minutes: 120
     steps:
       - uses: actions/checkout@v1

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -8,7 +8,7 @@ on:
 jobs:
   android_release_artifacts:
     name: android_release_artifacts
-    runs-on: macos-11
+    runs-on: macos-12
     timeout-minutes: 120
     steps:
       - uses: actions/checkout@v1
@@ -102,7 +102,7 @@ jobs:
 
   ios_release_artifacts_framework:
     name: ios_release_artifacts_framework
-    runs-on: macos-11
+    runs-on: macos-12
     timeout-minutes: 120
     steps:
       - uses: actions/checkout@v1
@@ -131,7 +131,7 @@ jobs:
 
   ios_release_artifacts_cocoapods:
     name: ios_release_artifacts_cocoapods
-    runs-on: macos-11
+    runs-on: macos-12
     timeout-minutes: 45
     needs: [ios_release_artifacts_framework]
     steps:
@@ -186,7 +186,7 @@ jobs:
 
   publish_to_cocoapods:
     name: publish_to_cocoapods
-    runs-on: macos-11
+    runs-on: macos-12
     timeout-minutes: 45
     needs: create_github_release
     steps:

--- a/.github/workflows/release_validation.yml
+++ b/.github/workflows/release_validation.yml
@@ -9,7 +9,7 @@ on:
 jobs:
   cocoapods_spec_lint:
     name: cocoapods_spec_lint
-    runs-on: macos-11
+    runs-on: macos-12
     timeout-minutes: 20
     if: ${{ false }} # TODO(jpsim): Fix this validation when bumping versions
     steps:

--- a/ci/mac_ci_setup.sh
+++ b/ci/mac_ci_setup.sh
@@ -6,7 +6,7 @@ set -e
 # Installs the dependencies required for a macOS build via homebrew.
 # Tools are not upgraded to new versions.
 # See:
-# https://github.com/actions/virtual-environments/blob/main/images/macos/macos-11-Readme.md for
+# https://github.com/actions/virtual-environments/blob/main/images/macos/macos-12-Readme.md for
 # a list of pre-installed tools in the macOS image.
 
 export HOMEBREW_NO_AUTO_UPDATE=1
@@ -44,7 +44,7 @@ fi
 ./bazelw version
 
 pip3 install slackclient
-# https://github.com/actions/virtual-environments/blob/main/images/macos/macos-11-Readme.md#xcode
+# https://github.com/actions/virtual-environments/blob/main/images/macos/macos-12-Readme.md#xcode
 sudo xcode-select --switch /Applications/Xcode_13.2.1.app
 
 if [[ "${1:-}" == "--android" ]]; then


### PR DESCRIPTION
https://github.com/actions/virtual-environments/blob/main/images/macos/macos-12-Readme.md

This is a pre-requisite for updating to the latest Xcode version (#2100)

Risk Level: Low, some tools we rely on may change versions
Testing: Locally for 2-3 months
Docs Changes: N/A
Release Notes: N/A