### PR TITLE
extensions: register `TestAccessor` filter

### DIFF
--- a/envoy_build_config/BUILD
+++ b/envoy_build_config/BUILD
@@ -36,6 +36,7 @@ envoy_cc_library(
         "@envoy_mobile//library/common/extensions/filters/http/network_configuration:config",
         "@envoy_mobile//library/common/extensions/filters/http/platform_bridge:config",
         "@envoy_mobile//library/common/extensions/filters/http/route_cache_reset:config",
+        "@envoy_mobile//library/common/extensions/filters/http/test_accessor:config",
         "@envoy_mobile//library/common/extensions/retry/options/network_configuration:config",
     ],
 )

--- a/envoy_build_config/extension_registry.cc
+++ b/envoy_build_config/extension_registry.cc
@@ -26,6 +26,7 @@
 #include "library/common/extensions/filters/http/network_configuration/config.h"
 #include "library/common/extensions/filters/http/platform_bridge/config.h"
 #include "library/common/extensions/filters/http/route_cache_reset/config.h"
+#include "library/common/extensions/filters/http/test_accessor/config.h"
 #include "library/common/extensions/retry/options/network_configuration/config.h"
 
 namespace Envoy {
@@ -51,6 +52,7 @@ void ExtensionRegistry::registerFactories() {
   Envoy::Extensions::HttpFilters::RouterFilter::forceRegisterRouterFilterConfig();
   Envoy::Extensions::HttpFilters::NetworkConfiguration::
       forceRegisterNetworkConfigurationFilterFactory();
+  Envoy::Extensions::HttpFilters::TestAccessor::forceRegisterTestAccessorFilterFactory();
   Envoy::Extensions::NetworkFilters::HttpConnectionManager::
       forceRegisterHttpConnectionManagerFilterConfigFactory();
   Envoy::Extensions::Retry::Options::

--- a/envoy_build_config/extensions_build_config.bzl
+++ b/envoy_build_config/extensions_build_config.bzl
@@ -14,6 +14,7 @@ EXTENSIONS = {
     "envoy.filters.http.network_configuration":            "@envoy_mobile//library/common/extensions/filters/http/network_configuration:config",
     "envoy.filters.http.route_cache_reset":                "@envoy_mobile//library/common/extensions/filters/http/route_cache_reset:config",
     "envoy.filters.http.router":                           "//source/extensions/filters/http/router:config",
+    "envoy.filters.http.test_accessor":                    "@envoy_mobile//library/common/extensions/filters/http/test_accessor:config",
     "envoy.filters.network.http_connection_manager":       "//source/extensions/filters/network/http_connection_manager:config",
     "envoy.http.original_ip_detection.xff":                "//source/extensions/http/original_ip_detection/xff:config",
     "envoy.key_value.platform":                            "@envoy_mobile//library/common/extensions/key_value/platform:config",


### PR DESCRIPTION
We use this in Lyft's integration with Envoy Mobile. It should be harmless to add even though we don't currently need it, and it will be helpful to keep the Envoy Mobile configuration close to the Lyft one considering that we're running Envoy Mobile in production and can help identify issues at scale.

Signed-off-by: JP Simard <jp@jpsim.com>