### PR TITLE
admin: disable admin html

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -3,6 +3,7 @@ try-import ./envoy/.bazelrc
 
 # Common flags for all builds
 build --platform_mappings=envoy/bazel/platform_mappings
+build --define=admin_html=disabled
 build --define=google_grpc=disabled
 build --define=hot_restart=disabled
 build --define=tcmalloc=disabled


### PR DESCRIPTION
This isn't something we want to expose when running Envoy Mobile.

For more details: https://github.com/envoyproxy/envoy/pull/21814

Risk Level: Low, will impact anyone who's used this feature before.
Testing: Verified that `admin_html.cc` is not compiled.
Docs Changes: N/A
Release Notes: N/A