### PR TITLE
Upgrade CI to Zulu JDK 11

### DIFF
--- a/.github/workflows/android_build.yml
+++ b/.github/workflows/android_build.yml
@@ -24,11 +24,11 @@ jobs:
       - run: echo "Found envoy.aar from previous run!"
         if: steps.check-cache.outputs.cache-hit == 'true'
         name: 'Build cache hit'
-      - uses: actions/setup-java@v1
+      - uses: actions/setup-java@v3
         if: steps.check-cache.outputs.cache-hit != 'true'
         with:
-          java-version: '8'
-          java-package: jdk
+          java-version: '11'
+          distribution: 'zulu'
           architecture: x64
       - name: 'Install dependencies'
         if: steps.check-cache.outputs.cache-hit != 'true'
@@ -52,10 +52,10 @@ jobs:
       - uses: actions/checkout@v1
         with:
           submodules: true
-      - uses: actions/setup-java@v1
+      - uses: actions/setup-java@v3
         with:
-          java-version: '8'
-          java-package: jdk
+          java-version: '11'
+          distribution: 'zulu'
           architecture: x64
       - run: ./ci/mac_ci_setup.sh --android
         name: 'Install dependencies'
@@ -94,10 +94,10 @@ jobs:
       - uses: actions/checkout@v1
         with:
           submodules: true
-      - uses: actions/setup-java@v1
+      - uses: actions/setup-java@v3
         with:
-          java-version: '8'
-          java-package: jdk
+          java-version: '11'
+          distribution: 'zulu'
           architecture: x64
       - name: 'Install dependencies'
         run: ./ci/mac_ci_setup.sh
@@ -137,10 +137,10 @@ jobs:
       - uses: actions/checkout@v1
         with:
           submodules: true
-      - uses: actions/setup-java@v1
+      - uses: actions/setup-java@v3
         with:
-          java-version: '8'
-          java-package: jdk
+          java-version: '11'
+          distribution: 'zulu'
           architecture: x64
       - name: 'Install dependencies'
         run: ./ci/mac_ci_setup.sh --android
@@ -180,10 +180,10 @@ jobs:
       - uses: actions/checkout@v1
         with:
           submodules: true
-      - uses: actions/setup-java@v1
+      - uses: actions/setup-java@v3
         with:
-          java-version: '8'
-          java-package: jdk
+          java-version: '11'
+          distribution: 'zulu'
           architecture: x64
       - name: 'Install dependencies'
         run: ./ci/mac_ci_setup.sh

--- a/.github/workflows/android_tests.yml
+++ b/.github/workflows/android_tests.yml
@@ -29,10 +29,10 @@ jobs:
           fi
       - name: 'Java setup'
         if: steps.check_context.outputs.run_tests == 'true'
-        uses: actions/setup-java@v1
+        uses: actions/setup-java@v3
         with:
-          java-version: '8'
-          java-package: jdk
+          java-version: '11'
+          distribution: 'zulu'
           architecture: x64
       - name: 'Install dependencies'
         if: steps.check_context.outputs.run_tests == 'true'
@@ -68,10 +68,10 @@ jobs:
           fi
       - name: 'Java setup'
         if: steps.check_context.outputs.run_tests == 'true'
-        uses: actions/setup-java@v1
+        uses: actions/setup-java@v3
         with:
-          java-version: '8'
-          java-package: jdk
+          java-version: '11'
+          distribution: 'zulu'
           architecture: x64
       - name: 'Install dependencies'
         if: steps.check_context.outputs.run_tests == 'true'
@@ -115,10 +115,10 @@ jobs:
           fi
       - name: 'Java setup'
         if: steps.check_context.outputs.run_tests == 'true'
-        uses: actions/setup-java@v1
+        uses: actions/setup-java@v3
         with:
-          java-version: '8'
-          java-package: jdk
+          java-version: '11'
+          distribution: 'zulu'
           architecture: x64
       - name: 'Run Kotlin library integration tests'
         if: steps.check_context.outputs.run_tests == 'true'

--- a/.github/workflows/asan.yml
+++ b/.github/workflows/asan.yml
@@ -30,11 +30,11 @@ jobs:
             echo "Skipping tests."
             echo "::set-output name=run_tests::false"
           fi
-      - uses: actions/setup-java@v1
+      - uses: actions/setup-java@v3
         if: steps.check-cache.outputs.cache-hit != 'true'
         with:
-          java-version: '8'
-          java-package: jdk
+          java-version: '11'
+          distribution: 'zulu'
           architecture: x64
       - name: 'Run tests'
         env:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,10 +14,10 @@ jobs:
       - uses: actions/checkout@v1
         with:
           submodules: true
-      - uses: actions/setup-java@v1
+      - uses: actions/setup-java@v3
         with:
-          java-version: '8'
-          java-package: jdk
+          java-version: '11'
+          distribution: 'zulu'
           architecture: x64
       - run: ./ci/mac_ci_setup.sh --android
         name: 'Install dependencies'

--- a/.github/workflows/tsan.yml
+++ b/.github/workflows/tsan.yml
@@ -30,11 +30,11 @@ jobs:
             echo "Skipping tests."
             echo "::set-output name=run_tests::false"
           fi
-      - uses: actions/setup-java@v1
+      - uses: actions/setup-java@v3
         if: steps.check-cache.outputs.cache-hit != 'true'
         with:
-          java-version: '8'
-          java-package: jdk
+          java-version: '11'
+          distribution: 'zulu'
           architecture: x64
       - name: 'Run tests'
         env:


### PR DESCRIPTION
Following up https://github.com/envoyproxy/envoy-mobile/pull/2249 to update the JDKs being pulled by CI to 11

Signed-off-by: Benjamin Lee <ben@ben.cm>