### PR TITLE
docs: fix sphinx reference mismatch warning

### DIFF
--- a/docs/root/development/debugging/ios_local.rst
+++ b/docs/root/development/debugging/ios_local.rst
@@ -68,7 +68,7 @@ by rules_xcodeproj, following these steps may work:
 4. Remove all apps without a provisioning profile from the ``xcodeproj``
    configuration in Envoy Mobile's root ``BUILD`` file.
 5. Follow the same steps as defined in the
-   :ref:`Using the Xcode GUI <using_xcode>`_ section above, but
+   :ref:`Using the Xcode GUI <using_xcode>` section above, but
    targeting your device instead of a simulator.
 
 *Note: You may need to clean from Xcode with cmd-shift-k between device


### PR DESCRIPTION
I'm not very familiar with reST so I'm not sure if this is correct, but it does remove the following warning:

> WARNING: Mismatch: both interpreted text role prefix and reference suffix