### PR TITLE
iOS: add `forceIPv6(...)` builder option

### DIFF
--- a/docs/root/api/starting_envoy.rst
+++ b/docs/root/api/starting_envoy.rst
@@ -487,6 +487,22 @@ SharedPreferences.
   // Coming soon.
 
 
+~~~~~~~~~~~~~~~~~~~~~~~~~~
+``forceIPv6``
+~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Specify whether to remap IPv4 addresses to the IPv6 space and always force connections
+to use IPv6. Note this is an experimental option and should be enabled with caution.
+
+**Example**::
+
+  // Kotlin
+  builder.forceIPv6(true)
+
+  // Swift
+  builder.forceIPv6(true)
+
+
 ----------------------
 Advanced configuration
 ----------------------

--- a/docs/root/intro/version_history.rst
+++ b/docs/root/intro/version_history.rst
@@ -8,8 +8,8 @@ Breaking changes:
 
 - api: replace the ``drainConnections()`` method with a broader ``resetConnectivityState()``. (:issue:`#2225 <2225>`).
 - api: disallow setting 'host' header directly (:issue:`#2275 <2275>`)
+- api: add experimental option to force all connections to use IPv6 (:issue: `#2379 <2379>`, :issue: `#2396 <2396>`)
 - android: respect Android's NetworkSecurityPolicy isCleartextTrafficPermitted APIs.
-- android: add experimental option to force all connections to use IPv6 (:issue: `#2379 <2379>`)
 - net: enable happy eyeballs by default (:issue:`#2272 <2272>`)
 - iOS: remove support for installing via CocoaPods, which had not worked since 2020 (:issue:`#2215 <2215>`)
 - iOS: enable usage of ``NWPathMonitor`` by default (:issue:`#2329 <2329>`)

--- a/library/common/config/config.cc
+++ b/library/common/config/config.cc
@@ -78,16 +78,16 @@ const char* brotli_config_insert = R"(
 // clang-format off
 const std::string config_header = R"(
 !ignore default_defs:
-- &android_force_ipv6 false
 - &connect_timeout 30s
 - &dns_fail_base_interval 2s
 - &dns_fail_max_interval 10s
-- &dns_query_timeout 25s
 - &dns_lookup_family ALL
 - &dns_min_refresh_rate 60s
 - &dns_multiple_addresses true
 - &dns_preresolve_hostnames []
+- &dns_query_timeout 25s
 - &dns_refresh_rate 60s
+- &force_ipv6 false
 )"
 #if defined(__APPLE__)
 R"(- &dns_resolver_name envoy.network.dns_resolver.apple
@@ -514,7 +514,7 @@ layered_runtime:
           disallow_global_stats: true
           reloadable_features:
             allow_multiple_dns_addresses: *dns_multiple_addresses
-            android_always_use_v6: *android_force_ipv6
+            always_use_v6: *force_ipv6
             http2_delay_keepalive_timeout: *h2_delay_keepalive_timeout
 )"
 // Needed due to warning in

--- a/library/java/io/envoyproxy/envoymobile/engine/EnvoyConfiguration.java
+++ b/library/java/io/envoyproxy/envoymobile/engine/EnvoyConfiguration.java
@@ -253,7 +253,7 @@ public class EnvoyConfiguration {
                               enableDrainPostDnsRefresh ? "true" : "false"))
         .append(String.format("- &enable_interface_binding %s\n",
                               enableInterfaceBinding ? "true" : "false"))
-        .append(String.format("- &android_force_ipv6 %s\n", forceIPv6 ? "true" : "false"))
+        .append(String.format("- &force_ipv6 %s\n", forceIPv6 ? "true" : "false"))
         .append(String.format("- &h2_connection_keepalive_idle_interval %ss\n",
                               h2ConnectionKeepaliveIdleIntervalMilliseconds / 1000.0))
         .append(String.format("- &h2_connection_keepalive_timeout %ss\n",

--- a/library/objective-c/EnvoyConfiguration.m
+++ b/library/objective-c/EnvoyConfiguration.m
@@ -19,6 +19,7 @@
                            enableInterfaceBinding:(BOOL)enableInterfaceBinding
                         enableDrainPostDnsRefresh:(BOOL)enableDrainPostDnsRefresh
                     enforceTrustChainVerification:(BOOL)enforceTrustChainVerification
+                                        forceIPv6:(BOOL)forceIPv6
     h2ConnectionKeepaliveIdleIntervalMilliseconds:
         (UInt32)h2ConnectionKeepaliveIdleIntervalMilliseconds
               h2ConnectionKeepaliveTimeoutSeconds:(UInt32)h2ConnectionKeepaliveTimeoutSeconds
@@ -63,6 +64,7 @@
   self.enableInterfaceBinding = enableInterfaceBinding;
   self.enableDrainPostDnsRefresh = enableDrainPostDnsRefresh;
   self.enforceTrustChainVerification = enforceTrustChainVerification;
+  self.forceIPv6 = forceIPv6;
   self.h2ConnectionKeepaliveIdleIntervalMilliseconds =
       h2ConnectionKeepaliveIdleIntervalMilliseconds;
   self.h2ConnectionKeepaliveTimeoutSeconds = h2ConnectionKeepaliveTimeoutSeconds;
@@ -180,6 +182,7 @@
   [definitions appendFormat:@"- &trust_chain_verification %@\n", self.enforceTrustChainVerification
                                                                      ? @"VERIFY_TRUST_CHAIN"
                                                                      : @"ACCEPT_UNTRUSTED"];
+  [definitions appendFormat:@"- &force_ipv6 %@\n", self.forceIPv6 ? @"true" : @"false"];
   [definitions appendFormat:@"- &h2_connection_keepalive_idle_interval %.*fs\n", 3,
                             (double)self.h2ConnectionKeepaliveIdleIntervalMilliseconds / 1000.0];
   [definitions appendFormat:@"- &h2_connection_keepalive_timeout %lus\n",

--- a/library/objective-c/EnvoyEngine.h
+++ b/library/objective-c/EnvoyEngine.h
@@ -361,6 +361,7 @@ extern const int kEnvoyFilterResumeStatusResumeIteration;
 @property (nonatomic, assign) BOOL enableInterfaceBinding;
 @property (nonatomic, assign) BOOL enableDrainPostDnsRefresh;
 @property (nonatomic, assign) BOOL enforceTrustChainVerification;
+@property (nonatomic, assign) BOOL forceIPv6;
 @property (nonatomic, assign) UInt32 h2ConnectionKeepaliveIdleIntervalMilliseconds;
 @property (nonatomic, assign) UInt32 h2ConnectionKeepaliveTimeoutSeconds;
 @property (nonatomic, assign) BOOL h2ExtendKeepaliveTimeout;
@@ -397,6 +398,7 @@ extern const int kEnvoyFilterResumeStatusResumeIteration;
                            enableInterfaceBinding:(BOOL)enableInterfaceBinding
                         enableDrainPostDnsRefresh:(BOOL)enableDrainPostDnsRefresh
                     enforceTrustChainVerification:(BOOL)enforceTrustChainVerification
+                                        forceIPv6:(BOOL)forceIPv6
     h2ConnectionKeepaliveIdleIntervalMilliseconds:
         (UInt32)h2ConnectionKeepaliveIdleIntervalMilliseconds
               h2ConnectionKeepaliveTimeoutSeconds:(UInt32)h2ConnectionKeepaliveTimeoutSeconds

--- a/library/swift/EngineBuilder.swift
+++ b/library/swift/EngineBuilder.swift
@@ -28,6 +28,7 @@ open class EngineBuilder: NSObject {
   private var enableInterfaceBinding: Bool = false
   private var enforceTrustChainVerification: Bool = true
   private var enableDrainPostDnsRefresh: Bool = false
+  private var forceIPv6: Bool = false
   private var h2ConnectionKeepaliveIdleIntervalMilliseconds: UInt32 = 1
   private var h2ConnectionKeepaliveTimeoutSeconds: UInt32 = 10
   private var h2ExtendKeepaliveTimeout: Bool = false
@@ -225,6 +226,18 @@ open class EngineBuilder: NSObject {
   @discardableResult
   public func enforceTrustChainVerification(_ enforceTrustChainVerification: Bool) -> Self {
     self.enforceTrustChainVerification = enforceTrustChainVerification
+    return self
+  }
+
+  /// Specify whether to remap IPv4 addresses to the IPv6 space and always force connections
+  /// to use IPv6. Note this is an experimental option and should be enabled with caution.
+  ///
+  /// - parameter forceIPv6: whether to force connections to use IPv6.
+  ///
+  /// - returns: This builder.
+  @discardableResult
+  public func forceIPv6(_ forceIPv6: Bool) -> Self {
+    self.forceIPv6 = forceIPv6
     return self
   }
 
@@ -506,6 +519,7 @@ open class EngineBuilder: NSObject {
       enableInterfaceBinding: self.enableInterfaceBinding,
       enableDrainPostDnsRefresh: self.enableDrainPostDnsRefresh,
       enforceTrustChainVerification: self.enforceTrustChainVerification,
+      forceIPv6: self.forceIPv6,
       h2ConnectionKeepaliveIdleIntervalMilliseconds:
         self.h2ConnectionKeepaliveIdleIntervalMilliseconds,
       h2ConnectionKeepaliveTimeoutSeconds: self.h2ConnectionKeepaliveTimeoutSeconds,

--- a/test/java/io/envoyproxy/envoymobile/engine/EnvoyConfigurationTest.kt
+++ b/test/java/io/envoyproxy/envoymobile/engine/EnvoyConfigurationTest.kt
@@ -142,7 +142,7 @@ class EnvoyConfigurationTest {
     assertThat(resolvedTemplate).contains("&enable_interface_binding false")
 
     // Forcing IPv6
-    assertThat(resolvedTemplate).contains("&android_force_ipv6 false")
+    assertThat(resolvedTemplate).contains("&force_ipv6 false")
 
     // H2 Ping
     assertThat(resolvedTemplate).contains("&h2_connection_keepalive_idle_interval 0.222s")
@@ -227,7 +227,7 @@ class EnvoyConfigurationTest {
     assertThat(resolvedTemplate).contains("&enable_interface_binding true")
 
     // Forcing IPv6
-    assertThat(resolvedTemplate).contains("&android_force_ipv6 true")
+    assertThat(resolvedTemplate).contains("&force_ipv6 true")
   }
 
   @Test

--- a/test/swift/EngineBuilderTests.swift
+++ b/test/swift/EngineBuilderTests.swift
@@ -137,6 +137,20 @@ final class EngineBuilderTests: XCTestCase {
     self.waitForExpectations(timeout: 0.01)
   }
 
+  func testForceIPv6AddsToConfigurationWhenRunningEnvoy() {
+    let expectation = self.expectation(description: "Run called with force IPv6")
+    MockEnvoyEngine.onRunWithConfig = { config, _ in
+      XCTAssertTrue(config.forceIPv6)
+      expectation.fulfill()
+    }
+
+    _ = EngineBuilder()
+      .addEngineType(MockEnvoyEngine.self)
+      .forceIPv6(true)
+      .build()
+    self.waitForExpectations(timeout: 0.01)
+  }
+
   func testAddinggrpcStatsDomainAddsToConfigurationWhenRunningEnvoy() {
     let expectation = self.expectation(description: "Run called with expected data")
     MockEnvoyEngine.onRunWithConfig = { config, _ in
@@ -471,6 +485,7 @@ final class EngineBuilderTests: XCTestCase {
       enableInterfaceBinding: true,
       enableDrainPostDnsRefresh: false,
       enforceTrustChainVerification: false,
+      forceIPv6: false,
       h2ConnectionKeepaliveIdleIntervalMilliseconds: 1,
       h2ConnectionKeepaliveTimeoutSeconds: 333,
       h2ExtendKeepaliveTimeout: true,
@@ -558,6 +573,7 @@ final class EngineBuilderTests: XCTestCase {
       enableInterfaceBinding: false,
       enableDrainPostDnsRefresh: true,
       enforceTrustChainVerification: true,
+      forceIPv6: true,
       h2ConnectionKeepaliveIdleIntervalMilliseconds: 1,
       h2ConnectionKeepaliveTimeoutSeconds: 333,
       h2ExtendKeepaliveTimeout: false,
@@ -610,6 +626,7 @@ final class EngineBuilderTests: XCTestCase {
       enableInterfaceBinding: false,
       enableDrainPostDnsRefresh: false,
       enforceTrustChainVerification: true,
+      forceIPv6: true,
       h2ConnectionKeepaliveIdleIntervalMilliseconds: 222,
       h2ConnectionKeepaliveTimeoutSeconds: 333,
       h2ExtendKeepaliveTimeout: false,

--- a/test/swift/apps/experimental/ViewController.swift
+++ b/test/swift/apps/experimental/ViewController.swift
@@ -24,11 +24,19 @@ final class ViewController: UITableViewController {
       .addPlatformFilter(AsyncDemoFilter.init)
       .h2ExtendKeepaliveTimeout(true)
       .enableInterfaceBinding(true)
-      // swiftlint:disable:next line_length
-      .addNativeFilter(name: "envoy.filters.http.buffer", typedConfig: "{\"@type\":\"type.googleapis.com/envoy.extensions.filters.http.buffer.v3.Buffer\",\"max_request_bytes\":5242880}")
+      .addNativeFilter(
+        name: "envoy.filters.http.buffer",
+        typedConfig: """
+            {\
+            "@type":"type.googleapis.com/envoy.extensions.filters.http.buffer.v3.Buffer",\
+            "max_request_bytes":5242880\
+            }
+            """
+      )
       .setOnEngineRunning { NSLog("Envoy async internal setup completed") }
       .addStringAccessor(name: "demo-accessor", accessor: { return "PlatformString" })
       .setEventTracker { NSLog("Envoy event emitted: \($0)") }
+      .forceIPv6(true)
       .build()
     self.streamClient = engine.streamClient()
     self.pulseClient = engine.pulseClient()


### PR DESCRIPTION
Mirroring what was done for Android in https://github.com/envoyproxy/envoy-mobile/pull/2379 and leveraging the recent changes in Envoy in https://github.com/envoyproxy/envoy/pull/21913.

Risk Level: Moderate.
Testing: Unit tests, integration tests & being exercised in the experimental app. Tested with the experimental app in the iOS Simulator and on an iPhone 13 Pro, verified that an IPv4 address gets mapped to a valid IPv6 address.
Docs Changes: Added.
Release Notes: Added.

Signed-off-by: JP Simard <jp@jpsim.com>