### PR TITLE
docs: Corrected typo in documentation for Android building requirements

### DIFF
--- a/docs/root/start/building/building.rst
+++ b/docs/root/start/building/building.rst
@@ -48,7 +48,7 @@ For local builds, set ``ANDROID_HOME`` and ``ANDROID_NDK_HOME`` to point to the 
 .. code-block:: bash
 
   ANDROID_HOME=$HOME/Library/Android/sdk
-  ANDROID_SDK_HOME=$HOME/Library/Android/ndk/21.3.6528147
+  ANDROID_NDK_HOME=$HOME/Library/Android/ndk/21.3.6528147
 
 See `ci/mac_ci_setup.sh` for the specific NDK version used during builds.
 


### PR DESCRIPTION
Signed-off-by: Andres Barco <andres@engflow.com>

Description: Corrected typo in NDK path definition (from SDK to NDK)
Risk Level: Low
Testing: N/A
Docs Changes: Ejample environment variable ANDROID_SDK_HOME changed to ANDROID_NDK_HOME
Release Notes:
[Optional Fixes #Issue]
[Optional Deprecated:]
