### PR TITLE
android: create persistent SharedPreferences-based KV store

### DIFF
--- a/docs/root/api/starting_envoy.rst
+++ b/docs/root/api/starting_envoy.rst
@@ -434,13 +434,13 @@ This can help negate the effect of head-of-line (HOL) blocking for slow connecti
 ~~~~~~~~~~~~~~~~~~~~
 
 Implementations of a public KeyValueStore interface may be added in their respective languages and
-made available to native code. General usage is supported, but typical future usage will be in
+made available to the library. General usage is supported, but typical future usage will be in
 support of HTTP and endpoint property caching.
 
 **Example**::
 
   // Kotlin
-  builder.addKeyValueStore(MyKeyValueStoreImpl())
+  builder.addKeyValueStore("io.envoyproxy.envoymobile.MyKeyValueStore", MyKeyValueStoreImpl())
 
   // Swift
   // Coming soon.
@@ -452,7 +452,7 @@ SharedPreferences.
 **Example**::
 
   // Android
-  val preferences = context.getSharedPreferences("MyPreferences", Context.MODE_PRIVATE)
+  val preferences = context.getSharedPreferences("io.envoyproxy.envoymobile.MyPreferences", Context.MODE_PRIVATE)
   builder.addKeyValueStore(SharedPreferencesStore(preferences))
 
   // iOS

--- a/docs/root/api/starting_envoy.rst
+++ b/docs/root/api/starting_envoy.rst
@@ -432,6 +432,37 @@ This can help negate the effect of head-of-line (HOL) blocking for slow connecti
   // Swift
   builder.h2ExtendKeepaliveTimeout(true)
 
+
+~~~~~~~~~~~~~~~~~~~~
+``addKeyValueStore``
+~~~~~~~~~~~~~~~~~~~~
+
+Implementations of a public KeyValueStore interface may be added in their respective languages and
+made available to native code. General usage is supported, but typical future usage will be in
+support of HTTP and endpoint property caching.
+
+**Example**::
+
+  // Kotlin
+  builder.addKeyValueStore(MyKeyValueStoreImpl())
+
+  // Swift
+  // Coming soon.
+
+
+The library also contains a simple Android-specific KeyValueStore implementation based on Android's
+SharedPreferences.
+
+**Example**::
+
+  // Android
+  val preferences = context.getSharedPreferences("MyPreferences", Context.MODE_PRIVATE)
+  builder.addKeyValueStore(SharedPreferencesStore(preferences))
+
+  // iOS
+  // Coming soon.
+
+
 ----------------------
 Advanced configuration
 ----------------------

--- a/docs/root/api/starting_envoy.rst
+++ b/docs/root/api/starting_envoy.rst
@@ -453,7 +453,7 @@ SharedPreferences.
 
   // Android
   val preferences = context.getSharedPreferences("io.envoyproxy.envoymobile.MyPreferences", Context.MODE_PRIVATE)
-  builder.addKeyValueStore(SharedPreferencesStore(preferences))
+  builder.addKeyValueStore("io.envoyproxy.envoymobile.MyKeyValueStore", SharedPreferencesStore(preferences))
 
   // iOS
   // Coming soon.

--- a/docs/root/intro/version_history.rst
+++ b/docs/root/intro/version_history.rst
@@ -29,6 +29,7 @@ Features:
 - android: enable the filtering of unroutable families by default. (:issues: `#2267 <2267>`)
 - instrumentation: add timers and warnings to platform-provided callbacks (:issue: `#2300 <2300>`)
 - iOS: add support for integrating Envoy Mobile via the Swift Package Manager
+- android: create simple persistent SharedPreferencesStore (:issue: `#2319 <2319>`)
 
 0.4.6 (April 26, 2022)
 ========================

--- a/library/kotlin/io/envoyproxy/envoymobile/BUILD
+++ b/library/kotlin/io/envoyproxy/envoymobile/BUILD
@@ -22,6 +22,7 @@ kt_android_library(
     name = "envoy_lib",
     srcs = [
         "AndroidEngineBuilder.kt",
+        "android/SharedPreferencesStore.kt",
     ],
     custom_package = "io.envoyproxy.envoymobile",
     manifest = "EnvoyManifest.xml",
@@ -68,7 +69,6 @@ envoy_mobile_kt_library(
         "StringAccessor.kt",
         "Trailers.kt",
         "UpstreamHttpProtocol.kt",
-        "extras/*.kt",
         "filters/*.kt",
         "grpc/*.kt",
         "mocks/*.kt",

--- a/library/kotlin/io/envoyproxy/envoymobile/BUILD
+++ b/library/kotlin/io/envoyproxy/envoymobile/BUILD
@@ -68,6 +68,7 @@ envoy_mobile_kt_library(
         "StringAccessor.kt",
         "Trailers.kt",
         "UpstreamHttpProtocol.kt",
+        "extras/*.kt",
         "filters/*.kt",
         "grpc/*.kt",
         "mocks/*.kt",

--- a/library/kotlin/io/envoyproxy/envoymobile/EngineBuilder.kt
+++ b/library/kotlin/io/envoyproxy/envoymobile/EngineBuilder.kt
@@ -455,7 +455,7 @@ open class EngineBuilder(
    * @return this builder.
    */
   fun addKeyValueStore(name: String, keyValueStore: KeyValueStore): EngineBuilder {
-    this.keyValueStores.put(name, EnvoyKeyValueStoreAdapter(keyValueStore))
+    this.keyValueStores.put(name, keyValueStore)
     return this
   }
 

--- a/library/kotlin/io/envoyproxy/envoymobile/KeyValueStore.kt
+++ b/library/kotlin/io/envoyproxy/envoymobile/KeyValueStore.kt
@@ -3,30 +3,7 @@ package io.envoyproxy.envoymobile
 import io.envoyproxy.envoymobile.engine.types.EnvoyKeyValueStore
 
 /**
- * `KeyValueStore` is bridged through to `EnvoyKeyValueStore` to communicate with the engine.
+ * `KeyValueStore` is an interface that may be implemented to provide access to an arbitrary
+ * key-value store implementation that may be made accessible to native Envoy Mobile code.
  */
-class KeyValueStore constructor (
-  val read: ((key: String) -> String?),
-  val remove: ((key: String) -> Unit),
-  val save: ((key: String, value: String) -> Unit)
-)
-
-/**
- * Class responsible for bridging between the platform-level `KeyValueStore` and the
- * engine's `EnvoyKeyValueStore`.
- */
-internal class EnvoyKeyValueStoreAdapter(
-  private val callbacks: KeyValueStore
-) : EnvoyKeyValueStore {
-  override fun read(key: String): String? {
-    return callbacks.read(key)
-  }
-
-  override fun remove(key: String) {
-    callbacks.remove(key)
-  }
-
-  override fun save(key: String, value: String) {
-    callbacks.save(key, value)
-  }
-}
+interface KeyValueStore : EnvoyKeyValueStore

--- a/library/kotlin/io/envoyproxy/envoymobile/android/SharedPreferencesStore.kt
+++ b/library/kotlin/io/envoyproxy/envoymobile/android/SharedPreferencesStore.kt
@@ -1,14 +1,15 @@
-package io.envoyproxy.envoymobile.extras
+package io.envoyproxy.envoymobile.android
 
 import android.content.SharedPreferences
 
 import io.envoyproxy.envoymobile.KeyValueStore
 
-class AndroidSharedPreferencesStore(String preferencesName) {
-  val editor = getSharedPreferences(perferencesName, Context.MODE_PRIVATE).edit()
-} : KeyValueStore {
+class SharedPreferencesStore(sharedPreferences: SharedPreferences) : KeyValueStore {
+  val preferences = sharedPreferences
+  val editor = sharedPreferences.edit()
+
   override fun read(key: String): String? {
-    return editor.getString(key, null)
+    return preferences.getString(key, null)
   }
 
   override fun remove(key: String) {
@@ -18,6 +19,6 @@ class AndroidSharedPreferencesStore(String preferencesName) {
 
   override fun save(key: String, value: String) {
     editor.putString(key, value)
-    editor.apply
+    editor.apply()
   }
 }

--- a/library/kotlin/io/envoyproxy/envoymobile/android/SharedPreferencesStore.kt
+++ b/library/kotlin/io/envoyproxy/envoymobile/android/SharedPreferencesStore.kt
@@ -4,9 +4,12 @@ import android.content.SharedPreferences
 
 import io.envoyproxy.envoymobile.KeyValueStore
 
+/**
+ * Simple implementation of a `KeyValueStore` leveraging `SharedPreferences` for persistence.
+ */
 class SharedPreferencesStore(sharedPreferences: SharedPreferences) : KeyValueStore {
-  val preferences = sharedPreferences
-  val editor = sharedPreferences.edit()
+  private val preferences = sharedPreferences
+  private val editor = sharedPreferences.edit()
 
   override fun read(key: String): String? {
     return preferences.getString(key, null)

--- a/library/kotlin/io/envoyproxy/envoymobile/extras/AndroidSharedPreferencesStore.kt
+++ b/library/kotlin/io/envoyproxy/envoymobile/extras/AndroidSharedPreferencesStore.kt
@@ -1,0 +1,23 @@
+package io.envoyproxy.envoymobile.extras
+
+import android.content.SharedPreferences
+
+import io.envoyproxy.envoymobile.KeyValueStore
+
+class AndroidSharedPreferencesStore(String preferencesName) {
+  val editor = getSharedPreferences(perferencesName, Context.MODE_PRIVATE).edit()
+} : KeyValueStore {
+  override fun read(key: String): String? {
+    return editor.getString(key, null)
+  }
+
+  override fun remove(key: String) {
+    editor.remove(key)
+    editor.apply()
+  }
+
+  override fun save(key: String, value: String) {
+    editor.putString(key, value)
+    editor.apply
+  }
+}

--- a/test/kotlin/apps/experimental/MainActivity.kt
+++ b/test/kotlin/apps/experimental/MainActivity.kt
@@ -26,6 +26,7 @@ private const val REQUEST_HANDLER_THREAD_NAME = "hello_envoy_kt"
 private const val REQUEST_AUTHORITY = "api.lyft.com"
 private const val REQUEST_PATH = "/ping"
 private const val REQUEST_SCHEME = "https"
+private const val PERSISTENCE_KEY = "EnvoyMobilePersistenceKey"
 private val FILTERED_HEADERS = setOf(
   "server",
   "filter-demo",
@@ -45,6 +46,8 @@ class MainActivity : Activity() {
     super.onCreate(savedInstanceState)
     setContentView(R.layout.activity_main)
 
+    val preferences = getSharedPreferences(PERSISTENCE_KEY, Context.MODE_PRIVATE)
+
     engine = AndroidEngineBuilder(application)
       .addLogLevel(LogLevel.DEBUG)
       .addPlatformFilter(::DemoFilter)
@@ -54,6 +57,7 @@ class MainActivity : Activity() {
       .enableInterfaceBinding(true)
       .addNativeFilter("envoy.filters.http.buffer", "{\"@type\":\"type.googleapis.com/envoy.extensions.filters.http.buffer.v3.Buffer\",\"max_request_bytes\":5242880}")
       .addStringAccessor("demo-accessor", { "PlatformString" })
+      .addKeyValueStore("demo-kv-store", SharedPreferencesStore(preferences))
       .setOnEngineRunning { Log.d("MainActivity", "Envoy async internal setup completed") }
       .setEventTracker({
         for (entry in it.entries) {

--- a/test/kotlin/apps/experimental/MainActivity.kt
+++ b/test/kotlin/apps/experimental/MainActivity.kt
@@ -1,7 +1,7 @@
 package io.envoyproxy.envoymobile.helloenvoykotlin
 
 import android.app.Activity
-import android.app.Context
+import android.content.Context
 import android.os.Bundle
 import android.os.Handler
 import android.os.HandlerThread

--- a/test/kotlin/apps/experimental/MainActivity.kt
+++ b/test/kotlin/apps/experimental/MainActivity.kt
@@ -9,10 +9,10 @@ import android.util.Log
 import androidx.recyclerview.widget.DividerItemDecoration
 import androidx.recyclerview.widget.LinearLayoutManager
 import androidx.recyclerview.widget.RecyclerView
+import io.envoyproxy.envoymobile.android.SharedPreferencesStore
 import io.envoyproxy.envoymobile.AndroidEngineBuilder
 import io.envoyproxy.envoymobile.Element
 import io.envoyproxy.envoymobile.Engine
-import io.envoyproxy.envoymobile.KeyValueStore
 import io.envoyproxy.envoymobile.LogLevel
 import io.envoyproxy.envoymobile.RequestHeadersBuilder
 import io.envoyproxy.envoymobile.RequestMethod

--- a/test/kotlin/apps/experimental/MainActivity.kt
+++ b/test/kotlin/apps/experimental/MainActivity.kt
@@ -1,6 +1,7 @@
 package io.envoyproxy.envoymobile.helloenvoykotlin
 
 import android.app.Activity
+import android.app.Context
 import android.os.Bundle
 import android.os.Handler
 import android.os.HandlerThread
@@ -11,6 +12,7 @@ import androidx.recyclerview.widget.RecyclerView
 import io.envoyproxy.envoymobile.AndroidEngineBuilder
 import io.envoyproxy.envoymobile.Element
 import io.envoyproxy.envoymobile.Engine
+import io.envoyproxy.envoymobile.KeyValueStore
 import io.envoyproxy.envoymobile.LogLevel
 import io.envoyproxy.envoymobile.RequestHeadersBuilder
 import io.envoyproxy.envoymobile.RequestMethod

--- a/test/kotlin/integration/KeyValueStoreTest.kt
+++ b/test/kotlin/integration/KeyValueStoreTest.kt
@@ -68,11 +68,11 @@ class KeyValueStoreTest {
 
     val readExpectation = CountDownLatch(3)
     val saveExpectation = CountDownLatch(1)
-    val testKeyValueStore = KeyValueStore(
-      read = { _ -> readExpectation.countDown(); null },
-      remove = { _ -> {}},
-      save = { _, _ -> saveExpectation.countDown() }
-    )
+    val testKeyValueStore = object : KeyValueStore {
+      override fun read(key: String): String? { readExpectation.countDown(); return null }
+      override fun remove(key: String) {}
+      override fun save(key: String, value: String) { saveExpectation.countDown() }
+    }
 
     val engine = EngineBuilder(Custom(config))
         .addKeyValueStore("envoy.key_value.platform_test", testKeyValueStore)


### PR DESCRIPTION
Description: Updates the exposed KeyValueStore type to be a more traditional implementable interface, and provides a simple persisting implementation based on Android SharedPreferences.
Risk: Low
Testing: Application

Signed-off-by: Mike Schore <mike.schore@gmail.com>