### PR TITLE
bazel: retry repository downloads

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -20,6 +20,7 @@ build --verbose_failures
 build --workspace_status_command=envoy/bazel/get_workspace_status
 build --xcode_version=13.2.1
 build --use_top_level_targets_for_symlinks
+build --experimental_repository_downloader_retries=2
 # https://github.com/bazelbuild/rules_jvm_external/issues/445
 build --repo_env=JAVA_HOME=../bazel_tools/jdk
 build --define disable_known_issue_asserts=true


### PR DESCRIPTION
Sometimes these downloads fail due to transient errors (example: https://github.com/envoyproxy/envoy-mobile/runs/6728606246?check_suite_focus=true) and a retry will succeed.

Configure the downloader to retry twice before giving up.

Fixes https://github.com/envoyproxy/envoy-mobile/issues/2337