### PR TITLE
test: making C++ integration test more authentic

### DIFF
--- a/test/common/integration/client_integration_test.cc
+++ b/test/common/integration/client_integration_test.cc
@@ -83,17 +83,6 @@ public:
       // The default stats config has overenthusiastic filters.
       bootstrap.clear_stats_config();
     });
-    // TODO(alyssawilk) upstream has an issue with logical DNS ipv6 clusters -
-    // remove this once #21359 lands.
-    config_helper_.addConfigModifier([](envoy::config::bootstrap::v3::Bootstrap& bootstrap) {
-      auto* static_resources = bootstrap.mutable_static_resources();
-      for (int i = 0; i < static_resources->clusters_size(); ++i) {
-        auto* cluster = static_resources->mutable_clusters(i);
-        if (cluster->type() == envoy::config::cluster::v3::Cluster::LOGICAL_DNS) {
-          cluster->clear_type();
-        }
-      }
-    });
   }
 
   void initialize() override {


### PR DESCRIPTION
Removing the modifier which cleared stats, now that the stats clusters work for IPv6.

Risk Level: n/a (test only)
Docs Changes: n/a
Release Notes: n/a
