### PR TITLE
Upgrade rules_foreign_cc

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -11,6 +11,18 @@ http_archive(
     ],
 )
 
+# TODO(yannic): Remove once https://github.com/bazelbuild/rules_foreign_cc/pull/938
+# is merged and released.
+http_archive(
+    name = "rules_foreign_cc",
+    sha256 = "bbc605fd36048923939845d6843464197df6e6ffd188db704423952825e4760a",
+    strip_prefix = "rules_foreign_cc-a473d42bada74afac4e32b767964c1785232e07b",
+    urls = [
+        "https://storage.googleapis.com/engflow-tools-public/rules_foreign_cc-a473d42bada74afac4e32b767964c1785232e07b.tar.gz",
+        "https://github.com/EngFlow/rules_foreign_cc/archive/a473d42bada74afac4e32b767964c1785232e07b.tar.gz",
+    ],
+)
+
 load("@envoy_mobile//bazel:envoy_mobile_repositories.bzl", "envoy_mobile_repositories")
 envoy_mobile_repositories()
 


### PR DESCRIPTION
This upgrades `rules_foreign_cc` to a version including
https://github.com/bazelbuild/rules_foreign_cc/pull/938, which fixes
a build failure when the requested Apple SDK from `--xcode_version` does
not match the system's default Xcode's SDKs.

Example output:
```
rules_foreign_cc: Build failed!
rules_foreign_cc: Keeping temp build directory and dependencies directory for debug.
rules_foreign_cc: Please note that the directories inside a sandbox are still cleaned unless you specify --sandbox_debug Bazel command line flag.
rules_foreign_cc: Printing build logs:
_____ BEGIN BUILD LOGS _____
xcrun: error: SDK "macosx12.1" cannot be located
xcrun: error: SDK "macosx12.1" cannot be located
xcrun: error: unable to lookup item 'Path' in SDK 'macosx12.1'
+ XCODE_VERSION_OVERRIDE=13.2.1.13C100
+ APPLE_SDK_VERSION_OVERRIDE=12.1
+ APPLE_SDK_PLATFORM=MacOSX
```

This fixes a hermeticity problem in the build and is a prerequisite for
upgradting the macOS RE cluster to macOS 12, which in turn is a
requirement for upgrading to Xcode 13.4.

Progress on https://github.com/envoyproxy/envoy-mobile/issues/2100
