### PR TITLE
engine: remove outdated comment about `registerFactories()`

### DIFF
--- a/library/common/engine.cc
+++ b/library/common/engine.cc
@@ -16,9 +16,6 @@ Engine::Engine(envoy_engine_callbacks callbacks, envoy_logger logger,
                envoy_event_tracker event_tracker)
     : callbacks_(callbacks), logger_(logger), event_tracker_(event_tracker),
       dispatcher_(std::make_unique<Event::ProvisionalDispatcher>()) {
-  // Ensure static factory registration occurs on time.
-  // TODO: ensure this is only called one time once multiple Engine objects can be allocated.
-  // https://github.com/envoyproxy/envoy-mobile/issues/332
   ExtensionRegistry::registerFactories();
 
   // TODO(Augustyniak): Capturing an address of event_tracker_ and registering it in the API


### PR DESCRIPTION
`ExtensionRegistry::registerFactories()` doesn't do any work at runtime, its purpose is to guarantee that the linker won't strip away these factories as dead code because they're discovered at runtime as opposed to being referenced statically.

So it's safe to call on engine creation because it's a no-op at runtime.