### PR TITLE
envoy: update to `d0befbb` & add `h2ExtendKeepaliveTimeout`

### DIFF
--- a/docs/root/api/starting_envoy.rst
+++ b/docs/root/api/starting_envoy.rst
@@ -416,6 +416,22 @@ Specify whether sockets may attempt to bind to a specific interface, based on ne
   // Swift
   builder.enableInterfaceBinding(true)
 
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+``h2ExtendKeepaliveTimeout``
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Extend the keepalive timeout when *any* frame is received on the owning HTTP/2 connection.
+
+This can help negate the effect of head-of-line (HOL) blocking for slow connections.
+
+**Example**::
+
+  // Kotlin
+  builder.h2ExtendKeepaliveTimeout(true)
+
+  // Swift
+  builder.h2ExtendKeepaliveTimeout(true)
+
 ----------------------
 Advanced configuration
 ----------------------

--- a/docs/root/intro/version_history.rst
+++ b/docs/root/intro/version_history.rst
@@ -14,7 +14,7 @@ Bugfixes:
 
 Features:
 
-- None
+- api: add option to extend the keepalive timeout when any frame is received on the owning HTTP/2 connection. (:issue:`#2229 <2229>`)
 
 0.4.6 (April 26, 2022)
 ========================

--- a/library/common/config/config.cc
+++ b/library/common/config/config.cc
@@ -55,6 +55,7 @@ const std::string config_header = R"(
 - &enable_interface_binding false
 - &h2_connection_keepalive_idle_interval 100000s
 - &h2_connection_keepalive_timeout 10s
+- &h2_delay_keepalive_timeout false
 - &h2_raw_domains []
 - &max_connections_per_host 7
 - &metadata {}
@@ -464,6 +465,7 @@ layered_runtime:
           reloadable_features:
             allow_multiple_dns_addresses: *dns_multiple_addresses
             override_request_timeout_by_gateway_timeout: false
+            http2_delay_keepalive_timeout: *h2_delay_keepalive_timeout
 )"
 // Needed due to warning in
 // https://github.com/envoyproxy/envoy/blob/6eb7e642d33f5a55b63c367188f09819925fca34/source/server/server.cc#L546

--- a/library/common/engine.cc
+++ b/library/common/engine.cc
@@ -304,7 +304,7 @@ void Engine::flushStats() {
 void Engine::drainConnections() {
   ASSERT(dispatcher_->isThreadSafe(),
          "drainConnections must be called from the dispatcher's context");
-  server_->clusterManager().drainConnections();
+  server_->clusterManager().drainConnections(nullptr);
 }
 
 Upstream::ClusterManager& Engine::getClusterManager() {

--- a/library/java/io/envoyproxy/envoymobile/engine/EnvoyConfiguration.java
+++ b/library/java/io/envoyproxy/envoymobile/engine/EnvoyConfiguration.java
@@ -40,6 +40,7 @@ public class EnvoyConfiguration {
   public final Boolean enableInterfaceBinding;
   public final Integer h2ConnectionKeepaliveIdleIntervalMilliseconds;
   public final Integer h2ConnectionKeepaliveTimeoutSeconds;
+  public final Boolean h2ExtendKeepaliveTimeout;
   public final List<String> h2RawDomains;
   public final Integer maxConnectionsPerHost;
   public final List<EnvoyHTTPFilterFactory> httpPlatformFilterFactories;
@@ -76,6 +77,8 @@ public class EnvoyConfiguration {
    * @param h2ConnectionKeepaliveIdleIntervalMilliseconds rate in milliseconds seconds to send h2
    *     pings on stream creation.
    * @param h2ConnectionKeepaliveTimeoutSeconds rate in seconds to timeout h2 pings.
+   * @param h2ExtendKeepaliveTimeout     Extend the keepalive timeout when *any* frame is received
+   *                                     on the owning HTTP/2 connection.
    * @param h2RawDomains                 list of domains to which connections should be raw h2.
    * @param maxConnectionsPerHost        maximum number of connections to open to a single host.
    * @param statsFlushSeconds            interval at which to flush Envoy stats.
@@ -96,10 +99,11 @@ public class EnvoyConfiguration {
       String dnsPreresolveHostnames, List<String> dnsFallbackNameservers,
       Boolean dnsFilterUnroutableFamilies, boolean enableHttp3, boolean enableHappyEyeballs,
       boolean enableInterfaceBinding, int h2ConnectionKeepaliveIdleIntervalMilliseconds,
-      int h2ConnectionKeepaliveTimeoutSeconds, List<String> h2RawDomains, int maxConnectionsPerHost,
-      int statsFlushSeconds, int streamIdleTimeoutSeconds, int perTryIdleTimeoutSeconds,
-      String appVersion, String appId, TrustChainVerification trustChainVerification,
-      String virtualClusters, List<EnvoyNativeFilterConfig> nativeFilterChain,
+      int h2ConnectionKeepaliveTimeoutSeconds, boolean h2ExtendKeepaliveTimeout,
+      List<String> h2RawDomains, int maxConnectionsPerHost, int statsFlushSeconds,
+      int streamIdleTimeoutSeconds, int perTryIdleTimeoutSeconds, String appVersion, String appId,
+      TrustChainVerification trustChainVerification, String virtualClusters,
+      List<EnvoyNativeFilterConfig> nativeFilterChain,
       List<EnvoyHTTPFilterFactory> httpPlatformFilterFactories,
       Map<String, EnvoyStringAccessor> stringAccessors) {
     this.adminInterfaceEnabled = adminInterfaceEnabled;
@@ -120,6 +124,7 @@ public class EnvoyConfiguration {
     this.h2ConnectionKeepaliveIdleIntervalMilliseconds =
         h2ConnectionKeepaliveIdleIntervalMilliseconds;
     this.h2ConnectionKeepaliveTimeoutSeconds = h2ConnectionKeepaliveTimeoutSeconds;
+    this.h2ExtendKeepaliveTimeout = h2ExtendKeepaliveTimeout;
     this.h2RawDomains = h2RawDomains;
     this.maxConnectionsPerHost = maxConnectionsPerHost;
     this.statsFlushSeconds = statsFlushSeconds;
@@ -212,6 +217,8 @@ public class EnvoyConfiguration {
                               enableHappyEyeballs ? "ALL" : "V4_PREFERRED"))
         .append(
             String.format("- &dns_multiple_addresses %s\n", enableHappyEyeballs ? "true" : "false"))
+        .append(String.format("- &h2_delay_keepalive_timeout %s\n",
+                              h2ExtendKeepaliveTimeout ? "true" : "false"))
         .append("- &dns_resolver_name envoy.network.dns_resolver.cares\n")
         .append(String.format("- &dns_refresh_rate %ss\n", dnsRefreshSeconds))
         .append(String.format("- &dns_resolver_config %s\n", dnsResolverConfig))

--- a/library/java/org/chromium/net/impl/NativeCronetEngineBuilderImpl.java
+++ b/library/java/org/chromium/net/impl/NativeCronetEngineBuilderImpl.java
@@ -65,6 +65,7 @@ public class NativeCronetEngineBuilderImpl extends CronetEngineBuilderImpl {
   private boolean mEnableInterfaceBinding = false;
   private int mH2ConnectionKeepaliveIdleIntervalMilliseconds = 100000000;
   private int mH2ConnectionKeepaliveTimeoutSeconds = 10;
+  private boolean mH2ExtendKeepaliveTimeout = false;
   private List<String> mH2RawDomains = Collections.emptyList();
   private int mMaxConnectionsPerHost = 7;
   private int mStatsFlushSeconds = 60;
@@ -125,8 +126,9 @@ public class NativeCronetEngineBuilderImpl extends CronetEngineBuilderImpl {
         mDnsFallbackNameservers, mEnableDnsFilterUnroutableFamilies, mEnableHttp3,
         mEnableHappyEyeballs, mEnableInterfaceBinding,
         mH2ConnectionKeepaliveIdleIntervalMilliseconds, mH2ConnectionKeepaliveTimeoutSeconds,
-        mH2RawDomains, mMaxConnectionsPerHost, mStatsFlushSeconds, mStreamIdleTimeoutSeconds,
-        mPerTryIdleTimeoutSeconds, mAppVersion, mAppId, mTrustChainVerification, mVirtualClusters,
-        nativeFilterChain, platformFilterChain, stringAccessors);
+        mH2ExtendKeepaliveTimeout, mH2RawDomains, mMaxConnectionsPerHost, mStatsFlushSeconds,
+        mStreamIdleTimeoutSeconds, mPerTryIdleTimeoutSeconds, mAppVersion, mAppId,
+        mTrustChainVerification, mVirtualClusters, nativeFilterChain, platformFilterChain,
+        stringAccessors);
   }
 }

--- a/library/kotlin/io/envoyproxy/envoymobile/EngineBuilder.kt
+++ b/library/kotlin/io/envoyproxy/envoymobile/EngineBuilder.kt
@@ -44,6 +44,7 @@ open class EngineBuilder(
   private var enableInterfaceBinding = false
   private var h2ConnectionKeepaliveIdleIntervalMilliseconds = 100000000
   private var h2ConnectionKeepaliveTimeoutSeconds = 10
+  private var h2ExtendKeepaliveTimeout = false
   private var h2RawDomains = listOf<String>()
   private var maxConnectionsPerHost = 7
   private var statsFlushSeconds = 60
@@ -259,6 +260,18 @@ open class EngineBuilder(
    */
   fun addH2ConnectionKeepaliveTimeoutSeconds(timeoutSeconds: Int): EngineBuilder {
     this.h2ConnectionKeepaliveTimeoutSeconds = timeoutSeconds
+    return this
+  }
+
+  /**
+   * Extend the keepalive timeout when *any* frame is received on the owning HTTP/2 connection.
+   *
+   * @param h2ExtendKeepaliveTimeout whether to extend the keepalive timeout.
+   *
+   * @return This builder.
+   */
+  fun h2ExtendKeepaliveTimeout(h2ExtendKeepaliveTimeout: Boolean): EngineBuilder {
+    this.h2ExtendKeepaliveTimeout = h2ExtendKeepaliveTimeout
     return this
   }
 
@@ -495,6 +508,7 @@ open class EngineBuilder(
       enableInterfaceBinding,
       h2ConnectionKeepaliveIdleIntervalMilliseconds,
       h2ConnectionKeepaliveTimeoutSeconds,
+      h2ExtendKeepaliveTimeout,
       h2RawDomains,
       maxConnectionsPerHost,
       statsFlushSeconds,

--- a/library/objective-c/EnvoyConfiguration.m
+++ b/library/objective-c/EnvoyConfiguration.m
@@ -19,6 +19,7 @@
     h2ConnectionKeepaliveIdleIntervalMilliseconds:
         (UInt32)h2ConnectionKeepaliveIdleIntervalMilliseconds
               h2ConnectionKeepaliveTimeoutSeconds:(UInt32)h2ConnectionKeepaliveTimeoutSeconds
+                         h2ExtendKeepaliveTimeout:(BOOL)h2ExtendKeepaliveTimeout
                                      h2RawDomains:(NSArray<NSString *> *)h2RawDomains
                             maxConnectionsPerHost:(UInt32)maxConnectionsPerHost
                                 statsFlushSeconds:(UInt32)statsFlushSeconds
@@ -56,6 +57,7 @@
   self.h2ConnectionKeepaliveIdleIntervalMilliseconds =
       h2ConnectionKeepaliveIdleIntervalMilliseconds;
   self.h2ConnectionKeepaliveTimeoutSeconds = h2ConnectionKeepaliveTimeoutSeconds;
+  self.h2ExtendKeepaliveTimeout = h2ExtendKeepaliveTimeout;
   self.h2RawDomains = h2RawDomains;
   self.maxConnectionsPerHost = maxConnectionsPerHost;
   self.statsFlushSeconds = statsFlushSeconds;
@@ -143,6 +145,8 @@
                             self.enableHappyEyeballs ? @"ALL" : @"V4_PREFERRED"];
   [definitions appendFormat:@"- &dns_multiple_addresses %@\n",
                             self.enableHappyEyeballs ? @"true" : @"false"];
+  [definitions appendFormat:@"- &h2_delay_keepalive_timeout %@\n",
+                            self.h2ExtendKeepaliveTimeout ? @"true" : @"false"];
   [definitions appendFormat:@"- &dns_refresh_rate %lus\n", (unsigned long)self.dnsRefreshSeconds];
   [definitions appendFormat:@"- &dns_resolver_name envoy.network.dns_resolver.apple\n"];
   // No additional values are currently needed for Apple-based DNS resolver.

--- a/library/objective-c/EnvoyEngine.h
+++ b/library/objective-c/EnvoyEngine.h
@@ -345,6 +345,7 @@ extern const int kEnvoyFilterResumeStatusResumeIteration;
 @property (nonatomic, assign) BOOL enforceTrustChainVerification;
 @property (nonatomic, assign) UInt32 h2ConnectionKeepaliveIdleIntervalMilliseconds;
 @property (nonatomic, assign) UInt32 h2ConnectionKeepaliveTimeoutSeconds;
+@property (nonatomic, assign) BOOL h2ExtendKeepaliveTimeout;
 @property (nonatomic, strong) NSArray<NSString *> *h2RawDomains;
 @property (nonatomic, assign) UInt32 maxConnectionsPerHost;
 @property (nonatomic, assign) UInt32 statsFlushSeconds;
@@ -377,6 +378,7 @@ extern const int kEnvoyFilterResumeStatusResumeIteration;
     h2ConnectionKeepaliveIdleIntervalMilliseconds:
         (UInt32)h2ConnectionKeepaliveIdleIntervalMilliseconds
               h2ConnectionKeepaliveTimeoutSeconds:(UInt32)h2ConnectionKeepaliveTimeoutSeconds
+                         h2ExtendKeepaliveTimeout:(BOOL)h2ExtendKeepaliveTimeout
                                      h2RawDomains:(NSArray<NSString *> *)h2RawDomains
                             maxConnectionsPerHost:(UInt32)maxConnectionsPerHost
                                 statsFlushSeconds:(UInt32)statsFlushSeconds

--- a/library/swift/EngineBuilder.swift
+++ b/library/swift/EngineBuilder.swift
@@ -27,6 +27,7 @@ open class EngineBuilder: NSObject {
   private var enforceTrustChainVerification: Bool = true
   private var h2ConnectionKeepaliveIdleIntervalMilliseconds: UInt32 = 100000000
   private var h2ConnectionKeepaliveTimeoutSeconds: UInt32 = 10
+  private var h2ExtendKeepaliveTimeout: Bool = false
   private var h2RawDomains: [String] = []
   private var maxConnectionsPerHost: UInt32 = 7
   private var statsFlushSeconds: UInt32 = 60
@@ -209,6 +210,17 @@ open class EngineBuilder: NSObject {
   public func addH2ConnectionKeepaliveTimeoutSeconds(
     _ h2ConnectionKeepaliveTimeoutSeconds: UInt32) -> Self {
     self.h2ConnectionKeepaliveTimeoutSeconds = h2ConnectionKeepaliveTimeoutSeconds
+    return self
+  }
+
+  /// Extend the keepalive timeout when *any* frame is received on the owning HTTP/2 connection.
+  ///
+  /// - parameter h2ExtendKeepaliveTimeout: whether to extend the keepalive timeout.
+  ///
+  /// - returns: This builder.
+  @discardableResult
+  public func h2ExtendKeepaliveTimeout(_ h2ExtendKeepaliveTimeout: Bool) -> Self {
+    self.h2ExtendKeepaliveTimeout = h2ExtendKeepaliveTimeout
     return self
   }
 
@@ -433,6 +445,7 @@ open class EngineBuilder: NSObject {
       h2ConnectionKeepaliveIdleIntervalMilliseconds:
         self.h2ConnectionKeepaliveIdleIntervalMilliseconds,
       h2ConnectionKeepaliveTimeoutSeconds: self.h2ConnectionKeepaliveTimeoutSeconds,
+      h2ExtendKeepaliveTimeout: self.h2ExtendKeepaliveTimeout,
       h2RawDomains: self.h2RawDomains,
       maxConnectionsPerHost: self.maxConnectionsPerHost,
       statsFlushSeconds: self.statsFlushSeconds,

--- a/test/java/io/envoyproxy/envoymobile/engine/EnvoyConfigurationTest.kt
+++ b/test/java/io/envoyproxy/envoymobile/engine/EnvoyConfigurationTest.kt
@@ -49,6 +49,7 @@ class EnvoyConfigurationTest {
     enableInterfaceBinding: Boolean = false,
     h2ConnectionKeepaliveIdleIntervalMilliseconds: Int = 222,
     h2ConnectionKeepaliveTimeoutSeconds: Int = 333,
+    h2ExtendKeepaliveTimeout: Boolean = false,
     h2RawDomains: List<String> = listOf("h2-raw.example.com"),
     maxConnectionsPerHost: Int = 543,
     statsFlushSeconds: Int = 567,
@@ -77,6 +78,7 @@ class EnvoyConfigurationTest {
       enableInterfaceBinding,
       h2ConnectionKeepaliveIdleIntervalMilliseconds,
       h2ConnectionKeepaliveTimeoutSeconds,
+      h2ExtendKeepaliveTimeout,
       h2RawDomains,
       maxConnectionsPerHost,
       statsFlushSeconds,
@@ -161,7 +163,8 @@ class EnvoyConfigurationTest {
       enableDnsFilterUnroutableFamilies = true,
       enableHappyEyeballs = true,
       enableHttp3 = true,
-      enableInterfaceBinding = true
+      enableInterfaceBinding = true,
+      h2ExtendKeepaliveTimeout = true
     )
 
     val resolvedTemplate = envoyConfiguration.resolveTemplate(
@@ -172,6 +175,9 @@ class EnvoyConfigurationTest {
     assertThat(resolvedTemplate).contains("&dns_resolver_config {\"@type\":\"type.googleapis.com/envoy.extensions.network.dns_resolver.cares.v3.CaresDnsResolverConfig\",\"resolvers\":[{\"socket_address\":{\"address\":\"8.8.8.8\"}}],\"use_resolvers_as_fallback\": true, \"filter_unroutable_families\": true}")
     assertThat(resolvedTemplate).contains("&dns_lookup_family ALL")
     assertThat(resolvedTemplate).contains("&dns_multiple_addresses true")
+
+    // H2
+    assertThat(resolvedTemplate).contains("&h2_delay_keepalive_timeout true")
 
     // H3
     assertThat(resolvedTemplate).contains(APCF_INSERT);

--- a/test/kotlin/apps/experimental/MainActivity.kt
+++ b/test/kotlin/apps/experimental/MainActivity.kt
@@ -51,6 +51,7 @@ class MainActivity : Activity() {
       .addPlatformFilter(::BufferDemoFilter)
       .addPlatformFilter(::AsyncDemoFilter)
       .enableHappyEyeballs(true)
+      .h2ExtendKeepaliveTimeout(true)
       .enableInterfaceBinding(true)
       .addNativeFilter("envoy.filters.http.buffer", "{\"@type\":\"type.googleapis.com/envoy.extensions.filters.http.buffer.v3.Buffer\",\"max_request_bytes\":5242880}")
       .addStringAccessor("demo-accessor", { "PlatformString" })

--- a/test/kotlin/io/envoyproxy/envoymobile/EngineBuilderTest.kt
+++ b/test/kotlin/io/envoyproxy/envoymobile/EngineBuilderTest.kt
@@ -161,6 +161,16 @@ class EngineBuilderTest {
   }
 
   @Test
+  fun `enabling h2 keepalive extension overrides default`() {
+    engineBuilder = EngineBuilder(Standard())
+    engineBuilder.addEngineType { envoyEngine }
+    engineBuilder.h2ExtendKeepaliveTimeout(true)
+
+    val engine = engineBuilder.build() as EngineImpl
+    assertThat(engine.envoyConfiguration!!.h2ExtendKeepaliveTimeout).isTrue()
+  }
+
+  @Test
   fun `specifying h2 hostnames overrides default`() {
     engineBuilder = EngineBuilder(Standard())
     engineBuilder.addEngineType { envoyEngine }

--- a/test/swift/EngineBuilderTests.swift
+++ b/test/swift/EngineBuilderTests.swift
@@ -250,6 +250,20 @@ final class EngineBuilderTests: XCTestCase {
     self.waitForExpectations(timeout: 0.01)
   }
 
+  func testAddingH2ExtendKeepaliveTimeoutAddsToConfigurationWhenRunningEnvoy() {
+    let expectation = self.expectation(description: "Run called with enabled happy eyeballs")
+    MockEnvoyEngine.onRunWithConfig = { config, _ in
+      XCTAssertTrue(config.h2ExtendKeepaliveTimeout)
+      expectation.fulfill()
+    }
+
+    _ = EngineBuilder()
+      .addEngineType(MockEnvoyEngine.self)
+      .h2ExtendKeepaliveTimeout(true)
+      .build()
+    self.waitForExpectations(timeout: 0.01)
+  }
+
   func testAddingH2RawDomainsAddsToConfigurationWhenRunningEnvoy() {
     let expectation = self.expectation(description: "Run called with expected data")
     MockEnvoyEngine.onRunWithConfig = { config, _ in
@@ -420,6 +434,7 @@ final class EngineBuilderTests: XCTestCase {
       enforceTrustChainVerification: false,
       h2ConnectionKeepaliveIdleIntervalMilliseconds: 1,
       h2ConnectionKeepaliveTimeoutSeconds: 333,
+      h2ExtendKeepaliveTimeout: true,
       h2RawDomains: ["h2-raw.domain"],
       maxConnectionsPerHost: 100,
       statsFlushSeconds: 600,
@@ -451,9 +466,10 @@ final class EngineBuilderTests: XCTestCase {
     XCTAssertTrue(resolvedYAML.contains("&enable_interface_binding true"))
     XCTAssertTrue(resolvedYAML.contains("&trust_chain_verification ACCEPT_UNTRUSTED"))
 
+    // HTTP/2
     XCTAssertTrue(resolvedYAML.contains("&h2_connection_keepalive_idle_interval 0.001s"))
     XCTAssertTrue(resolvedYAML.contains("&h2_connection_keepalive_timeout 333s"))
-
+    XCTAssertTrue(resolvedYAML.contains("&h2_delay_keepalive_timeout true"))
     XCTAssertTrue(resolvedYAML.contains("&h2_raw_domains [\"h2-raw.domain\"]"))
 
     XCTAssertTrue(resolvedYAML.contains("&max_connections_per_host 100"))

--- a/test/swift/EngineBuilderTests.swift
+++ b/test/swift/EngineBuilderTests.swift
@@ -251,7 +251,7 @@ final class EngineBuilderTests: XCTestCase {
   }
 
   func testAddingH2ExtendKeepaliveTimeoutAddsToConfigurationWhenRunningEnvoy() {
-    let expectation = self.expectation(description: "Run called with enabled happy eyeballs")
+    let expectation = self.expectation(description: "Run called with h2ExtendKeepaliveTimeout")
     MockEnvoyEngine.onRunWithConfig = { config, _ in
       XCTAssertTrue(config.h2ExtendKeepaliveTimeout)
       expectation.fulfill()

--- a/test/swift/EngineBuilderTests.swift
+++ b/test/swift/EngineBuilderTests.swift
@@ -512,6 +512,7 @@ final class EngineBuilderTests: XCTestCase {
       enforceTrustChainVerification: true,
       h2ConnectionKeepaliveIdleIntervalMilliseconds: 1,
       h2ConnectionKeepaliveTimeoutSeconds: 333,
+      h2ExtendKeepaliveTimeout: false,
       h2RawDomains: [],
       maxConnectionsPerHost: 100,
       statsFlushSeconds: 600,
@@ -535,6 +536,7 @@ final class EngineBuilderTests: XCTestCase {
     XCTAssertTrue(resolvedYAML.contains("&dns_multiple_addresses false"))
     XCTAssertTrue(resolvedYAML.contains("&enable_interface_binding false"))
     XCTAssertTrue(resolvedYAML.contains("&trust_chain_verification VERIFY_TRUST_CHAIN"))
+    XCTAssertTrue(resolvedYAML.contains("&h2_delay_keepalive_timeout false"))
   }
 
   func testReturnsNilWhenUnresolvedValueInTemplate() {
@@ -553,6 +555,7 @@ final class EngineBuilderTests: XCTestCase {
       enforceTrustChainVerification: true,
       h2ConnectionKeepaliveIdleIntervalMilliseconds: 222,
       h2ConnectionKeepaliveTimeoutSeconds: 333,
+      h2ExtendKeepaliveTimeout: false,
       h2RawDomains: [],
       maxConnectionsPerHost: 100,
       statsFlushSeconds: 600,

--- a/test/swift/apps/experimental/ViewController.swift
+++ b/test/swift/apps/experimental/ViewController.swift
@@ -23,6 +23,7 @@ final class ViewController: UITableViewController {
       .addPlatformFilter(BufferDemoFilter.init)
       .addPlatformFilter(AsyncDemoFilter.init)
       .enableHappyEyeballs(true)
+      .h2ExtendKeepaliveTimeout(true)
       .enableInterfaceBinding(true)
       // swiftlint:disable:next line_length
       .addNativeFilter(name: "envoy.filters.http.buffer", typedConfig: "{\"@type\":\"type.googleapis.com/envoy.extensions.filters.http.buffer.v3.Buffer\",\"max_request_bytes\":5242880}")


### PR DESCRIPTION
Diff: https://github.com/envoyproxy/envoy/compare/03f23769d19e1baaf37fe52dcfe3f840429f9d06...d0befbbb952c979782857bdb986bec562d9a3c2f

To Do:

- [x] Add `h2ExtendKeepaliveTimeout` option to engine builders
- [x] Add unit tests validating that `h2ExtendKeepaliveTimeout` properly sets the `http2_delay_keepalive_timeout` reloadable feature in the yaml configuration
- [x] Add release notes
- [x] Add documentation
- [x] Verify that the expected code paths from https://github.com/envoyproxy/envoy/pull/21077 are hit with the flag on and off
