### PR TITLE
Revert "android: use local addresses as opposed to prefix"

### DIFF
--- a/third_party/android/ifaddrs-android.h
+++ b/third_party/android/ifaddrs-android.h
@@ -198,7 +198,7 @@ inline int getifaddrs(ifaddrs** result) {
                     rtattr* rta = IFA_RTA(address);
                     size_t ifaPayloadLength = IFA_PAYLOAD(hdr);
                     while (RTA_OK(rta, ifaPayloadLength)) {
-                        if (rta->rta_type == IFA_LOCAL) {
+                        if (rta->rta_type == IFA_ADDRESS) {
                             int family = address->ifa_family;
                             if (family == AF_INET || family == AF_INET6) {
                                 *result = new ifaddrs(*result);


### PR DESCRIPTION
Reverts envoyproxy/envoy-mobile#2081

This broke detection of ipv6 interfaces.