### PR TITLE
docs: revert "docs: use sphinx githubpages extension (#2418)"

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -67,7 +67,7 @@ blob_sha = os.environ['ENVOY_BLOB_SHA']
 # Add any Sphinx extension module names here, as strings. They can be
 # extensions coming with Sphinx (named 'sphinx.ext.*') or your custom
 # ones.
-extensions = ['sphinxcontrib.httpdomain', 'sphinx.ext.extlinks', 'sphinx.ext.ifconfig', 'sphinx.ext.githubpages']
+extensions = ['sphinxcontrib.httpdomain', 'sphinx.ext.extlinks', 'sphinx.ext.ifconfig']
 extlinks = {
     'issue': ('https://github.com/envoyproxy/envoy-mobile/issues/%s', ''),
     'repo': ('https://github.com/envoyproxy/envoy-mobile/blob/{}/%s'.format(blob_sha), ''),


### PR DESCRIPTION
Description: Revert https://github.com/envoyproxy/envoy-mobile/pull/2418 as the change did not fix the issues with images not appearing in documentation. https://github.com/envoy-mobile/envoy-mobile.github.io/pull/24 fixed the issues instead.
Risk Level: None. 
Testing: N/A
Docs Changes: N/A
Release Notes: N/A

Signed-off-by: Rafal Augustyniak <raugustyniak@lyft.com>