### PR TITLE
docs: use sphinx githubpages extension

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -67,7 +67,7 @@ blob_sha = os.environ['ENVOY_BLOB_SHA']
 # Add any Sphinx extension module names here, as strings. They can be
 # extensions coming with Sphinx (named 'sphinx.ext.*') or your custom
 # ones.
-extensions = ['sphinxcontrib.httpdomain', 'sphinx.ext.extlinks', 'sphinx.ext.ifconfig']
+extensions = ['sphinxcontrib.httpdomain', 'sphinx.ext.extlinks', 'sphinx.ext.ifconfig', 'sphinx.ext.githubpages']
 extlinks = {
     'issue': ('https://github.com/envoyproxy/envoy-mobile/issues/%s', ''),
     'repo': ('https://github.com/envoyproxy/envoy-mobile/blob/{}/%s'.format(blob_sha), ''),


### PR DESCRIPTION
Description: This change is an attempt to fix images in the generated documentation. As it is now they do not work - [example](https://envoy-mobile.github.io/docs/envoy-mobile/latest/development/debugging/android_local.html). The issues seems to be caused by the fact that Sphinx puts all of the images in `_images` directory and Github Pages, backed by `jekyll`, ignores all directories whose names start with `_`. The idea is to use `sphinx.ext.githubpages` extension that puts `.nojekyll` file in the root of the generated sphinx artifacts which is supposed to fix the issue as reported in https://stackoverflow.com/a/64544659. Not a great way to test this e2e locally so may need to revert the change if it turns out that the issue persists.
Risk Level: Low, documentation changes
Testing: Generated sphinx's artifacts locally with and without the change. Confirmed that with the change I can see `.nojekyll` file being added to `generated/docs` directory.
Docs Changes:
Release Notes:

Signed-off-by: Rafal Augustyniak <raugustyniak@lyft.com>