### PR TITLE
ci: Re-enable release_validation job

### DIFF
--- a/.github/workflows/release_validation.yml
+++ b/.github/workflows/release_validation.yml
@@ -11,7 +11,6 @@ jobs:
     name: cocoapods_spec_lint
     runs-on: macos-11
     timeout-minutes: 20
-    if: ${{ false }} # TODO(jpsim): Fix this validation when bumping versions
     steps:
       - uses: actions/checkout@v1
       - uses: ruby/setup-ruby@v1


### PR DESCRIPTION
This doesn't handle version bumps so I had to temporarily disable it to release 0.4.6.