### PR TITLE
tests: add -Xcheck:jni to kotlin integration tests by default

### DIFF
--- a/bazel/kotlin_test.bzl
+++ b/bazel/kotlin_test.bzl
@@ -41,6 +41,7 @@ def envoy_mobile_jni_kt_test(name, srcs, native_deps = [], deps = [], library_pa
         jvm_flags = [
             "-Djava.library.path={}".format(library_path),
             "-Denvoy_jni_library_name={}".format(lib_name),
+            "-Xcheck:jni",
         ],
         repository = repository,
         exec_properties = exec_properties,


### PR DESCRIPTION
Signed-off-by: Mike Schore <mike.schore@gmail.com>