### PR TITLE
stats: disable global stats in config

### DIFF
--- a/library/common/config/config.cc
+++ b/library/common/config/config.cc
@@ -508,6 +508,8 @@ layered_runtime:
     - name: static_layer_0
       static_layer:
         envoy:
+          # This disables envoy bug stats, which are filtered out of our stats inclusion list anyway
+          disallow_global_stats: true
           reloadable_features:
             allow_multiple_dns_addresses: *dns_multiple_addresses
             http2_delay_keepalive_timeout: *h2_delay_keepalive_timeout


### PR DESCRIPTION
These are already being filtered out of our stats inclusion list, so this isn't a user-facing change, but this is needed to support the singleton removal work in https://github.com/envoyproxy/envoy-mobile/pull/2129.

Splitting this out into its own PR to reduce the scope of the singleton removal change.

Risk Level: Low
Testing: None
Docs Changes: N/A, not a user-facing change
Release Notes: N/A, not a user-facing change