### PR TITLE
add support for http/2 prior knowledge over plaintext

### DIFF
--- a/docs/root/intro/version_history.rst
+++ b/docs/root/intro/version_history.rst
@@ -22,6 +22,7 @@ Features:
 - api: add option to control whether Envoy should drain connections after a soft DNS refresh completes. (:issue:`#2225 <2225>`, :issue:`#2242 <2242>`)
 - configuration: enable h2 ping by default. (:issue: `#2270 <2270>`)
 - android: enable the filtering of unroutable families by default. (:issues: `#2267 <2267>`)
+- http: added support for plaintext HTTP/2 prior knowledge via setting x-envoy-mobile-upstream-protocol to `h2c` (:issue:`#2281 (2281)`)
 
 0.4.6 (April 26, 2022)
 ========================

--- a/library/common/config/config.cc
+++ b/library/common/config/config.cc
@@ -386,6 +386,17 @@ R"(
     upstream_connection_options: *upstream_opts
     circuit_breakers: *circuit_breakers_settings
     typed_extension_protocol_options: *h1_protocol_options
+  - name: base_h2_clear
+    connect_timeout: *connect_timeout
+    lb_policy: CLUSTER_PROVIDED
+    cluster_type: *base_cluster_type
+    transport_socket:
+      name: envoy.transport_sockets.raw_buffer
+      typed_config:
+        "@type": type.googleapis.com/envoy.extensions.transport_sockets.raw_buffer.v3.RawBuffer
+    upstream_connection_options: *upstream_opts
+    circuit_breakers: *circuit_breakers_settings
+    typed_extension_protocol_options: *h2_protocol_options
   - name: base_h2
     http2_protocol_options: {}
     connect_timeout: *connect_timeout

--- a/library/common/http/client.cc
+++ b/library/common/http/client.cc
@@ -611,12 +611,10 @@ void Client::setDestinationCluster(Http::RequestHeaderMap& headers) {
   const char* cluster{};
   auto protocol_header = headers.get(ProtocolHeader);
   if (headers.getSchemeValue() == Headers::get().SchemeValues.Http) {
-    if (!protocol_header.empty()) {
-      if (protocol_header[0]->value().getStringView() == "h2c") {
-        cluster = ClearTextH2Cluster;
-      } else {
-        cluster = ClearTextCluster;
-      }
+    if (!protocol_header.empty() && protocol_header[0]->value().getStringValue() == "h2c") {
+      cluster = ClearTextH2Cluster;
+    } else {
+      cluster = ClearTextCluster;
     }
   } else if (!protocol_header.empty()) {
     ASSERT(protocol_header.size() == 1);

--- a/library/common/http/client.cc
+++ b/library/common/http/client.cc
@@ -611,7 +611,7 @@ void Client::setDestinationCluster(Http::RequestHeaderMap& headers) {
   const char* cluster{};
   auto protocol_header = headers.get(ProtocolHeader);
   if (headers.getSchemeValue() == Headers::get().SchemeValues.Http) {
-    if (!protocol_header.empty() && protocol_header[0]->value().getStringValue() == "h2c") {
+    if (!protocol_header.empty() && protocol_header[0]->value().getStringView() == "h2c") {
       cluster = ClearTextH2Cluster;
     } else {
       cluster = ClearTextCluster;

--- a/test/common/http/client_test.cc
+++ b/test/common/http/client_test.cc
@@ -224,6 +224,25 @@ TEST_P(ClientTest, SetDestinationClusterUpstreamProtocol) {
   EXPECT_CALL(*request_decoder_, decodeHeaders_(HeaderMapEqual(&expected_headers4), true));
   http_client_.sendHeaders(stream_, c_headers4, true);
 
+  // Setting http2 prior knowledge.
+  TestRequestHeaderMapImpl headers5{{"x-envoy-mobile-upstream-protocol", "h2c"}};
+  HttpTestUtility::addDefaultHeaders(headers5);
+  headers5.setScheme("http");
+  envoy_headers c_headers5 = Utility::toBridgeHeaders(headers5);
+
+  TestResponseHeaderMapImpl expected_headers5{
+      {":scheme", "http"},
+      {":method", "GET"},
+      {":authority", "host"},
+      {":path", "/"},
+      {"x-envoy-mobile-cluster", "base_h2_clear"},
+      {"x-forwarded-proto", "https"},
+  };
+  EXPECT_CALL(dispatcher_, pushTrackedObject(_));
+  EXPECT_CALL(dispatcher_, popTrackedObject(_));
+  EXPECT_CALL(*request_decoder_, decodeHeaders_(HeaderMapEqual(&expected_headers5), true));
+  http_client_.sendHeaders(stream_, c_headers5, true);
+
   // Encode response headers.
   EXPECT_CALL(dispatcher_, pushTrackedObject(_));
   EXPECT_CALL(dispatcher_, popTrackedObject(_));


### PR DESCRIPTION
This adds support for using HTTP/2 over plaintext by setting "h2c" as the protocol, which matches the mechanism used by other HTTP clients/servers. This allows using http/2 prior knowledge with plaintext, which was previously only possible when using TLS.

Risk Level: Medium
Testing: New UT
Docs Changes: n/a
Release Notes: Added
