### PR TITLE
network: perform post-DNS connection drain on a per-host basis

### DIFF
--- a/library/common/network/configurator.cc
+++ b/library/common/network/configurator.cc
@@ -195,9 +195,8 @@ void Configurator::onDnsResolutionComplete(
     // TODO(goaway): check the set of cached hosts from the last triggered DNS refresh for this
     // host, and if present, remove it and trigger connection drain for this host specifically.
     ENVOY_LOG_EVENT(debug, "netconf_post_dns_drain_cx", host);
-    cluster_manager_.drainConnections([host](const Upstream::Host& host) {
-      return host.hostname() == host;
-    });
+    cluster_manager_.drainConnections(
+        [host](const Upstream::Host& host) { return host.hostname() == host; });
   }
 }
 
@@ -236,8 +235,9 @@ void Configurator::refreshDns(envoy_netconf_t configuration_key, bool drain_conn
     ENVOY_LOG_EVENT(debug, "netconf_refresh_dns", std::to_string(configuration_key));
 
     if (drain_connections && enable_drain_post_dns_refresh_) {
-      dns_cache_->iterateHostMap(
-        [&](absl::string_view host, const DnsHostInfoSharedPtr&) { hosts_to_drain_.emplace(host); });
+      dns_cache_->iterateHostMap([&](absl::string_view host, const DnsHostInfoSharedPtr&) {
+        hosts_to_drain_.emplace(host);
+      });
     }
 
     dns_cache->forceRefreshHosts();

--- a/library/common/network/configurator.cc
+++ b/library/common/network/configurator.cc
@@ -183,8 +183,11 @@ void Configurator::reportNetworkUsage(envoy_netconf_t configuration_key, bool ne
 void Configurator::onDnsResolutionComplete(
     const std::string& host, const Extensions::Common::DynamicForwardProxy::DnsHostInfoSharedPtr&,
     Network::DnsResolver::ResolutionStatus) {
-  if (enable_drain_post_dns_refresh_ && pending_drain_) {
-    pending_drain_ = false;
+  if (enable_drain_post_dns_refresh_) {
+    // Check if the set of hosts pending drain contains the current resolved host.
+    if (hosts_to_drain_.erase(host) == 0) {
+      return;
+    }
 
     // We ignore whether DNS resolution has succeeded here. If it failed, we may be offline and
     // should probably drain connections. If it succeeds, we may have new DNS entries and so we
@@ -192,14 +195,16 @@ void Configurator::onDnsResolutionComplete(
     // TODO(goaway): check the set of cached hosts from the last triggered DNS refresh for this
     // host, and if present, remove it and trigger connection drain for this host specifically.
     ENVOY_LOG_EVENT(debug, "netconf_post_dns_drain_cx", host);
-    cluster_manager_.drainConnections(nullptr);
+    cluster_manager_.drainConnections([host](const Upstream::Host& host) {
+      return host.hostname() == host;
+    });
   }
 }
 
 void Configurator::setDrainPostDnsRefreshEnabled(bool enabled) {
   enable_drain_post_dns_refresh_ = enabled;
   if (!enabled) {
-    pending_drain_ = false;
+    hosts_to_drain_.clear();
   } else if (!dns_callbacks_handle_) {
     // Register callbacks once, on demand, using the handle as a sentinel. There may not be
     // a DNS cache during initialization, but if one is available, it should always exist by the
@@ -229,9 +234,12 @@ void Configurator::refreshDns(envoy_netconf_t configuration_key, bool drain_conn
 
   if (auto dns_cache = dnsCache()) {
     ENVOY_LOG_EVENT(debug, "netconf_refresh_dns", std::to_string(configuration_key));
-    pending_drain_ = drain_connections && enable_drain_post_dns_refresh_;
-    // TODO(goaway): capture the list of currently cached hosts here in a set, to be checked
-    // for draining when DNS resolutions occur.
+
+    if (drain_connections && enable_drain_post_dns_refresh_) {
+      dns_cache_->iterateHostMap(
+        [&](absl::string_view host, const DnsHostInfoSharedPtr&) { hosts_to_drain_.emplace(host); });
+    }
+
     dns_cache->forceRefreshHosts();
   }
 }

--- a/library/common/network/configurator.h
+++ b/library/common/network/configurator.h
@@ -203,7 +203,7 @@ private:
 
   bool enable_drain_post_dns_refresh_{false};
   bool enable_interface_binding_{false};
-  bool pending_drain_{false};
+  absl::flat_hash_set<std::string> hosts_to_drain_;
   Extensions::Common::DynamicForwardProxy::DnsCache::AddUpdateCallbacksHandlePtr
       dns_callbacks_handle_{nullptr};
   Upstream::ClusterManager& cluster_manager_;

--- a/test/common/network/configurator_test.cc
+++ b/test/common/network/configurator_test.cc
@@ -64,13 +64,23 @@ TEST_F(ConfiguratorTest, WhenDrainPostDnsRefreshEnabledDrainsPostDnsRefresh) {
   EXPECT_CALL(*dns_cache_, addUpdateCallbacks_(Ref(*configurator_)));
   configurator_->setDrainPostDnsRefreshEnabled(true);
 
+  auto host_info = std::make_shared<Extensions::Common::DynamicForwardProxy::MockDnsHostInfo>();
+  EXPECT_CALL(*dns_cache_, iterateHostMap(_))
+    .WillOnce(Invoke([&](Extensions::Common::DynamicForwardProxy::DnsCache::IterateHostMapCb callback) {
+      callback("cached.example.com", host_info);
+      callback("cached2.example.com", host_info);
+    }));
+
   EXPECT_CALL(*dns_cache_, forceRefreshHosts());
   envoy_netconf_t configuration_key = configurator_->getConfigurationKey();
   configurator_->refreshDns(configuration_key, true);
 
-  EXPECT_CALL(cm_, drainConnections(_));
+  EXPECT_CALL(cm_, drainConnections(_)).Times(1);
   configurator_->onDnsResolutionComplete(
-      "example.com", std::make_shared<Extensions::Common::DynamicForwardProxy::MockDnsHostInfo>(),
+      "cached.example.com", std::make_shared<Extensions::Common::DynamicForwardProxy::MockDnsHostInfo>(),
+      Network::DnsResolver::ResolutionStatus::Success);
+  configurator_->onDnsResolutionComplete(
+      "not-cached.example.com", std::make_shared<Extensions::Common::DynamicForwardProxy::MockDnsHostInfo>(),
       Network::DnsResolver::ResolutionStatus::Success);
 }
 

--- a/test/common/network/configurator_test.cc
+++ b/test/common/network/configurator_test.cc
@@ -66,21 +66,24 @@ TEST_F(ConfiguratorTest, WhenDrainPostDnsRefreshEnabledDrainsPostDnsRefresh) {
 
   auto host_info = std::make_shared<Extensions::Common::DynamicForwardProxy::MockDnsHostInfo>();
   EXPECT_CALL(*dns_cache_, iterateHostMap(_))
-    .WillOnce(Invoke([&](Extensions::Common::DynamicForwardProxy::DnsCache::IterateHostMapCb callback) {
-      callback("cached.example.com", host_info);
-      callback("cached2.example.com", host_info);
-    }));
+      .WillOnce(
+          Invoke([&](Extensions::Common::DynamicForwardProxy::DnsCache::IterateHostMapCb callback) {
+            callback("cached.example.com", host_info);
+            callback("cached2.example.com", host_info);
+          }));
 
   EXPECT_CALL(*dns_cache_, forceRefreshHosts());
   envoy_netconf_t configuration_key = configurator_->getConfigurationKey();
   configurator_->refreshDns(configuration_key, true);
 
-  EXPECT_CALL(cm_, drainConnections(_)).Times(1);
+  EXPECT_CALL(cm_, drainConnections(_));
   configurator_->onDnsResolutionComplete(
-      "cached.example.com", std::make_shared<Extensions::Common::DynamicForwardProxy::MockDnsHostInfo>(),
+      "cached.example.com",
+      std::make_shared<Extensions::Common::DynamicForwardProxy::MockDnsHostInfo>(),
       Network::DnsResolver::ResolutionStatus::Success);
   configurator_->onDnsResolutionComplete(
-      "not-cached.example.com", std::make_shared<Extensions::Common::DynamicForwardProxy::MockDnsHostInfo>(),
+      "not-cached.example.com",
+      std::make_shared<Extensions::Common::DynamicForwardProxy::MockDnsHostInfo>(),
       Network::DnsResolver::ResolutionStatus::Success);
 }
 


### PR DESCRIPTION
Description: Limits connection draining to be based on specific hosts as each host's DNS resolution occurs following a triggered DNS refresh.
Risk Level: Moderate
Testing: Additional Unit Coverage

Signed-off-by: Mike Schore <mike.schore@gmail.com>