### PR TITLE
ci: pin external GitHub Action

### DIFF
--- a/.github/workflows/bump_support_rotation.yml
+++ b/.github/workflows/bump_support_rotation.yml
@@ -20,7 +20,7 @@ jobs:
         run: ./tools/bump_lyft_support_rotation.sh
       - name: Create PR
         id: pr
-        uses: peter-evans/create-pull-request@v3
+        uses: peter-evans/create-pull-request@923ad837f191474af6b1721408744feb989a4c27
         with:
           token: ${{ secrets.CREDENTIALS_GITHUB_PUSH_TOKEN }}
           title: Bump Lyft Support Rotation

--- a/.github/workflows/submodule_update.yml
+++ b/.github/workflows/submodule_update.yml
@@ -34,7 +34,7 @@ jobs:
         echo "::set-output name=maintainer::$current"
     - name: Create PR
       if: steps.state.outputs.dirty == 'true'
-      uses: peter-evans/create-pull-request@v3
+      uses: peter-evans/create-pull-request@923ad837f191474af6b1721408744feb989a4c27
       with:
         token: ${{ secrets.CREDENTIALS_GITHUB_PUSH_TOKEN }}
         title: Update Envoy


### PR DESCRIPTION
Description: Improves security with respect to third-party actions. See:
https://docs.github.com/en/actions/security-guides/security-hardening-for-github-actions

I also read through the recent commits and updated to the latest release, since it contained a few bugfixes.

Risk: Low
Testing: CI

Signed-off-by: Mike Schore <mike.schore@gmail.com>
