### PR TITLE
network: handle no network connectivity state

### DIFF
--- a/library/objective-c/EnvoyNetworkMonitor.m
+++ b/library/objective-c/EnvoyNetworkMonitor.m
@@ -7,7 +7,7 @@
 #import <SystemConfiguration/SystemConfiguration.h>
 #import <netinet/in.h>
 
-static NSString * network_type_description(envoy_network_t network_type) {
+static NSString *network_type_description(envoy_network_t network_type) {
   if (network_type == ENVOY_NET_GENERIC) {
     return @"Generic";
   } else if (network_type == ENVOY_NET_WLAN) {
@@ -111,7 +111,8 @@ static NSString * network_type_description(envoy_network_t network_type) {
   address.sin6_len = sizeof(address);
   address.sin6_family = AF_INET6;
 
-  SCNetworkReachabilityRef reachability = SCNetworkReachabilityCreateWithAddress(nil, (const struct sockaddr *)&address);
+  SCNetworkReachabilityRef reachability =
+      SCNetworkReachabilityCreateWithAddress(nil, (const struct sockaddr *)&address);
   if (!reachability) {
     return;
   }


### PR DESCRIPTION
Signed-off-by: Rafal Augustyniak <raugustyniak@lyft.com>

Description: The original thought behind this PR was for Envoy Mobile to be able to differentiate between "no network connectivity" and wi-fi connectivity cases. This is what dictated changes in `_reachability_callback` method. During testing I noticed that for every transition from "no connection" to "wi-fi connection" I was seeing two updates: first saying that we have wi-fi connectivity and the second one saying that there is not connectivity.

It turned out that this was always the case and my change to remove `if (flags == 0)` from the implementation of `_reachability_callback` just surfaced this issue. After some googling I found https://github.com/ashleymills/Reachability.swift/issues/95#issuecomment-229401474 which seems to provide an explanation for as to why I saw 2 consecutive updates. The issue have been caused by us passing a fake domain to the `SCNetworkReachabilityCreateWithName` method which is why I decided to move to the `SCNetworkReachabilityCreateWithAddress` method instead. That's something that AFNetworking does for cases when it does not have access to a domain - see https://github.com/AFNetworking/AFNetworking/blob/master/AFNetworking/AFNetworkReachabilityManager.m#L150-L153.


Risk Level: medium
Testing: Manual
Docs Changes:
Release Notes:
