### PR TITLE
envoy: update to `aa19a78`

### DIFF
--- a/.github/workflows/android_build.yml
+++ b/.github/workflows/android_build.yml
@@ -33,6 +33,9 @@ jobs:
       - name: 'Install dependencies'
         if: steps.check-cache.outputs.cache-hit != 'true'
         run: ./ci/mac_ci_setup.sh --android
+      - name: 'Pin Bazel to 5.1.1'
+        # TODO(jpsim): Support bazel 6.x
+        run: echo "5.1.1" > .bazelversion
       - name: 'Build envoy.aar distributable'
         if: steps.check-cache.outputs.cache-hit != 'true'
         env:

--- a/.github/workflows/android_build.yml
+++ b/.github/workflows/android_build.yml
@@ -75,6 +75,9 @@ jobs:
       # Return to using:
       #   ./bazelw mobile-install --fat_apk_cpu=x86_64 --start_app //examples/java/hello_world:hello_envoy
       # When https://github.com/envoyproxy/envoy-mobile/issues/853 is fixed.
+      - name: 'Pin Bazel to 5.1.1'
+        # TODO(jpsim): Support bazel 6.x
+        run: echo "5.1.1" > .bazelversion
       - name: 'Start java app'
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -118,6 +121,9 @@ jobs:
       # Return to using:
       #   ./bazelw mobile-install --fat_apk_cpu=x86_64 --start_app //examples/kotlin/hello_world:hello_envoy_kt
       # When https://github.com/envoyproxy/envoy-mobile/issues/853 is fixed.
+      - name: 'Pin Bazel to 5.1.1'
+        # TODO(jpsim): Support bazel 6.x
+        run: echo "5.1.1" > .bazelversion
       - name: 'Start kotlin app'
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -161,6 +167,9 @@ jobs:
       # Return to using:
       #   ./bazelw mobile-install --fat_apk_cpu=x86_64 --start_app //examples/kotlin/hello_world:hello_envoy_kt
       # When https://github.com/envoyproxy/envoy-mobile/issues/853 is fixed.
+      - name: 'Pin Bazel to 5.1.1'
+        # TODO(jpsim): Support bazel 6.x
+        run: echo "5.1.1" > .bazelversion
       - name: 'Start kotlin app'
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -204,6 +213,9 @@ jobs:
       # Return to using:
       #   ./bazelw mobile-install --fat_apk_cpu=x86_64 --start_app //examples/kotlin/hello_world:hello_envoy_kt
       # When https://github.com/envoyproxy/envoy-mobile/issues/853 is fixed.
+      - name: 'Pin Bazel to 5.1.1'
+        # TODO(jpsim): Support bazel 6.x
+        run: echo "5.1.1" > .bazelversion
       - name: 'Start kotlin app'
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/android_tests.yml
+++ b/.github/workflows/android_tests.yml
@@ -37,6 +37,9 @@ jobs:
       - name: 'Install dependencies'
         if: steps.check_context.outputs.run_tests == 'true'
         run: ./ci/mac_ci_setup.sh
+      - name: 'Pin Bazel to 5.1.1'
+        # TODO(jpsim): Support bazel 6.x
+        run: echo "5.1.1" > .bazelversion
       - name: 'Run Kotlin library tests'
         if: steps.check_context.outputs.run_tests == 'true'
         env:
@@ -77,6 +80,9 @@ jobs:
       - name: 'Install dependencies'
         if: steps.check_context.outputs.run_tests == 'true'
         run: ./ci/mac_ci_setup.sh
+      - name: 'Pin Bazel to 5.1.1'
+        # TODO(jpsim): Support bazel 6.x
+        run: echo "5.1.1" > .bazelversion
       - name: 'Run Java library tests'
         if: steps.check_context.outputs.run_tests == 'true'
         env:
@@ -122,6 +128,9 @@ jobs:
           java-version: '8'
           java-package: jdk
           architecture: x64
+      - name: 'Pin Bazel to 5.1.1'
+        # TODO(jpsim): Support bazel 6.x
+        run: echo "5.1.1" > .bazelversion
       - name: 'Run Kotlin library integration tests'
         if: steps.check_context.outputs.run_tests == 'true'
         env:

--- a/bazel/envoy_mobile_repositories.bzl
+++ b/bazel/envoy_mobile_repositories.bzl
@@ -72,9 +72,8 @@ def upstream_envoy_overrides():
 def swift_repos():
     http_archive(
         name = "build_bazel_rules_apple",
-        sha256 = "633a7f4b886ddd54db82f36f9103dd86e51d4d9be1247574be536988ea8c70e3",
-        strip_prefix = "rules_apple-2e6a8c625e519b18803c30fbd5e960061cc4c4af",
-        url = "https://github.com/bazelbuild/rules_apple/archive/2e6a8c625e519b18803c30fbd5e960061cc4c4af.tar.gz",
+        sha256 = "12865e5944f09d16364aa78050366aca9dc35a32a018fa35f5950238b08bf744",
+        url = "https://github.com/bazelbuild/rules_apple/releases/download/0.34.2/rules_apple.0.34.2.tar.gz",
     )
 
     http_archive(

--- a/bazel/envoy_mobile_repositories.bzl
+++ b/bazel/envoy_mobile_repositories.bzl
@@ -72,8 +72,9 @@ def upstream_envoy_overrides():
 def swift_repos():
     http_archive(
         name = "build_bazel_rules_apple",
-        sha256 = "4161b2283f80f33b93579627c3bd846169b2d58848b0ffb29b5d4db35263156a",
-        url = "https://github.com/bazelbuild/rules_apple/releases/download/0.34.0/rules_apple.0.34.0.tar.gz",
+        sha256 = "633a7f4b886ddd54db82f36f9103dd86e51d4d9be1247574be536988ea8c70e3",
+        strip_prefix = "rules_apple-2e6a8c625e519b18803c30fbd5e960061cc4c4af",
+        url = "https://github.com/bazelbuild/rules_apple/archive/2e6a8c625e519b18803c30fbd5e960061cc4c4af.tar.gz",
     )
 
     http_archive(


### PR DESCRIPTION
This bumps the bazel version to 6.0.0-pre.20220414.2, which breaks a few of our CI jobs that I'll pin to 5.1.1 as I work on resolving them.

Diff: https://github.com/envoyproxy/envoy/compare/d0befbbb952c979782857bdb986bec562d9a3c2f...aa19a78404e285d5cd219c564a68e67c59484075