### PR TITLE
use 64 bit emulators for test

### DIFF
--- a/.github/workflows/android_build.yml
+++ b/.github/workflows/android_build.yml
@@ -41,7 +41,7 @@ jobs:
           ./bazelw build \
             --config=remote-ci-macos \
             --remote_header="Authorization=Bearer $GITHUB_TOKEN" \
-            --fat_apk_cpu=arm64-v8a \
+            --fat_apk_cpu=x86_64 \
             //:android_dist_ci
   javahelloworld:
     name: java_helloworld
@@ -70,7 +70,7 @@ jobs:
       - name: 'Start simulator'
         run: ./ci/mac_start_emulator.sh
       # Return to using:
-      #   ./bazelw mobile-install --fat_apk_cpu=arm64-v8a --start_app //examples/java/hello_world:hello_envoy
+      #   ./bazelw mobile-install --fat_apk_cpu=x86_64 --start_app //examples/java/hello_world:hello_envoy
       # When https://github.com/envoyproxy/envoy-mobile/issues/853 is fixed.
       - name: 'Start java app'
         env:
@@ -79,7 +79,7 @@ jobs:
           ./bazelw build \
             --config=remote-ci-macos \
             --remote_header="Authorization=Bearer $GITHUB_TOKEN" \
-            --fat_apk_cpu=arm64-v8a \
+            --fat_apk_cpu=x86_64 \
             //examples/java/hello_world:hello_envoy
           adb install -r --no-incremental bazel-bin/examples/java/hello_world/hello_envoy.apk
           adb shell am start -n io.envoyproxy.envoymobile.helloenvoy/.MainActivity
@@ -113,7 +113,7 @@ jobs:
       - name: 'Start simulator'
         run: ./ci/mac_start_emulator.sh
       # Return to using:
-      #   ./bazelw mobile-install --fat_apk_cpu=arm64-v8a --start_app //examples/kotlin/hello_world:hello_envoy_kt
+      #   ./bazelw mobile-install --fat_apk_cpu=x86_64 --start_app //examples/kotlin/hello_world:hello_envoy_kt
       # When https://github.com/envoyproxy/envoy-mobile/issues/853 is fixed.
       - name: 'Start kotlin app'
         env:
@@ -122,7 +122,7 @@ jobs:
           ./bazelw build \
             --config=remote-ci-macos \
             --remote_header="Authorization=Bearer $GITHUB_TOKEN" \
-            --fat_apk_cpu=arm64-v8a \
+            --fat_apk_cpu=x86_64 \
             //examples/kotlin/hello_world:hello_envoy_kt
           adb install -r --no-incremental bazel-bin/examples/kotlin/hello_world/hello_envoy_kt.apk
           adb shell am start -n io.envoyproxy.envoymobile.helloenvoykotlin/.MainActivity
@@ -156,7 +156,7 @@ jobs:
       - name: 'Start simulator'
         run: ./ci/mac_start_emulator.sh
       # Return to using:
-      #   ./bazelw mobile-install --fat_apk_cpu=arm64-v8a --start_app //examples/kotlin/hello_world:hello_envoy_kt
+      #   ./bazelw mobile-install --fat_apk_cpu=x86_64 --start_app //examples/kotlin/hello_world:hello_envoy_kt
       # When https://github.com/envoyproxy/envoy-mobile/issues/853 is fixed.
       - name: 'Start kotlin app'
         env:
@@ -165,7 +165,7 @@ jobs:
           ./bazelw build \
             --config=remote-ci-macos \
             --remote_header="Authorization=Bearer $GITHUB_TOKEN" \
-            --fat_apk_cpu=arm64-v8a \
+            --fat_apk_cpu=x86_64 \
             //test/kotlin/apps/baseline:hello_envoy_kt
           adb install -r --no-incremental bazel-bin/test/kotlin/apps/baseline/hello_envoy_kt.apk
           adb shell am start -n io.envoyproxy.envoymobile.helloenvoykotlin/.MainActivity
@@ -199,7 +199,7 @@ jobs:
       - name: 'Start simulator'
         run: ./ci/mac_start_emulator.sh
       # Return to using:
-      #   ./bazelw mobile-install --fat_apk_cpu=arm64-v8a --start_app //examples/kotlin/hello_world:hello_envoy_kt
+      #   ./bazelw mobile-install --fat_apk_cpu=x86_64 --start_app //examples/kotlin/hello_world:hello_envoy_kt
       # When https://github.com/envoyproxy/envoy-mobile/issues/853 is fixed.
       - name: 'Start kotlin app'
         env:
@@ -208,7 +208,7 @@ jobs:
           ./bazelw build \
             --config=remote-ci-macos \
             --remote_header="Authorization=Bearer $GITHUB_TOKEN" \
-            --fat_apk_cpu=arm64-v8a \
+            --fat_apk_cpu=x86_64 \
             //test/kotlin/apps/experimental:hello_envoy_kt
           adb install -r --no-incremental bazel-bin/test/kotlin/apps/experimental/hello_envoy_kt.apk
           adb shell am start -n io.envoyproxy.envoymobile.helloenvoykotlin/.MainActivity

--- a/.github/workflows/android_build.yml
+++ b/.github/workflows/android_build.yml
@@ -41,7 +41,7 @@ jobs:
           ./bazelw build \
             --config=remote-ci-macos \
             --remote_header="Authorization=Bearer $GITHUB_TOKEN" \
-            --fat_apk_cpu=x86 \
+            --fat_apk_cpu=arm64-v8a \
             //:android_dist_ci
   javahelloworld:
     name: java_helloworld
@@ -70,7 +70,7 @@ jobs:
       - name: 'Start simulator'
         run: ./ci/mac_start_emulator.sh
       # Return to using:
-      #   ./bazelw mobile-install --fat_apk_cpu=x86 --start_app //examples/java/hello_world:hello_envoy
+      #   ./bazelw mobile-install --fat_apk_cpu=arm64-v8a --start_app //examples/java/hello_world:hello_envoy
       # When https://github.com/envoyproxy/envoy-mobile/issues/853 is fixed.
       - name: 'Start java app'
         env:
@@ -79,7 +79,7 @@ jobs:
           ./bazelw build \
             --config=remote-ci-macos \
             --remote_header="Authorization=Bearer $GITHUB_TOKEN" \
-            --fat_apk_cpu=x86 \
+            --fat_apk_cpu=arm64-v8a \
             //examples/java/hello_world:hello_envoy
           adb install -r --no-incremental bazel-bin/examples/java/hello_world/hello_envoy.apk
           adb shell am start -n io.envoyproxy.envoymobile.helloenvoy/.MainActivity
@@ -113,7 +113,7 @@ jobs:
       - name: 'Start simulator'
         run: ./ci/mac_start_emulator.sh
       # Return to using:
-      #   ./bazelw mobile-install --fat_apk_cpu=x86 --start_app //examples/kotlin/hello_world:hello_envoy_kt
+      #   ./bazelw mobile-install --fat_apk_cpu=arm64-v8a --start_app //examples/kotlin/hello_world:hello_envoy_kt
       # When https://github.com/envoyproxy/envoy-mobile/issues/853 is fixed.
       - name: 'Start kotlin app'
         env:
@@ -122,7 +122,7 @@ jobs:
           ./bazelw build \
             --config=remote-ci-macos \
             --remote_header="Authorization=Bearer $GITHUB_TOKEN" \
-            --fat_apk_cpu=x86 \
+            --fat_apk_cpu=arm64-v8a \
             //examples/kotlin/hello_world:hello_envoy_kt
           adb install -r --no-incremental bazel-bin/examples/kotlin/hello_world/hello_envoy_kt.apk
           adb shell am start -n io.envoyproxy.envoymobile.helloenvoykotlin/.MainActivity
@@ -156,7 +156,7 @@ jobs:
       - name: 'Start simulator'
         run: ./ci/mac_start_emulator.sh
       # Return to using:
-      #   ./bazelw mobile-install --fat_apk_cpu=x86 --start_app //examples/kotlin/hello_world:hello_envoy_kt
+      #   ./bazelw mobile-install --fat_apk_cpu=arm64-v8a --start_app //examples/kotlin/hello_world:hello_envoy_kt
       # When https://github.com/envoyproxy/envoy-mobile/issues/853 is fixed.
       - name: 'Start kotlin app'
         env:
@@ -165,7 +165,7 @@ jobs:
           ./bazelw build \
             --config=remote-ci-macos \
             --remote_header="Authorization=Bearer $GITHUB_TOKEN" \
-            --fat_apk_cpu=x86 \
+            --fat_apk_cpu=arm64-v8a \
             //test/kotlin/apps/baseline:hello_envoy_kt
           adb install -r --no-incremental bazel-bin/test/kotlin/apps/baseline/hello_envoy_kt.apk
           adb shell am start -n io.envoyproxy.envoymobile.helloenvoykotlin/.MainActivity
@@ -199,7 +199,7 @@ jobs:
       - name: 'Start simulator'
         run: ./ci/mac_start_emulator.sh
       # Return to using:
-      #   ./bazelw mobile-install --fat_apk_cpu=x86 --start_app //examples/kotlin/hello_world:hello_envoy_kt
+      #   ./bazelw mobile-install --fat_apk_cpu=arm64-v8a --start_app //examples/kotlin/hello_world:hello_envoy_kt
       # When https://github.com/envoyproxy/envoy-mobile/issues/853 is fixed.
       - name: 'Start kotlin app'
         env:
@@ -208,7 +208,7 @@ jobs:
           ./bazelw build \
             --config=remote-ci-macos \
             --remote_header="Authorization=Bearer $GITHUB_TOKEN" \
-            --fat_apk_cpu=x86 \
+            --fat_apk_cpu=arm64-v8a \
             //test/kotlin/apps/experimental:hello_envoy_kt
           adb install -r --no-incremental bazel-bin/test/kotlin/apps/experimental/hello_envoy_kt.apk
           adb shell am start -n io.envoyproxy.envoymobile.helloenvoykotlin/.MainActivity

--- a/ci/mac_start_emulator.sh
+++ b/ci/mac_start_emulator.sh
@@ -2,7 +2,7 @@
 
 set -e
 
-echo "y" | $ANDROID_HOME/tools/bin/sdkmanager --install 'system-images;android-29;google_apis;x86' --channel=3
-echo "no" | $ANDROID_HOME/tools/bin/avdmanager create avd -n test_android_emulator -k 'system-images;android-29;google_apis;x86' --force
+echo "y" | $ANDROID_HOME/tools/bin/sdkmanager --install 'system-images;android-29;google_apis;arm64-v8a' --channel=3
+echo "no" | $ANDROID_HOME/tools/bin/avdmanager create avd -n test_android_emulator -k 'system-images;android-29;google_apis;arm64-v8a' --force
 ls $ANDROID_HOME/tools/bin/
 nohup $ANDROID_HOME/emulator/emulator -partition-size 1024 -avd test_android_emulator -no-snapshot > /dev/null 2>&1 & $ANDROID_HOME/platform-tools/adb wait-for-device shell 'while [[ -z $(getprop sys.boot_completed | tr -d '\r') ]]; do sleep 1; done; input keyevent 82'

--- a/ci/mac_start_emulator.sh
+++ b/ci/mac_start_emulator.sh
@@ -2,7 +2,7 @@
 
 set -e
 
-echo "y" | $ANDROID_HOME/tools/bin/sdkmanager --install 'system-images;android-29;google_apis;arm64-v8a' --channel=3
-echo "no" | $ANDROID_HOME/tools/bin/avdmanager create avd -n test_android_emulator -k 'system-images;android-29;google_apis;arm64-v8a' --force
+echo "y" | $ANDROID_HOME/tools/bin/sdkmanager --install 'system-images;android-29;google_apis;x86_64' --channel=3
+echo "no" | $ANDROID_HOME/tools/bin/avdmanager create avd -n test_android_emulator -k 'system-images;android-29;google_apis;x86_64' --force
 ls $ANDROID_HOME/tools/bin/
 nohup $ANDROID_HOME/emulator/emulator -partition-size 1024 -avd test_android_emulator -no-snapshot > /dev/null 2>&1 & $ANDROID_HOME/platform-tools/adb wait-for-device shell 'while [[ -z $(getprop sys.boot_completed | tr -d '\r') ]]; do sleep 1; done; input keyevent 82'


### PR DESCRIPTION
This is much more common than 32 bit, so it makes sense to test for this over x86

Signed-off-by: Snow Pettersen <snowp@lyft.com>

Risk Level: Low
Testing: Existing tests
Docs Changes: n/a
Release Notes: n/a
