### PR TITLE
CancelProofEnvoyStream

### DIFF
--- a/library/java/org/chromium/net/impl/BUILD
+++ b/library/java/org/chromium/net/impl/BUILD
@@ -13,6 +13,7 @@ android_library(
         "AtomicCombinatoryState.java",
         "BidirectionalStreamBuilderImpl.java",
         "CallbackExceptionImpl.java",
+        "CancelProofEnvoyStream.java",
         "CronetEngineBase.java",
         "CronetEngineBuilderImpl.java",
         "CronetExceptionImpl.java",

--- a/library/java/org/chromium/net/impl/CancelProofEnvoyStream.java
+++ b/library/java/org/chromium/net/impl/CancelProofEnvoyStream.java
@@ -1,0 +1,143 @@
+package org.chromium.net.impl;
+
+import java.nio.ByteBuffer;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.atomic.AtomicInteger;
+import io.envoyproxy.envoymobile.engine.EnvoyHTTPStream;
+
+/**
+ * CancelProofEnvoyStream is a consistency layer above the {@link EnvoyHTTPStream} preventing
+ * unwarranted Stream operations after a "cancel" operation. There are no "synchronized" - this is
+ * Compare And Swap based logic. This class is Thread Safe.
+ *
+ * <p>This contraption ensures that once a "cancel" operation is invoked, there will be no further
+ * operations allowed with the EnvoyHTTPStream - subsequent operations will be ignored silently.
+ * However, in the event that that one or more EnvoyHTTPStream operations are currently being
+ * executed, the "cancel" operation gets postponed: the last concurrent operation will invoke
+ * "cancel" at the end.
+ *
+ * <p>Instances of this class start with a state of "Busy Starting". This ensure that if a cancel
+ * is invoked while the stream is being created, that cancel will be executed only once the stream
+ * is completely initialized. Doing otherwise leads to unpredictable outcomes.
+ */
+final class CancelProofEnvoyStream {
+
+  private static final int CANCEL_BIT = 0x8000;
+  /**
+   * Mainly maintains a counter of how many Stream operations are currently in-flight. However when
+   * bit 15 (0x8000) is set, it indicates that the cancel operation has been requested. If the
+   * counter is greater than 0, then that "cancel" operation is postponed until the last in-flight
+   * operation finishes, i.e. then the counter is back to 0. Then that last operation also invokes
+   * "cancel". On the other hand, if the counter is already 0 when invoking "cancel", then it means
+   * that there are no in-flight operations: the "cancel" operation is immediately executed. Once
+   * the state is "canceled", any new stream operation is silently ignored.
+   */
+  private final AtomicInteger mConcurrentInvocationCount = new AtomicInteger();
+  private volatile EnvoyHTTPStream mStream; // Cancel can come from any Thread.
+
+  /**
+   * The "mConcurrentInvocationCount" does not start with "zero" - this is on purpose. At this
+   * stage, the Stream is considered to be in its initialization/starting phase. That phase ends
+   * when mStream is set: {@link #setStream}. This way, if "cancel" gets called before the
+   * {@link #setStream} method, then the intent is recorded, and the effect will be delivered
+   * when {@link #setStream} will be invoked.
+   */
+  CancelProofEnvoyStream() { mConcurrentInvocationCount.set(1); }
+
+  /** Sets the stream. Can only be invoked once. */
+  void setStream(EnvoyHTTPStream stream) {
+    // "if (returnTrueIfCanceledOrIncreaseConcurrentlyRunningStreamOperations()) { ..."
+    // is not called here - see the Constructor's comment.
+    assert mStream == null;
+    mStream = stream;
+    if (decreaseConcurrentlyRunningStreamOperationsAndReturnTrueIfAwaitingCancel()) {
+      mStream.cancel(); // Cancel was called meanwhile, so now this is honored.
+    }
+  }
+
+  /** Initiates the sending of the request headers if the state permits. */
+  void sendHeaders(Map<String, List<String>> envoyRequestHeaders, boolean endStream) {
+    if (returnTrueIfCanceledOrIncreaseConcurrentlyRunningStreamOperations()) {
+      return; // Already Cancelled - to late to send something.
+    }
+    mStream.sendHeaders(envoyRequestHeaders, endStream);
+    if (decreaseConcurrentlyRunningStreamOperationsAndReturnTrueIfAwaitingCancel()) {
+      mStream.cancel(); // Cancel was called previously, so now this is honored.
+    }
+  }
+
+  /** Initiates the sending of one chunk of the request body if the state permits. */
+  void sendData(ByteBuffer buffer, boolean finalChunk) {
+    if (returnTrueIfCanceledOrIncreaseConcurrentlyRunningStreamOperations()) {
+      return; // Already Cancelled - to late to send something.
+    }
+    // The Envoy Mobile library only cares about the capacity - must use the correct ByteBuffer
+    if (buffer.position() == 0) {
+      mStream.sendData(buffer, buffer.remaining(), finalChunk);
+    } else {
+      ByteBuffer resizedBuffer = ByteBuffer.allocateDirect(buffer.remaining());
+      buffer.mark();
+      resizedBuffer.put(buffer);
+      buffer.reset();
+      mStream.sendData(resizedBuffer, finalChunk);
+    }
+    if (decreaseConcurrentlyRunningStreamOperationsAndReturnTrueIfAwaitingCancel()) {
+      mStream.cancel(); // Cancel was called previously, so now this is honored.
+    }
+  }
+
+  /** Initiates the reading of one chunk of the the request body if the state permits. */
+  void readData(int size) {
+    if (returnTrueIfCanceledOrIncreaseConcurrentlyRunningStreamOperations()) {
+      return; // Already Cancelled - to late to read something.
+    }
+    mStream.readData(size);
+    if (decreaseConcurrentlyRunningStreamOperationsAndReturnTrueIfAwaitingCancel()) {
+      mStream.cancel(); // Cancel was called previously, so now this is honored.
+    }
+  }
+
+  /**
+   * Cancels the Stream if the state permits. Will be delayed when an operation is concurrently
+   * running. Idempotent and Thread Safe.
+   */
+  void cancel() {
+    // With "Compare And Swap", the contract is the mutation succeeds only if the original value
+    // matches the expected one - this is atomic at the assembly language level: most CPUs have
+    // dedicated mnemonics for this operation - extremely efficient. And this might look like an
+    // infinite loop. There is always one Thread that will succeed - the others may/will loop, and
+    // so forth. "Compare And Swap" maybe bad under heavy contention - in that case it is probably
+    // better to go with "synchronized" blocks. In our case, there is none or very little
+    // contention. What matters is correctness and efficiency.
+    while (true) {
+      int count = mConcurrentInvocationCount.get();
+      if ((count & CANCEL_BIT) != 0) {
+        return; // Cancel already invoked.
+      }
+      if (mConcurrentInvocationCount.compareAndSet(count, count | CANCEL_BIT)) {
+        if (count == 0) {
+          mStream.cancel(); // Was not busy with other EM operations - cancel right now.
+        }
+        return;
+      }
+    }
+  }
+
+  private boolean returnTrueIfCanceledOrIncreaseConcurrentlyRunningStreamOperations() {
+    while (true) {
+      int count = mConcurrentInvocationCount.get();
+      if ((count & CANCEL_BIT) != 0) {
+        return true; // Already canceled
+      }
+      if (mConcurrentInvocationCount.compareAndSet(count, count + 1)) {
+        return false;
+      }
+    }
+  }
+
+  private boolean decreaseConcurrentlyRunningStreamOperationsAndReturnTrueIfAwaitingCancel() {
+    // Only true if the count is back to zero and the cancel bit is set.
+    return mConcurrentInvocationCount.decrementAndGet() == CANCEL_BIT;
+  }
+}

--- a/test/java/org/chromium/net/impl/BUILD
+++ b/test/java/org/chromium/net/impl/BUILD
@@ -9,6 +9,7 @@ envoy_mobile_android_test(
     name = "cronvoy_test",
     srcs = [
         "AtomicCombinatoryStateTest.java",
+        "CancelProofEnvoyStreamTest.java",
         "CronvoyEngineTest.java",
         "UrlRequestCallbackTester.java",
     ],

--- a/test/java/org/chromium/net/impl/CancelProofEnvoyStreamTest.java
+++ b/test/java/org/chromium/net/impl/CancelProofEnvoyStreamTest.java
@@ -1,0 +1,403 @@
+package org.chromium.net.impl;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import androidx.test.ext.junit.runners.AndroidJUnit4;
+
+import org.chromium.net.testing.ConditionVariable;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import java.nio.ByteBuffer;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicReference;
+
+import io.envoyproxy.envoymobile.engine.EnvoyHTTPStream;
+
+@RunWith(AndroidJUnit4.class)
+public class CancelProofEnvoyStreamTest {
+
+  private static final ByteBuffer BYTE_BUFFER = ByteBuffer.allocateDirect(1);
+  private static final HashMap<String, List<String>> HEADERS = new HashMap<>();
+
+  private final ConditionVariable mSendHeadersBlock = new ConditionVariable();
+  private final ConditionVariable mSendDataBlock = new ConditionVariable();
+  private final ConditionVariable mReadDataBlock = new ConditionVariable();
+  private final AtomicInteger mSendHeadersInvocationCount = new AtomicInteger();
+  private final AtomicInteger mSendDataInvocationCount = new AtomicInteger();
+  private final AtomicInteger mReadDataInvocationCount = new AtomicInteger();
+  private final AtomicInteger mCancelInvocationCount = new AtomicInteger();
+  private final AtomicReference<ByteBuffer> mByteBufferSent = new AtomicReference<>();
+  private final MockedStream mMockedStream = new MockedStream();
+  private CountDownLatch mStartLatch = new CountDownLatch(0); // By default no latch.
+
+  private final CancelProofEnvoyStream cancelProofEnvoyStream = new CancelProofEnvoyStream();
+
+  @Before
+  public void setUp() {
+    // By default MockStream's methods are not blocking.
+    mSendHeadersBlock.open();
+    mSendDataBlock.open();
+    mReadDataBlock.open();
+  }
+
+  @After
+  public void tearDown() {
+    // For the cases where a Thread is being blocked.
+    mSendHeadersBlock.open();
+    mSendDataBlock.open();
+    mReadDataBlock.open();
+  }
+
+  @Test
+  public void setStream() {
+    cancelProofEnvoyStream.setStream(mMockedStream);
+
+    assertThat(mCancelInvocationCount.get()).isZero();
+  }
+
+  @Test
+  public void setStream_twice() {
+    cancelProofEnvoyStream.setStream(mMockedStream);
+
+    assertThatThrownBy(() -> cancelProofEnvoyStream.setStream(mMockedStream))
+        .isInstanceOf(AssertionError.class);
+  }
+
+  @Test
+  public void sendHeaders() {
+    cancelProofEnvoyStream.setStream(mMockedStream);
+
+    cancelProofEnvoyStream.sendHeaders(HEADERS, false);
+
+    assertThat(mSendHeadersInvocationCount.get()).isOne();
+    assertThat(mCancelInvocationCount.get()).isZero();
+  }
+
+  @Test
+  public void sendHeaders_withoutStreamSet() {
+    assertThatThrownBy(() -> cancelProofEnvoyStream.sendHeaders(HEADERS, false))
+        .isInstanceOf(NullPointerException.class);
+  }
+
+  @Test
+  public void sendHeaders_afterCancel() {
+    cancelProofEnvoyStream.setStream(mMockedStream);
+    cancelProofEnvoyStream.cancel();
+
+    cancelProofEnvoyStream.sendHeaders(HEADERS, false);
+
+    assertThat(mSendHeadersInvocationCount.get()).isZero();
+    assertThat(mCancelInvocationCount.get()).isOne();
+  }
+
+  @Test
+  public void sendHeaders_canceledBeforeSettingStream() {
+    cancelProofEnvoyStream.cancel();
+    cancelProofEnvoyStream.setStream(mMockedStream);
+
+    cancelProofEnvoyStream.sendHeaders(HEADERS, false);
+
+    assertThat(mSendHeadersInvocationCount.get()).isZero();
+    assertThat(mCancelInvocationCount.get()).isOne();
+  }
+
+  @Test
+  public void sendHeaders_postponedCancelGetsExecutedToo() throws Exception {
+    cancelProofEnvoyStream.setStream(mMockedStream);
+    mSendHeadersBlock.close(); // Following Thread will block on executing sendHeaders
+    Thread thread = new Thread(() -> cancelProofEnvoyStream.sendHeaders(HEADERS, false));
+    thread.start();
+    mStartLatch = new CountDownLatch(1); // Only one method to wait for.
+    mStartLatch.await(); // Wait for the above Thread to enter the sendHeaders method.
+    cancelProofEnvoyStream.cancel();
+    mSendHeadersBlock.open();
+    thread.join(); // Wait for the Thread to die.
+
+    assertThat(mSendHeadersInvocationCount.get()).isOne();
+    assertThat(mCancelInvocationCount.get()).isOne();
+  }
+
+  @Test
+  public void sendData() {
+    cancelProofEnvoyStream.setStream(mMockedStream);
+
+    cancelProofEnvoyStream.sendData(BYTE_BUFFER, false);
+
+    assertThat(mSendDataInvocationCount.get()).isOne();
+    assertThat(mCancelInvocationCount.get()).isZero();
+  }
+
+  @Test
+  public void sendData_withoutStreamSet() {
+    assertThatThrownBy(() -> cancelProofEnvoyStream.sendData(BYTE_BUFFER, false))
+        .isInstanceOf(NullPointerException.class);
+  }
+
+  @Test
+  public void sendData_afterCancel() {
+    cancelProofEnvoyStream.setStream(mMockedStream);
+    cancelProofEnvoyStream.cancel();
+
+    cancelProofEnvoyStream.sendData(BYTE_BUFFER, false);
+
+    assertThat(mSendDataInvocationCount.get()).isZero();
+    assertThat(mCancelInvocationCount.get()).isOne();
+  }
+
+  @Test
+  public void sendData_canceledBeforeSettingStream() {
+    cancelProofEnvoyStream.cancel();
+    cancelProofEnvoyStream.setStream(mMockedStream);
+
+    cancelProofEnvoyStream.sendData(BYTE_BUFFER, false);
+
+    assertThat(mSendDataInvocationCount.get()).isZero();
+    assertThat(mCancelInvocationCount.get()).isOne();
+  }
+
+  @Test
+  public void sendData_postponedCancelGetsExecutedToo() throws Exception {
+    cancelProofEnvoyStream.setStream(mMockedStream);
+    mSendDataBlock.close(); // Following Thread will block on executing sendData
+    Thread thread = new Thread(() -> cancelProofEnvoyStream.sendData(BYTE_BUFFER, false));
+    thread.start();
+    mStartLatch = new CountDownLatch(1); // Only one method to wait for.
+    mStartLatch.await();                 // Wait for the above Thread to enter the sendData method.
+    cancelProofEnvoyStream.cancel();
+    mSendDataBlock.open();
+    thread.join(); // Wait for the Thread to die.
+
+    assertThat(mSendDataInvocationCount.get()).isOne();
+    assertThat(mCancelInvocationCount.get()).isOne();
+  }
+
+  @Test
+  public void readData() {
+    cancelProofEnvoyStream.setStream(mMockedStream);
+
+    cancelProofEnvoyStream.readData(1);
+
+    assertThat(mReadDataInvocationCount.get()).isOne();
+    assertThat(mCancelInvocationCount.get()).isZero();
+  }
+
+  @Test
+  public void readData_withoutStreamSet() {
+    assertThatThrownBy(() -> cancelProofEnvoyStream.readData(1))
+        .isInstanceOf(NullPointerException.class);
+  }
+
+  @Test
+  public void readData_afterCancel() {
+    cancelProofEnvoyStream.setStream(mMockedStream);
+    cancelProofEnvoyStream.cancel();
+
+    cancelProofEnvoyStream.readData(1);
+
+    assertThat(mReadDataInvocationCount.get()).isZero();
+    assertThat(mCancelInvocationCount.get()).isOne();
+  }
+
+  @Test
+  public void readData_canceledBeforeSettingStream() {
+    cancelProofEnvoyStream.cancel();
+    cancelProofEnvoyStream.setStream(mMockedStream);
+
+    cancelProofEnvoyStream.readData(1);
+
+    assertThat(mReadDataInvocationCount.get()).isZero();
+    assertThat(mCancelInvocationCount.get()).isOne();
+  }
+
+  @Test
+  public void readData_postponedCancelGetsExecutedToo() throws Exception {
+    cancelProofEnvoyStream.setStream(mMockedStream);
+    mReadDataBlock.close(); // Following Thread will block on executing readData
+    Thread thread = new Thread(() -> cancelProofEnvoyStream.readData(1));
+    thread.start();
+    mStartLatch = new CountDownLatch(1); // Only one method to wait for.
+    mStartLatch.await();                 // Wait for the above Thread to enter the readData method.
+    cancelProofEnvoyStream.cancel();
+    mReadDataBlock.open();
+    thread.join(); // Wait for the Thread to die.
+
+    assertThat(mReadDataInvocationCount.get()).isOne();
+    assertThat(mCancelInvocationCount.get()).isOne();
+  }
+
+  @Test
+  public void cancel() {
+    cancelProofEnvoyStream.setStream(mMockedStream);
+
+    cancelProofEnvoyStream.cancel();
+
+    assertThat(mCancelInvocationCount.get()).isOne();
+  }
+
+  @Test
+  public void cancel_twice_executedOnlyOnce() {
+    cancelProofEnvoyStream.setStream(mMockedStream);
+
+    cancelProofEnvoyStream.cancel();
+    cancelProofEnvoyStream.cancel();
+
+    assertThat(mCancelInvocationCount.get()).isOne();
+  }
+
+  @Test
+  public void cancel_manyConcurrentThreads_executedOnlyOnce() throws Exception {
+    cancelProofEnvoyStream.setStream(mMockedStream);
+    Thread[] threads = new Thread[100];
+    for (int i = 0; i < threads.length; i++) {
+      threads[i] = new Thread(cancelProofEnvoyStream::cancel);
+    }
+    for (Thread thread : threads) {
+      thread.start();
+    }
+    // Wait for all the Threads to die.
+    for (Thread thread : threads) {
+      thread.join();
+    }
+
+    assertThat(mCancelInvocationCount.get()).isOne();
+  }
+
+  @Test
+  public void cancel_withoutStreamSet() {
+    // Does nothing because the "Concurrently Running Stream Operations Count" starts with "1".
+    // This is the desired outcome - the cancel is postponed. Once the stream is set, the next
+    // Stream Operation will invoke "cancel".
+    cancelProofEnvoyStream.cancel();
+  }
+
+  @Test
+  public void cancel_whileSendHeadersIsExecuting_cancelGetsPostponed() throws Exception {
+    cancelProofEnvoyStream.setStream(mMockedStream);
+    mSendHeadersBlock.close(); // Following Thread will block on executing sendHeaders
+    new Thread(() -> cancelProofEnvoyStream.sendHeaders(HEADERS, false)).start();
+    mStartLatch = new CountDownLatch(1); // Only one method to wait for.
+    mStartLatch.await(); // Wait for the above Thread to enter the sendHeaders method.
+
+    cancelProofEnvoyStream.cancel();
+
+    assertThat(mSendHeadersInvocationCount.get()).isOne();
+    assertThat(mCancelInvocationCount.get()).isZero();
+  }
+
+  @Test
+  public void cancel_whileSendDataIsExecuting_cancelGetsPostponed() throws Exception {
+    cancelProofEnvoyStream.setStream(mMockedStream);
+    mSendDataBlock.close(); // Following Thread will block on executing sendData
+    new Thread(() -> cancelProofEnvoyStream.sendData(BYTE_BUFFER, false)).start();
+    mStartLatch = new CountDownLatch(1); // Only one method to wait for.
+    mStartLatch.await();                 // Wait for the above Thread to enter the sendData method.
+
+    cancelProofEnvoyStream.cancel();
+
+    assertThat(mSendDataInvocationCount.get()).isOne();
+    assertThat(mCancelInvocationCount.get()).isZero();
+  }
+
+  @Test
+  public void cancel_whileReadDataIsExecuting_cancelGetsPostponed() throws Exception {
+    cancelProofEnvoyStream.setStream(mMockedStream);
+    mReadDataBlock.close(); // Following Thread will block on executing readData
+    new Thread(() -> cancelProofEnvoyStream.readData(1)).start();
+    mStartLatch = new CountDownLatch(1); // Only one method to wait for.
+    mStartLatch.await();                 // Wait for the above Thread to enter the readData method.
+
+    cancelProofEnvoyStream.cancel();
+
+    assertThat(mReadDataInvocationCount.get()).isOne();
+    assertThat(mCancelInvocationCount.get()).isZero();
+  }
+
+  @Test
+  public void cancel_manyConcurrentStreamOperationsInFlight() throws Exception {
+    cancelProofEnvoyStream.setStream(mMockedStream);
+    Thread[] threads = new Thread[300];
+    AtomicInteger count = new AtomicInteger();
+    for (int i = 0; i < threads.length; i++) {
+      threads[i] = new Thread(() -> {
+        switch (count.getAndIncrement() % 3) {
+          case 0:
+            cancelProofEnvoyStream.sendHeaders(HEADERS, false);
+            break;
+          case 1:
+            cancelProofEnvoyStream.sendData(BYTE_BUFFER, false);
+            break;
+          case 2:
+            cancelProofEnvoyStream.readData(1);
+            break;
+        }
+      });
+    }
+    // Every Thread will be blocked while executing one of the cancelProofEnvoyStream's method.
+    mSendHeadersBlock.close();
+    mSendDataBlock.close();
+    mReadDataBlock.close();
+    mStartLatch = new CountDownLatch(threads.length);
+    for (Thread thread : threads) {
+      thread.start();
+    }
+    mStartLatch.await(); // Wait for all Thread to reach the blocking point.
+    // Sanity check
+    assertThat(mSendHeadersInvocationCount.get()).isEqualTo(threads.length / 3);
+    assertThat(mSendDataInvocationCount.get()).isEqualTo(threads.length / 3);
+    assertThat(mReadDataInvocationCount.get()).isEqualTo(threads.length / 3);
+
+    cancelProofEnvoyStream.cancel();
+    assertThat(mCancelInvocationCount.get()).isZero();
+
+    // Let all the Threads to finish executing the cancelProofEnvoyStream's methods.
+    mSendHeadersBlock.open();
+    mSendDataBlock.open();
+    mReadDataBlock.open();
+    // Wait for all the Threads to die.
+    for (Thread thread : threads) {
+      thread.join();
+    }
+    assertThat(mCancelInvocationCount.get()).isOne();
+  }
+
+  private class MockedStream extends EnvoyHTTPStream {
+
+    private MockedStream() { super(0, 0, null, false); }
+
+    @Override
+    public void sendHeaders(Map<String, List<String>> headers, boolean endStream) {
+      mSendHeadersInvocationCount.incrementAndGet();
+      mStartLatch.countDown();
+      mSendHeadersBlock.block();
+    }
+
+    @Override
+    public void sendData(ByteBuffer data, int length, boolean endStream) {
+      mByteBufferSent.set(data);
+      mSendDataInvocationCount.incrementAndGet();
+      mStartLatch.countDown();
+      mSendDataBlock.block();
+    }
+
+    @Override
+    public void readData(long byteCount) {
+      mReadDataInvocationCount.incrementAndGet();
+      mStartLatch.countDown();
+      mReadDataBlock.block();
+    }
+
+    @Override
+    public int cancel() {
+      mCancelInvocationCount.incrementAndGet();
+      return 0;
+    }
+  }
+}

--- a/test/java/org/chromium/net/impl/CancelProofEnvoyStreamTest.java
+++ b/test/java/org/chromium/net/impl/CancelProofEnvoyStreamTest.java
@@ -64,6 +64,15 @@ public class CancelProofEnvoyStreamTest {
   }
 
   @Test
+  public void setStream_afterCancel() {
+    cancelProofEnvoyStream.cancel();
+
+    cancelProofEnvoyStream.setStream(mMockedStream);
+
+    assertThat(mCancelInvocationCount.get()).isOne();
+  }
+
+  @Test
   public void setStream_twice() {
     cancelProofEnvoyStream.setStream(mMockedStream);
 
@@ -91,17 +100,6 @@ public class CancelProofEnvoyStreamTest {
   public void sendHeaders_afterCancel() {
     cancelProofEnvoyStream.setStream(mMockedStream);
     cancelProofEnvoyStream.cancel();
-
-    cancelProofEnvoyStream.sendHeaders(HEADERS, false);
-
-    assertThat(mSendHeadersInvocationCount.get()).isZero();
-    assertThat(mCancelInvocationCount.get()).isOne();
-  }
-
-  @Test
-  public void sendHeaders_canceledBeforeSettingStream() {
-    cancelProofEnvoyStream.cancel();
-    cancelProofEnvoyStream.setStream(mMockedStream);
 
     cancelProofEnvoyStream.sendHeaders(HEADERS, false);
 
@@ -153,17 +151,6 @@ public class CancelProofEnvoyStreamTest {
   }
 
   @Test
-  public void sendData_canceledBeforeSettingStream() {
-    cancelProofEnvoyStream.cancel();
-    cancelProofEnvoyStream.setStream(mMockedStream);
-
-    cancelProofEnvoyStream.sendData(BYTE_BUFFER, false);
-
-    assertThat(mSendDataInvocationCount.get()).isZero();
-    assertThat(mCancelInvocationCount.get()).isOne();
-  }
-
-  @Test
   public void sendData_postponedCancelGetsExecutedToo() throws Exception {
     cancelProofEnvoyStream.setStream(mMockedStream);
     mSendDataBlock.close(); // Following Thread will block on executing sendData
@@ -199,17 +186,6 @@ public class CancelProofEnvoyStreamTest {
   public void readData_afterCancel() {
     cancelProofEnvoyStream.setStream(mMockedStream);
     cancelProofEnvoyStream.cancel();
-
-    cancelProofEnvoyStream.readData(1);
-
-    assertThat(mReadDataInvocationCount.get()).isZero();
-    assertThat(mCancelInvocationCount.get()).isOne();
-  }
-
-  @Test
-  public void readData_canceledBeforeSettingStream() {
-    cancelProofEnvoyStream.cancel();
-    cancelProofEnvoyStream.setStream(mMockedStream);
 
     cancelProofEnvoyStream.readData(1);
 
@@ -328,15 +304,15 @@ public class CancelProofEnvoyStreamTest {
     for (int i = 0; i < threads.length; i++) {
       threads[i] = new Thread(() -> {
         switch (count.getAndIncrement() % 3) {
-          case 0:
-            cancelProofEnvoyStream.sendHeaders(HEADERS, false);
-            break;
-          case 1:
-            cancelProofEnvoyStream.sendData(BYTE_BUFFER, false);
-            break;
-          case 2:
-            cancelProofEnvoyStream.readData(1);
-            break;
+        case 0:
+          cancelProofEnvoyStream.sendHeaders(HEADERS, false);
+          break;
+        case 1:
+          cancelProofEnvoyStream.sendData(BYTE_BUFFER, false);
+          break;
+        case 2:
+          cancelProofEnvoyStream.readData(1);
+          break;
         }
       });
     }


### PR DESCRIPTION
Description: Wrapper for the EnvoyStream guaranteeing that a another stream method can't be called after a "cancel"
Risk Level: None - Cronvoy only
Testing: CI
Docs Changes: N/A
Release Notes: N/A
Signed-off-by: Charles Le Borgne <cleborgne@google.com>
