### PR TITLE
bazel: use `device_and_simulator` rule

### DIFF
--- a/BUILD
+++ b/BUILD
@@ -1,6 +1,10 @@
 load("@build_bazel_rules_android//android:rules.bzl", "aar_import")
 load("@build_bazel_rules_apple//apple:apple.bzl", "apple_static_framework_import")
 load("@io_bazel_rules_kotlin//kotlin/internal:toolchains.bzl", "define_kt_toolchain")
+load(
+    "@com_github_buildbuddy_io_rules_xcodeproj//xcodeproj:experimental.bzl",
+    "device_and_simulator",
+)
 load("@com_github_buildbuddy_io_rules_xcodeproj//xcodeproj:xcodeproj.bzl", "xcodeproj")
 load("//bazel:framework_imports_extractor.bzl", "framework_imports_extractor")
 
@@ -95,6 +99,20 @@ genrule(
     tools = ["@kotlin_formatter//file"],
 )
 
+device_and_simulator(
+    name = "ios_examples",
+    tags = ["manual"],
+    targets = [
+        # TODO(jpsim): Fix Objective-C app support
+        # "//examples/objective-c/hello_world:app",
+        "//examples/swift/async_await:app",
+        "//examples/swift/hello_world:app",
+        "//test/swift/apps/baseline:app",
+        "//test/swift/apps/experimental:app",
+    ],
+    visibility = ["//visibility:public"],
+)
+
 xcodeproj(
     name = "xcodeproj",
     archived_bundles_allowed = True,
@@ -108,12 +126,7 @@ xcodeproj(
         "//library/objective-c:envoy_engine_objc_lib",
         "//library/common:envoy_main_interface_lib",
         # Apps
-        # TODO(jpsim): Fix Objective-C app support
-        # "//examples/objective-c/hello_world:app",
-        "//examples/swift/async_await:app",
-        "//examples/swift/hello_world:app",
-        "//test/swift/apps/baseline:app",
-        "//test/swift/apps/experimental:app",
+        "//:ios_examples",
         # Tests
         "//experimental/swift:quic_stream_test",
         "//test/objective-c:envoy_bridge_utility_test",

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -67,3 +67,12 @@ android_workspace()
 
 load("@com_github_buildbuddy_io_rules_xcodeproj//xcodeproj:repositories.bzl", "xcodeproj_rules_dependencies")
 xcodeproj_rules_dependencies()
+
+load(
+    "@build_bazel_rules_apple//apple:apple.bzl",
+    "provisioning_profile_repository",
+)
+
+provisioning_profile_repository(
+    name = "local_provisioning_profiles",
+)

--- a/bazel/envoy_mobile_repositories.bzl
+++ b/bazel/envoy_mobile_repositories.bzl
@@ -70,12 +70,12 @@ def upstream_envoy_overrides():
     )
 
 def swift_repos():
-    # https://github.com/bazelbuild/rules_apple/pull/1488
+    # https://github.com/bazelbuild/rules_apple/pull/1492
     http_archive(
         name = "build_bazel_rules_apple",
-        sha256 = "0f2275197c950d82fc5defc81cfe53a71e4c9cae2d79852df1b2e9d0f0fb9fcf",
-        strip_prefix = "rules_apple-ac43c1e467564d9df6b3355ff93fcaf224f2c0f9",
-        url = "https://github.com/bazelbuild/rules_apple/archive/ac43c1e467564d9df6b3355ff93fcaf224f2c0f9.tar.gz",
+        sha256 = "80b54235cc7b4118ae5a644c2375a41995bb24868b1e58793b9ca99d9adf4c34",
+        strip_prefix = "rules_apple-029eab0a6bbb4147d227d623721b205eb62aca9c",
+        url = "https://github.com/bazelbuild/rules_apple/archive/029eab0a6bbb4147d227d623721b205eb62aca9c.tar.gz",
     )
 
     # https://github.com/bazelbuild/rules_swift/pull/838
@@ -100,10 +100,12 @@ def swift_repos():
         url = "https://github.com/realm/SwiftLint/releases/download/0.47.1/portable_swiftlint.zip",
     )
 
+    # https://github.com/buildbuddy-io/rules_xcodeproj/pull/552
     http_archive(
         name = "com_github_buildbuddy_io_rules_xcodeproj",
-        sha256 = "5a902801e2337fc14faeb2613d70202f2dd4755bba3d94ba068c1f622edba89e",
-        url = "https://github.com/buildbuddy-io/rules_xcodeproj/releases/download/0.3.0/release.tar.gz",
+        sha256 = "23c0b0a4a76725350deaaa70e0dedd27f3a2f449ef05ab7959577bc9eafe27ad",
+        strip_prefix = "rules_xcodeproj-0f6e85cf892f6739ee489b931699595559f5d805",
+        url = "https://github.com/buildbuddy-io/rules_xcodeproj/archive/0f6e85cf892f6739ee489b931699595559f5d805.tar.gz",
     )
 
 def kotlin_repos():

--- a/docs/root/development/debugging/ios_local.rst
+++ b/docs/root/development/debugging/ios_local.rst
@@ -55,21 +55,12 @@ compiled source files in C/C++/Objective-C/Objective-C++/Swift:
 Running on a real iPhone
 ------------------------
 
-Although building and running on a physical device is
-`not yet officially supported <https://github.com/buildbuddy-io/rules_xcodeproj/issues/285>`_
-by rules_xcodeproj, following these steps may work:
+You can build and run the example iOS apps on a physical iPhone by
+following these steps:
 
-1. Add ``build --ios_multi_cpus=arm64`` to ``.bazelrc``.
-2. Add a ``.mobileprovision`` provisioning profile capable of signing
-   the app you want to run next to its ``BUILD`` file.
-   E.g. ``examples/swift/hello_world/dev.mobileprovision``
-3. Set the provisioning profile on the ``ios_application`` you want to
-   run. E.g. ``provisioning_profile = "dev.mobileprovision",``
-4. Remove all apps without a provisioning profile from the ``xcodeproj``
-   configuration in Envoy Mobile's root ``BUILD`` file.
-5. Follow the same steps as defined in the
+1. Set the ``TEAMID`` value in ``examples/BUILD`` to your Apple
+   Developer Team ID found in the
+   `Apple Developer Portal <https://developer.apple.com/account/#!/membership>`_.
+2. Follow the same steps as defined in the
    :ref:`Using the Xcode GUI <using_xcode>` section above, but
    targeting your device instead of a simulator.
-
-*Note: You may need to clean from Xcode with cmd-shift-k between device
-runs.*

--- a/docs/root/development/debugging/ios_local.rst
+++ b/docs/root/development/debugging/ios_local.rst
@@ -58,9 +58,12 @@ Running on a real iPhone
 You can build and run the example iOS apps on a physical iPhone by
 following these steps:
 
-1. Set the ``TEAMID`` value in ``examples/BUILD`` to your Apple
+1. Set the ``TEAM_ID`` value in ``examples/BUILD`` to your Apple
    Developer Team ID found in the
    `Apple Developer Portal <https://developer.apple.com/account/#!/membership>`_.
-2. Follow the same steps as defined in the
+2. If needed, change the ``PROFILE_NAME`` value to the name shown by
+   clicking the (i) next to "Xcode Managed Profile" in Xcode's
+   "Signing and Capabilities" tab.
+3. Follow the same steps as defined in the
    :ref:`Using the Xcode GUI <using_xcode>` section above, but
    targeting your device instead of a simulator.

--- a/examples/BUILD
+++ b/examples/BUILD
@@ -8,7 +8,11 @@ licenses(["notice"])  # Apache 2
 
 # Change to your Apple Developer Team ID as shown in
 # https://developer.apple.com/account/#!/membership
-TEAMID = "X4ST43AL9W"
+TEAM_ID = "X4ST43AL9W"
+
+# If needed, change to the name shown by clicking the (i) next to
+# "Xcode Managed Profile" in the "Signing and Capabilities" tab
+PROFILE_NAME = "iOS Team Provisioning Profile: *"
 
 xcode_provisioning_profile(
     name = "ios_provisioning_profile",
@@ -20,7 +24,7 @@ xcode_provisioning_profile(
 
 local_provisioning_profile(
     name = "xcode_managed_profile",
-    profile_name = "iOS Team Provisioning Profile: *",
+    profile_name = PROFILE_NAME,
     tags = ["manual"],
-    team_id = TEAMID,
+    team_id = TEAM_ID,
 )

--- a/examples/BUILD
+++ b/examples/BUILD
@@ -1,0 +1,26 @@
+load("@build_bazel_rules_apple//apple:apple.bzl", "local_provisioning_profile")
+load(
+    "@com_github_buildbuddy_io_rules_xcodeproj//xcodeproj:experimental.bzl",
+    "xcode_provisioning_profile",
+)
+
+licenses(["notice"])  # Apache 2
+
+# Change to your Apple Developer Team ID as shown in
+# https://developer.apple.com/account/#!/membership
+TEAMID = "X4ST43AL9W"
+
+xcode_provisioning_profile(
+    name = "ios_provisioning_profile",
+    managed_by_xcode = True,
+    provisioning_profile = ":xcode_managed_profile",
+    tags = ["manual"],
+    visibility = ["//visibility:public"],
+)
+
+local_provisioning_profile(
+    name = "xcode_managed_profile",
+    profile_name = "iOS Team Provisioning Profile: *",
+    tags = ["manual"],
+    team_id = TEAMID,
+)

--- a/examples/swift/async_await/BUILD
+++ b/examples/swift/async_await/BUILD
@@ -15,6 +15,10 @@ ios_application(
     families = ["iphone"],
     infoplists = ["Info.plist"],
     minimum_os_version = "15.0",
+    provisioning_profile = select({
+        "@envoy//bazel:ios_arm64": "//examples:ios_provisioning_profile",
+        "//conditions:default": None,
+    }),
     visibility = ["//visibility:public"],
     deps = ["appmain"],
 )

--- a/examples/swift/hello_world/BUILD
+++ b/examples/swift/hello_world/BUILD
@@ -16,6 +16,10 @@ ios_application(
     families = ["iphone"],
     infoplists = ["Info.plist"],
     minimum_os_version = MINIMUM_IOS_VERSION,
+    provisioning_profile = select({
+        "@envoy//bazel:ios_arm64": "//examples:ios_provisioning_profile",
+        "//conditions:default": None,
+    }),
     visibility = ["//visibility:public"],
     deps = ["appmain"],
 )

--- a/test/swift/apps/baseline/BUILD
+++ b/test/swift/apps/baseline/BUILD
@@ -16,6 +16,10 @@ ios_application(
     families = ["iphone"],
     infoplists = ["Info.plist"],
     minimum_os_version = MINIMUM_IOS_VERSION,
+    provisioning_profile = select({
+        "@envoy//bazel:ios_arm64": "//examples:ios_provisioning_profile",
+        "//conditions:default": None,
+    }),
     visibility = ["//visibility:public"],
     deps = ["appmain"],
 )

--- a/test/swift/apps/experimental/BUILD
+++ b/test/swift/apps/experimental/BUILD
@@ -16,6 +16,10 @@ ios_application(
     families = ["iphone"],
     infoplists = ["Info.plist"],
     minimum_os_version = MINIMUM_IOS_VERSION,
+    provisioning_profile = select({
+        "@envoy//bazel:ios_arm64": "//examples:ios_provisioning_profile",
+        "//conditions:default": None,
+    }),
     visibility = ["//visibility:public"],
     deps = ["appmain"],
 )


### PR DESCRIPTION
To simplify running sample iOS apps for physical devices.

Signed-off-by: JP Simard <jp@jpsim.com>