### PR TITLE
ci: add scheduled job to update Envoy weekly

### DIFF
--- a/.github/workflows/submodule_update.yml
+++ b/.github/workflows/submodule_update.yml
@@ -1,0 +1,41 @@
+name: submodule_update
+
+on:
+  workflow_dispatch:
+  schedule:
+    # Mondays at 2pm UTC (9am EST)
+    - cron: "0 14 * * 1"
+
+jobs:
+  submodule_update:
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout source
+      uses: actions/checkout@v2
+      with:
+        submodules: true
+    - name: Fetch latest submodule
+      run: |
+        git submodule update --remote
+    - name: Check for changes
+      id: state
+      run: |
+        if ! git diff-index --quiet HEAD --; then
+          echo "Detected changes..."
+          echo "::set-output name=dirty::true"
+        fi
+    - name: Create PR
+      if: steps.state.outputs.dirty == 'true'
+      uses: peter-evans/create-pull-request@v3
+      with:
+        token: ${{ secrets.CREDENTIALS_GITHUB_PUSH_TOKEN }}
+        title: Update Envoy
+        commit-message: |
+            Update Envoy
+
+            Signed-off-by: GitHub Action <noreply@github.com>
+        committer: GitHub Action <noreply@github.com>
+        base: main
+        delete-branch: true
+        branch: update-envoy
+        branch-suffix: short-commit-hash


### PR DESCRIPTION
We're currently 2.5 weeks behind, and there are a significant number of breaking changes to account for.

This would be easier to manage if we kept the updates smaller.