### PR TITLE
instrumentation: add timers and warnings to platform callbacks

### DIFF
--- a/docs/root/intro/version_history.rst
+++ b/docs/root/intro/version_history.rst
@@ -27,6 +27,7 @@ Features:
 - api: add option to control whether Envoy should drain connections after a soft DNS refresh completes. (:issue:`#2225 <2225>`, :issue:`#2242 <2242>`)
 - configuration: enable h2 ping by default. (:issue: `#2270 <2270>`)
 - android: enable the filtering of unroutable families by default. (:issues: `#2267 <2267>`)
+- instrumentation: add timers and warnings to platform-provided callbacks (:issue: `#2300 <2300>`)
 
 0.4.6 (April 26, 2022)
 ========================

--- a/library/common/extensions/filters/http/platform_bridge/BUILD
+++ b/library/common/extensions/filters/http/platform_bridge/BUILD
@@ -36,8 +36,13 @@ envoy_cc_extension(
         "//library/common/types:c_types_lib",
         "@envoy//envoy/common:scope_tracker_interface",
         "@envoy//envoy/http:filter_interface",
+        "@envoy//envoy/stats:stats_interface",
+        "@envoy//envoy/stats:stats_macros",
+        "@envoy//envoy/stats:timespan_interface",
         "@envoy//source/common/common:minimal_logger_lib",
         "@envoy//source/common/common:scope_tracker",
+        "@envoy//source/common/stats:timespan_lib",
+        "@envoy//source/extensions/filters/http/common:factory_base_lib",
         "@envoy//source/extensions/filters/http/common:pass_through_filter_lib",
     ],
 )

--- a/library/common/extensions/filters/http/platform_bridge/config.cc
+++ b/library/common/extensions/filters/http/platform_bridge/config.cc
@@ -12,7 +12,7 @@ Http::FilterFactoryCb PlatformBridgeFilterFactory::createFilterFactoryFromProtoT
     const std::string&, Server::Configuration::FactoryContext& context) {
 
   PlatformBridgeFilterConfigSharedPtr filter_config =
-      std::make_shared<PlatformBridgeFilterConfig>(proto_config);
+      std::make_shared<PlatformBridgeFilterConfig>(context, proto_config);
   return [filter_config, &context](Http::FilterChainFactoryCallbacks& callbacks) -> void {
     callbacks.addStreamFilter(
         std::make_shared<PlatformBridgeFilter>(filter_config, context.mainThreadDispatcher()));

--- a/library/common/extensions/filters/http/platform_bridge/filter.cc
+++ b/library/common/extensions/filters/http/platform_bridge/filter.cc
@@ -72,8 +72,7 @@ static void envoy_filter_reset_idle(const void* context) {
 PlatformBridgeFilterConfig::PlatformBridgeFilterConfig(
     Server::Configuration::FactoryContext& context,
     const envoymobile::extensions::filters::http::platform_bridge::PlatformBridge& proto_config)
-    : root_scope_(context.scope()),
-      stats_(generateStats("", root_scope_)),
+    : root_scope_(context.scope()), stats_(generateStats("", root_scope_)),
       filter_name_(proto_config.platform_filter_name()),
       platform_filter_(static_cast<envoy_http_filter*>(
           Api::External::retrieveApi(proto_config.platform_filter_name()))) {}
@@ -102,7 +101,8 @@ PlatformBridgeFilter::PlatformBridgeFilter(PlatformBridgeFilterConfigSharedPtr c
     callback_time_ms->complete();
     auto elapsed = callback_time_ms->elapsed();
     if (elapsed > SlowCallbackWarningThreshold) {
-      ENVOY_LOG_EVENT(warn, "slow_init_cb", filter_name_ + "|" + std::to_string(elapsed.count()) + "ms");
+      ENVOY_LOG_EVENT(warn, "slow_init_cb",
+                      filter_name_ + "|" + std::to_string(elapsed.count()) + "ms");
     }
 
     ASSERT(platform_filter_.instance_context,
@@ -185,7 +185,8 @@ void PlatformBridgeFilter::onDestroy() {
     callback_time_ms->complete();
     auto elapsed = callback_time_ms->elapsed();
     if (elapsed > SlowCallbackWarningThreshold) {
-      ENVOY_LOG_EVENT(warn, "slow_on_error_cb", filter_name_ + "|" + std::to_string(elapsed.count()) + "ms");
+      ENVOY_LOG_EVENT(warn, "slow_on_error_cb",
+                      filter_name_ + "|" + std::to_string(elapsed.count()) + "ms");
     }
   } else if (!response_filter_base_->state_.stream_complete_ && platform_filter_.on_cancel) {
     // If the filter chain is destroyed before a response is received, treat as cancellation.
@@ -200,7 +201,8 @@ void PlatformBridgeFilter::onDestroy() {
     callback_time_ms->complete();
     auto elapsed = callback_time_ms->elapsed();
     if (elapsed > SlowCallbackWarningThreshold) {
-      ENVOY_LOG_EVENT(warn, "slow_on_cancel_cb", filter_name_ + "|" + std::to_string(elapsed.count()) + "ms");
+      ENVOY_LOG_EVENT(warn, "slow_on_cancel_cb",
+                      filter_name_ + "|" + std::to_string(elapsed.count()) + "ms");
     }
   }
 
@@ -304,7 +306,8 @@ Http::FilterHeadersStatus PlatformBridgeFilter::FilterBase::onHeaders(Http::Head
   callback_time_ms->complete();
   auto elapsed = callback_time_ms->elapsed();
   if (elapsed > SlowCallbackWarningThreshold) {
-    ENVOY_LOG_EVENT(warn, "slow_on_" + direction_ + "_headers_cb", parent_.filter_name_ + "|" + std::to_string(elapsed.count()) + "ms");
+    ENVOY_LOG_EVENT(warn, "slow_on_" + direction_ + "_headers_cb",
+                    parent_.filter_name_ + "|" + std::to_string(elapsed.count()) + "ms");
   }
 
   state_.on_headers_called_ = true;
@@ -364,7 +367,8 @@ Http::FilterDataStatus PlatformBridgeFilter::FilterBase::onData(Buffer::Instance
   callback_time_ms->complete();
   auto elapsed = callback_time_ms->elapsed();
   if (elapsed > SlowCallbackWarningThreshold) {
-    ENVOY_LOG_EVENT(warn, "slow_on_" + direction_ + "_data_cb", parent_.filter_name_ + "|" + std::to_string(elapsed.count()) + "ms");
+    ENVOY_LOG_EVENT(warn, "slow_on_" + direction_ + "_data_cb",
+                    parent_.filter_name_ + "|" + std::to_string(elapsed.count()) + "ms");
   }
 
   state_.on_data_called_ = true;
@@ -458,7 +462,8 @@ Http::FilterTrailersStatus PlatformBridgeFilter::FilterBase::onTrailers(Http::He
   callback_time_ms->complete();
   auto elapsed = callback_time_ms->elapsed();
   if (elapsed > SlowCallbackWarningThreshold) {
-    ENVOY_LOG_EVENT(warn, "slow_on_" + direction_ + "_trailers_cb", parent_.filter_name_ + "|" + std::to_string(elapsed.count()) + "ms");
+    ENVOY_LOG_EVENT(warn, "slow_on_" + direction_ + "_trailers_cb",
+                    parent_.filter_name_ + "|" + std::to_string(elapsed.count()) + "ms");
   }
 
   state_.on_trailers_called_ = true;
@@ -696,7 +701,8 @@ void PlatformBridgeFilter::FilterBase::onResume() {
   callback_time_ms->complete();
   auto elapsed = callback_time_ms->elapsed();
   if (elapsed > SlowCallbackWarningThreshold) {
-    ENVOY_LOG_EVENT(warn, "slow_on_" + direction_ + "_resume_cb", parent_.filter_name_ + "|" + std::to_string(elapsed.count()) + "ms");
+    ENVOY_LOG_EVENT(warn, "slow_on_" + direction_ + "_resume_cb",
+                    parent_.filter_name_ + "|" + std::to_string(elapsed.count()) + "ms");
   }
 
   state_.on_resume_called_ = true;

--- a/library/common/extensions/filters/http/platform_bridge/filter.cc
+++ b/library/common/extensions/filters/http/platform_bridge/filter.cc
@@ -23,6 +23,9 @@ namespace HttpFilters {
 namespace PlatformBridge {
 
 namespace {
+
+constexpr auto SlowCallbackWarningThreshold = std::chrono::seconds(1);
+
 // TODO: https://github.com/envoyproxy/envoy-mobile/issues/1287
 void replaceHeaders(Http::HeaderMap& headers, envoy_headers c_headers) {
   headers.clear();
@@ -90,7 +93,18 @@ PlatformBridgeFilter::PlatformBridgeFilter(PlatformBridgeFilterConfigSharedPtr c
     // Set the instance_context to the result of the initialization call. Cleanup will ultimately
     // occur within the onDestroy() invocation below.
     ENVOY_LOG(trace, "PlatformBridgeFilter({})->init_filter", filter_name_);
+
+    auto callback_time_ms = std::make_unique<Stats::HistogramCompletableTimespanImpl>(
+        config_->stats().init_callback_latency_, timeSource());
+
     platform_filter_.instance_context = platform_filter_.init_filter(&platform_filter_);
+
+    callback_time_ms->complete();
+    auto elapsed = callback_time_ms->elapsed();
+    if (elapsed > SlowCallbackWarningThreshold) {
+      ENVOY_LOG_EVENT(warn, "slow_init_cb", filter_name_ + "|" + std::to_string(elapsed.count()) + "ms");
+    }
+
     ASSERT(platform_filter_.instance_context,
            fmt::format("PlatformBridgeFilter({}): init_filter unsuccessful", filter_name_));
   } else {
@@ -161,13 +175,33 @@ void PlatformBridgeFilter::onDestroy() {
     envoy_data error_message = Data::Utility::copyToBridgeData("Stream idle timeout");
     auto& info = decoder_callbacks_->streamInfo();
     int32_t attempts = static_cast<int32_t>(info.attemptCount().value_or(0));
+
+    auto callback_time_ms = std::make_unique<Stats::HistogramCompletableTimespanImpl>(
+        config_->stats().on_error_callback_latency_, timeSource());
+
     platform_filter_.on_error({ENVOY_REQUEST_TIMEOUT, error_message, attempts}, streamIntel(),
                               finalStreamIntel(), platform_filter_.instance_context);
+
+    callback_time_ms->complete();
+    auto elapsed = callback_time_ms->elapsed();
+    if (elapsed > SlowCallbackWarningThreshold) {
+      ENVOY_LOG_EVENT(warn, "slow_on_error_cb", filter_name_ + "|" + std::to_string(elapsed.count()) + "ms");
+    }
   } else if (!response_filter_base_->state_.stream_complete_ && platform_filter_.on_cancel) {
     // If the filter chain is destroyed before a response is received, treat as cancellation.
     ENVOY_LOG(trace, "PlatformBridgeFilter({})->on_cancel", filter_name_);
+
+    auto callback_time_ms = std::make_unique<Stats::HistogramCompletableTimespanImpl>(
+        config_->stats().on_cancel_callback_latency_, timeSource());
+
     platform_filter_.on_cancel(streamIntel(), finalStreamIntel(),
                                platform_filter_.instance_context);
+
+    callback_time_ms->complete();
+    auto elapsed = callback_time_ms->elapsed();
+    if (elapsed > SlowCallbackWarningThreshold) {
+      ENVOY_LOG_EVENT(warn, "slow_on_cancel_cb", filter_name_ + "|" + std::to_string(elapsed.count()) + "ms");
+    }
   }
 
   // Allow nullptr as no-op only if nothing was initialized.
@@ -269,8 +303,8 @@ Http::FilterHeadersStatus PlatformBridgeFilter::FilterBase::onHeaders(Http::Head
 
   callback_time_ms->complete();
   auto elapsed = callback_time_ms->elapsed();
-  if (elapsed > std::chrono::seconds(1)) {
-    ENVOY_LOG_EVENT(warn, "slow_on_" + direction_ + "_headers_cb", std::to_string(elapsed.count()) + "ms");
+  if (elapsed > SlowCallbackWarningThreshold) {
+    ENVOY_LOG_EVENT(warn, "slow_on_" + direction_ + "_headers_cb", parent_.filter_name_ + "|" + std::to_string(elapsed.count()) + "ms");
   }
 
   state_.on_headers_called_ = true;
@@ -319,9 +353,20 @@ Http::FilterDataStatus PlatformBridgeFilter::FilterBase::onData(Buffer::Instance
     in_data = Data::Utility::copyToBridgeData(data);
   }
 
-  ENVOY_LOG(trace, "PlatformBridgeFilter({})->on_*_data", parent_.filter_name_);
+  ENVOY_LOG(trace, "PlatformBridgeFilter({})->on_{}_data", parent_.filter_name_, direction_);
+
+  auto callback_time_ms = std::make_unique<Stats::HistogramCompletableTimespanImpl>(
+      on_data_callback_latency_, parent_.timeSource());
+
   envoy_filter_data_status result =
       on_data_(in_data, end_stream, streamIntel(), parent_.platform_filter_.instance_context);
+
+  callback_time_ms->complete();
+  auto elapsed = callback_time_ms->elapsed();
+  if (elapsed > SlowCallbackWarningThreshold) {
+    ENVOY_LOG_EVENT(warn, "slow_on_" + direction_ + "_data_cb", parent_.filter_name_ + "|" + std::to_string(elapsed.count()) + "ms");
+  }
+
   state_.on_data_called_ = true;
 
   switch (result.status) {
@@ -402,9 +447,20 @@ Http::FilterTrailersStatus PlatformBridgeFilter::FilterBase::onTrailers(Http::He
 
   auto internal_buffer = buffer();
   envoy_headers in_trailers = Http::Utility::toBridgeHeaders(trailers);
-  ENVOY_LOG(trace, "PlatformBridgeFilter({})->on_*_trailers", parent_.filter_name_);
+  ENVOY_LOG(trace, "PlatformBridgeFilter({})->on_{}_trailers", parent_.filter_name_, direction_);
+
+  auto callback_time_ms = std::make_unique<Stats::HistogramCompletableTimespanImpl>(
+      on_trailers_callback_latency_, parent_.timeSource());
+
   envoy_filter_trailers_status result =
       on_trailers_(in_trailers, streamIntel(), parent_.platform_filter_.instance_context);
+
+  callback_time_ms->complete();
+  auto elapsed = callback_time_ms->elapsed();
+  if (elapsed > SlowCallbackWarningThreshold) {
+    ENVOY_LOG_EVENT(warn, "slow_on_" + direction_ + "_trailers_cb", parent_.filter_name_ + "|" + std::to_string(elapsed.count()) + "ms");
+  }
+
   state_.on_trailers_called_ = true;
 
   switch (result.status) {
@@ -628,10 +684,21 @@ void PlatformBridgeFilter::FilterBase::onResume() {
     pending_trailers = &bridged_trailers;
   }
 
-  ENVOY_LOG(trace, "PlatformBridgeFilter({})->on_resume_*", parent_.filter_name_);
+  ENVOY_LOG(trace, "PlatformBridgeFilter({})->on_resume_{}", parent_.filter_name_, direction_);
+
+  auto callback_time_ms = std::make_unique<Stats::HistogramCompletableTimespanImpl>(
+      on_resume_callback_latency_, parent_.timeSource());
+
   envoy_filter_resume_status result =
       on_resume_(pending_headers, pending_data, pending_trailers, state_.stream_complete_,
                  streamIntel(), parent_.platform_filter_.instance_context);
+
+  callback_time_ms->complete();
+  auto elapsed = callback_time_ms->elapsed();
+  if (elapsed > SlowCallbackWarningThreshold) {
+    ENVOY_LOG_EVENT(warn, "slow_on_" + direction_ + "_resume_cb", parent_.filter_name_ + "|" + std::to_string(elapsed.count()) + "ms");
+  }
+
   state_.on_resume_called_ = true;
 
   if (result.status == kEnvoyFilterResumeStatusStopIteration) {

--- a/library/common/extensions/filters/http/platform_bridge/filter.h
+++ b/library/common/extensions/filters/http/platform_bridge/filter.h
@@ -2,8 +2,11 @@
 
 #include "envoy/common/scope_tracker.h"
 #include "envoy/http/filter.h"
+#include "envoy/stats/stats_macros.h"
 
 #include "source/common/common/logger.h"
+#include "source/common/stats/timespan_impl.h"
+#include "source/extensions/filters/http/common/factory_base.h"
 #include "source/extensions/filters/http/common/pass_through_filter.h"
 
 #include "library/common/extensions/filters/http/platform_bridge/c_types.h"
@@ -14,17 +17,52 @@ namespace Extensions {
 namespace HttpFilters {
 namespace PlatformBridge {
 
+/**
+ * All PlatformBridge Filter stats. @see stats_macros.h
+ */
+#define ALL_PLATFORM_BRIDGE_FILTER_STATS(COUNTER, HISTOGRAM)                                       \
+  COUNTER(init_failures)                                                                           \
+  HISTOGRAM(init_callback_latency, Milliseconds)                                                   \
+  HISTOGRAM(on_rq_headers_callback_latency, Milliseconds)                                          \
+  HISTOGRAM(on_rq_data_callback_latency, Milliseconds)                                             \
+  HISTOGRAM(on_rq_trailers_callback_latency, Milliseconds)                                         \
+  HISTOGRAM(on_rq_resume_callback_latency, Milliseconds)                                           \
+  HISTOGRAM(on_rs_headers_callback_latency, Milliseconds)                                          \
+  HISTOGRAM(on_rs_data_callback_latency, Milliseconds)                                             \
+  HISTOGRAM(on_rs_trailers_callback_latency, Milliseconds)                                         \
+  HISTOGRAM(on_rs_resume_callback_latency, Milliseconds)                                           \
+  HISTOGRAM(on_cancel_callback_latency, Milliseconds)                                              \
+  HISTOGRAM(on_error_callback_latency, Milliseconds)                                               \
+
+/**
+ * Struct definition for all DNS Filter stats. @see stats_macros.h
+ */
+struct PlatformBridgeFilterStats {
+  ALL_PLATFORM_BRIDGE_FILTER_STATS(GENERATE_COUNTER_STRUCT, GENERATE_HISTOGRAM_STRUCT)
+};
+
 class PlatformBridgeFilter;
 
 class PlatformBridgeFilterConfig {
 public:
   PlatformBridgeFilterConfig(
+      Server::Configuration::FactoryContext& context,
       const envoymobile::extensions::filters::http::platform_bridge::PlatformBridge& proto_config);
 
+  PlatformBridgeFilterStats& stats() const { return stats_; }
   const std::string& filter_name() { return filter_name_; }
   const envoy_http_filter* platform_filter() const { return platform_filter_; }
 
 private:
+  static PlatformBridgeFilterStats generateStats(const std::string& stat_prefix,
+                                                       Stats::Scope& scope) {
+    const auto final_prefix = absl::StrCat("pbf_filter.", stat_prefix);
+    return {ALL_PLATFORM_BRIDGE_FILTER_STATS(POOL_COUNTER_PREFIX(scope, final_prefix),
+                                             POOL_HISTOGRAM_PREFIX(scope, final_prefix))};
+  }
+
+  Stats::Scope& root_scope_;
+  mutable PlatformBridgeFilterStats stats_;
   const std::string filter_name_;
   const envoy_http_filter* platform_filter_;
 };
@@ -93,17 +131,26 @@ public:
   // Filter state.
   bool isAlive() { return alive_; }
 
+  TimeSource& timeSource() { return dispatcher_.timeSource(); }
+
 private:
   /**
    * Internal delegate for managing logic and state that exists for both the request (decoding)
    * and response (encoding) paths.
    */
   struct FilterBase : public Logger::Loggable<Logger::Id::filter> {
-    FilterBase(PlatformBridgeFilter& parent, envoy_filter_on_headers_f on_headers,
+    FilterBase(PlatformBridgeFilter& parent, std::string direction,
+               envoy_filter_on_headers_f on_headers,
                envoy_filter_on_data_f on_data, envoy_filter_on_trailers_f on_trailers,
-               envoy_filter_on_resume_f on_resume)
-        : parent_(parent), on_headers_(on_headers), on_data_(on_data), on_trailers_(on_trailers),
-          on_resume_(on_resume) {
+               envoy_filter_on_resume_f on_resume, Stats::Histogram& on_headers_callback_latency,
+               Stats::Histogram& on_data_callback_latency,
+               Stats::Histogram& on_trailers_callback_latency,
+               Stats::Histogram& on_resume_callback_latency)
+        : parent_(parent), direction_(std::move(direction)), on_headers_(on_headers), on_data_(on_data), on_trailers_(on_trailers),
+          on_resume_(on_resume), on_headers_callback_latency_(on_headers_callback_latency),
+          on_data_callback_latency_(on_data_callback_latency),
+          on_trailers_callback_latency_(on_trailers_callback_latency),
+          on_resume_callback_latency_(on_resume_callback_latency) {
       state_.iteration_state_ = IterationState::Ongoing;
     }
 
@@ -147,21 +194,31 @@ private:
     };
 
     PlatformBridgeFilter& parent_;
+    const std::string direction_;
     FilterState state_;
     envoy_filter_on_headers_f on_headers_;
     envoy_filter_on_data_f on_data_;
     envoy_filter_on_trailers_f on_trailers_;
     envoy_filter_on_resume_f on_resume_;
+    Stats::Histogram& on_headers_callback_latency_;
+    Stats::Histogram& on_data_callback_latency_;
+    Stats::Histogram& on_trailers_callback_latency_;
+    Stats::Histogram& on_resume_callback_latency_;
     Http::HeaderMap* pending_headers_{};
     Http::HeaderMap* pending_trailers_{};
   };
 
   struct RequestFilterBase : FilterBase {
     RequestFilterBase(PlatformBridgeFilter& parent)
-        : FilterBase(parent, parent.platform_filter_.on_request_headers,
+        : FilterBase(parent, "request",
+                     parent.platform_filter_.on_request_headers,
                      parent.platform_filter_.on_request_data,
                      parent.platform_filter_.on_request_trailers,
-                     parent.platform_filter_.on_resume_request) {}
+                     parent.platform_filter_.on_resume_request,
+                     parent.config_->stats().on_rq_headers_callback_latency_,
+                     parent.config_->stats().on_rq_data_callback_latency_,
+                     parent.config_->stats().on_rq_trailers_callback_latency_,
+                     parent.config_->stats().on_rq_resume_callback_latency_) {}
 
     // FilterBase
     void addData(envoy_data data) override;
@@ -174,10 +231,15 @@ private:
 
   struct ResponseFilterBase : FilterBase {
     ResponseFilterBase(PlatformBridgeFilter& parent)
-        : FilterBase(parent, parent.platform_filter_.on_response_headers,
+        : FilterBase(parent, "response",
+                     parent.platform_filter_.on_response_headers,
                      parent.platform_filter_.on_response_data,
                      parent.platform_filter_.on_response_trailers,
-                     parent.platform_filter_.on_resume_response) {}
+                     parent.platform_filter_.on_resume_response,
+                     parent.config_->stats().on_rs_headers_callback_latency_,
+                     parent.config_->stats().on_rs_data_callback_latency_,
+                     parent.config_->stats().on_rs_trailers_callback_latency_,
+                     parent.config_->stats().on_rs_resume_callback_latency_) {}
 
     // FilterBase
     void addData(envoy_data data) override;
@@ -190,6 +252,7 @@ private:
 
   Event::ScopeTracker& scopeTracker() const { return dispatcher_; }
 
+  PlatformBridgeFilterConfigSharedPtr config_;
   Event::Dispatcher& dispatcher_;
   const std::string filter_name_;
   envoy_http_filter platform_filter_;

--- a/library/common/extensions/filters/http/platform_bridge/filter.h
+++ b/library/common/extensions/filters/http/platform_bridge/filter.h
@@ -21,7 +21,6 @@ namespace PlatformBridge {
  * All PlatformBridge Filter stats. @see stats_macros.h
  */
 #define ALL_PLATFORM_BRIDGE_FILTER_STATS(COUNTER, HISTOGRAM)                                       \
-  COUNTER(init_failures)                                                                           \
   HISTOGRAM(init_callback_latency, Milliseconds)                                                   \
   HISTOGRAM(on_rq_headers_callback_latency, Milliseconds)                                          \
   HISTOGRAM(on_rq_data_callback_latency, Milliseconds)                                             \

--- a/library/common/extensions/filters/http/platform_bridge/filter.h
+++ b/library/common/extensions/filters/http/platform_bridge/filter.h
@@ -31,7 +31,7 @@ namespace PlatformBridge {
   HISTOGRAM(on_rs_trailers_callback_latency, Milliseconds)                                         \
   HISTOGRAM(on_rs_resume_callback_latency, Milliseconds)                                           \
   HISTOGRAM(on_cancel_callback_latency, Milliseconds)                                              \
-  HISTOGRAM(on_error_callback_latency, Milliseconds)                                               \
+  HISTOGRAM(on_error_callback_latency, Milliseconds)
 
 /**
  * Struct definition for all DNS Filter stats. @see stats_macros.h
@@ -54,7 +54,7 @@ public:
 
 private:
   static PlatformBridgeFilterStats generateStats(const std::string& stat_prefix,
-                                                       Stats::Scope& scope) {
+                                                 Stats::Scope& scope) {
     const auto final_prefix = absl::StrCat("pbf_filter.", stat_prefix);
     return {ALL_PLATFORM_BRIDGE_FILTER_STATS(POOL_COUNTER_PREFIX(scope, final_prefix),
                                              POOL_HISTOGRAM_PREFIX(scope, final_prefix))};
@@ -139,14 +139,15 @@ private:
    */
   struct FilterBase : public Logger::Loggable<Logger::Id::filter> {
     FilterBase(PlatformBridgeFilter& parent, std::string direction,
-               envoy_filter_on_headers_f on_headers,
-               envoy_filter_on_data_f on_data, envoy_filter_on_trailers_f on_trailers,
-               envoy_filter_on_resume_f on_resume, Stats::Histogram& on_headers_callback_latency,
+               envoy_filter_on_headers_f on_headers, envoy_filter_on_data_f on_data,
+               envoy_filter_on_trailers_f on_trailers, envoy_filter_on_resume_f on_resume,
+               Stats::Histogram& on_headers_callback_latency,
                Stats::Histogram& on_data_callback_latency,
                Stats::Histogram& on_trailers_callback_latency,
                Stats::Histogram& on_resume_callback_latency)
-        : parent_(parent), direction_(std::move(direction)), on_headers_(on_headers), on_data_(on_data), on_trailers_(on_trailers),
-          on_resume_(on_resume), on_headers_callback_latency_(on_headers_callback_latency),
+        : parent_(parent), direction_(std::move(direction)), on_headers_(on_headers),
+          on_data_(on_data), on_trailers_(on_trailers), on_resume_(on_resume),
+          on_headers_callback_latency_(on_headers_callback_latency),
           on_data_callback_latency_(on_data_callback_latency),
           on_trailers_callback_latency_(on_trailers_callback_latency),
           on_resume_callback_latency_(on_resume_callback_latency) {
@@ -209,8 +210,7 @@ private:
 
   struct RequestFilterBase : FilterBase {
     RequestFilterBase(PlatformBridgeFilter& parent)
-        : FilterBase(parent, "request",
-                     parent.platform_filter_.on_request_headers,
+        : FilterBase(parent, "request", parent.platform_filter_.on_request_headers,
                      parent.platform_filter_.on_request_data,
                      parent.platform_filter_.on_request_trailers,
                      parent.platform_filter_.on_resume_request,
@@ -230,8 +230,7 @@ private:
 
   struct ResponseFilterBase : FilterBase {
     ResponseFilterBase(PlatformBridgeFilter& parent)
-        : FilterBase(parent, "response",
-                     parent.platform_filter_.on_response_headers,
+        : FilterBase(parent, "response", parent.platform_filter_.on_response_headers,
                      parent.platform_filter_.on_response_data,
                      parent.platform_filter_.on_response_trailers,
                      parent.platform_filter_.on_resume_response,

--- a/library/common/http/BUILD
+++ b/library/common/http/BUILD
@@ -29,6 +29,7 @@ envoy_cc_library(
         "@envoy//envoy/http:header_map_interface",
         "@envoy//envoy/stats:stats_interface",
         "@envoy//envoy/stats:stats_macros",
+        "@envoy//envoy/stats:timespan_interface",
         "@envoy//source/common/buffer:buffer_lib",
         "@envoy//source/common/buffer:watermark_buffer_lib",
         "@envoy//source/common/common:lock_guard_lib",
@@ -39,6 +40,7 @@ envoy_cc_library(
         "@envoy//source/common/http:header_map_lib",
         "@envoy//source/common/http:headers_lib",
         "@envoy//source/common/http:utility_lib",
+        "@envoy//source/common/stats:timespan_lib",
     ],
 )
 

--- a/library/common/http/client.cc
+++ b/library/common/http/client.cc
@@ -27,6 +27,12 @@ namespace Http {
  * For implementation details @see Client::DirectStreamCallbacks::closeRemote.
  */
 
+namespace {
+
+constexpr auto SlowCallbackWarningTreshold = std::chrono::seconds(1);
+
+} // namespace
+
 Client::DirectStreamCallbacks::DirectStreamCallbacks(DirectStream& direct_stream,
                                                      envoy_http_callbacks bridge_callbacks,
                                                      Client& http_client)
@@ -66,8 +72,19 @@ void Client::DirectStreamCallbacks::encodeHeaders(const ResponseHeaderMap& heade
 
   ENVOY_LOG(debug, "[S{}] dispatching to platform response headers for stream (end_stream={}):\n{}",
             direct_stream_.stream_handle_, end_stream, headers);
+
+  auto callback_time_ms = std::make_unique<Stats::HistogramCompletableTimespanImpl>(
+      http_client_.stats().on_headers_callback_latency_, http_client_.timeSource());
+
   bridge_callbacks_.on_headers(Utility::toBridgeHeaders(headers, alpn), end_stream, streamIntel(),
                                bridge_callbacks_.context);
+
+  callback_time_ms->complete();
+  auto elapsed = callback_time_ms->elapsed();
+  if (elapsed > SlowCallbackWarningTreshold) {
+    ENVOY_LOG_EVENT(warn, "slow_on_headers_cb", std::to_string(elapsed.count()) + "ms");
+  }
+
   response_headers_forwarded_ = true;
   if (end_stream) {
     onComplete();
@@ -136,8 +153,18 @@ void Client::DirectStreamCallbacks::sendDataToBridge(Buffer::Instance& data, boo
             "[S{}] dispatching to platform response data for stream (length={} end_stream={})",
             direct_stream_.stream_handle_, bytes_to_send, send_end_stream);
 
+  auto callback_time_ms = std::make_unique<Stats::HistogramCompletableTimespanImpl>(
+      http_client_.stats().on_data_callback_latency_, http_client_.timeSource());
+
   bridge_callbacks_.on_data(Data::Utility::toBridgeData(data, bytes_to_send), send_end_stream,
                             streamIntel(), bridge_callbacks_.context);
+
+  callback_time_ms->complete();
+  auto elapsed = callback_time_ms->elapsed();
+  if (elapsed > SlowCallbackWarningTreshold) {
+    ENVOY_LOG_EVENT(warn, "slow_on_data_cb", std::to_string(elapsed.count()) + "ms");
+  }
+
   if (send_end_stream) {
     onComplete();
   }
@@ -170,8 +197,19 @@ void Client::DirectStreamCallbacks::sendTrailersToBridge(const ResponseTrailerMa
   ENVOY_LOG(debug, "[S{}] dispatching to platform response trailers for stream:\n{}",
             direct_stream_.stream_handle_, trailers);
 
+
+  auto callback_time_ms = std::make_unique<Stats::HistogramCompletableTimespanImpl>(
+      http_client_.stats().on_trailers_callback_latency_, http_client_.timeSource());
+
   bridge_callbacks_.on_trailers(Utility::toBridgeHeaders(trailers), streamIntel(),
                                 bridge_callbacks_.context);
+
+  callback_time_ms->complete();
+  auto elapsed = callback_time_ms->elapsed();
+  if (elapsed > SlowCallbackWarningTreshold) {
+    ENVOY_LOG_EVENT(warn, "slow_on_trailers_cb", std::to_string(elapsed.count()) + "ms");
+  }
+
   onComplete();
 }
 
@@ -228,7 +266,6 @@ void Client::DirectStreamCallbacks::onComplete() {
     http_client_.stats().stream_failure_.inc();
   }
 
-
   auto callback_time_ms = std::make_unique<Stats::HistogramCompletableTimespanImpl>(
       http_client_.stats().on_complete_callback_latency_, http_client_.timeSource());
 
@@ -236,7 +273,7 @@ void Client::DirectStreamCallbacks::onComplete() {
 
   callback_time_ms->complete();
   auto elapsed = callback_time_ms->elapsed();
-  if (elapsed > std::chrono::seconds(1)) {
+  if (elapsed > SlowCallbackWarningTreshold) {
     ENVOY_LOG_EVENT(warn, "slow_on_complete_cb", std::to_string(elapsed.count()) + "ms");
   }
 }
@@ -273,7 +310,7 @@ void Client::DirectStreamCallbacks::onError() {
 
   callback_time_ms->complete();
   auto elapsed = callback_time_ms->elapsed();
-  if (elapsed > std::chrono::seconds(1)) {
+  if (elapsed > SlowCallbackWarningTreshold) {
     ENVOY_LOG_EVENT(warn, "slow_on_error_cb", std::to_string(elapsed.count()) + "ms");
   }
 }
@@ -299,7 +336,7 @@ void Client::DirectStreamCallbacks::onCancel() {
 
   callback_time_ms->complete();
   auto elapsed = callback_time_ms->elapsed();
-  if (elapsed > std::chrono::seconds(1)) {
+  if (elapsed > SlowCallbackWarningTreshold) {
     ENVOY_LOG_EVENT(warn, "slow_on_cancel_cb", std::to_string(elapsed.count()) + "ms");
   }
 }

--- a/library/common/http/client.cc
+++ b/library/common/http/client.cc
@@ -197,7 +197,6 @@ void Client::DirectStreamCallbacks::sendTrailersToBridge(const ResponseTrailerMa
   ENVOY_LOG(debug, "[S{}] dispatching to platform response trailers for stream:\n{}",
             direct_stream_.stream_handle_, trailers);
 
-
   auto callback_time_ms = std::make_unique<Stats::HistogramCompletableTimespanImpl>(
       http_client_.stats().on_trailers_callback_latency_, http_client_.timeSource());
 

--- a/library/common/http/client.h
+++ b/library/common/http/client.h
@@ -7,11 +7,13 @@
 #include "envoy/http/api_listener.h"
 #include "envoy/http/codec.h"
 #include "envoy/http/header_map.h"
+#include "envoy/stats/histogram.h"
 #include "envoy/stats/stats_macros.h"
 
 #include "source/common/buffer/watermark_buffer.h"
 #include "source/common/common/logger.h"
 #include "source/common/http/codec_helper.h"
+#include "source/common/stats/timespan_impl.h"
 
 #include "absl/container/flat_hash_map.h"
 #include "absl/types/optional.h"
@@ -25,16 +27,22 @@ namespace Http {
 /**
  * All http client stats. @see stats_macros.h
  */
-#define ALL_HTTP_CLIENT_STATS(COUNTER)                                                             \
+#define ALL_HTTP_CLIENT_STATS(COUNTER, HISTOGRAM)                                                  \
   COUNTER(stream_success)                                                                          \
   COUNTER(stream_failure)                                                                          \
-  COUNTER(stream_cancel)
+  COUNTER(stream_cancel)                                                                           \
+  HISTOGRAM(on_headers_callback_latency, Milliseconds)                                             \
+  HISTOGRAM(on_data_callback_latency, Milliseconds)                                                \
+  HISTOGRAM(on_trailers_callback_latency, Milliseconds)                                            \
+  HISTOGRAM(on_complete_callback_latency, Milliseconds)                                            \
+  HISTOGRAM(on_cancel_callback_latency, Milliseconds)                                              \
+  HISTOGRAM(on_error_callback_latency, Milliseconds)                                               \
 
 /**
  * Struct definition for client stats. @see stats_macros.h
  */
 struct HttpClientStats {
-  ALL_HTTP_CLIENT_STATS(GENERATE_COUNTER_STRUCT)
+  ALL_HTTP_CLIENT_STATS(GENERATE_COUNTER_STRUCT, GENERATE_HISTOGRAM_STRUCT)
 };
 
 /**
@@ -45,7 +53,8 @@ public:
   Client(ApiListener& api_listener, Event::ProvisionalDispatcher& dispatcher, Stats::Scope& scope,
          Random::RandomGenerator& random)
       : api_listener_(api_listener), dispatcher_(dispatcher),
-        stats_(HttpClientStats{ALL_HTTP_CLIENT_STATS(POOL_COUNTER_PREFIX(scope, "http.client."))}),
+        stats_(HttpClientStats{ALL_HTTP_CLIENT_STATS(POOL_COUNTER_PREFIX(scope, "http.client."),
+                                                     POOL_HISTOGRAM_PREFIX(scope, "http.client."))}),
         address_(std::make_shared<Network::Address::SyntheticAddressImpl>()), random_(random) {}
 
   /**
@@ -107,6 +116,8 @@ public:
 
   const HttpClientStats& stats() const;
   Event::ScopeTracker& scopeTracker() const { return dispatcher_; }
+
+  TimeSource& timeSource() { return dispatcher_.timeSource(); }
 
   // Used to fill response code details for streams that are cancelled via cancelStream.
   const std::string& getCancelDetails() {

--- a/library/common/http/client.h
+++ b/library/common/http/client.h
@@ -36,7 +36,7 @@ namespace Http {
   HISTOGRAM(on_trailers_callback_latency, Milliseconds)                                            \
   HISTOGRAM(on_complete_callback_latency, Milliseconds)                                            \
   HISTOGRAM(on_cancel_callback_latency, Milliseconds)                                              \
-  HISTOGRAM(on_error_callback_latency, Milliseconds)                                               \
+  HISTOGRAM(on_error_callback_latency, Milliseconds)
 
 /**
  * Struct definition for client stats. @see stats_macros.h
@@ -53,8 +53,9 @@ public:
   Client(ApiListener& api_listener, Event::ProvisionalDispatcher& dispatcher, Stats::Scope& scope,
          Random::RandomGenerator& random)
       : api_listener_(api_listener), dispatcher_(dispatcher),
-        stats_(HttpClientStats{ALL_HTTP_CLIENT_STATS(POOL_COUNTER_PREFIX(scope, "http.client."),
-                                                     POOL_HISTOGRAM_PREFIX(scope, "http.client."))}),
+        stats_(
+            HttpClientStats{ALL_HTTP_CLIENT_STATS(POOL_COUNTER_PREFIX(scope, "http.client."),
+                                                  POOL_HISTOGRAM_PREFIX(scope, "http.client."))}),
         address_(std::make_shared<Network::Address::SyntheticAddressImpl>()), random_(random) {}
 
   /**

--- a/test/common/extensions/filters/http/platform_bridge/BUILD
+++ b/test/common/extensions/filters/http/platform_bridge/BUILD
@@ -20,6 +20,7 @@ envoy_extension_cc_test(
         "//library/common/extensions/filters/http/platform_bridge:filter_cc_proto",
         "@envoy//test/mocks/event:event_mocks",
         "@envoy//test/mocks/http:http_mocks",
+        "@envoy//test/mocks/server:factory_context_mocks",
         "@envoy//test/test_common:utility_lib",
     ],
 )

--- a/test/common/extensions/filters/http/platform_bridge/platform_bridge_filter_test.cc
+++ b/test/common/extensions/filters/http/platform_bridge/platform_bridge_filter_test.cc
@@ -1,5 +1,6 @@
 #include "test/mocks/event/mocks.h"
 #include "test/mocks/http/mocks.h"
+#include "test/mocks/server/factory_context.h"
 #include "test/test_common/utility.h"
 
 #include "gtest/gtest.h"
@@ -44,7 +45,7 @@ public:
     TestUtility::loadFromYaml(yaml, config);
     Api::External::registerApi(config.platform_filter_name(), platform_filter);
 
-    config_ = std::make_shared<PlatformBridgeFilterConfig>(config);
+    config_ = std::make_shared<PlatformBridgeFilterConfig>(context_, config);
     filter_ = std::make_shared<PlatformBridgeFilter>(config_, dispatcher_);
     filter_->setDecoderFilterCallbacks(decoder_callbacks_);
     filter_->setEncoderFilterCallbacks(encoder_callbacks_);
@@ -98,6 +99,7 @@ public:
     unsigned int release_filter_calls;
   } filter_invocations;
 
+  NiceMock<Server::Configuration::MockFactoryContext> context_;
   PlatformBridgeFilterConfigSharedPtr config_;
   PlatformBridgeFilterSharedPtr filter_;
   NiceMock<Event::MockDispatcher> dispatcher_;


### PR DESCRIPTION
Description: Adds Envoy histograms (timers) to most platform-provided callbacks in the Http::Client and in PlatformBridge Filters. Beyond a hardcoded threshold (1s), a warn-level LOG_EVENT will be emitted for slow-to-execute callbacks.
Risk Level: Low
Testing: Manual & Existing Coverage

Signed-off-by: Mike Schore <mike.schore@gmail.com>