### PR TITLE
dns: allow using the `getaddrinfo`-based system DNS resolver

### DIFF
--- a/docs/root/intro/version_history.rst
+++ b/docs/root/intro/version_history.rst
@@ -44,7 +44,7 @@ Features:
 - android: create simple persistent SharedPreferencesStore (:issue: `#2319 <2319>`)
 - iOS: A documentation archive is now included in the GitHub release artifact (:issue: `#2335 <2335>`)
 - api: improved C++ APIs compatibility with Java / Kotlin / Swift (:issue `#2362 <2362>`)
-- api: add option to use the a ``getaddr``-based system DNS resolver instead of c-ares (:issue: `#2419 <2419>`)
+- api: add option to use the a ``getaddrinfo``-based system DNS resolver instead of c-ares (:issue: `#2419 <2419>`)
 
 0.4.6 (April 26, 2022)
 ========================

--- a/docs/root/intro/version_history.rst
+++ b/docs/root/intro/version_history.rst
@@ -44,6 +44,7 @@ Features:
 - android: create simple persistent SharedPreferencesStore (:issue: `#2319 <2319>`)
 - iOS: A documentation archive is now included in the GitHub release artifact (:issue: `#2335 <2335>`)
 - api: improved C++ APIs compatibility with Java / Kotlin / Swift (:issue `#2362 <2362>`)
+- api: add option to use the a ``getaddr``-based system DNS resolver instead of c-ares (:issue: `#2419 <2419>`)
 
 0.4.6 (April 26, 2022)
 ========================

--- a/envoy_build_config/extensions_build_config.bzl
+++ b/envoy_build_config/extensions_build_config.bzl
@@ -18,6 +18,7 @@ EXTENSIONS = {
     "envoy.http.original_ip_detection.xff":                "//source/extensions/http/original_ip_detection/xff:config",
     "envoy.key_value.platform":                            "@envoy_mobile//library/common/extensions/key_value/platform:config",
     "envoy.network.dns_resolver.apple":                    "//source/extensions/network/dns_resolver/apple:config",
+    "envoy.network.dns_resolver.getaddrinfo":              "//source/extensions/network/dns_resolver/getaddrinfo:config",
     "envoy.retry.options.network_configuration":           "@envoy_mobile//library/common/extensions/retry/options/network_configuration:config",
     "envoy.stat_sinks.metrics_service":                    "//source/extensions/stat_sinks/metrics_service:config",
     "envoy.transport_sockets.raw_buffer":                  "//source/extensions/transport_sockets/raw_buffer:config",

--- a/library/cc/engine_builder.cc
+++ b/library/cc/engine_builder.cc
@@ -11,17 +11,7 @@ namespace Platform {
 
 EngineBuilder::EngineBuilder(std::string config_template)
     : callbacks_(std::make_shared<EngineCallbacks>()), config_template_(config_template) {}
-EngineBuilder::EngineBuilder() : EngineBuilder(std::string(config_template)) {
-#if defined(__APPLE__)
-  dns_resolver_name_ = "envoy.network.dns_resolver.apple";
-  dns_resolver_config_ = "{\"@type\":\"type.googleapis.com/"
-                         "envoy.extensions.network.dns_resolver.apple.v3.AppleDnsResolverConfig\"}";
-#else
-  dns_resolver_name_ = "envoy.network.dns_resolver.cares";
-  dns_resolver_config_ = "{\"@type\":\"type.googleapis.com/"
-                         "envoy.extensions.network.dns_resolver.cares.v3.CaresDnsResolverConfig\"}";
-#endif
-}
+EngineBuilder::EngineBuilder() : EngineBuilder(std::string(config_template)) {}
 
 EngineBuilder& EngineBuilder::addLogLevel(LogLevel log_level) {
   this->log_level_ = log_level;
@@ -62,6 +52,11 @@ EngineBuilder& EngineBuilder::addDnsQueryTimeoutSeconds(int dns_query_timeout_se
 EngineBuilder&
 EngineBuilder::addDnsPreresolveHostnames(const std::string& dns_preresolve_hostnames) {
   this->dns_preresolve_hostnames_ = dns_preresolve_hostnames;
+  return *this;
+}
+
+EngineBuilder& EngineBuilder::useDnsSystemResolver(bool use_system_resolver) {
+  this->use_system_resolver_ = use_system_resolver;
   return *this;
 }
 
@@ -119,6 +114,27 @@ EngineBuilder& EngineBuilder::enableBrotli(bool brotli_on) {
 }
 
 std::string EngineBuilder::generateConfigStr() {
+#if defined(__APPLE__)
+  std::string dns_resolver_name = "envoy.network.dns_resolver.apple";
+  std::string dns_resolver_config =
+      "{\"@type\":\"type.googleapis.com/"
+      "envoy.extensions.network.dns_resolver.apple.v3.AppleDnsResolverConfig\"}";
+#else
+  std::string dns_resolver_name = "";
+  std::string dns_resolver_config = "";
+  if (this->use_system_resolver_) {
+    dns_resolver_name = "envoy.network.dns_resolver.getaddrinfo";
+    dns_resolver_config =
+        "{\"@type\":\"type.googleapis.com/"
+        "envoy.extensions.network.dns_resolver.getaddrinfo.v3.GetAddrInfoDnsResolverConfig\"}";
+  } else {
+    dns_resolver_name = "envoy.network.dns_resolver.cares";
+    dns_resolver_config =
+        "{\"@type\":\"type.googleapis.com/"
+        "envoy.extensions.network.dns_resolver.cares.v3.CaresDnsResolverConfig\"}";
+  }
+#endif
+
   std::vector<std::pair<std::string, std::string>> replacements{
       {"connect_timeout", fmt::format("{}s", this->connect_timeout_seconds_)},
       {"dns_fail_base_interval", fmt::format("{}s", this->dns_failure_refresh_seconds_base_)},
@@ -126,8 +142,8 @@ std::string EngineBuilder::generateConfigStr() {
       {"dns_preresolve_hostnames", this->dns_preresolve_hostnames_},
       {"dns_refresh_rate", fmt::format("{}s", this->dns_refresh_seconds_)},
       {"dns_query_timeout", fmt::format("{}s", this->dns_query_timeout_seconds_)},
-      {"dns_resolver_name", dns_resolver_name_},
-      {"dns_resolver_config", dns_resolver_config_},
+      {"dns_resolver_name", dns_resolver_name},
+      {"dns_resolver_config", dns_resolver_config},
       {"h2_connection_keepalive_idle_interval",
        fmt::format("{}s", this->h2_connection_keepalive_idle_interval_milliseconds_ / 1000.0)},
       {"h2_connection_keepalive_timeout",

--- a/library/cc/engine_builder.h
+++ b/library/cc/engine_builder.h
@@ -24,6 +24,7 @@ public:
   EngineBuilder& addDnsFailureRefreshSeconds(int base, int max);
   EngineBuilder& addDnsQueryTimeoutSeconds(int dns_query_timeout_seconds);
   EngineBuilder& addDnsPreresolveHostnames(const std::string& dns_preresolve_hostnames);
+  EngineBuilder& useDnsSystemResolver(bool use_system_resolver);
   EngineBuilder& addH2ConnectionKeepaliveIdleIntervalMilliseconds(
       int h2_connection_keepalive_idle_interval_milliseconds);
   EngineBuilder&
@@ -63,6 +64,7 @@ private:
   int dns_failure_refresh_seconds_max_ = 10;
   int dns_query_timeout_seconds_ = 25;
   std::string dns_preresolve_hostnames_ = "[]";
+  bool use_system_resolver_ = false;
   int h2_connection_keepalive_idle_interval_milliseconds_ = 100000000;
   int h2_connection_keepalive_timeout_seconds_ = 10;
   int stats_flush_seconds_ = 60;
@@ -72,8 +74,6 @@ private:
   std::string virtual_clusters_ = "[]";
   std::string config_override_for_tests_ = "";
   std::string admin_address_path_for_tests_ = "";
-  std::string dns_resolver_name_ = "";
-  std::string dns_resolver_config_ = "";
   int stream_idle_timeout_seconds_ = 15;
   int per_try_idle_timeout_seconds_ = 15;
   bool gzip_filter_ = true;

--- a/library/java/io/envoyproxy/envoymobile/engine/EnvoyConfiguration.java
+++ b/library/java/io/envoyproxy/envoymobile/engine/EnvoyConfiguration.java
@@ -36,6 +36,7 @@ public class EnvoyConfiguration {
   public final String dnsPreresolveHostnames;
   public final List<String> dnsFallbackNameservers;
   public final Boolean dnsFilterUnroutableFamilies;
+  public final Boolean dnsUseSystemResolver;
   public final Boolean enableDrainPostDnsRefresh;
   public final Boolean enableHttp3;
   public final Boolean enableGzip;
@@ -77,6 +78,7 @@ public class EnvoyConfiguration {
    * @param dnsPreresolveHostnames       hostnames to preresolve on Envoy Client construction.
    * @param dnsFallbackNameservers       addresses to use as DNS name server fallback.
    * @param dnsFilterUnroutableFamilies  whether to filter unroutable IP families or not.
+   * @param dnsUseSystemResolver         whether to use the getaddr-based system resolver or c-ares.
    * @param enableDrainPostDnsRefresh    whether to drain connections after soft DNS refresh.
    * @param enableHttp3                  whether to enable experimental support for HTTP/3 (QUIC).
    * @param enableGzip                   whether to enable response gzip decompression.
@@ -104,18 +106,19 @@ public class EnvoyConfiguration {
    * @param keyValueStores               platform key-value store implementations.
    */
   public EnvoyConfiguration(
-      Boolean adminInterfaceEnabled, String grpcStatsDomain, @Nullable Integer statsdPort,
+      boolean adminInterfaceEnabled, String grpcStatsDomain, @Nullable Integer statsdPort,
       int connectTimeoutSeconds, int dnsRefreshSeconds, int dnsFailureRefreshSecondsBase,
       int dnsFailureRefreshSecondsMax, int dnsQueryTimeoutSeconds, int dnsMinRefreshSeconds,
       String dnsPreresolveHostnames, List<String> dnsFallbackNameservers,
-      Boolean dnsFilterUnroutableFamilies, boolean enableDrainPostDnsRefresh, boolean enableHttp3,
-      boolean enableGzip, boolean enableBrotli, boolean enableHappyEyeballs,
-      boolean enableInterfaceBinding, boolean forceIPv6,
-      int h2ConnectionKeepaliveIdleIntervalMilliseconds, int h2ConnectionKeepaliveTimeoutSeconds,
-      boolean h2ExtendKeepaliveTimeout, List<String> h2RawDomains, int maxConnectionsPerHost,
-      int statsFlushSeconds, int streamIdleTimeoutSeconds, int perTryIdleTimeoutSeconds,
-      String appVersion, String appId, TrustChainVerification trustChainVerification,
-      String virtualClusters, List<EnvoyNativeFilterConfig> nativeFilterChain,
+      boolean dnsFilterUnroutableFamilies, boolean dnsUseSystemResolver,
+      boolean enableDrainPostDnsRefresh, boolean enableHttp3, boolean enableGzip,
+      boolean enableBrotli, boolean enableHappyEyeballs, boolean enableInterfaceBinding,
+      boolean forceIPv6, int h2ConnectionKeepaliveIdleIntervalMilliseconds,
+      int h2ConnectionKeepaliveTimeoutSeconds, boolean h2ExtendKeepaliveTimeout,
+      List<String> h2RawDomains, int maxConnectionsPerHost, int statsFlushSeconds,
+      int streamIdleTimeoutSeconds, int perTryIdleTimeoutSeconds, String appVersion, String appId,
+      TrustChainVerification trustChainVerification, String virtualClusters,
+      List<EnvoyNativeFilterConfig> nativeFilterChain,
       List<EnvoyHTTPFilterFactory> httpPlatformFilterFactories,
       Map<String, EnvoyStringAccessor> stringAccessors,
       Map<String, EnvoyKeyValueStore> keyValueStores) {
@@ -131,6 +134,7 @@ public class EnvoyConfiguration {
     this.dnsPreresolveHostnames = dnsPreresolveHostnames;
     this.dnsFallbackNameservers = dnsFallbackNameservers;
     this.dnsFilterUnroutableFamilies = dnsFilterUnroutableFamilies;
+    this.dnsUseSystemResolver = dnsUseSystemResolver;
     this.enableDrainPostDnsRefresh = enableDrainPostDnsRefresh;
     this.enableHttp3 = enableHttp3;
     this.enableGzip = enableGzip;
@@ -228,10 +232,19 @@ public class EnvoyConfiguration {
       h2RawDomainsAsString = sb.toString();
     }
 
-    String dnsResolverConfig = String.format(
-        "{\"@type\":\"type.googleapis.com/envoy.extensions.network.dns_resolver.cares.v3.CaresDnsResolverConfig\",\"resolvers\":%s,\"use_resolvers_as_fallback\": %s, \"filter_unroutable_families\": %s}",
-        dnsFallbackNameserversAsString, !dnsFallbackNameservers.isEmpty() ? "true" : "false",
-        dnsFilterUnroutableFamilies ? "true" : "false");
+    String dnsResolverName = "";
+    String dnsResolverConfig = "";
+    if (dnsUseSystemResolver) {
+      dnsResolverName = "envoy.network.dns_resolver.getaddrinfo";
+      dnsResolverConfig =
+          "{\"@type\":\"type.googleapis.com/envoy.extensions.network.dns_resolver.getaddrinfo.v3.GetAddrInfoDnsResolverConfig\"}";
+    } else {
+      dnsResolverName = "envoy.network.dns_resolver.cares";
+      dnsResolverConfig = String.format(
+          "{\"@type\":\"type.googleapis.com/envoy.extensions.network.dns_resolver.cares.v3.CaresDnsResolverConfig\",\"resolvers\":%s,\"use_resolvers_as_fallback\": %s, \"filter_unroutable_families\": %s}",
+          dnsFallbackNameserversAsString, !dnsFallbackNameservers.isEmpty() ? "true" : "false",
+          dnsFilterUnroutableFamilies ? "true" : "false");
+    }
 
     StringBuilder configBuilder = new StringBuilder("!ignore platform_defs:\n");
     configBuilder.append(String.format("- &connect_timeout %ss\n", connectTimeoutSeconds))
@@ -246,7 +259,7 @@ public class EnvoyConfiguration {
             String.format("- &dns_multiple_addresses %s\n", enableHappyEyeballs ? "true" : "false"))
         .append(String.format("- &h2_delay_keepalive_timeout %s\n",
                               h2ExtendKeepaliveTimeout ? "true" : "false"))
-        .append("- &dns_resolver_name envoy.network.dns_resolver.cares\n")
+        .append(String.format("- &dns_resolver_name %s\n", dnsResolverName))
         .append(String.format("- &dns_refresh_rate %ss\n", dnsRefreshSeconds))
         .append(String.format("- &dns_resolver_config %s\n", dnsResolverConfig))
         .append(String.format("- &enable_drain_post_dns_refresh %s\n",

--- a/library/java/io/envoyproxy/envoymobile/engine/EnvoyConfiguration.java
+++ b/library/java/io/envoyproxy/envoymobile/engine/EnvoyConfiguration.java
@@ -78,7 +78,7 @@ public class EnvoyConfiguration {
    * @param dnsPreresolveHostnames       hostnames to preresolve on Envoy Client construction.
    * @param dnsFallbackNameservers       addresses to use as DNS name server fallback.
    * @param dnsFilterUnroutableFamilies  whether to filter unroutable IP families or not.
-   * @param dnsUseSystemResolver         whether to use the getaddr-based system resolver or c-ares.
+   * @param dnsUseSystemResolver         whether to use the getaddrinfo-based system resolver or c-ares.
    * @param enableDrainPostDnsRefresh    whether to drain connections after soft DNS refresh.
    * @param enableHttp3                  whether to enable experimental support for HTTP/3 (QUIC).
    * @param enableGzip                   whether to enable response gzip decompression.

--- a/library/java/io/envoyproxy/envoymobile/engine/EnvoyConfiguration.java
+++ b/library/java/io/envoyproxy/envoymobile/engine/EnvoyConfiguration.java
@@ -78,7 +78,8 @@ public class EnvoyConfiguration {
    * @param dnsPreresolveHostnames       hostnames to preresolve on Envoy Client construction.
    * @param dnsFallbackNameservers       addresses to use as DNS name server fallback.
    * @param dnsFilterUnroutableFamilies  whether to filter unroutable IP families or not.
-   * @param dnsUseSystemResolver         whether to use the getaddrinfo-based system resolver or c-ares.
+   * @param dnsUseSystemResolver         whether to use the getaddrinfo-based system resolver or
+   *     c-ares.
    * @param enableDrainPostDnsRefresh    whether to drain connections after soft DNS refresh.
    * @param enableHttp3                  whether to enable experimental support for HTTP/3 (QUIC).
    * @param enableGzip                   whether to enable response gzip decompression.

--- a/library/java/org/chromium/net/impl/NativeCronetEngineBuilderImpl.java
+++ b/library/java/org/chromium/net/impl/NativeCronetEngineBuilderImpl.java
@@ -43,6 +43,7 @@ public class NativeCronetEngineBuilderImpl extends CronetEngineBuilderImpl {
   private String mDnsPreresolveHostnames = "[]";
   private List<String> mDnsFallbackNameservers = Collections.emptyList();
   private boolean mEnableDnsFilterUnroutableFamilies = false;
+  private boolean mDnsUseSystemResolver = false;
   private boolean mEnableDrainPostDnsRefresh = false;
   private boolean mEnableHttp3 = false;
   private boolean mEnableGzip = true;
@@ -107,12 +108,13 @@ public class NativeCronetEngineBuilderImpl extends CronetEngineBuilderImpl {
         mAdminInterfaceEnabled, mGrpcStatsDomain, mStatsDPort, mConnectTimeoutSeconds,
         mDnsRefreshSeconds, mDnsFailureRefreshSecondsBase, mDnsFailureRefreshSecondsMax,
         mDnsQueryTimeoutSeconds, mDnsMinRefreshSeconds, mDnsPreresolveHostnames,
-        mDnsFallbackNameservers, mEnableDnsFilterUnroutableFamilies, mEnableDrainPostDnsRefresh,
-        mEnableHttp3, mEnableGzip, brotliEnabled(), mEnableHappyEyeballs, mEnableInterfaceBinding,
-        mForceIPv6, mH2ConnectionKeepaliveIdleIntervalMilliseconds,
-        mH2ConnectionKeepaliveTimeoutSeconds, mH2ExtendKeepaliveTimeout, mH2RawDomains,
-        mMaxConnectionsPerHost, mStatsFlushSeconds, mStreamIdleTimeoutSeconds,
-        mPerTryIdleTimeoutSeconds, mAppVersion, mAppId, mTrustChainVerification, mVirtualClusters,
-        nativeFilterChain, platformFilterChain, stringAccessors, keyValueStores);
+        mDnsFallbackNameservers, mEnableDnsFilterUnroutableFamilies, mDnsUseSystemResolver,
+        mEnableDrainPostDnsRefresh, mEnableHttp3, mEnableGzip, brotliEnabled(),
+        mEnableHappyEyeballs, mEnableInterfaceBinding, mForceIPv6,
+        mH2ConnectionKeepaliveIdleIntervalMilliseconds, mH2ConnectionKeepaliveTimeoutSeconds,
+        mH2ExtendKeepaliveTimeout, mH2RawDomains, mMaxConnectionsPerHost, mStatsFlushSeconds,
+        mStreamIdleTimeoutSeconds, mPerTryIdleTimeoutSeconds, mAppVersion, mAppId,
+        mTrustChainVerification, mVirtualClusters, nativeFilterChain, platformFilterChain,
+        stringAccessors, keyValueStores);
   }
 }

--- a/library/kotlin/io/envoyproxy/envoymobile/EngineBuilder.kt
+++ b/library/kotlin/io/envoyproxy/envoymobile/EngineBuilder.kt
@@ -49,6 +49,7 @@ open class EngineBuilder(
   private var dnsFailureRefreshSecondsMax = 10
   private var dnsFallbackNameservers = listOf<String>()
   private var dnsFilterUnroutableFamilies = true
+  private var dnsUseSystemResolver = false
   private var dnsQueryTimeoutSeconds = 25
   private var dnsMinRefreshSeconds = 60
   private var dnsPreresolveHostnames = "[]"
@@ -215,6 +216,19 @@ open class EngineBuilder(
    */
   fun enableDNSFilterUnroutableFamilies(dnsFilterUnroutableFamilies: Boolean): EngineBuilder {
     this.dnsFilterUnroutableFamilies = dnsFilterUnroutableFamilies
+    return this
+  }
+
+  /**
+   * Specify whether to use the getaddr-based system DNS resolver or the c-ares resolver.
+   * Defaults to false.
+   *
+   * @param dnsUseSystemResolver whether to use the system DNS resolver.
+   *
+   * @return this builder.
+   */
+  fun enableDNSUseSystemResolver(dnsUseSystemResolver: Boolean): EngineBuilder {
+    this.dnsUseSystemResolver = dnsUseSystemResolver
     return this
   }
 
@@ -591,6 +605,7 @@ open class EngineBuilder(
       dnsPreresolveHostnames,
       dnsFallbackNameservers,
       dnsFilterUnroutableFamilies,
+      dnsUseSystemResolver,
       enableDrainPostDnsRefresh,
       enableHttp3,
       enableGzip,

--- a/library/kotlin/io/envoyproxy/envoymobile/EngineBuilder.kt
+++ b/library/kotlin/io/envoyproxy/envoymobile/EngineBuilder.kt
@@ -220,7 +220,7 @@ open class EngineBuilder(
   }
 
   /**
-   * Specify whether to use the getaddr-based system DNS resolver or the c-ares resolver.
+   * Specify whether to use the getaddrinfo-based system DNS resolver or the c-ares resolver.
    * Defaults to false.
    *
    * @param dnsUseSystemResolver whether to use the system DNS resolver.

--- a/library/kotlin/io/envoyproxy/envoymobile/EngineBuilder.kt
+++ b/library/kotlin/io/envoyproxy/envoymobile/EngineBuilder.kt
@@ -222,7 +222,7 @@ open class EngineBuilder(
   /**
    * Specify whether to use the getaddrinfo-based system DNS resolver or the c-ares resolver.
    * Defaults to false.
-   * 
+   *
    * Note that if this is set, the values of `dnsFallbackNameservers` and
    * `dnsFilterUnroutableFamilies` will be ignored.
    *

--- a/library/kotlin/io/envoyproxy/envoymobile/EngineBuilder.kt
+++ b/library/kotlin/io/envoyproxy/envoymobile/EngineBuilder.kt
@@ -222,6 +222,9 @@ open class EngineBuilder(
   /**
    * Specify whether to use the getaddrinfo-based system DNS resolver or the c-ares resolver.
    * Defaults to false.
+   * 
+   * Note that if this is set, the values of `dnsFallbackNameservers` and
+   * `dnsFilterUnroutableFamilies` will be ignored.
    *
    * @param dnsUseSystemResolver whether to use the system DNS resolver.
    *

--- a/test/cc/unit/envoy_config_test.cc
+++ b/test/cc/unit/envoy_config_test.cc
@@ -76,6 +76,19 @@ TEST(TestConfig, ConfigIsValid) {
 #endif
 }
 
+#if !defined(__APPLE__)
+TEST(TestConfig, SetUseDnsSystemResolver) {
+  auto engine_builder = EngineBuilder();
+  engine_builder.useDnsSystemResolver(true);
+  auto config_str = engine_builder.generateConfigStr();
+  envoy::config::bootstrap::v3::Bootstrap bootstrap;
+  TestUtility::loadFromYaml(absl::StrCat(config_header, config_str), bootstrap);
+
+  ASSERT_THAT(bootstrap.DebugString(), HasSubstr("envoy.network.dns_resolver.getaddrinfo"));
+  ASSERT_THAT(bootstrap.DebugString(), Not(HasSubstr("envoy.network.dns_resolver.cares")));
+}
+#endif
+
 TEST(TestConfig, SetGzip) {
   auto engine_builder = EngineBuilder();
 

--- a/test/java/io/envoyproxy/envoymobile/engine/EnvoyConfigurationTest.kt
+++ b/test/java/io/envoyproxy/envoymobile/engine/EnvoyConfigurationTest.kt
@@ -54,6 +54,7 @@ class EnvoyConfigurationTest {
     dnsPreresolveHostnames: String = "[hostname]",
     dnsFallbackNameservers: List<String> = emptyList(),
     enableDnsFilterUnroutableFamilies: Boolean = true,
+    dnsUseSystemResolver: Boolean = false,
     enableDrainPostDnsRefresh: Boolean = false,
     enableHttp3: Boolean = false,
     enableGzip: Boolean = true,
@@ -87,6 +88,7 @@ class EnvoyConfigurationTest {
       dnsPreresolveHostnames,
       dnsFallbackNameservers,
       enableDnsFilterUnroutableFamilies,
+      dnsUseSystemResolver,
       enableDrainPostDnsRefresh,
       enableHttp3,
       enableGzip,
@@ -228,6 +230,20 @@ class EnvoyConfigurationTest {
 
     // Forcing IPv6
     assertThat(resolvedTemplate).contains("&force_ipv6 true")
+  }
+
+  @Test
+  fun `configuration resolves with system DNS resolver`() {
+    val envoyConfiguration = buildTestEnvoyConfiguration(
+      dnsUseSystemResolver = true
+    )
+
+    val resolvedTemplate = envoyConfiguration.resolveTemplate(
+      TEST_CONFIG, PLATFORM_FILTER_CONFIG, NATIVE_FILTER_CONFIG, APCF_INSERT, GZIP_INSERT, BROTLI_INSERT
+    )
+
+    assertThat(resolvedTemplate).contains("&dns_resolver_config {\"@type\":\"type.googleapis.com/envoy.extensions.network.dns_resolver.getaddrinfo.v3.GetAddrInfoDnsResolverConfig\"}")
+    assertThat(resolvedTemplate).contains("&dns_resolver_name envoy.network.dns_resolver.cares")
   }
 
   @Test

--- a/test/java/io/envoyproxy/envoymobile/engine/EnvoyConfigurationTest.kt
+++ b/test/java/io/envoyproxy/envoymobile/engine/EnvoyConfigurationTest.kt
@@ -243,7 +243,7 @@ class EnvoyConfigurationTest {
     )
 
     assertThat(resolvedTemplate).contains("&dns_resolver_config {\"@type\":\"type.googleapis.com/envoy.extensions.network.dns_resolver.getaddrinfo.v3.GetAddrInfoDnsResolverConfig\"}")
-    assertThat(resolvedTemplate).contains("&dns_resolver_name envoy.network.dns_resolver.cares")
+    assertThat(resolvedTemplate).contains("&dns_resolver_name envoy.network.dns_resolver.getaddrinfo")
   }
 
   @Test

--- a/test/kotlin/apps/experimental/MainActivity.kt
+++ b/test/kotlin/apps/experimental/MainActivity.kt
@@ -57,6 +57,7 @@ class MainActivity : Activity() {
       .addPlatformFilter(::AsyncDemoFilter)
       .h2ExtendKeepaliveTimeout(true)
       .enableInterfaceBinding(true)
+      .enableDNSUseSystemResolver(true)
       .forceIPv6(true)
       .addNativeFilter("envoy.filters.http.buffer", "{\"@type\":\"type.googleapis.com/envoy.extensions.filters.http.buffer.v3.Buffer\",\"max_request_bytes\":5242880}")
       .addStringAccessor("demo-accessor", { "PlatformString" })


### PR DESCRIPTION
For non-Apple platforms like Linux and Android.

Updated the Kotlin, Java & C++ builders.

Added here: https://github.com/envoyproxy/envoy/pull/22080

Risk Level: Low to moderate, off by default but I had to refactor some stuff.
Testing: Added.
Docs Changes: Documentation comments.
Release Notes: Added.

Signed-off-by: JP Simard <jp@jpsim.com>