### PR TITLE
iOS: stop embedding bitcode in releases

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -93,10 +93,8 @@ build:release-common --config=sizeopt
 build:release-common --copt=-fvisibility=hidden
 
 # Flags for release builds targeting iOS
-build:release-ios --apple_bitcode=embedded
 build:release-ios --config=ios
 build:release-ios --config=release-common
-build:release-ios --copt=-fembed-bitcode
 build:release-ios --compilation_mode=opt
 
 # Flags for release builds targeting Android or the JVM

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -126,13 +126,6 @@ jobs:
             --config=remote-ci-macos \
             --remote_header="Authorization=Bearer $GITHUB_TOKEN" \
             //:ios_xcframework
-      # Recompress as bazel's zip leads to bad CRC values
-      # See https://github.com/bazelbuild/rules_apple/issues/1489
-      - name: 'Recompress Envoy.xcframework.zip'
-        run: |
-          unzip bazel-bin/library/swift/Envoy.xcframework.zip || true
-          zip -r Envoy.xcframework.zip Envoy.xcframework
-          rm -rf Envoy.xcframework
       - uses: actions/upload-artifact@v2
         with:
           name: ios_framework

--- a/docs/root/intro/version_history.rst
+++ b/docs/root/intro/version_history.rst
@@ -13,6 +13,7 @@ Breaking changes:
 - iOS: remove support for installing via CocoaPods, which had not worked since 2020 (:issue:`#2215 <2215>`)
 - iOS: enable usage of ``NWPathMonitor`` by default (:issue:`#2329 <2329>`)
 - iOS: replace ``enableNetworkPathMonitor`` with a new ``setNetworkMonitoringMode`` API to allow disabling monitoring (:issue:`#2345 <2345>`)
+- iOS: release artifacts no longer embed bitcode
 
 Bugfixes:
 


### PR DESCRIPTION
Bitcode is all but dead at this point.

Here's a deprecation note from the Xcode 14 beta 1 release notes:

https://developer.apple.com/documentation/Xcode-Release-Notes/xcode-14-release-notes

> Starting with Xcode 14, bitcode is no longer required for watchOS and
> tvOS applications, and the App Store no longer accepts bitcode
> submissions from Xcode 14.

> Xcode no longer builds bitcode by default and generates a warning
> message if a project explicitly enables bitcode: “Building with
> bitcode is deprecated. Please update your project and/or target
> settings to disable bitcode.” The capability to build with bitcode
> will be removed in a future Xcode release. IPAs that contain bitcode
> will have the bitcode stripped before being submitted to the App
> Store. Debug symbols for past bitcode submissions remain available
> for download. (86118779)