### PR TITLE
ci: update codespell to v2.1.0

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -14,7 +14,7 @@ repos:
       exclude: 'experimental/swift/QUICStreamTest.swift'
     - id: mixed-line-ending
 - repo: https://github.com/codespell-project/codespell
-  rev: v1.16.0
+  rev: v1.17.1
   hooks:
     - id: codespell
       args: [-L=uint, -L=keyserver]

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -17,4 +17,4 @@ repos:
   rev: v1.17.1
   hooks:
     - id: codespell
-      args: [-L=uint, -L=keyserver]
+      args: [-L=uint, '-L=keyserver,inout']

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -14,7 +14,7 @@ repos:
       exclude: 'experimental/swift/QUICStreamTest.swift'
     - id: mixed-line-ending
 - repo: https://github.com/codespell-project/codespell
-  rev: v1.17.1
+  rev: v2.1.0
   hooks:
     - id: codespell
       args: [-L=uint, '-L=keyserver,inout']

--- a/docs/root/api/stats.rst
+++ b/docs/root/api/stats.rst
@@ -76,7 +76,7 @@ The count argument of ``increment`` is defaulted with a value of ``1``.
   // Swift
   counter.increment(count: 5)
 
-A ``Counter`` can be incremented with custom tags. To be concise, this doc shows examples of attching custom tagging for ``Counter`` on increment. Similar APIs are available for all metrics types to attach tags on metrics reporting.
+A ``Counter`` can be incremented with custom tags. To be concise, this doc shows examples of attaching custom tagging for ``Counter`` on increment. Similar APIs are available for all metrics types to attach tags on metrics reporting.
 
 **Example**::
 

--- a/docs/root/intro/version_history.rst
+++ b/docs/root/intro/version_history.rst
@@ -41,7 +41,7 @@ Features:
 - android: create simple persistent SharedPreferencesStore (:issue: `#2319 <2319>`)
 - iOS: A documentation archive is now included in the GitHub release artifact (:issue: `#2335 <2335>`)
 - api: improved C++ APIs compatibility with Java / Kotlin / Swift (:issue `#2362 <2362>`)
-- ci: update codespell to v1.17.1 (:issue `#2406 <2406>`)
+- ci: update codespell to v2.1.0 (:issue `#2406 <2406>`)
 
 0.4.6 (April 26, 2022)
 ========================

--- a/docs/root/intro/version_history.rst
+++ b/docs/root/intro/version_history.rst
@@ -41,7 +41,7 @@ Features:
 - android: create simple persistent SharedPreferencesStore (:issue: `#2319 <2319>`)
 - iOS: A documentation archive is now included in the GitHub release artifact (:issue: `#2335 <2335>`)
 - api: improved C++ APIs compatibility with Java / Kotlin / Swift (:issue `#2362 <2362>`)
-- ci: update codespell to v2.1.0 (:issue `#2406 <2406>`)
+- ci: bump codespell version to v2.1.0 (:issue `#2406 <2406>`)
 
 0.4.6 (April 26, 2022)
 ========================

--- a/docs/root/intro/version_history.rst
+++ b/docs/root/intro/version_history.rst
@@ -41,6 +41,7 @@ Features:
 - android: create simple persistent SharedPreferencesStore (:issue: `#2319 <2319>`)
 - iOS: A documentation archive is now included in the GitHub release artifact (:issue: `#2335 <2335>`)
 - api: improved C++ APIs compatibility with Java / Kotlin / Swift (:issue `#2362 <2362>`)
+- ci: update codespell to v1.17.1 (:issue `#2406 <2406>`)
 
 0.4.6 (April 26, 2022)
 ========================

--- a/docs/root/intro/version_history.rst
+++ b/docs/root/intro/version_history.rst
@@ -41,7 +41,6 @@ Features:
 - android: create simple persistent SharedPreferencesStore (:issue: `#2319 <2319>`)
 - iOS: A documentation archive is now included in the GitHub release artifact (:issue: `#2335 <2335>`)
 - api: improved C++ APIs compatibility with Java / Kotlin / Swift (:issue `#2362 <2362>`)
-- ci: bump codespell version to v2.1.0 (:issue `#2406 <2406>`)
 
 0.4.6 (April 26, 2022)
 ========================

--- a/library/java/org/chromium/net/CronetEngine.java
+++ b/library/java/org/chromium/net/CronetEngine.java
@@ -260,9 +260,10 @@ public abstract class CronetEngine {
      * for local trust anchors is highly discouraged since it may prohibit the app from
      * communicating with the pinned hosts. E.g., a user may want to send all traffic through an SSL
      * enabled proxy by changing the device proxy settings and adding the proxy certificate to the
-     * list of local trust anchor. Disabling the bypass will most likely prevent the app from sending
-     * any traffic to the pinned hosts. For more information see 'How does key pinning interact with
-     * local proxies and filters?' at https://www.chromium.org/Home/chromium-security/security-faq
+     * list of local trust anchor. Disabling the bypass will most likely prevent the app from
+     * sending any traffic to the pinned hosts. For more information see 'How does key pinning
+     * interact with local proxies and filters?' at
+     * https://www.chromium.org/Home/chromium-security/security-faq
      *
      * @param value {@code true} to enable the bypass, {@code false} to disable.
      * @return the builder to facilitate chaining.

--- a/library/java/org/chromium/net/CronetEngine.java
+++ b/library/java/org/chromium/net/CronetEngine.java
@@ -260,7 +260,7 @@ public abstract class CronetEngine {
      * for local trust anchors is highly discouraged since it may prohibit the app from
      * communicating with the pinned hosts. E.g., a user may want to send all traffic through an SSL
      * enabled proxy by changing the device proxy settings and adding the proxy certificate to the
-     * list of local trust anchor. Disabling the bypass will most likly prevent the app from sending
+     * list of local trust anchor. Disabling the bypass will most likely prevent the app from sending
      * any traffic to the pinned hosts. For more information see 'How does key pinning interact with
      * local proxies and filters?' at https://www.chromium.org/Home/chromium-security/security-faq
      *

--- a/test/python/unit/test_pre_build_engine.py
+++ b/test/python/unit/test_pre_build_engine.py
@@ -1,5 +1,5 @@
 # This module can't be tested normally
-# becuse it needs the Engine not to exist in the process
+# because it needs the Engine not to exist in the process
 # so each of the tests here are marked to be run
 # only in a particular instance of the test runner
 # and targets are specified in //library/python/...


### PR DESCRIPTION
Description: Update codespell to v2.1.0 due to an issue that surfaced in https://github.com/envoyproxy/envoy-mobile/pull/2400 : `/usr/local/Cellar/python@3.10/3.10.5/Frameworks/Python.framework/Versions/3.10/lib/python3.10/codecs.py:905: RuntimeWarning: line buffering (buffering=1) isn't supported in binary mode, the default buffer size will be used
  file = builtins.open(filename, mode, buffering)`. According to https://github.com/codespell-project/codespell/issues/1331 the update is what fixes it.
Risk Level: Low, linting change only
Testing: N/A
Docs Changes: N/A
Release Notes: Done

Signed-off-by: Rafal Augustyniak <raugustyniak@lyft.com>

