### PR TITLE
ci: add support for `/retest` command

### DIFF
--- a/.github/actions/retest-action/Dockerfile
+++ b/.github/actions/retest-action/Dockerfile
@@ -1,0 +1,7 @@
+FROM alpine:3.10
+
+RUN apk add --no-cache curl jq
+
+COPY entrypoint.sh /entrypoint.sh
+
+ENTRYPOINT ["/entrypoint.sh"]

--- a/.github/actions/retest-action/action.yml
+++ b/.github/actions/retest-action/action.yml
@@ -1,0 +1,11 @@
+name: 'Re-Test'
+description: 'Re-Runs the last workflow for a PR'
+inputs:
+  token:
+    description: 'GitHub API Token'
+    required: true
+runs:
+  using: 'docker'
+  image: 'Dockerfile'
+  env:
+    GITHUB_TOKEN: ${{ inputs.token }}

--- a/.github/actions/retest-action/action.yml
+++ b/.github/actions/retest-action/action.yml
@@ -1,5 +1,5 @@
 name: 'Re-Test'
-description: 'Re-Runs the last workflow for a PR'
+description: 'Re-Runs the failing jobs from the last workflow for a PR'
 inputs:
   token:
     description: 'GitHub API Token'

--- a/.github/actions/retest-action/entrypoint.sh
+++ b/.github/actions/retest-action/entrypoint.sh
@@ -1,0 +1,45 @@
+#!/bin/sh
+
+set -ex
+
+if ! jq -e '.issue.pull_request' ${GITHUB_EVENT_PATH}; then
+    echo "Not a PR... Exiting."
+    exit 0
+fi
+
+if [ "$(jq -r '.comment.body' ${GITHUB_EVENT_PATH})" != "/retest" ]; then
+    echo "Nothing to do... Exiting."
+    exit 0
+fi
+
+PR_URL=$(jq -r '.issue.pull_request.url' ${GITHUB_EVENT_PATH})
+
+curl --request GET \
+    --url "${PR_URL}" \
+    --header "authorization: Bearer ${GITHUB_TOKEN}" \
+    --header "content-type: application/json" > pr.json
+
+ACTOR=$(jq -r '.user.login' pr.json)
+BRANCH=$(jq -r '.head.ref' pr.json)
+
+curl --request GET \
+    --url "https://api.github.com/repos/${GITHUB_REPOSITORY}/actions/runs?event=pull_request&actor=${ACTOR}&branch=${BRANCH}" \
+    --header "authorization: Bearer ${GITHUB_TOKEN}" \
+    --header "content-type: application/json" | jq '.workflow_runs | max_by(.run_number)' > run.json
+
+RERUN_URL=$(jq -r '.rerun_url' run.json)
+
+curl --request POST \
+    --url "${RERUN_URL}" \
+    --header "authorization: Bearer ${GITHUB_TOKEN}" \
+    --header "content-type: application/json"
+
+
+REACTION_URL="$(jq -r '.comment.url' ${GITHUB_EVENT_PATH})/reactions"
+
+curl --request POST \
+    --url "${REACTION_URL}" \
+    --header "authorization: Bearer ${GITHUB_TOKEN}" \
+    --header "accept: application/vnd.github.squirrel-girl-preview+json" \
+    --header "content-type: application/json" \
+    --data '{ "content" : "rocket" }'

--- a/.github/actions/retest-action/entrypoint.sh
+++ b/.github/actions/retest-action/entrypoint.sh
@@ -27,10 +27,10 @@ curl --request GET \
     --header "authorization: Bearer ${GITHUB_TOKEN}" \
     --header "content-type: application/json" | jq '.workflow_runs | max_by(.run_number)' > run.json
 
-RERUN_URL=$(jq -r '.rerun_url' run.json)
+RUN_URL=$(jq -r '.url' run.json)
 
 curl --request POST \
-    --url "${RERUN_URL}" \
+    --url "${RUN_URL}/rerun-failed-jobs" \
     --header "authorization: Bearer ${GITHUB_TOKEN}" \
     --header "content-type: application/json"
 

--- a/.github/workflows/commands.yml
+++ b/.github/workflows/commands.yml
@@ -1,0 +1,16 @@
+name: commands
+on:
+  issue_comment:
+    types: [created]
+
+jobs:
+  retest:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out code
+        uses: actions/checkout@v2
+
+      - name: Re-Test Action
+        uses: ./.github/actions/retest-action
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Commenting `/retest` on a PR will re-run failed jobs in its GitHub Actions workflows.

<img width="926" alt="image" src="https://user-images.githubusercontent.com/474794/165400179-cbb3f72d-8d31-4b52-a7c7-9094d618360b.png">

Copied from https://github.com/containernetworking/plugins.