### PR TITLE
Cancel the scheduled onSendWindowAvailable callback when a stream is cancelled

### DIFF
--- a/library/common/http/client.cc
+++ b/library/common/http/client.cc
@@ -516,6 +516,7 @@ void Client::cancelStream(envoy_stream_t stream) {
   // whether it was closed or not.
   Client::DirectStreamSharedPtr direct_stream =
       getStream(stream, GetStreamFilters::ALLOW_FOR_ALL_STREAMS);
+  scheduled_callback_ = nullptr;
   if (direct_stream) {
     bool stream_was_open =
         getStream(stream, GetStreamFilters::ALLOW_ONLY_FOR_OPEN_STREAMS) != nullptr;

--- a/test/java/org/chromium/net/BidirectionalStreamTest.java
+++ b/test/java/org/chromium/net/BidirectionalStreamTest.java
@@ -450,7 +450,6 @@ public class BidirectionalStreamTest {
   @SmallTest
   @Feature({"Cronet"})
   @OnlyRunNativeCronet
-  @Ignore("https://github.com/envoyproxy/envoy-mobile/issues/2213")
   // Regression test for crbug.com/692168.
   public void testCancelWhileWriteDataPending() throws Exception {
     String url = Http2TestServer.getEchoStreamUrl();


### PR DESCRIPTION
Cancel the scheduled onSendWindowAvailable callback when a stream is cancelled

Fixes: #2213

Signed-off-by: Ryan Hamilton <rch@google.com>

Risk Level: Low
Testing: New unit tests
Docs Changes: None
Release Notes: Updated
