### PR TITLE
bazel: remove rules_cc references

### DIFF
--- a/bazel/android_artifacts.bzl
+++ b/bazel/android_artifacts.bzl
@@ -1,7 +1,6 @@
 load("@build_bazel_rules_android//android:rules.bzl", "android_binary")
 load("@envoy_mobile//bazel:dokka.bzl", "sources_javadocs")
 load("@rules_java//java:defs.bzl", "java_binary")
-load("@rules_cc//cc:defs.bzl", "cc_library")
 load("@google_bazel_common//tools/maven:pom_file.bzl", "pom_file")
 
 # This file is based on https://github.com/aj-michael/aar_with_jni which is
@@ -203,7 +202,7 @@ def _create_jni_library(name, native_deps = []):
     # We wrap our native so dependencies in a cc_library because android_binaries
     # require a library target as dependencies in order to generate the appropriate
     # architectures in the directory `lib/`
-    cc_library(
+    native.cc_library(
         name = cc_lib_name,
         srcs = native_deps,
     )

--- a/bazel/apple_test.bzl
+++ b/bazel/apple_test.bzl
@@ -1,6 +1,5 @@
 load("@build_bazel_rules_apple//apple:ios.bzl", "ios_unit_test")
 load("@build_bazel_rules_swift//swift:swift.bzl", "swift_library")
-load("@rules_cc//cc:defs.bzl", "objc_library")
 load("//bazel:config.bzl", "MINIMUM_IOS_VERSION")
 
 # Macro providing a way to easily/consistently define Swift unit test targets.
@@ -44,7 +43,7 @@ def envoy_mobile_swift_test(name, srcs, data = [], deps = [], tags = [], reposit
 
 def envoy_mobile_objc_test(name, srcs, data = [], deps = [], tags = [], visibility = []):
     test_lib_name = name + "_lib"
-    objc_library(
+    native.objc_library(
         name = test_lib_name,
         srcs = srcs,
         data = data,

--- a/examples/objective-c/hello_world/BUILD
+++ b/examples/objective-c/hello_world/BUILD
@@ -1,5 +1,4 @@
 load("//bazel:config.bzl", "MINIMUM_IOS_VERSION")
-load("@rules_cc//cc:defs.bzl", "objc_library")
 load("@build_bazel_rules_apple//apple:ios.bzl", "ios_application")
 
 licenses(["notice"])  # Apache 2

--- a/library/common/jni/BUILD
+++ b/library/common/jni/BUILD
@@ -1,6 +1,5 @@
 load("//bazel:kotlin_lib.bzl", "envoy_mobile_so_to_jni_lib")
 load("//bazel:android_debug_info.bzl", "android_debug_info")
-load("@rules_cc//cc:defs.bzl", "cc_binary", "cc_library")
 load("@envoy//bazel:envoy_build_system.bzl", "envoy_package")
 load("//bazel:envoy_mobile_test_extensions.bzl", "TEST_EXTENSIONS")
 

--- a/library/common/jni/import/BUILD
+++ b/library/common/jni/import/BUILD
@@ -1,4 +1,3 @@
-load("@rules_cc//cc:defs.bzl", "cc_library")
 load("@envoy//bazel:envoy_build_system.bzl", "envoy_package")
 
 licenses(["notice"])  # Apache 2

--- a/library/objective-c/BUILD
+++ b/library/objective-c/BUILD
@@ -1,5 +1,3 @@
-load("@rules_cc//cc:defs.bzl", "objc_library")
-
 licenses(["notice"])  # Apache 2
 
 exports_files([

--- a/test/common/jni/BUILD
+++ b/test/common/jni/BUILD
@@ -1,5 +1,4 @@
 load("@envoy//bazel:envoy_build_system.bzl", "envoy_package")
-load("@rules_cc//cc:defs.bzl", "cc_binary")
 load("//bazel:kotlin_lib.bzl", "envoy_mobile_so_to_jni_lib")
 
 licenses(["notice"])  # Apache 2

--- a/test/swift/integration/BUILD
+++ b/test/swift/integration/BUILD
@@ -1,4 +1,3 @@
-load("@rules_cc//cc:defs.bzl", "objc_library")
 load("@envoy_mobile//bazel:apple_test.bzl", "envoy_mobile_swift_test")
 load("@envoy_mobile//bazel:envoy_mobile_test_extensions.bzl", "TEST_EXTENSIONS")
 load("@envoy//bazel:envoy_build_system.bzl", "envoy_cc_library")

--- a/third_party/rbe_configs/cc/BUILD
+++ b/third_party/rbe_configs/cc/BUILD
@@ -16,7 +16,6 @@
 
 load(":cc_toolchain_config.bzl", "cc_toolchain_config")
 load(":armeabi_cc_toolchain_config.bzl", "armeabi_cc_toolchain_config")
-load("@rules_cc//cc:defs.bzl", "cc_toolchain", "cc_toolchain_suite")
 
 package(default_visibility = ["//visibility:public"])
 


### PR DESCRIPTION
I'm removing rules_cc from
envoy as well https://github.com/envoyproxy/envoy/pull/19760 so this
mirrors that.

Signed-off-by: Keith Smiley <keithbsmiley@gmail.com>