### PR TITLE
network: add enableDrainPostDnsRefresh to swift

### DIFF
--- a/library/objective-c/EnvoyConfiguration.m
+++ b/library/objective-c/EnvoyConfiguration.m
@@ -15,6 +15,7 @@
                            dnsPreresolveHostnames:(NSString *)dnsPreresolveHostnames
                               enableHappyEyeballs:(BOOL)enableHappyEyeballs
                            enableInterfaceBinding:(BOOL)enableInterfaceBinding
+                        enableDrainPostDnsRefresh:(BOOL)enableDrainPostDnsRefresh
                     enforceTrustChainVerification:(BOOL)enforceTrustChainVerification
     h2ConnectionKeepaliveIdleIntervalMilliseconds:
         (UInt32)h2ConnectionKeepaliveIdleIntervalMilliseconds
@@ -53,6 +54,7 @@
   self.dnsPreresolveHostnames = dnsPreresolveHostnames;
   self.enableHappyEyeballs = enableHappyEyeballs;
   self.enableInterfaceBinding = enableInterfaceBinding;
+  self.enableDrainPostDnsRefresh = enableDrainPostDnsRefresh;
   self.enforceTrustChainVerification = enforceTrustChainVerification;
   self.h2ConnectionKeepaliveIdleIntervalMilliseconds =
       h2ConnectionKeepaliveIdleIntervalMilliseconds;
@@ -149,6 +151,8 @@
                             self.h2ExtendKeepaliveTimeout ? @"true" : @"false"];
   [definitions appendFormat:@"- &dns_refresh_rate %lus\n", (unsigned long)self.dnsRefreshSeconds];
   [definitions appendFormat:@"- &dns_resolver_name envoy.network.dns_resolver.apple\n"];
+  [definitions appendFormat:@"- &enable_drain_post_dns_refresh %@\n",
+                            self.enableDrainPostDnsRefresh ? "true" : "false"];
   // No additional values are currently needed for Apple-based DNS resolver.
   [definitions
       appendFormat:@"- &dns_resolver_config "

--- a/library/swift/EngineBuilder.swift
+++ b/library/swift/EngineBuilder.swift
@@ -25,6 +25,7 @@ open class EngineBuilder: NSObject {
   private var enableHappyEyeballs: Bool = false
   private var enableInterfaceBinding: Bool = false
   private var enforceTrustChainVerification: Bool = true
+  private var enableDrainPostDnsRefresh: Bool = false
   private var h2ConnectionKeepaliveIdleIntervalMilliseconds: UInt32 = 100000000
   private var h2ConnectionKeepaliveTimeoutSeconds: UInt32 = 10
   private var h2ExtendKeepaliveTimeout: Bool = false
@@ -173,6 +174,21 @@ open class EngineBuilder: NSObject {
   @discardableResult
   public func enableInterfaceBinding(_ enableInterfaceBinding: Bool) -> Self {
     self.enableInterfaceBinding = enableInterfaceBinding
+    return self
+  }
+
+  /// Specify whether to drain connections after the resolution of a soft DNS refresh. A refresh may
+  /// be triggered directly via the Engine API, or as a result of a network status update provided by
+  /// the OS. Draining connections does not interrupt existing connections or requests, but will
+  /// establish new connections for any further requests.
+  ///
+  /// - parameter enableDrainPostDnsRefresh: whether to drain connections after soft DNS refresh.
+  ///
+  /// - returns: This builder.
+  ///
+  @discardableResult
+  public func enableDrainPostDnsRefresh(_ enableDrainPostDnsRefresh: Bool) -> Self {
+    self.enableDrainPostDnsRefresh = enableDrainPostDnsRefresh
     return self
   }
 
@@ -441,6 +457,7 @@ open class EngineBuilder: NSObject {
       dnsPreresolveHostnames: self.dnsPreresolveHostnames,
       enableHappyEyeballs: self.enableHappyEyeballs,
       enableInterfaceBinding: self.enableInterfaceBinding,
+      enableDrainPostDnsRefresh: self.enableDrainPostDnsRefresh,
       enforceTrustChainVerification: self.enforceTrustChainVerification,
       h2ConnectionKeepaliveIdleIntervalMilliseconds:
         self.h2ConnectionKeepaliveIdleIntervalMilliseconds,

--- a/test/swift/EngineBuilderTests.swift
+++ b/test/swift/EngineBuilderTests.swift
@@ -431,6 +431,7 @@ final class EngineBuilderTests: XCTestCase {
       dnsPreresolveHostnames: "[test]",
       enableHappyEyeballs: true,
       enableInterfaceBinding: true,
+      enableDrainPostDnsRefresh: false,
       enforceTrustChainVerification: false,
       h2ConnectionKeepaliveIdleIntervalMilliseconds: 1,
       h2ConnectionKeepaliveTimeoutSeconds: 333,
@@ -465,6 +466,7 @@ final class EngineBuilderTests: XCTestCase {
     XCTAssertTrue(resolvedYAML.contains("&dns_multiple_addresses true"))
     XCTAssertTrue(resolvedYAML.contains("&enable_interface_binding true"))
     XCTAssertTrue(resolvedYAML.contains("&trust_chain_verification ACCEPT_UNTRUSTED"))
+    XCTAssertTrue(resolvedYAML.contains("&enable_drain_post_dns_refresh false"))
 
     // HTTP/2
     XCTAssertTrue(resolvedYAML.contains("&h2_connection_keepalive_idle_interval 0.001s"))
@@ -509,6 +511,7 @@ final class EngineBuilderTests: XCTestCase {
       dnsPreresolveHostnames: "[test]",
       enableHappyEyeballs: false,
       enableInterfaceBinding: false,
+      enableDrainPostDnsRefresh: true,
       enforceTrustChainVerification: true,
       h2ConnectionKeepaliveIdleIntervalMilliseconds: 1,
       h2ConnectionKeepaliveTimeoutSeconds: 333,
@@ -537,6 +540,7 @@ final class EngineBuilderTests: XCTestCase {
     XCTAssertTrue(resolvedYAML.contains("&enable_interface_binding false"))
     XCTAssertTrue(resolvedYAML.contains("&trust_chain_verification VERIFY_TRUST_CHAIN"))
     XCTAssertTrue(resolvedYAML.contains("&h2_delay_keepalive_timeout false"))
+    XCTAssertTrue(resolvedYAML.contains("&enable_drain_post_dns_refresh true"))
   }
 
   func testReturnsNilWhenUnresolvedValueInTemplate() {


### PR DESCRIPTION
Signed-off-by: Rafal Augustyniak <raugustyniak@lyft.com>

Description: Expose an option to enable connections draining post dns refresh on iOS builder. This change was accidentally not implemented as part of https://github.com/envoyproxy/envoy-mobile/pull/2225
Risk Level: Low, addition of a new functionality.
Testing: Unit
Docs Changes:
Release Notes:
[Optional Fixes #Issue]
[Optional Deprecated:]
