### PR TITLE
Squelch two JNI build warnings

### DIFF
--- a/library/common/jni/jni_interface.cc
+++ b/library/common/jni/jni_interface.cc
@@ -1191,6 +1191,8 @@ static jobject call_jvm_verify_x509_cert_chain(JNIEnv* env,
   return result;
 }
 
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wunused-function"
 // `auth_type` and `host` are expected to be UTF-8 encoded.
 static void jvm_verify_x509_cert_chain(const std::vector<std::string>& cert_chain,
                                        std::string auth_type, std::string host,
@@ -1202,6 +1204,7 @@ static void jvm_verify_x509_cert_chain(const std::vector<std::string>& cert_chai
   ExtractCertVerifyResult(get_env(), result, status, is_issued_by_known_root, verified_chain);
   env->DeleteLocalRef(result);
 }
+#pragma clang diagnostic pop
 
 static void jvm_add_test_root_certificate(const uint8_t* cert, size_t len) {
   jni_log("[Envoy]", "jvm_add_test_root_certificate");

--- a/library/common/jni/jni_utility.cc
+++ b/library/common/jni/jni_utility.cc
@@ -25,8 +25,8 @@ JNIEnv* get_env() {
   jint result = static_jvm->GetEnv(reinterpret_cast<void**>(&local_env), JNI_VERSION);
   if (result == JNI_EDETACHED) {
     // Note: the only thread that should need to be attached is Envoy's engine std::thread.
-    static char* thread_name = "EnvoyMain";
-    JavaVMAttachArgs args = {JNI_VERSION, thread_name, nullptr};
+    static const char* thread_name = "EnvoyMain";
+    JavaVMAttachArgs args = {JNI_VERSION, const_cast<char*>(thread_name), nullptr};
     result = attach_jvm(static_jvm, &local_env, &args);
   }
   RELEASE_ASSERT(result == JNI_OK, "Unable to get a JVM env for the current thread");


### PR DESCRIPTION
I currently see 3 build warnings when I try to build Envoy Mobile. 

```
INFO: From Compiling library/common/jni/jni_interface.cc:
library/common/jni/jni_interface.cc:1195:13: warning: unused function 'jvm_verify_x509_cert_chain' [-Wunused-function]
static void jvm_verify_x509_cert_chain(const std::vector<std::string>& cert_chain,
            ^
1 warning generated.
INFO: From Compiling library/common/jni/jni_utility.cc:
In file included from library/common/jni/jni_utility.cc:6:
In file included from external/envoy/source/common/common/assert.h:5:
In file included from external/envoy/source/common/common/logger.h:13:
external/envoy/source/common/common/fine_grain_logger.h:20:1: warning: inline variables are a C++17 extension [-Wc++17-extensions]
inline const char* kDefaultFineGrainLogFormat = "[%Y-%m-%d %T.%e][%t][%l] [%g:%#] %v";
^
library/common/jni/jni_utility.cc:28:32: warning: ISO C++11 does not allow conversion from string literal to 'char *' [-Wwritable-strings]
    static char* thread_name = "EnvoyMain";
                               ^
2 warnings generated.
```
This PR squelches the two of them that are in Envoy Mobile code.

Signed-off-by: Ryan Hamilton <rch@google.com>

Risk Level: Low
Testing: Builds
Docs Changes: N/A
Release Notes: N/A