### PR TITLE
Add version history entries for user-facing changes

### DIFF
--- a/docs/root/intro/version_history.rst
+++ b/docs/root/intro/version_history.rst
@@ -12,6 +12,8 @@ Bugfixes:
 
 - iOS: change release artifacts to use xcframeworks (:issue:`#2216 <2216>`)
 - iOS: fix CocoaPods releases (:issue:`#2215 <2215>`)
+- fix bug where writing prevented the read loop from running (:issue:`#2221 <2221>`)
+- Android: update Kotlin standard libraries to 1.6.21 (:issue:`#2256 <2256>`)
 
 Features:
 


### PR DESCRIPTION
I found these while looking at the changeset since 0.4.6.