### PR TITLE
xcode: add libraries & tests to Xcode project

### DIFF
--- a/BUILD
+++ b/BUILD
@@ -112,11 +112,23 @@ xcodeproj(
     project_name = "Envoy",
     tags = ["manual"],
     targets = [
+        # Libraries
+        "//library/swift:ios_lib",
+        "//library/objective-c:envoy_engine_objc_lib",
+        "//library/common:envoy_main_interface_lib",
+        # Apps
         # TODO(jpsim): Fix Objective-C app support
         # "//examples/objective-c/hello_world:app",
         "//examples/swift/async_await:app",
         "//examples/swift/hello_world:app",
         "//test/swift/apps/baseline:app",
         "//test/swift/apps/experimental:app",
+        # Tests
+        "//experimental/swift:quic_stream_test",
+        "//test/objective-c:envoy_bridge_utility_test",
+        "//test/swift/integration:flatbuffer_test",
+        "//test/swift/integration:test",
+        "//test/swift/stats:test",
+        "//test/swift:test",
     ],
 )

--- a/bazel/apple_test.bzl
+++ b/bazel/apple_test.bzl
@@ -19,7 +19,7 @@ load("//bazel:config.bzl", "MINIMUM_IOS_VERSION")
 #     ],
 # )
 #
-def envoy_mobile_swift_test(name, srcs, data = [], deps = [], tags = [], repository = ""):
+def envoy_mobile_swift_test(name, srcs, data = [], deps = [], tags = [], repository = "", visibility = []):
     test_lib_name = name + "_lib"
     swift_library(
         name = test_lib_name,
@@ -39,9 +39,10 @@ def envoy_mobile_swift_test(name, srcs, data = [], deps = [], tags = [], reposit
         deps = [test_lib_name],
         minimum_os_version = MINIMUM_IOS_VERSION,
         tags = tags,
+        visibility = visibility,
     )
 
-def envoy_mobile_objc_test(name, srcs, data = [], deps = [], tags = []):
+def envoy_mobile_objc_test(name, srcs, data = [], deps = [], tags = [], visibility = []):
     test_lib_name = name + "_lib"
     objc_library(
         name = test_lib_name,
@@ -57,4 +58,5 @@ def envoy_mobile_objc_test(name, srcs, data = [], deps = [], tags = []):
         deps = [test_lib_name],
         minimum_os_version = MINIMUM_IOS_VERSION,
         tags = tags,
+        visibility = visibility,
     )

--- a/experimental/swift/BUILD
+++ b/experimental/swift/BUILD
@@ -10,6 +10,7 @@ envoy_mobile_swift_test(
     data = [
         "@envoy//test/config/integration/certs",
     ],
+    visibility = ["//visibility:public"],
     deps = [
         "//library/objective-c:envoy_engine_objc_lib",
     ],

--- a/experimental/swift/QUICStreamTest.swift
+++ b/experimental/swift/QUICStreamTest.swift
@@ -156,7 +156,7 @@ final class QUICStreamTests: XCTestCase {
     """
     let expectation = self.expectation(description: "Complete response received.")
 
-    let client = try EngineBuilder(yaml: config)
+    let client = EngineBuilder(yaml: config)
       .addLogLevel(.trace)
       .build()
       .streamClient()
@@ -167,18 +167,18 @@ final class QUICStreamTests: XCTestCase {
 
     client
       .newStreamPrototype()
-      .setOnResponseHeaders { responseHeaders, endStream in
+      .setOnResponseHeaders { responseHeaders, endStream, _ in
         XCTAssertEqual(200, responseHeaders.httpStatus)
         if endStream {
           expectation.fulfill()
         }
       }
-      .setOnResponseData { _, endStream in
+      .setOnResponseData { _, endStream, _ in
         if endStream {
           expectation.fulfill()
         }
       }
-      .setOnError { _ in
+      .setOnError { _, _ in
         XCTFail("Unexpected error")
       }
       .start()

--- a/test/objective-c/BUILD
+++ b/test/objective-c/BUILD
@@ -7,6 +7,7 @@ envoy_mobile_objc_test(
     srcs = [
         "EnvoyBridgeUtilityTest.m",
     ],
+    visibility = ["//visibility:public"],
     deps = [
         "//library/objective-c:envoy_objc_bridge_lib",
     ],

--- a/test/swift/BUILD
+++ b/test/swift/BUILD
@@ -15,6 +15,7 @@ envoy_mobile_swift_test(
         "RetryPolicyMapperTests.swift",
         "RetryPolicyTests.swift",
     ],
+    visibility = ["//visibility:public"],
     deps = [
         "//library/objective-c:envoy_engine_objc_lib",
     ],

--- a/test/swift/integration/BUILD
+++ b/test/swift/integration/BUILD
@@ -35,6 +35,7 @@ envoy_mobile_swift_test(
     tags = [
         "no-remote-exec",
     ],
+    visibility = ["//visibility:public"],
     deps = [
         ":test_extensions",
         "//library/objective-c:envoy_engine_objc_lib",
@@ -48,6 +49,7 @@ envoy_mobile_swift_test(
     ] + [
         "//test/fbs:test_fb_swift_srcs",
     ],
+    visibility = ["//visibility:public"],
     deps = [
         "@swift_flatbuffers//:FlatBuffers",
     ],

--- a/test/swift/stats/BUILD
+++ b/test/swift/stats/BUILD
@@ -9,6 +9,7 @@ envoy_mobile_swift_test(
         "ElementTests.swift",
         "TagsBuilderTests.swift",
     ],
+    visibility = ["//visibility:public"],
     deps = [
         "//library/objective-c:envoy_engine_objc_lib",
     ],


### PR DESCRIPTION
This list isn't comprehensive, but it's the most common targets in which I work with for the iOS side of things.

Note that it doesn't look like the Objective-C/C++ targets correctly reflect build failures right now, but you still get autocomplete and other IDE features.

![image](https://user-images.githubusercontent.com/474794/169400758-4a3b4183-723f-4cec-9b40-4045af4d467c.png)
