### PR TITLE
ios: add support for registering a platform KV store

### DIFF
--- a/docs/root/intro/version_history.rst
+++ b/docs/root/intro/version_history.rst
@@ -23,7 +23,7 @@ Bugfixes:
 
 Features:
 
-- android: add support for registering a platform KV store (:issue: `#2134 <2134>`)
+- Android & iOS: add support for registering a platform KV store (:issue: `#2134 <2134>`) (:issue: `#2335 <2335>`)
 - api: add option to extend the keepalive timeout when any frame is received on the owning HTTP/2 connection. (:issue:`#2229 <2229>`)
 - api: add option to control whether Envoy should drain connections after a soft DNS refresh completes. (:issue:`#2225 <2225>`, :issue:`#2242 <2242>`)
 - configuration: enable h2 ping by default. (:issue: `#2270 <2270>`)
@@ -31,7 +31,6 @@ Features:
 - instrumentation: add timers and warnings to platform-provided callbacks (:issue: `#2300 <2300>`)
 - iOS: add support for integrating Envoy Mobile via the Swift Package Manager
 - iOS: add support for registering a platform KV store (:issue: `#2334 <2334>`)
-- iOS: A documentation archive is now included in the GitHub release artifact (:issue: `#2335 <2335>`)
 
 0.4.6 (April 26, 2022)
 ========================

--- a/docs/root/intro/version_history.rst
+++ b/docs/root/intro/version_history.rst
@@ -30,6 +30,7 @@ Features:
 - android: enable the filtering of unroutable families by default. (:issues: `#2267 <2267>`)
 - instrumentation: add timers and warnings to platform-provided callbacks (:issue: `#2300 <2300>`)
 - iOS: add support for integrating Envoy Mobile via the Swift Package Manager
+- iOS: add support for registering a platform KV store (:issue: `#2334 <2334>`)
 
 0.4.6 (April 26, 2022)
 ========================

--- a/docs/root/intro/version_history.rst
+++ b/docs/root/intro/version_history.rst
@@ -30,7 +30,7 @@ Features:
 - android: enable the filtering of unroutable families by default. (:issues: `#2267 <2267>`)
 - instrumentation: add timers and warnings to platform-provided callbacks (:issue: `#2300 <2300>`)
 - iOS: add support for integrating Envoy Mobile via the Swift Package Manager
-- iOS: add support for registering a platform KV store (:issue: `#2334 <2334>`)
+- iOS: A documentation archive is now included in the GitHub release artifact (:issue: `#2335 <2335>`)
 
 0.4.6 (April 26, 2022)
 ========================

--- a/library/objective-c/EnvoyConfiguration.m
+++ b/library/objective-c/EnvoyConfiguration.m
@@ -37,7 +37,10 @@
                                   (NSArray<EnvoyHTTPFilterFactory *> *)httpPlatformFilterFactories
                                   stringAccessors:
                                       (NSDictionary<NSString *, EnvoyStringAccessor *> *)
-                                          stringAccessors {
+                                          stringAccessors
+                                  keyValueStores:
+                                      (NSDictionary<NSString *, id<EnvoyKeyValueStore>> *)
+                                          keyValueStores {
   self = [super init];
   if (!self) {
     return nil;
@@ -73,6 +76,7 @@
   self.nativeFilterChain = nativeFilterChain;
   self.httpPlatformFilterFactories = httpPlatformFilterFactories;
   self.stringAccessors = stringAccessors;
+  self.keyValueStores = keyValueStores;
   return self;
 }
 

--- a/library/objective-c/EnvoyConfiguration.m
+++ b/library/objective-c/EnvoyConfiguration.m
@@ -38,9 +38,9 @@
                                   stringAccessors:
                                       (NSDictionary<NSString *, EnvoyStringAccessor *> *)
                                           stringAccessors
-                                  keyValueStores:
-                                      (NSDictionary<NSString *, id<EnvoyKeyValueStore>> *)
-                                          keyValueStores {
+                                   keyValueStores:
+                                       (NSDictionary<NSString *, id<EnvoyKeyValueStore>> *)
+                                           keyValueStores {
   self = [super init];
   if (!self) {
     return nil;

--- a/library/objective-c/EnvoyEngine.h
+++ b/library/objective-c/EnvoyEngine.h
@@ -315,6 +315,23 @@ extern const int kEnvoyFilterResumeStatusResumeIteration;
 
 @end
 
+#pragma mark - EnvoyKeyValueStore
+
+@protocol EnvoyKeyValueStore
+
+/// Read a value from the key value store iplementation.
+- (NSString *_Nullable)read:(NSString *)key;
+
+
+/// Remove a value from the key value store implementation.
+- (void)save:(NSString *)key value:(NSString *)value;
+
+
+/// Save a value to the key value store implementation.
+- (void)remove:(NSString *)key;
+
+@end
+
 #pragma mark - EnvoyNativeFilterConfig
 
 @interface EnvoyNativeFilterConfig : NSObject
@@ -360,6 +377,7 @@ extern const int kEnvoyFilterResumeStatusResumeIteration;
 @property (nonatomic, strong) NSArray<EnvoyNativeFilterConfig *> *nativeFilterChain;
 @property (nonatomic, strong) NSArray<EnvoyHTTPFilterFactory *> *httpPlatformFilterFactories;
 @property (nonatomic, strong) NSDictionary<NSString *, EnvoyStringAccessor *> *stringAccessors;
+@property (nonatomic, strong) NSDictionary<NSString *, id<EnvoyKeyValueStore>> *keyValueStores;
 
 /**
  Create a new instance of the configuration.
@@ -397,7 +415,10 @@ extern const int kEnvoyFilterResumeStatusResumeIteration;
                                   (NSArray<EnvoyHTTPFilterFactory *> *)httpPlatformFilterFactories
                                   stringAccessors:
                                       (NSDictionary<NSString *, EnvoyStringAccessor *> *)
-                                          stringAccessors;
+                                          stringAccessors
+                                  keyValueStores:
+                                      (NSDictionary<NSString *, id<EnvoyKeyValueStore>> *)
+                                          keyValueStores;
 
 /**
  Resolves the provided configuration template using properties on this configuration.

--- a/library/objective-c/EnvoyEngine.h
+++ b/library/objective-c/EnvoyEngine.h
@@ -320,15 +320,15 @@ extern const int kEnvoyFilterResumeStatusResumeIteration;
 @protocol EnvoyKeyValueStore
 
 /// Read a value from the key value store iplementation.
-- (NSString *_Nullable)read:(NSString *)key;
+- (NSString *_Nullable)readValueForKey:(NSString *)key;
 
 
 /// Remove a value from the key value store implementation.
-- (void)save:(NSString *)key value:(NSString *)value;
+- (void)saveValue:(NSString *)value toKey:(NSString *)key;
 
 
 /// Save a value to the key value store implementation.
-- (void)remove:(NSString *)key;
+- (void)removeKey:(NSString *)key;
 
 @end
 

--- a/library/objective-c/EnvoyEngine.h
+++ b/library/objective-c/EnvoyEngine.h
@@ -322,10 +322,10 @@ extern const int kEnvoyFilterResumeStatusResumeIteration;
 /// Read a value from the key value store iplementation.
 - (NSString *_Nullable)readValueForKey:(NSString *)key;
 
-/// Remove a value from the key value store implementation.
+/// Save a value to the key value store implementation.
 - (void)saveValue:(NSString *)value toKey:(NSString *)key;
 
-/// Save a value to the key value store implementation.
+/// Remove a value from the key value store implementation.
 - (void)removeKey:(NSString *)key;
 
 @end

--- a/library/objective-c/EnvoyEngine.h
+++ b/library/objective-c/EnvoyEngine.h
@@ -322,10 +322,8 @@ extern const int kEnvoyFilterResumeStatusResumeIteration;
 /// Read a value from the key value store iplementation.
 - (NSString *_Nullable)readValueForKey:(NSString *)key;
 
-
 /// Remove a value from the key value store implementation.
 - (void)saveValue:(NSString *)value toKey:(NSString *)key;
-
 
 /// Save a value to the key value store implementation.
 - (void)removeKey:(NSString *)key;
@@ -416,9 +414,9 @@ extern const int kEnvoyFilterResumeStatusResumeIteration;
                                   stringAccessors:
                                       (NSDictionary<NSString *, EnvoyStringAccessor *> *)
                                           stringAccessors
-                                  keyValueStores:
-                                      (NSDictionary<NSString *, id<EnvoyKeyValueStore>> *)
-                                          keyValueStores;
+                                   keyValueStores:
+                                       (NSDictionary<NSString *, id<EnvoyKeyValueStore>> *)
+                                           keyValueStores;
 
 /**
  Resolves the provided configuration template using properties on this configuration.

--- a/library/objective-c/EnvoyEngine.h
+++ b/library/objective-c/EnvoyEngine.h
@@ -319,7 +319,7 @@ extern const int kEnvoyFilterResumeStatusResumeIteration;
 
 @protocol EnvoyKeyValueStore
 
-/// Read a value from the key value store iplementation.
+/// Read a value from the key value store implementation.
 - (NSString *_Nullable)readValueForKey:(NSString *)key;
 
 /// Save a value to the key value store implementation.

--- a/library/swift/BUILD
+++ b/library/swift/BUILD
@@ -17,6 +17,7 @@ swift_library(
         "FinalStreamIntel.swift",
         "Headers.swift",
         "HeadersBuilder.swift",
+        "KeyValueStore.swift",
         "LogLevel.swift",
         "PulseClient.swift",
         "PulseClientImpl.swift",

--- a/library/swift/EngineBuilder.swift
+++ b/library/swift/EngineBuilder.swift
@@ -44,6 +44,7 @@ open class EngineBuilder: NSObject {
   private var nativeFilterChain: [EnvoyNativeFilterConfig] = []
   private var platformFilterChain: [EnvoyHTTPFilterFactory] = []
   private var stringAccessors: [String: EnvoyStringAccessor] = [:]
+  private var keyValueStores: [String: EnvoyKeyValueStore] = [:]
   private var directResponses: [DirectResponse] = []
 
   // MARK: - Public
@@ -355,6 +356,18 @@ open class EngineBuilder: NSObject {
     return self
   }
 
+  /// Register a key-value store implementation for internal use.
+  ///
+  /// - parameter name: the name of the KV store.
+  /// - parameter keyValueStore: the KV store implementation.
+  ///
+  /// - returns this builder.
+  @discardableResult
+  public func addKeyValueStore(name: String, keyValueStore: KeyValueStore) -> Self {
+    self.keyValueStores[name] = KeyValueStoreImpl(implementation: keyValueStore)
+    return self
+  }
+
   /// Set a closure to be called when the engine finishes its async startup and begins running.
   ///
   /// - parameter closure: The closure to be called.
@@ -482,7 +495,8 @@ open class EngineBuilder: NSObject {
         .joined(separator: "\n"),
       nativeFilterChain: self.nativeFilterChain,
       platformFilterChain: self.platformFilterChain,
-      stringAccessors: self.stringAccessors
+      stringAccessors: self.stringAccessors,
+      keyValueStores: self.keyValueStores
     )
 
     switch self.base {

--- a/library/swift/EngineBuilder.swift
+++ b/library/swift/EngineBuilder.swift
@@ -349,7 +349,7 @@ open class EngineBuilder: NSObject {
   /// - parameter name: the name of the accessor.
   /// - parameter accessor: lambda to access a string from the platform layer.
   ///
-  /// - returns this builder.
+  /// - returns: This builder.
   @discardableResult
   public func addStringAccessor(name: String, accessor: @escaping () -> String) -> Self {
     self.stringAccessors[name] = EnvoyStringAccessor(block: accessor)
@@ -361,7 +361,7 @@ open class EngineBuilder: NSObject {
   /// - parameter name: the name of the KV store.
   /// - parameter keyValueStore: the KV store implementation.
   ///
-  /// - returns this builder.
+  /// - returns: This builder.
   @discardableResult
   public func addKeyValueStore(name: String, keyValueStore: KeyValueStore) -> Self {
     self.keyValueStores[name] = KeyValueStoreImpl(implementation: keyValueStore)

--- a/library/swift/KeyValueStore.swift
+++ b/library/swift/KeyValueStore.swift
@@ -3,13 +3,18 @@ import Foundation
 
 /// `KeyValueStore` is an interface that may be implemented to provide access to an arbitrary
 /// key-value store implementation that may be made accessible to native Envoy Mobile code.
-
 public protocol KeyValueStore {
+  /// Read a value from the key value store iplementation.
   func readValue(forKey key: String) -> String?
+
+  /// Save a value to the key value store implementation.
   func saveValue(_ value: String, toKey key: String)
+
+  /// Remove a value from the key value store implementation.
   func removeKey(_ key: String)
 }
 
+/// KeyValueStoreImpl is an internal type used for mapping calls from the common library layer.
 internal class KeyValueStoreImpl: EnvoyKeyValueStore {
   internal let implementation: KeyValueStore
 

--- a/library/swift/KeyValueStore.swift
+++ b/library/swift/KeyValueStore.swift
@@ -4,7 +4,7 @@ import Foundation
 /// `KeyValueStore` is an interface that may be implemented to provide access to an arbitrary
 /// key-value store implementation that may be made accessible to native Envoy Mobile code.
 public protocol KeyValueStore {
-  /// Read a value from the key value store iplementation.
+  /// Read a value from the key value store implementation.
   func readValue(forKey key: String) -> String?
 
   /// Save a value to the key value store implementation.

--- a/library/swift/KeyValueStore.swift
+++ b/library/swift/KeyValueStore.swift
@@ -4,14 +4,13 @@ import Foundation
 /// `KeyValueStore` is an interface that may be implemented to provide access to an arbitrary
 /// key-value store implementation that may be made accessible to native Envoy Mobile code.
 
-
 public protocol KeyValueStore {
   func readValue(forKey key: String) -> String?
   func saveValue(_ value: String, toKey key: String)
   func removeKey(_ key: String)
 }
 
-internal class KeyValueStoreImpl : EnvoyKeyValueStore {
+internal class KeyValueStoreImpl: EnvoyKeyValueStore {
   internal let implementation: KeyValueStore
 
   init(implementation: KeyValueStore) {

--- a/library/swift/KeyValueStore.swift
+++ b/library/swift/KeyValueStore.swift
@@ -1,0 +1,32 @@
+@_implementationOnly import EnvoyEngine
+import Foundation
+
+/// `KeyValueStore` is an interface that may be implemented to provide access to an arbitrary
+/// key-value store implementation that may be made accessible to native Envoy Mobile code.
+
+
+public protocol KeyValueStore {
+  func readValue(forKey key: String) -> String?
+  func saveValue(_ value: String, toKey key: String)
+  func removeKey(_ key: String)
+}
+
+internal class KeyValueStoreImpl : EnvoyKeyValueStore {
+  internal let implementation: KeyValueStore
+
+  init(implementation: KeyValueStore) {
+    self.implementation = implementation
+  }
+
+  func readValue(forKey key: String) -> String? {
+    return implementation.readValue(forKey: key)
+  }
+
+  func saveValue(_ value: String, toKey key: String) {
+    implementation.saveValue(value, toKey: key)
+  }
+
+  func removeKey(_ key: String) {
+    implementation.removeKey(key)
+  }
+}

--- a/test/swift/EngineBuilderTests.swift
+++ b/test/swift/EngineBuilderTests.swift
@@ -426,7 +426,7 @@ final class EngineBuilderTests: XCTestCase {
     }
 
     let testStore: KeyValueStore = {
-      class TestStore : KeyValueStore {
+      class TestStore: KeyValueStore {
         private var dict: [String: String] = [:]
 
         func readValue(forKey key: String) -> String? {

--- a/test/swift/EngineBuilderTests.swift
+++ b/test/swift/EngineBuilderTests.swift
@@ -452,7 +452,8 @@ final class EngineBuilderTests: XCTestCase {
       platformFilterChain: [
         EnvoyHTTPFilterFactory(filterName: "TestFilter", factory: TestFilter.init),
       ],
-      stringAccessors: [:]
+      stringAccessors: [:],
+      keyValueStores: [:]
     )
     let resolvedYAML = try XCTUnwrap(config.resolveTemplate(kMockTemplate))
     XCTAssertTrue(resolvedYAML.contains("&connect_timeout 200s"))
@@ -532,7 +533,8 @@ final class EngineBuilderTests: XCTestCase {
       platformFilterChain: [
         EnvoyHTTPFilterFactory(filterName: "TestFilter", factory: TestFilter.init),
       ],
-      stringAccessors: [:]
+      stringAccessors: [:],
+      keyValueStores: [:]
     )
     let resolvedYAML = try XCTUnwrap(config.resolveTemplate(kMockTemplate))
     XCTAssertTrue(resolvedYAML.contains("&dns_lookup_family V4_PREFERRED"))
@@ -573,7 +575,8 @@ final class EngineBuilderTests: XCTestCase {
       directResponses: "",
       nativeFilterChain: [],
       platformFilterChain: [],
-      stringAccessors: [:]
+      stringAccessors: [:],
+      keyValueStores: [:]
     )
     XCTAssertNil(config.resolveTemplate("{{ missing }}"))
   }


### PR DESCRIPTION
Description: Adds EngineBuilder API and internal support for registering a platform key-value store on iOS. Internally this may be leveraged for HTTP caching, endpoint protocol support caching, and use in filters.
Risk: Moderate
Testing: Updated coverage.

Signed-off-by: Mike Schore <mike.schore@gmail.com>