### PR TITLE
Remove bintray as a maven source

### DIFF
--- a/bazel/envoy_mobile_dependencies.bzl
+++ b/bazel/envoy_mobile_dependencies.bzl
@@ -93,7 +93,6 @@ def kotlin_dependencies(extra_maven_dependencies = []):
         version_conflict_policy = "pinned",
         repositories = [
             "https://repo1.maven.org/maven2",
-            "https://jcenter.bintray.com/",
             "https://maven.google.com",
         ],
     )


### PR DESCRIPTION
Bintray has been deprecated and should be removed as a source.


Signed-off-by: ben@ben.cm