### PR TITLE
Fix `bump_lyft_support_rotation.sh` posting to Slack

### DIFF
--- a/tools/bump_lyft_support_rotation.sh
+++ b/tools/bump_lyft_support_rotation.sh
@@ -51,7 +51,7 @@ set_maintainer "$next" "$maintainers_file"
 message="Lyft support maintainer changing from <https://github.com/$current|$current> to <https://github.com/$next|$next>"
 echo "$message"
 
-curl -H "Content-type: application/json" \
+curl -H "Content-type: application/json; charset=utf-8" \
   --data "{\"channel\":\"C02F93EEJCE\",\"blocks\":[{\"type\":\"section\",\"text\":{\"type\":\"mrkdwn\",\"text\":\"$message\"}}]}" \
   -H "Authorization: Bearer $SLACK_BOT_TOKEN" \
   -X POST \


### PR DESCRIPTION
Got this error when bumping this morning:

```
{"ok":false,"error":"channel_not_found","warning":"missing_charset","response_metadata":{"warnings":["missing_charset"]}}
```

Logs: https://github.com/envoyproxy/envoy-mobile/runs/6258460166?check_suite_focus=true