### PR TITLE
iOS: default path monitor to `true`

### DIFF
--- a/docs/root/api/starting_envoy.rst
+++ b/docs/root/api/starting_envoy.rst
@@ -374,11 +374,7 @@ Specify a closure to be called by Envoy to access arbitrary strings from Platfor
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 Configure the engine to use ``NWPathMonitor`` rather than ``SCNetworkReachability``
-on supported platforms (iOS 12+) to update the preferred Envoy network cluster (e.g. WLAN vs WWAN).
-
-.. attention::
-
-    Only available on iOS 12 or later.
+to update the preferred Envoy network cluster (e.g. WLAN vs WWAN). Defaults to true.
 
 **Example**::
 
@@ -386,7 +382,7 @@ on supported platforms (iOS 12+) to update the preferred Envoy network cluster (
   // N/A
 
   // Swift
-  builder.enableNetworkPathMonitor()
+  builder.enableNetworkPathMonitor(false)
 
 ~~~~~~~~~~~~~~~~~~~~~~~
 ``enableHappyEyeballs``

--- a/docs/root/intro/version_history.rst
+++ b/docs/root/intro/version_history.rst
@@ -6,10 +6,11 @@ Pending Release
 
 Breaking changes:
 
-- api: replace the `drainConnections()` method with a broader `resetConnectivityState()`. (:issue:`#2225 <2225>`).
+- api: replace the ``drainConnections()`` method with a broader ``resetConnectivityState()``. (:issue:`#2225 <2225>`).
 - api: disallow setting 'host' header directly (:issue:`#2275 <2275>`)
 - net: enable happy eyeballs by default (:issue:`#2272 <2272>`)
 - iOS: remove support for installing via CocoaPods, which had not worked since 2020 (:issue:`#2215 <2215>`)
+- iOS: enable usage of ``NWPathMonitor`` by default (:issue:`#2329 <2329>`)
 
 Bugfixes:
 

--- a/library/swift/EngineBuilder.swift
+++ b/library/swift/EngineBuilder.swift
@@ -40,7 +40,7 @@ open class EngineBuilder: NSObject {
   private var onEngineRunning: (() -> Void)?
   private var logger: ((String) -> Void)?
   private var eventTracker: (([String: String]) -> Void)?
-  private(set) var enableNetworkPathMonitor = false
+  private(set) var enableNetworkPathMonitor = true
   private var nativeFilterChain: [EnvoyNativeFilterConfig] = []
   private var platformFilterChain: [EnvoyHTTPFilterFactory] = []
   private var stringAccessors: [String: EnvoyStringAccessor] = [:]
@@ -389,6 +389,7 @@ open class EngineBuilder: NSObject {
   }
 
   /// Configure the engine to use `NWPathMonitor` to observe network reachability.
+  /// Defaults to `true`. Set to `false` to use `SCNetworkReachability`.
   ///
   /// - returns: This builder.
   @discardableResult

--- a/test/swift/EngineBuilderTests.swift
+++ b/test/swift/EngineBuilderTests.swift
@@ -28,17 +28,17 @@ final class EngineBuilderTests: XCTestCase {
     MockEnvoyEngine.onRunWithTemplate = nil
   }
 
-  func testEnableNetworkPathMonitorDefaultsToFalse() {
+  func testEnableNetworkPathMonitorDefaultsToTrue() {
     let builder = EngineBuilder()
     XCTAssertFalse(builder.enableNetworkPathMonitor)
   }
 
   func testEnableNetworkPathMonitorSetsToValue() {
     let builder = EngineBuilder()
-      .enableNetworkPathMonitor(true)
-    XCTAssertTrue(builder.enableNetworkPathMonitor)
-    builder.enableNetworkPathMonitor(false)
+      .enableNetworkPathMonitor(false)
     XCTAssertFalse(builder.enableNetworkPathMonitor)
+    builder.enableNetworkPathMonitor(true)
+    XCTAssertTrue(builder.enableNetworkPathMonitor)
   }
 
   func testCustomConfigTemplateUsesSpecifiedYAMLWhenRunningEnvoy() {


### PR DESCRIPTION
Lyft ran an experiment with this enabled and noticed some statistically significant improvements in two areas:

* A 3.6% increase in cases where Envoy Mobile connectivity checks kept succeeding where URLSession ones were failing.
* A 5.1% drop in crashes while the app is being terminated.

Risk Level: Low
Testing: Production experiment & unit tests
Docs Changes: Added
Release Notes: Added