### PR TITLE
jni: fix mismatched return value types

### DIFF
--- a/library/common/jni/jni_interface.cc
+++ b/library/common/jni/jni_interface.cc
@@ -1015,12 +1015,12 @@ Java_io_envoyproxy_envoymobile_engine_JniLibrary_registerStringAccessor(JNIEnv* 
   return result;
 }
 
-extern "C" JNIEXPORT void JNICALL
+extern "C" JNIEXPORT int JNICALL
 Java_io_envoyproxy_envoymobile_engine_JniLibrary_resetConnectivityState(JNIEnv* env,
                                                                         jclass, // class
                                                                         jlong engine) {
   jni_log("[Envoy]", "resetConnectivityState");
-  reset_connectivity_state(engine);
+  return reset_connectivity_state(engine);
 }
 
 extern "C" JNIEXPORT jint JNICALL

--- a/library/common/jni/jni_interface.cc
+++ b/library/common/jni/jni_interface.cc
@@ -1015,7 +1015,7 @@ Java_io_envoyproxy_envoymobile_engine_JniLibrary_registerStringAccessor(JNIEnv* 
   return result;
 }
 
-extern "C" JNIEXPORT int JNICALL
+extern "C" JNIEXPORT jint JNICALL
 Java_io_envoyproxy_envoymobile_engine_JniLibrary_resetConnectivityState(JNIEnv* env,
                                                                         jclass, // class
                                                                         jlong engine) {


### PR DESCRIPTION
The Java side expects an `int` return value: https://github.com/envoyproxy/envoy-mobile/blob/c930fec015c363e2a6db56f93635beddba19fa5f/library/java/io/envoyproxy/envoymobile/engine/JniLibrary.java#L323

Risk Level: Low