### PR TITLE
release: re-package xcframework zip

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -126,8 +126,13 @@ jobs:
             --config=remote-ci-macos \
             --remote_header="Authorization=Bearer $GITHUB_TOKEN" \
             //:ios_xcframework
-      - name: 'Move Envoy.xcframework.zip'
-        run: mv bazel-bin/library/swift/Envoy.xcframework.zip .
+      # Recompress as bazel's zip leads to bad CRC values
+      # See https://github.com/bazelbuild/rules_apple/issues/1489
+      - name: 'Recompress Envoy.xcframework.zip'
+        run: |
+          unzip bazel-bin/library/swift/Envoy.xcframework.zip || true
+          zip -r Envoy.xcframework.zip Envoy.xcframework
+          rm -rf Envoy.xcframework
       - uses: actions/upload-artifact@v2
         with:
           name: ios_framework


### PR DESCRIPTION
Bazel's archive leads to bad CRC values.

Works around https://github.com/bazelbuild/rules_apple/issues/1489.