### PR TITLE
Corrected typo (SDK to NDK) in the Android requirements documentation

### DIFF
--- a/docs/root/start/building/building.rst
+++ b/docs/root/start/building/building.rst
@@ -48,7 +48,7 @@ For local builds, set ``ANDROID_HOME`` and ``ANDROID_NDK_HOME`` to point to the 
 .. code-block:: bash
 
   ANDROID_HOME=$HOME/Library/Android/sdk
-  ANDROID_SDK_HOME=$HOME/Library/Android/ndk/21.3.6528147
+  ANDROID_NDK_HOME=$HOME/Library/Android/ndk/21.3.6528147
 
 See `ci/mac_ci_setup.sh` for the specific NDK version used during builds.
 


### PR DESCRIPTION
For an explanation of how to fill out the fields, please see the relevant section
in [PULL_REQUESTS.md](https://github.com/envoyproxy/envoy/blob/master/PULL_REQUESTS.md)

Description: Corrected typo in NDK path definition (android requirements documentation)
Risk Level: Low to none
Testing: 
Docs Changes: One section
Release Notes:
[Optional Fixes #Issue]
[Optional Deprecated:]
