### PR TITLE
xcode: update to 13.4

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -15,10 +15,10 @@ build --host_force_python=PY3
 build --macos_minimum_os=10.14
 build --ios_minimum_os=12.0
 build --ios_simulator_device="iPhone 13"
-build --ios_simulator_version=15.2
+build --ios_simulator_version=15.5
 build --verbose_failures
 build --workspace_status_command=envoy/bazel/get_workspace_status
-build --xcode_version=13.2.1
+build --xcode_version=13.4.0
 build --use_top_level_targets_for_symlinks
 build --experimental_repository_downloader_retries=2
 # https://github.com/bazelbuild/rules_jvm_external/issues/445

--- a/.github/workflows/format.yml
+++ b/.github/workflows/format.yml
@@ -53,6 +53,8 @@ jobs:
         with:
           submodules: true
       - name: 'Run DrString'
+        env:
+          DEVELOPER_DIR: /Applications/Xcode_13.4.app
         run: ./bazelw run @DrString//:drstring check
   kotlinlint:
     name: kotlin_lint

--- a/ci/BUILD
+++ b/ci/BUILD
@@ -1,27 +1,27 @@
 licenses(["notice"])  # Apache 2
 
 xcode_version(
-    name = "xcode_13_2_1",
-    default_ios_sdk_version = "15.2",
-    default_macos_sdk_version = "12.1",
-    default_tvos_sdk_version = "15.2",
-    default_watchos_sdk_version = "8.3",
-    version = "13.2.1",
+    name = "xcode_13_4_0",
+    default_ios_sdk_version = "15.5",
+    default_macos_sdk_version = "12.3",
+    default_tvos_sdk_version = "15.4",
+    default_watchos_sdk_version = "8.5",
+    version = "13.4.0",
 )
 
 available_xcodes(
     name = "local_xcodes",
-    default = ":xcode_13_2_1",
+    default = ":xcode_13_4_0",
     versions = [
-        ":xcode_13_2_1",
+        ":xcode_13_4_0",
     ],
 )
 
 available_xcodes(
     name = "remote_xcodes",
-    default = ":xcode_13_2_1",
+    default = ":xcode_13_4_0",
     versions = [
-        ":xcode_13_2_1",
+        ":xcode_13_4_0",
     ],
 )
 

--- a/ci/mac_ci_setup.sh
+++ b/ci/mac_ci_setup.sh
@@ -45,7 +45,7 @@ fi
 
 pip3 install slackclient
 # https://github.com/actions/virtual-environments/blob/main/images/macos/macos-12-Readme.md#xcode
-sudo xcode-select --switch /Applications/Xcode_13.2.1.app
+sudo xcode-select --switch /Applications/Xcode_13.4.app
 
 if [[ "${1:-}" == "--android" ]]; then
   # Download and set up ndk 21 after GitHub update

--- a/docs/root/start/building/building.rst
+++ b/docs/root/start/building/building.rst
@@ -58,7 +58,7 @@ See `ci/mac_ci_setup.sh` for the specific NDK version used during builds.
 iOS requirements
 ----------------
 
-- Xcode 13.2.1
+- Xcode 13.4
 - iOS 12.0 or later
 - Note: Requirements are listed in the :repo:`.bazelrc file <.bazelrc>` and CI scripts
 


### PR DESCRIPTION
Updates the version of Xcode Envoy Mobile is compatible with to the latest stable version (sorta, 13.4.1 also exists but doesn't have relevant changes).

Risk Level: Low.
Testing: Local & CI.
Docs Changes: Done.
Release Notes: Done.
Fixes #2100
[Optional Deprecated:]

Signed-off-by: JP Simard <jp@jpsim.com>