### PR TITLE
Fix spelling of Cronvoy in release notes

### DIFF
--- a/docs/root/intro/version_history.rst
+++ b/docs/root/intro/version_history.rst
@@ -14,7 +14,7 @@ Bugfixes:
 
 - iOS: change release artifacts to use xcframeworks (:issue:`#2216 <2216>`)
 - iOS: fix CocoaPods releases (:issue:`#2215 <2215>`)
-- Cronvy: Cancel the scheduled onSendWindowAvailable callback when a stream is cancelled (:issue:`#2213 <2213>`)
+- Cronvoy: Cancel the scheduled onSendWindowAvailable callback when a stream is cancelled (:issue:`#2213 <2213>`)
 - fix bug where writing prevented the read loop from running (:issue:`#2221 <2221>`)
 - Android: update Kotlin standard libraries to 1.6.21 (:issue:`#2256 <2256>`)
 - fix bug where finalStreamIntel was not consistently set on cancel (:issue:`#2285 <2285>`)


### PR DESCRIPTION
Fix spelling of Cronvoy in release notes which I broken in #2292.