### PR TITLE
Fix isCleartextTrafficPermitted

### DIFF
--- a/library/common/jni/android_jni_utility.cc
+++ b/library/common/jni/android_jni_utility.cc
@@ -20,10 +20,11 @@ bool is_cleartext_permitted(absl::string_view hostname) {
   envoy_data host = Envoy::Data::Utility::copyToBridgeData(hostname);
   JNIEnv* env = get_env();
   jstring java_host = native_data_to_string(env, host);
-  jclass jcls_Boolean = env->FindClass("org/chromium/net/AndroidNetworkLibrary");
-  jmethodID jmid_isCleartextTrafficPermitted =
-      env->GetMethodID(jcls_Boolean, "isCleartextTrafficPermitted", "(Ljava/lang/String;)Z");
-  jboolean result = env->CallBooleanMethod(java_host, jmid_isCleartextTrafficPermitted);
+  jclass jcls_AndroidNetworkLibrary = env->FindClass("org/chromium/net/AndroidNetworkLibrary");
+  jmethodID jmid_isCleartextTrafficPermitted = env->GetStaticMethodID(
+      jcls_AndroidNetworkLibrary, "isCleartextTrafficPermitted", "(Ljava/lang/String;)Z");
+  jboolean result = env->CallStaticBooleanMethod(jcls_AndroidNetworkLibrary,
+                                                 jmid_isCleartextTrafficPermitted, java_host);
   env->DeleteLocalRef(java_host);
   release_envoy_data(host);
   return result == JNI_TRUE;


### PR DESCRIPTION
Fix isCleartextTrafficPermitted by finding a static method (instead of an object method) and calling 
the static method of the AndroidNetworkLibrary class instead of calling the instance method on a string.

Testing: Needs tests :)]
