### PR TITLE
bazel: move back to symbol mapping table files

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -76,6 +76,10 @@ build:tsan-dev --copt -DEVENT__DISABLE_DEBUG_MODE
 # https://github.com/google/sanitizers/issues/953
 build:tsan-dev --test_env="TSAN_OPTIONS=report_atomic_races=0"
 
+# Exclude debug info from the release binary since it makes it too large to fit
+# into a zip file. This shouldn't affect crash reports.
+build:release-common --define=no_debug_info=1
+
 # Compile releases optimizing for size (eg -Os, etc).
 build:release-common --config=sizeopt
 
@@ -88,11 +92,6 @@ build:release-ios --config=ios
 build:release-ios --config=release-common
 build:release-ios --copt=-fembed-bitcode
 build:release-ios --compilation_mode=opt
-# Exclude debug info from the release binary since it makes it too large to fit
-# into a zip file. This shouldn't affect iOS crash reports. We do not define it for Android
-# builds as it leads to a removal of relevant symbols from Android binaries (and
-# corresponding objdump files).
-build:release-ios --define=no_debug_info=1
 
 # Flags for release builds targeting Android or the JVM
 # Release does not use the option --define=logger=android

--- a/bazel/android_debug_info.bzl
+++ b/bazel/android_debug_info.bzl
@@ -25,9 +25,9 @@ def _impl(ctx):
         ctx.actions.run_shell(
             inputs = [lib],
             outputs = [objdump_output],
-            command = cc_toolchain.objdump_executable + " --dwarf=info --dwarf=rawline " + lib.path + "| gzip -c >" + objdump_output.path,
+            command = cc_toolchain.objdump_executable + " --syms " + lib.path + "| gzip -c >" + objdump_output.path,
             tools = [cc_toolchain.all_files],
-            progress_message = "Generating symbol mapping file " + platform_name,
+            progress_message = "Generating symbol map " + platform_name,
         )
 
         strip_output = ctx.actions.declare_file(platform_name + "/" + lib.basename)


### PR DESCRIPTION
Description: The new files turned out to be so big (1.1GB each, 4 of them total) that using them may lead to pipeline issues. We are moving back to using symbol mapping table files and may revisit using symbol mapping files again after we figure out aforementioned pipeline issues.
Risk Level: Low
Testing: N/A
Docs Changes: N/A
Release Notes: N/A
