### PR TITLE
config: hopefully fixing C++ config default for apple

### DIFF
--- a/library/common/config/config.cc
+++ b/library/common/config/config.cc
@@ -69,9 +69,17 @@ const std::string config_header = R"(
 - &dns_multiple_addresses true
 - &dns_preresolve_hostnames []
 - &dns_refresh_rate 60s
-- &dns_resolver_name envoy.network.dns_resolver.cares
+)"
+#if defined(__APPLE__)
+R"(- &dns_resolver_name envoy.network.dns_resolver.apple
+- &dns_resolver_config {"@type":"type.googleapis.com/envoy.extensions.network.dns_resolver.apple.v3.AppleDnsResolverConfig"}
+)"
+#else
+R"(- &dns_resolver_name envoy.network.dns_resolver.cares
 - &dns_resolver_config {"@type":"type.googleapis.com/envoy.extensions.network.dns_resolver.cares.v3.CaresDnsResolverConfig"}
-- &enable_drain_post_dns_refresh false
+)"
+#endif
+R"(- &enable_drain_post_dns_refresh false
 - &enable_interface_binding false
 - &h2_connection_keepalive_idle_interval 100000s
 - &h2_connection_keepalive_timeout 10s

--- a/library/objective-c/EnvoyConfiguration.m
+++ b/library/objective-c/EnvoyConfiguration.m
@@ -150,7 +150,6 @@
   [definitions appendFormat:@"- &h2_delay_keepalive_timeout %@\n",
                             self.h2ExtendKeepaliveTimeout ? @"true" : @"false"];
   [definitions appendFormat:@"- &dns_refresh_rate %lus\n", (unsigned long)self.dnsRefreshSeconds];
-  [definitions appendFormat:@"- &dns_resolver_name envoy.network.dns_resolver.apple\n"];
   [definitions appendFormat:@"- &enable_drain_post_dns_refresh %@\n",
                             self.enableDrainPostDnsRefresh ? @"true" : @"false"];
   // No additional values are currently needed for Apple-based DNS resolver.


### PR DESCRIPTION
Replacing the default dns resolver in the config string to be correct for the OS in question.
Replaced overrides in the swift code now that the base config handles it.

Risk Level: low
Testing: existing tests should verify correctness
Docs Changes: n/a
Release Notes: did not add