### PR TITLE
api: make RequestTrailersBuilder and ResponseHeadersBuilder constructors public

### DIFF
--- a/library/kotlin/io/envoyproxy/envoymobile/RequestTrailersBuilder.kt
+++ b/library/kotlin/io/envoyproxy/envoymobile/RequestTrailersBuilder.kt
@@ -7,7 +7,7 @@ class RequestTrailersBuilder : HeadersBuilder {
   /*
    * Instantiate a new builder.
    */
-  internal constructor() : super(HeadersContainer(mapOf()))
+  constructor() : super(HeadersContainer(mapOf()))
 
   /*
    * Instantiate a new instance of the builder.

--- a/library/kotlin/io/envoyproxy/envoymobile/ResponseHeadersBuilder.kt
+++ b/library/kotlin/io/envoyproxy/envoymobile/ResponseHeadersBuilder.kt
@@ -8,7 +8,7 @@ class ResponseHeadersBuilder : HeadersBuilder {
   /*
    * Instantiate a new builder.
    */
-  internal constructor() : super(HeadersContainer(mapOf()))
+  constructor() : super(HeadersContainer(mapOf()))
 
   /*
    * Instantiate a new builder. Used only by ResponseHeaders to convert back to


### PR DESCRIPTION
Description: Revert to the state from before https://github.com/envoyproxy/envoy-mobile/pull/2400. These constructors were supposed to be public.
Risk Level: None
Testing: None
Docs Changes: N/A
Release Notes: N/A

Signed-off-by: Rafal Augustyniak <raugustyniak@lyft.com>