### PR TITLE
bazel: update rules_kotlin and rules_detekt

### DIFF
--- a/BUILD
+++ b/BUILD
@@ -1,4 +1,4 @@
-load("@io_bazel_rules_kotlin//kotlin/internal:toolchains.bzl", "define_kt_toolchain")
+load("@io_bazel_rules_kotlin//kotlin:core.bzl", "define_kt_toolchain")
 
 licenses(["notice"])  # Apache 2
 

--- a/bazel/envoy_mobile_dependencies.bzl
+++ b/bazel/envoy_mobile_dependencies.bzl
@@ -74,8 +74,8 @@ def kotlin_dependencies(extra_maven_dependencies = []):
             # Test artifacts
             "org.assertj:assertj-core:3.12.0",
             "junit:junit:4.12",
-            "org.mockito:mockito-inline:2.28.2",
-            "org.mockito:mockito-core:2.28.2",
+            "org.mockito:mockito-inline:4.5.1",
+            "org.mockito:mockito-core:4.5.1",
             "com.squareup.okhttp3:okhttp:4.9.1",
             "com.squareup.okhttp3:mockwebserver:4.9.1",
             "io.github.classgraph:classgraph:4.8.121",

--- a/bazel/envoy_mobile_dependencies.bzl
+++ b/bazel/envoy_mobile_dependencies.bzl
@@ -3,7 +3,7 @@ load("@build_bazel_rules_apple//apple:repositories.bzl", "apple_rules_dependenci
 load("@build_bazel_apple_support//lib:repositories.bzl", "apple_support_dependencies")
 load("@rules_jvm_external//:defs.bzl", "maven_install")
 load("@rules_detekt//detekt:dependencies.bzl", "rules_detekt_dependencies")
-load("@io_bazel_rules_kotlin//kotlin:kotlin.bzl", "kotlin_repositories")
+load("@io_bazel_rules_kotlin//kotlin:repositories.bzl", "kotlin_repositories")
 load("@io_grpc_grpc_java//:repositories.bzl", "grpc_java_repositories")
 load("@rules_proto_grpc//protobuf:repositories.bzl", "protobuf_repos")
 load("@rules_proto_grpc//java:repositories.bzl", rules_proto_grpc_java_repos = "java_repos")

--- a/bazel/envoy_mobile_repositories.bzl
+++ b/bazel/envoy_mobile_repositories.bzl
@@ -92,17 +92,15 @@ def kotlin_repos():
 
     http_archive(
         name = "io_bazel_rules_kotlin",
-        sha256 = "dc1c76f91228ddaf4f7ca4190b82d61939e95369f61dea715e8be28792072b1b",
-        strip_prefix = "rules_kotlin-legacy-1.3.0-rc2",
-        type = "zip",
-        urls = ["https://github.com/bazelbuild/rules_kotlin/archive/legacy-1.3.0-rc2.zip"],
+        sha256 = "12d22a3d9cbcf00f2e2d8f0683ba87d3823cb8c7f6837568dd7e48846e023307",
+        url = "https://github.com/bazelbuild/rules_kotlin/releases/download/v1.5.0/rules_kotlin_release.tgz",
     )
 
     http_archive(
         name = "rules_detekt",
-        sha256 = "b1b4c8a3228f880a169ab60a817619bc4cf254443196e7e108ece411cb9c580e",
-        strip_prefix = "bazel_rules_detekt-0.3.0",
-        url = "https://github.com/buildfoundation/bazel_rules_detekt/archive/v0.3.0.tar.gz",
+        sha256 = "44912c74dc2e164227b1102ef36227d0e78fdbd7c7359868ae13424eb4f0d5c2",
+        strip_prefix = "bazel_rules_detekt-0.6.0",
+        url = "https://github.com/buildfoundation/bazel_rules_detekt/archive/refs/tags/v0.6.0.tar.gz",
     )
 
     # gRPC java for @rules_proto_grpc

--- a/bazel/envoy_mobile_toolchains.bzl
+++ b/bazel/envoy_mobile_toolchains.bzl
@@ -4,5 +4,5 @@ load("@rules_proto_grpc//:repositories.bzl", "rules_proto_grpc_toolchains")
 
 def envoy_mobile_toolchains():
     kt_register_toolchains()
-    rules_detekt_toolchains(detekt_version = "1.8.0")
+    rules_detekt_toolchains(detekt_version = "1.20.0")
     rules_proto_grpc_toolchains()

--- a/bazel/envoy_mobile_toolchains.bzl
+++ b/bazel/envoy_mobile_toolchains.bzl
@@ -1,4 +1,4 @@
-load("@io_bazel_rules_kotlin//kotlin:kotlin.bzl", "kt_register_toolchains")
+load("@io_bazel_rules_kotlin//kotlin:core.bzl", "kt_register_toolchains")
 load("@rules_detekt//detekt:toolchains.bzl", "rules_detekt_toolchains")
 load("@rules_proto_grpc//:repositories.bzl", "rules_proto_grpc_toolchains")
 


### PR DESCRIPTION
rules_detekt pins rules_java, which needed to be updated to support
https://github.com/bazelbuild/bazel/commit/d5559c16ac008b86345fbbade5d600181a2fce6f
and bazel rolling releases.

Signed-off-by: Keith Smiley <keithbsmiley@gmail.com>