### PR TITLE
build: simplify jnilib copy

### DIFF
--- a/bazel/kotlin_lib.bzl
+++ b/bazel/kotlin_lib.bzl
@@ -1,4 +1,5 @@
 load("@io_bazel_rules_kotlin//kotlin:kotlin.bzl", "kt_jvm_library")
+load("@bazel_skylib//rules:copy_file.bzl", "copy_file")
 
 # This is the magic function which helps get the name of the native library
 # from the native dependency. In general, the bazel cc_binary rules will
@@ -49,14 +50,9 @@ def envoy_mobile_kt_library(name, visibility = None, srcs = [], deps = [], expor
 # )
 def envoy_mobile_so_to_jni_lib(name, native_dep, testonly = False):
     lib_name = native_lib_name(native_dep)
-    output = "{}.jnilib".format(lib_name)
-
-    return native.genrule(
+    copy_file(
         name = name,
+        src = native_dep,
+        out = "{}.jnilib".format(lib_name),
         testonly = testonly,
-        outs = [output],
-        srcs = [native_dep],
-        cmd = """
-        cp $< $@
-        """.replace("{}", lib_name),
     )

--- a/bazel/kotlin_lib.bzl
+++ b/bazel/kotlin_lib.bzl
@@ -57,14 +57,6 @@ def envoy_mobile_so_to_jni_lib(name, native_dep, testonly = False):
         outs = [output],
         srcs = [native_dep],
         cmd = """
-        so_file="{}.so"
-        if [ ! -f $$so_file ]; then
-            dir=$$(dirname $@)
-            cp $< $$dir/{}.so 2>/dev/null || :
-            chmod 755 $$dir/{}.so
-        fi
-
         cp $< $@
-        chmod 755 $@
         """.replace("{}", lib_name),
     )


### PR DESCRIPTION
The genrule doesn't work well with sandboxing on Linux since we're modifying files we're not supposed to touch:

```
chmod: changing permissions of 'bazel-out/aarch64-dbg/bin/loop/test/kt/io/envoyproxy/loop/logging/libloop_test_lib.so': Read-only file system
```

This simplifies the rule to just copy the .so into a .jnilib.

Signed-off-by: Snow Pettersen <snowp@lyft.com>

Risk Level: Low, build only
Testing: Existing tests
Docs Changes: n/a
Release Notes: n/a
