### PR TITLE
android: add experimental option to force all connections to use IPv6

### DIFF
--- a/library/common/config/config.cc
+++ b/library/common/config/config.cc
@@ -78,6 +78,7 @@ const char* brotli_config_insert = R"(
 // clang-format off
 const std::string config_header = R"(
 !ignore default_defs:
+- &android_force_ipv6 false
 - &connect_timeout 30s
 - &dns_fail_base_interval 2s
 - &dns_fail_max_interval 10s
@@ -513,6 +514,7 @@ layered_runtime:
           disallow_global_stats: true
           reloadable_features:
             allow_multiple_dns_addresses: *dns_multiple_addresses
+            android_always_use_v6: *android_force_ipv6
             http2_delay_keepalive_timeout: *h2_delay_keepalive_timeout
 )"
 // Needed due to warning in

--- a/library/java/io/envoyproxy/envoymobile/engine/EnvoyConfiguration.java
+++ b/library/java/io/envoyproxy/envoymobile/engine/EnvoyConfiguration.java
@@ -42,6 +42,7 @@ public class EnvoyConfiguration {
   public final Boolean enableBrotli;
   public final Boolean enableHappyEyeballs;
   public final Boolean enableInterfaceBinding;
+  public final Boolean forceIPv6;
   public final Integer h2ConnectionKeepaliveIdleIntervalMilliseconds;
   public final Integer h2ConnectionKeepaliveTimeoutSeconds;
   public final Boolean h2ExtendKeepaliveTimeout;
@@ -76,6 +77,7 @@ public class EnvoyConfiguration {
    * @param dnsPreresolveHostnames       hostnames to preresolve on Envoy Client construction.
    * @param dnsFallbackNameservers       addresses to use as DNS name server fallback.
    * @param dnsFilterUnroutableFamilies  whether to filter unroutable IP families or not.
+   * @param forceIPv6                    whether to force connections to use IPv6.
    * @param enableDrainPostDnsRefresh    whether to drain connections after soft DNS refresh.
    * @param enableHttp3                  whether to enable experimental support for HTTP/3 (QUIC).
    * @param enableGzip                   whether to enable response gzip decompression.
@@ -105,7 +107,7 @@ public class EnvoyConfiguration {
       Boolean adminInterfaceEnabled, String grpcStatsDomain, @Nullable Integer statsdPort,
       int connectTimeoutSeconds, int dnsRefreshSeconds, int dnsFailureRefreshSecondsBase,
       int dnsFailureRefreshSecondsMax, int dnsQueryTimeoutSeconds, int dnsMinRefreshSeconds,
-      String dnsPreresolveHostnames, List<String> dnsFallbackNameservers,
+      String dnsPreresolveHostnames, List<String> dnsFallbackNameservers, boolean forceIPv6,
       Boolean dnsFilterUnroutableFamilies, boolean enableDrainPostDnsRefresh, boolean enableHttp3,
       boolean enableGzip, boolean enableBrotli, boolean enableHappyEyeballs,
       boolean enableInterfaceBinding, int h2ConnectionKeepaliveIdleIntervalMilliseconds,
@@ -129,6 +131,7 @@ public class EnvoyConfiguration {
     this.dnsPreresolveHostnames = dnsPreresolveHostnames;
     this.dnsFallbackNameservers = dnsFallbackNameservers;
     this.dnsFilterUnroutableFamilies = dnsFilterUnroutableFamilies;
+    this.forceIPv6 = forceIPv6;
     this.enableDrainPostDnsRefresh = enableDrainPostDnsRefresh;
     this.enableHttp3 = enableHttp3;
     this.enableGzip = enableGzip;
@@ -250,6 +253,7 @@ public class EnvoyConfiguration {
                               enableDrainPostDnsRefresh ? "true" : "false"))
         .append(String.format("- &enable_interface_binding %s\n",
                               enableInterfaceBinding ? "true" : "false"))
+        .append(String.format("- &android_force_ipv6 %s\n", forceIPv6 ? "true" : "false"))
         .append(String.format("- &h2_connection_keepalive_idle_interval %ss\n",
                               h2ConnectionKeepaliveIdleIntervalMilliseconds / 1000.0))
         .append(String.format("- &h2_connection_keepalive_timeout %ss\n",

--- a/library/kotlin/io/envoyproxy/envoymobile/EngineBuilder.kt
+++ b/library/kotlin/io/envoyproxy/envoymobile/EngineBuilder.kt
@@ -46,6 +46,7 @@ open class EngineBuilder(
   private var enableGzip = true
   private var enableBrotli = false
   private var enableInterfaceBinding = false
+  private var forceIPv6 = false
   private var h2ConnectionKeepaliveIdleIntervalMilliseconds = 1
   private var h2ConnectionKeepaliveTimeoutSeconds = 10
   private var h2ExtendKeepaliveTimeout = false
@@ -281,6 +282,19 @@ open class EngineBuilder(
    */
   fun enableInterfaceBinding(enableInterfaceBinding: Boolean): EngineBuilder {
     this.enableInterfaceBinding = enableInterfaceBinding
+    return this
+  }
+
+  /**
+   * Specify whether to remap IPv4 addresses to the IPv6 space and always force connections
+   * to use IPv6. Note this is an experimental configuration and should be enabled with caution.
+   *
+   * @param forceIPv6 whether to force connections to use IPv6.
+   *
+   * @return This builder.
+   */
+  fun forceIPv6(forceIPv6: Boolean): EngineBuilder {
+    this.forceIPv6 = forceIPv6
     return this
   }
 
@@ -571,6 +585,7 @@ open class EngineBuilder(
       enableBrotli,
       enableHappyEyeballs,
       enableInterfaceBinding,
+      forceIPv6,
       h2ConnectionKeepaliveIdleIntervalMilliseconds,
       h2ConnectionKeepaliveTimeoutSeconds,
       h2ExtendKeepaliveTimeout,


### PR DESCRIPTION
Description: Adds EngineBuilder option to remap destination IPv4 addresses to the IPv6 address space, and thereby force all connections to use IPv6.
Risk Level: High
Testing: Ongoing

Signed-off-by: Mike Schore <mike.schore@gmail.com>