### PR TITLE
tools: add arm64 debug run configuration

### DIFF
--- a/docs/root/development/debugging/android_local.rst
+++ b/docs/root/development/debugging/android_local.rst
@@ -17,7 +17,7 @@ Setting up the environment
 Before we start, you'll need to download Android Studio and the `Bazel plugin <https://plugins.jetbrains.com/plugin/9185-bazel>`_, you can find it in Preferences -> Plugins
 .
 
-1. Go `here <https://developer.android.com/studio/>`_ and install Android Studio.
+1. Go `here <https://developer.android.com/studio/>`_ and install Android Studio
 2. Install the bazel plugin
 
 Adding Envoy-Mobile Project into Android Studio
@@ -51,16 +51,8 @@ Entering a debugging session
 
 With the project ready, you can now start debugging with Android Studio.
 
-1. Compile your envoy-mobile with debug symbols to the architecture of the device or emulator you are about to run.
-
-For example:
-::
-
-    $ ./bazelw build android_dist --config=android --fat_apk_cpu=x86 -c dbg
-
-Android supported archs are `arm64_v8a`, `armeabi-v7a`, `x86`, `x86_64`.
-
-2. From Android Studio select the `Example App x86 (Debug)` configuration and hit the debug icon. Note: if you don't see this option go to "Add configuration" and it'll be there on the Bazel category, just select it and hit Ok.
+1. From Android Studio select either `Example App (Debug) [x86]` or `Example App (Debug) [arm64]` configuration. Note: the `x86` configuration doesn't work on ARM machines (i.e., M1 Macbooks).
+2. Hit the debug icon. Note: if you don't see this option go to "Add configuration" and it'll be there on the Bazel category, just select it and hit Ok.
 3. Optionally you could create symbolic breakpoints before running by going to the Debugger tab.
 
 Your environment should look like this at this point:

--- a/examples/kotlin/hello_world/.bazelproject
+++ b/examples/kotlin/hello_world/.bazelproject
@@ -13,6 +13,7 @@ directories:
 
 import_run_configurations:
   examples/kotlin/hello_world/tools/android-studio-run-configurations/run_configuration_example_debug_x86.xml
+  examples/kotlin/hello_world/tools/android-studio-run-configurations/run_configuration_example_debug_arm64.xml
 
 targets:
   //examples/kotlin/hello_world:hello_envoy_kt

--- a/examples/kotlin/hello_world/tools/android-studio-run-configurations/run_configuration_example_debug_arm64.xml
+++ b/examples/kotlin/hello_world/tools/android-studio-run-configurations/run_configuration_example_debug_arm64.xml
@@ -1,4 +1,4 @@
-<configuration name="Example App (Debug) [x86]"
+<configuration name="Example App (Debug) [arm64]"
     type="BlazeCommandRunConfigurationType"
     factoryName="Bazel Command"
     nameIsGenerated="false">
@@ -14,7 +14,7 @@
         use-work-profile-if-present="false"
         show-logcat-automatically="false"
         AM_START_OPTIONS="">
-        <blaze-user-flag>--fat_apk_cpu=x86</blaze-user-flag>
+        <blaze-user-flag>--fat_apk_cpu=arm64-v8a</blaze-user-flag>
         <blaze-target>//examples/kotlin/hello_world:hello_envoy_kt</blaze-target>
         <Profilers>
             <option name="ADVANCED_PROFILING_ENABLED"


### PR DESCRIPTION
Description: Add an arm64 run configuration for Envoy example app so that it's possible to run and debug Envoy Mobile example app on ARM machines (i.e., M1 Macbooks). Following steps from https://envoy-mobile.github.io/docs/envoy-mobile/latest/development/debugging/android_local.html#adding-envoy-mobile-project-into-android-studio it's possible to set up an Android project that makes it possible to run and debug Envoy Mobile example app (put symbolic breakpoints in Envoy code). As it is now, the configured/added run configuration supports running of x86 builds only which do not work on ARM machines. 
Risk Level: None
Testing: Run new configuration locally on M1 Macbook.
Docs Changes: N/A
Release Notes: N/A

Signed-off-by: Rafal Augustyniak <raugustyniak@lyft.com>

