### PR TITLE
ci: change submodule_update PR branch name to use a timestamp strategy

### DIFF
--- a/.github/workflows/submodule_update.yml
+++ b/.github/workflows/submodule_update.yml
@@ -46,5 +46,5 @@ jobs:
         base: main
         delete-branch: true
         branch: update-envoy
-        branch-suffix: short-commit-hash
+        branch-suffix: timestamp
         reviewers: ${{ steps.support.outputs.maintainer }}


### PR DESCRIPTION
To prevent it from force-pushing to an existing branch like it did in https://github.com/envoyproxy/envoy-mobile/pull/2373