### PR TITLE
Continuous writes make onResponseHeaders to never happen

### DIFF
--- a/test/java/org/chromium/net/testing/AndroidEnvoyExplicitH2FlowTest.java
+++ b/test/java/org/chromium/net/testing/AndroidEnvoyExplicitH2FlowTest.java
@@ -1,0 +1,107 @@
+package org.chromium.net.testing;
+
+import static io.envoyproxy.envoymobile.engine.EnvoyConfiguration.TrustChainVerification.ACCEPT_UNTRUSTED;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.chromium.net.testing.CronetTestRule.SERVER_CERT_PEM;
+import static org.chromium.net.testing.CronetTestRule.SERVER_KEY_PKCS8_PEM;
+
+import android.content.Context;
+import androidx.test.core.app.ApplicationProvider;
+import androidx.test.ext.junit.runners.AndroidJUnit4;
+import io.envoyproxy.envoymobile.AndroidEngineBuilder;
+import io.envoyproxy.envoymobile.Engine;
+import io.envoyproxy.envoymobile.LogLevel;
+import io.envoyproxy.envoymobile.RequestHeaders;
+import io.envoyproxy.envoymobile.RequestHeadersBuilder;
+import io.envoyproxy.envoymobile.RequestMethod;
+import io.envoyproxy.envoymobile.Stream;
+import io.envoyproxy.envoymobile.UpstreamHttpProtocol;
+import io.envoyproxy.envoymobile.engine.AndroidJniLibrary;
+import java.net.URL;
+import java.nio.ByteBuffer;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicReference;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+@RunWith(AndroidJUnit4.class)
+public class AndroidEnvoyExplicitH2FlowTest {
+
+  private Engine engine;
+
+  @BeforeClass
+  public static void loadJniLibrary() {
+    AndroidJniLibrary.loadTestLibrary();
+  }
+
+  @Before
+  public void setUpEngine() throws Exception {
+    CountDownLatch latch = new CountDownLatch(1);
+    Context appContext = ApplicationProvider.getApplicationContext();
+    engine = new AndroidEngineBuilder(appContext)
+                 .setTrustChainVerification(ACCEPT_UNTRUSTED)
+                 .addLogLevel(LogLevel.DEBUG)
+                 .setOnEngineRunning(() -> {
+                   latch.countDown();
+                   return null;
+                 })
+                 .build();
+    Http2TestServer.startHttp2TestServer(appContext, SERVER_CERT_PEM, SERVER_KEY_PKCS8_PEM);
+    latch.await(); // Don't launch a request before initialization has completed.
+  }
+
+  @After
+  public void shutdown() throws Exception {
+    engine.terminate();
+    Http2TestServer.shutdownHttp2TestServer();
+  }
+
+  @Test
+  public void continuousWrite_withCancelOnResponseHeaders() throws Exception {
+    URL url = new URL(Http2TestServer.getEchoAllHeadersUrl());
+    RequestHeadersBuilder requestHeadersBuilder = new RequestHeadersBuilder(
+        RequestMethod.POST, url.getProtocol(), url.getAuthority(), url.getPath());
+    RequestHeaders requestHeaders =
+        requestHeadersBuilder.addUpstreamHttpProtocol(UpstreamHttpProtocol.HTTP2).build();
+
+    final CountDownLatch latch = new CountDownLatch(1);
+    final AtomicReference<Stream> stream = new AtomicReference<>();
+    final AtomicInteger bufferSent = new AtomicInteger(0);
+
+    stream.set(
+        engine.streamClient()
+            .newStreamPrototype()
+            .setExplicitFlowControl(true)
+            .setOnSendWindowAvailable((streamIntel -> { // Loops forever
+              ByteBuffer bf = ByteBuffer.allocateDirect(1);
+              bf.put((byte)'a');
+              if (bufferSent.incrementAndGet() == 1000) {
+                stream.get().close(bf);
+              } else {
+                stream.get().sendData(bf);
+              }
+              return null;
+            }))
+            .setOnResponseHeaders((responseHeaders, endStream, ignored) -> {
+              stream.get().cancel(); // This never gets executed
+              return null;
+            })
+            .setOnCancel((ignored) -> {
+              latch.countDown();
+              return null;
+            })
+            .start(Runnable::run) // direct executor - all the logic runs on the EM Network Thread.
+            .sendHeaders(requestHeaders, false));
+    ByteBuffer bf = ByteBuffer.allocateDirect(1);
+    bf.put((byte)'a');
+    stream.get().sendData(bf);
+
+    latch.await();
+
+    assertThat(bufferSent.get()).isNotEqualTo(1000);
+  }
+}

--- a/test/java/org/chromium/net/testing/BUILD
+++ b/test/java/org/chromium/net/testing/BUILD
@@ -90,3 +90,22 @@ envoy_mobile_android_test(
         "//library/kotlin/io/envoyproxy/envoymobile:envoy_lib",
     ],
 )
+
+envoy_mobile_android_test(
+    name = "temporary_test",
+    srcs = [
+        "AndroidEnvoyExplicitH2FlowTest.java",
+    ],
+    exec_properties = {
+        # TODO(lfpino): Remove this once the sandboxNetwork=off works for ipv4 localhost addresses.
+        "sandboxNetwork": "standard",
+    },
+    native_deps = [
+        "//library/common/jni:libndk_envoy_jni.so",
+        "//library/common/jni:libndk_envoy_jni.jnilib",
+    ],
+    deps = [
+        ":testing",
+        "//library/kotlin/io/envoyproxy/envoymobile:envoy_lib",
+    ],
+)


### PR DESCRIPTION
For testing - do not submit.

```
bazel test --config=clang  --define=signal_trace=disabled --spawn_strategy=standalone  test/java/org/chromium/net/testing:temporary_test
```


Description:
Risk Level:
Testing:
Docs Changes:
Release Notes:
Signed-off-by: Charles Le Borgne <cleborgne@google.com>
