### PR TITLE
git: avoid merge conflicts when adding changelog entries

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,1 +1,2 @@
 library/common/certificates.inc linguist-vendored
+docs/root/intro/version_history.rst merge=union


### PR DESCRIPTION
From https://git-scm.com/docs/git-merge-file

> Instead of leaving conflicts in the file, resolve conflicts favouring our (or their or both) side of the lines.

Also see this blog post: https://about.gitlab.com/blog/2015/02/10/gitlab-reduced-merge-conflicts-by-90-percent-with-changelog-placeholders/