### PR TITLE
tools: Enable the VSCode completion db to use bazelisk if available

### DIFF
--- a/tools/vscode_compdb.sh
+++ b/tools/vscode_compdb.sh
@@ -4,8 +4,12 @@
 # This is a modification of evnoy/tools/vscode/refresh_compdb.sh which hits
 # the correct envoy-mobile Bazel targets.
 
+# Use bazelisk if present, if not use bazel.
+bazel_or_isk=bazelisk
+command -v bazelisk &> /dev/null || bazel_or_isk=bazel
+
 # Setting TEST_TMPDIR here so the compdb headers won't be overwritten by another bazel run
-CC=clang TEST_TMPDIR=${BUILD_DIR:-/tmp}/envoy-mobile-compdb envoy/tools/gen_compilation_database.py --vscode //library/cc/... //library/common/... //test/cc/... //test/common/...
+CC=clang TEST_TMPDIR=${BUILD_DIR:-/tmp}/envoy-mobile-compdb envoy/tools/gen_compilation_database.py --vscode --bazel=$bazel_or_isk //library/cc/... //library/common/... //test/cc/... //test/common/...
 
 # Kill clangd to reload the compilation database
 pkill clangd || :


### PR DESCRIPTION
Running tools/vscode_compdb.py to generate the code completion symbols for VSCode produces an error because the .bazelversion in Envoy may not be available in certain environments. The recommendation is to use bazelisk, but the compilation database script defaults to using bazel. This change enables the VSCode compilation database generation script to use bazelisk if it is available on the system; if not, it will use bazel.

Signed-off-by: Ali Beyad abeyad@google.com

Risk Level: low
Testing: local
Docs Changes: N/A
Release Notes: N/A
