### PR TITLE
iOS: add SwiftPM example

### DIFF
--- a/.github/workflows/release_validation.yml
+++ b/.github/workflows/release_validation.yml
@@ -1,0 +1,28 @@
+name: release_validation
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+
+jobs:
+  validate_swiftpm_example:
+    name: validate_swiftpm_example
+    runs-on: macos-12
+    timeout-minutes: 120
+    steps:
+      - uses: actions/checkout@v1
+        with:
+          submodules: true
+      - run: ./ci/mac_ci_setup.sh
+        name: 'Install dependencies'
+      - env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: ./bazelw build --config=ios --config=remote-ci-macos --remote_header="Authorization=Bearer $GITHUB_TOKEN" //:ios_xcframework
+        name: 'Build xcframework'
+      # Ignore errors: Bad CRC when unzipping large files: https://bbs.archlinux.org/viewtopic.php?id=153011
+      - run: unzip bazel-bin/library/swift/Envoy.xcframework.zip -d examples/swift/swiftpm/Packages || true
+      - run: xcodebuild -project examples/swift/swiftpm/EnvoySwiftPMExample.xcodeproj -scheme EnvoySwiftPMExample -destination platform="iOS Simulator,name=iPhone 13 Pro Max,OS=15.2"
+        name: 'Build app'
+      # TODO(jpsim): Run app and inspect logs to validate

--- a/.gitignore
+++ b/.gitignore
@@ -12,6 +12,7 @@
 *.pyc
 *.tulsiconf-user
 *.xcodeproj
+*.xcframework
 clang.bazelrc
 user.bazelrc
 tags

--- a/examples/swift/swiftpm/EnvoySwiftPMExample.xcodeproj/project.pbxproj
+++ b/examples/swift/swiftpm/EnvoySwiftPMExample.xcodeproj/project.pbxproj
@@ -1,0 +1,356 @@
+// !$*UTF8*$!
+{
+	archiveVersion = 1;
+	classes = {
+	};
+	objectVersion = 55;
+	objects = {
+
+/* Begin PBXBuildFile section */
+		8F4CC51328465BDA009BAB1D /* EnvoySwiftPMExampleApp.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8F4CC51228465BDA009BAB1D /* EnvoySwiftPMExampleApp.swift */; };
+		8F4CC51528465BDA009BAB1D /* ContentView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8F4CC51428465BDA009BAB1D /* ContentView.swift */; };
+		8FA85F632846650100C778FC /* NetworkClient in Frameworks */ = {isa = PBXBuildFile; productRef = 8FA85F622846650100C778FC /* NetworkClient */; };
+/* End PBXBuildFile section */
+
+/* Begin PBXFileReference section */
+		8F4CC50F28465BDA009BAB1D /* EnvoySwiftPMExample.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = EnvoySwiftPMExample.app; sourceTree = BUILT_PRODUCTS_DIR; };
+		8F4CC51228465BDA009BAB1D /* EnvoySwiftPMExampleApp.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EnvoySwiftPMExampleApp.swift; sourceTree = "<group>"; };
+		8F4CC51428465BDA009BAB1D /* ContentView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContentView.swift; sourceTree = "<group>"; };
+		8FA85F60284664D000C778FC /* Packages */ = {isa = PBXFileReference; lastKnownFileType = wrapper; path = Packages; sourceTree = "<group>"; };
+/* End PBXFileReference section */
+
+/* Begin PBXFrameworksBuildPhase section */
+		8F4CC50C28465BDA009BAB1D /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				8FA85F632846650100C778FC /* NetworkClient in Frameworks */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXFrameworksBuildPhase section */
+
+/* Begin PBXGroup section */
+		8F4CC50628465BDA009BAB1D = {
+			isa = PBXGroup;
+			children = (
+				8FA85F5F284664D000C778FC /* Packages */,
+				8F4CC51128465BDA009BAB1D /* EnvoySwiftPMExample */,
+				8F4CC51028465BDA009BAB1D /* Products */,
+				8FA85F612846650100C778FC /* Frameworks */,
+			);
+			sourceTree = "<group>";
+		};
+		8F4CC51028465BDA009BAB1D /* Products */ = {
+			isa = PBXGroup;
+			children = (
+				8F4CC50F28465BDA009BAB1D /* EnvoySwiftPMExample.app */,
+			);
+			name = Products;
+			sourceTree = "<group>";
+		};
+		8F4CC51128465BDA009BAB1D /* EnvoySwiftPMExample */ = {
+			isa = PBXGroup;
+			children = (
+				8F4CC51228465BDA009BAB1D /* EnvoySwiftPMExampleApp.swift */,
+				8F4CC51428465BDA009BAB1D /* ContentView.swift */,
+			);
+			path = EnvoySwiftPMExample;
+			sourceTree = "<group>";
+		};
+		8FA85F5F284664D000C778FC /* Packages */ = {
+			isa = PBXGroup;
+			children = (
+				8FA85F60284664D000C778FC /* Packages */,
+			);
+			name = Packages;
+			sourceTree = "<group>";
+		};
+		8FA85F612846650100C778FC /* Frameworks */ = {
+			isa = PBXGroup;
+			children = (
+			);
+			name = Frameworks;
+			sourceTree = "<group>";
+		};
+/* End PBXGroup section */
+
+/* Begin PBXNativeTarget section */
+		8F4CC50E28465BDA009BAB1D /* EnvoySwiftPMExample */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = 8F4CC51D28465BDB009BAB1D /* Build configuration list for PBXNativeTarget "EnvoySwiftPMExample" */;
+			buildPhases = (
+				8F4CC50B28465BDA009BAB1D /* Sources */,
+				8F4CC50C28465BDA009BAB1D /* Frameworks */,
+				8F4CC50D28465BDA009BAB1D /* Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			name = EnvoySwiftPMExample;
+			packageProductDependencies = (
+				8FA85F622846650100C778FC /* NetworkClient */,
+			);
+			productName = EnvoySwiftPMExample;
+			productReference = 8F4CC50F28465BDA009BAB1D /* EnvoySwiftPMExample.app */;
+			productType = "com.apple.product-type.application";
+		};
+/* End PBXNativeTarget section */
+
+/* Begin PBXProject section */
+		8F4CC50728465BDA009BAB1D /* Project object */ = {
+			isa = PBXProject;
+			attributes = {
+				BuildIndependentTargetsInParallel = 1;
+				LastSwiftUpdateCheck = 1320;
+				LastUpgradeCheck = 1320;
+				TargetAttributes = {
+					8F4CC50E28465BDA009BAB1D = {
+						CreatedOnToolsVersion = 13.2.1;
+					};
+				};
+			};
+			buildConfigurationList = 8F4CC50A28465BDA009BAB1D /* Build configuration list for PBXProject "EnvoySwiftPMExample" */;
+			compatibilityVersion = "Xcode 13.0";
+			developmentRegion = en;
+			hasScannedForEncodings = 0;
+			knownRegions = (
+				en,
+				Base,
+			);
+			mainGroup = 8F4CC50628465BDA009BAB1D;
+			productRefGroup = 8F4CC51028465BDA009BAB1D /* Products */;
+			projectDirPath = "";
+			projectRoot = "";
+			targets = (
+				8F4CC50E28465BDA009BAB1D /* EnvoySwiftPMExample */,
+			);
+		};
+/* End PBXProject section */
+
+/* Begin PBXResourcesBuildPhase section */
+		8F4CC50D28465BDA009BAB1D /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXResourcesBuildPhase section */
+
+/* Begin PBXSourcesBuildPhase section */
+		8F4CC50B28465BDA009BAB1D /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				8F4CC51528465BDA009BAB1D /* ContentView.swift in Sources */,
+				8F4CC51328465BDA009BAB1D /* EnvoySwiftPMExampleApp.swift in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXSourcesBuildPhase section */
+
+/* Begin XCBuildConfiguration section */
+		8F4CC51B28465BDB009BAB1D /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				CLANG_ANALYZER_NONNULL = YES;
+				CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++17";
+				CLANG_CXX_LIBRARY = "libc++";
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_ENABLE_OBJC_WEAK = YES;
+				CLANG_WARN_BLOCK_CAPTURE_AUTORELEASING = YES;
+				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_COMMA = YES;
+				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_DEPRECATED_OBJC_IMPLEMENTATIONS = YES;
+				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
+				CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
+				CLANG_WARN_EMPTY_BODY = YES;
+				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INFINITE_RECURSION = YES;
+				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_NON_LITERAL_NULL_CONVERSION = YES;
+				CLANG_WARN_OBJC_IMPLICIT_RETAIN_SELF = YES;
+				CLANG_WARN_OBJC_LITERAL_CONVERSION = YES;
+				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_QUOTED_INCLUDE_IN_FRAMEWORK_HEADER = YES;
+				CLANG_WARN_RANGE_LOOP_ANALYSIS = YES;
+				CLANG_WARN_STRICT_PROTOTYPES = YES;
+				CLANG_WARN_SUSPICIOUS_MOVE = YES;
+				CLANG_WARN_UNGUARDED_AVAILABILITY = YES_AGGRESSIVE;
+				CLANG_WARN_UNREACHABLE_CODE = YES;
+				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
+				COPY_PHASE_STRIP = NO;
+				DEBUG_INFORMATION_FORMAT = dwarf;
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				ENABLE_TESTABILITY = YES;
+				GCC_C_LANGUAGE_STANDARD = gnu11;
+				GCC_DYNAMIC_NO_PIC = NO;
+				GCC_NO_COMMON_BLOCKS = YES;
+				GCC_OPTIMIZATION_LEVEL = 0;
+				GCC_PREPROCESSOR_DEFINITIONS = (
+					"DEBUG=1",
+					"$(inherited)",
+				);
+				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
+				GCC_WARN_UNDECLARED_SELECTOR = YES;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
+				GCC_WARN_UNUSED_FUNCTION = YES;
+				GCC_WARN_UNUSED_VARIABLE = YES;
+				IPHONEOS_DEPLOYMENT_TARGET = 15.2;
+				MTL_ENABLE_DEBUG_INFO = INCLUDE_SOURCE;
+				MTL_FAST_MATH = YES;
+				ONLY_ACTIVE_ARCH = YES;
+				SDKROOT = iphoneos;
+				SWIFT_ACTIVE_COMPILATION_CONDITIONS = DEBUG;
+				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
+			};
+			name = Debug;
+		};
+		8F4CC51C28465BDB009BAB1D /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				CLANG_ANALYZER_NONNULL = YES;
+				CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++17";
+				CLANG_CXX_LIBRARY = "libc++";
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_ENABLE_OBJC_WEAK = YES;
+				CLANG_WARN_BLOCK_CAPTURE_AUTORELEASING = YES;
+				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_COMMA = YES;
+				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_DEPRECATED_OBJC_IMPLEMENTATIONS = YES;
+				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
+				CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
+				CLANG_WARN_EMPTY_BODY = YES;
+				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INFINITE_RECURSION = YES;
+				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_NON_LITERAL_NULL_CONVERSION = YES;
+				CLANG_WARN_OBJC_IMPLICIT_RETAIN_SELF = YES;
+				CLANG_WARN_OBJC_LITERAL_CONVERSION = YES;
+				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_QUOTED_INCLUDE_IN_FRAMEWORK_HEADER = YES;
+				CLANG_WARN_RANGE_LOOP_ANALYSIS = YES;
+				CLANG_WARN_STRICT_PROTOTYPES = YES;
+				CLANG_WARN_SUSPICIOUS_MOVE = YES;
+				CLANG_WARN_UNGUARDED_AVAILABILITY = YES_AGGRESSIVE;
+				CLANG_WARN_UNREACHABLE_CODE = YES;
+				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
+				COPY_PHASE_STRIP = NO;
+				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
+				ENABLE_NS_ASSERTIONS = NO;
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				GCC_C_LANGUAGE_STANDARD = gnu11;
+				GCC_NO_COMMON_BLOCKS = YES;
+				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
+				GCC_WARN_UNDECLARED_SELECTOR = YES;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
+				GCC_WARN_UNUSED_FUNCTION = YES;
+				GCC_WARN_UNUSED_VARIABLE = YES;
+				IPHONEOS_DEPLOYMENT_TARGET = 15.2;
+				MTL_ENABLE_DEBUG_INFO = NO;
+				MTL_FAST_MATH = YES;
+				SDKROOT = iphoneos;
+				SWIFT_COMPILATION_MODE = wholemodule;
+				SWIFT_OPTIMIZATION_LEVEL = "-O";
+				VALIDATE_PRODUCT = YES;
+			};
+			name = Release;
+		};
+		8F4CC51E28465BDB009BAB1D /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
+				CODE_SIGN_STYLE = Automatic;
+				CURRENT_PROJECT_VERSION = 1;
+				DEVELOPMENT_TEAM = X4ST43AL9W;
+				ENABLE_PREVIEWS = YES;
+				GENERATE_INFOPLIST_FILE = YES;
+				INFOPLIST_KEY_UIApplicationSceneManifest_Generation = YES;
+				INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents = YES;
+				INFOPLIST_KEY_UILaunchScreen_Generation = YES;
+				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPad = "UIInterfaceOrientationPortrait UIInterfaceOrientationPortraitUpsideDown UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
+				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPhone = "UIInterfaceOrientationPortrait UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+				);
+				MARKETING_VERSION = 1.0;
+				PRODUCT_BUNDLE_IDENTIFIER = io.envoyproxy.envoymobile.EnvoySwiftPMExample;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_EMIT_LOC_STRINGS = YES;
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+			};
+			name = Debug;
+		};
+		8F4CC51F28465BDB009BAB1D /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
+				CODE_SIGN_STYLE = Automatic;
+				CURRENT_PROJECT_VERSION = 1;
+				DEVELOPMENT_TEAM = X4ST43AL9W;
+				ENABLE_PREVIEWS = YES;
+				GENERATE_INFOPLIST_FILE = YES;
+				INFOPLIST_KEY_UIApplicationSceneManifest_Generation = YES;
+				INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents = YES;
+				INFOPLIST_KEY_UILaunchScreen_Generation = YES;
+				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPad = "UIInterfaceOrientationPortrait UIInterfaceOrientationPortraitUpsideDown UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
+				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPhone = "UIInterfaceOrientationPortrait UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+				);
+				MARKETING_VERSION = 1.0;
+				PRODUCT_BUNDLE_IDENTIFIER = io.envoyproxy.envoymobile.EnvoySwiftPMExample;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_EMIT_LOC_STRINGS = YES;
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+			};
+			name = Release;
+		};
+/* End XCBuildConfiguration section */
+
+/* Begin XCConfigurationList section */
+		8F4CC50A28465BDA009BAB1D /* Build configuration list for PBXProject "EnvoySwiftPMExample" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				8F4CC51B28465BDB009BAB1D /* Debug */,
+				8F4CC51C28465BDB009BAB1D /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		8F4CC51D28465BDB009BAB1D /* Build configuration list for PBXNativeTarget "EnvoySwiftPMExample" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				8F4CC51E28465BDB009BAB1D /* Debug */,
+				8F4CC51F28465BDB009BAB1D /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+/* End XCConfigurationList section */
+
+/* Begin XCSwiftPackageProductDependency section */
+		8FA85F622846650100C778FC /* NetworkClient */ = {
+			isa = XCSwiftPackageProductDependency;
+			productName = NetworkClient;
+		};
+/* End XCSwiftPackageProductDependency section */
+	};
+	rootObject = 8F4CC50728465BDA009BAB1D /* Project object */;
+}

--- a/examples/swift/swiftpm/EnvoySwiftPMExample/ContentView.swift
+++ b/examples/swift/swiftpm/EnvoySwiftPMExample/ContentView.swift
@@ -1,0 +1,36 @@
+import NetworkClient
+import SwiftUI
+
+struct ContentView: View {
+    @State private var text = "Loading..."
+    @State private var isLoading = true
+    @State private var isError = false
+
+    var body: some View {
+        Button("Get cat fact") {
+            Task { await getFact() }
+        }
+
+        Text(text)
+            .foregroundColor(isError ? .red : nil)
+            .redacted(reason: isLoading ? .placeholder : [])
+            .padding()
+            .task { await getFact() }
+    }
+
+    private func getFact() async {
+        isLoading = true
+        isError = false
+
+        do {
+            text = try await NetworkClient.getCatFact()
+            print("Successfully got cat fact:", text)
+        } catch {
+            isError = true
+            text = error.localizedDescription
+            print("Failed to get cat fact:", text)
+        }
+
+        isLoading = false
+    }
+}

--- a/examples/swift/swiftpm/EnvoySwiftPMExample/EnvoySwiftPMExampleApp.swift
+++ b/examples/swift/swiftpm/EnvoySwiftPMExample/EnvoySwiftPMExampleApp.swift
@@ -1,0 +1,10 @@
+import SwiftUI
+
+@main
+struct EnvoySwiftPMExampleApp: App {
+    var body: some Scene {
+        WindowGroup {
+            ContentView()
+        }
+    }
+}

--- a/examples/swift/swiftpm/Packages/Package.swift
+++ b/examples/swift/swiftpm/Packages/Package.swift
@@ -1,0 +1,37 @@
+// swift-tools-version:5.5
+
+import PackageDescription
+
+// swiftlint:disable line_length
+
+let package = Package(
+    name: "NetworkClient",
+    platforms: [.iOS(.v15)],
+    products: [
+        .library(
+            name: "NetworkClient",
+            targets: ["NetworkClient"]),
+    ],
+    targets: [
+        .target(
+            name: "NetworkClient",
+            dependencies: ["Envoy"],
+            linkerSettings: [
+                .linkedLibrary("c++"),
+                .linkedLibrary("Network"),
+                .linkedFramework("SystemConfiguration"),
+            ]
+        ),
+        // Local xcframework
+        .binaryTarget(
+            name: "Envoy",
+            path: "Envoy.xcframework"
+        ),
+        // GitHub Releases xcframework
+        // .binaryTarget(
+        //     name: "Envoy",
+        //     url: "https://github.com/envoyproxy/envoy-mobile/releases/download/v0.4.6.20220530/Envoy.xcframework.zip",
+        //     checksum: "b73ce19128f314a43bce735f057d7ae57eef92e646d1df93723e8c71a86e5479"
+        // ),
+    ]
+)

--- a/examples/swift/swiftpm/Packages/Sources/NetworkClient/NetworkClient.swift
+++ b/examples/swift/swiftpm/Packages/Sources/NetworkClient/NetworkClient.swift
@@ -1,0 +1,70 @@
+import Envoy
+import Foundation
+
+// MARK: - Network Client
+
+public enum NetworkClient {
+    public static func getCatFact() async throws -> String {
+        try await withCheckedThrowingContinuation { continuation in
+            DispatchQueue.networking.async {
+                let stream = EngineBuilder.demoEngine
+                    .streamClient()
+                    .newStreamPrototype()
+                    .setOnResponseData(closure: { body, _, _ in
+                        do {
+                            let fact = try JSONDecoder().decode(FactResponse.self, from: body)
+                            continuation.resume(returning: fact.fact)
+                        } catch {
+                            continuation.resume(throwing: FactError.parse)
+                        }
+                    })
+                    .setOnError(closure: { error, _ in
+                        continuation.resume(throwing: FactError.network(error))
+                    })
+                    .start(queue: .networking)
+
+                let headers = RequestHeadersBuilder(
+                    method: .get, scheme: "https", authority: "catfact.ninja", path: "/fact"
+                ).build()
+                stream.sendHeaders(headers, endStream: true)
+            }
+        }
+    }
+}
+
+// MARK: - Envoy Engine
+
+private extension EngineBuilder {
+    static let demoEngine = EngineBuilder()
+        .build()
+}
+
+// MARK: - Networking Concurrent Queue
+
+private extension DispatchQueue {
+    static let networking = DispatchQueue(label: "io.envoyproxy.envoymobile.networking",
+                                          qos: .userInitiated, attributes: .concurrent)
+}
+
+// MARK: - Models
+
+private struct FactResponse: Codable {
+    let fact: String
+}
+
+private enum FactError: LocalizedError {
+    case parse
+    case network(Error)
+
+    var localizedDescription: String {
+        switch self {
+        case .parse:
+            return "Could not parse fact response"
+        case .network(let error):
+            return """
+                Could not fetch fact
+                \(error.localizedDescription)
+                """
+        }
+    }
+}

--- a/tools/check_format.sh
+++ b/tools/check_format.sh
@@ -23,7 +23,7 @@ TARGET_PATH="$2"
 # TODO(mattklein123): WORKSPACE is excluded due to warning about @bazel_tools reference. Fix here
 #                     or in the upstream checker.
 ENVOY_BAZEL_PREFIX=@envoy envoy/tools/code_format/check_format.py \
-    --add-excluded-prefixes ./envoy/ ./envoy_build_config/extensions_build_config.bzl ./WORKSPACE ./Envoy.xcodeproj/ ./dist/ ./library/common/config_template.cc ./bazel/envoy_mobile_swift_bazel_support.bzl ./bazel/envoy_mobile_repositories.bzl \
+    --add-excluded-prefixes ./envoy/ ./envoy_build_config/extensions_build_config.bzl ./WORKSPACE ./Envoy.xcodeproj/ ./dist/ ./library/common/config_template.cc ./bazel/envoy_mobile_swift_bazel_support.bzl ./bazel/envoy_mobile_repositories.bzl ./examples/swift/swiftpm/Packages/Envoy.xcframework \
     --skip_envoy_build_rule_check "$ENVOY_FORMAT_ACTION" $TARGET_PATH \
     --namespace_check_excluded_paths ./envoy ./examples/ ./library/java/ ./library/kotlin ./library/objective-c ./test/java ./test/java ./test/objective-c ./test/swift ./experimental/swift \
     --build_fixer_check_excluded_paths ./envoy ./BUILD ./dist ./examples ./library/java ./library/kotlin ./library/objective-c ./library/swift ./library/common/extensions ./test/java ./test/kotlin ./test/objective-c ./test/swift ./experimental/swift


### PR DESCRIPTION
And validate that it builds successfully on CI.

Ideally we'd have a whole suite of example integrations that validate all our supported installation methods, but this should be a good start.

I reached out to the owner of https://catfacts.ninja to make sure this usage is within the terms of service and will update to use something else if necessary.

https://user-images.githubusercontent.com/474794/171312056-2167333a-fb88-4cfe-aa30-353cceaa49a0.mp4

Signed-off-by: JP Simard <jp@jpsim.com>