### PR TITLE
tools: fix source mapping

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -40,6 +40,7 @@ build --java_language_version=8
 # Override PGV validation with NOP functions
 build --@com_envoyproxy_protoc_gen_validate//bazel:template-flavor=nop
 
+build:dbg --compilation_mode=debug
 # Enable source map for debugging in IDEs
 build:dbg --copt="-fdebug-compilation-dir" --copt="/proc/self/cwd"
 

--- a/.bazelrc
+++ b/.bazelrc
@@ -40,7 +40,7 @@ build --java_language_version=8
 # Override PGV validation with NOP functions
 build --@com_envoyproxy_protoc_gen_validate//bazel:template-flavor=nop
 
-build:dbg --compilation_mode=debug
+build:dbg --compilation_mode=dbg
 # Enable source map for debugging in IDEs
 build:dbg --copt="-fdebug-compilation-dir" --copt="/proc/self/cwd"
 

--- a/examples/kotlin/hello_world/tools/android-studio-run-configurations/run_configuration_example_debug_arm64.xml
+++ b/examples/kotlin/hello_world/tools/android-studio-run-configurations/run_configuration_example_debug_arm64.xml
@@ -14,6 +14,7 @@
         use-work-profile-if-present="false"
         show-logcat-automatically="false"
         AM_START_OPTIONS="">
+        <blaze-user-flag>--config=dbg</blaze-user-flag>
         <blaze-user-flag>--fat_apk_cpu=arm64-v8a</blaze-user-flag>
         <blaze-target>//examples/kotlin/hello_world:hello_envoy_kt</blaze-target>
         <Profilers>

--- a/examples/kotlin/hello_world/tools/android-studio-run-configurations/run_configuration_example_debug_x86.xml
+++ b/examples/kotlin/hello_world/tools/android-studio-run-configurations/run_configuration_example_debug_x86.xml
@@ -14,6 +14,7 @@
         use-work-profile-if-present="false"
         show-logcat-automatically="false"
         AM_START_OPTIONS="">
+        <blaze-user-flag>--config=dbg</blaze-user-flag>
         <blaze-user-flag>--fat_apk_cpu=x86</blaze-user-flag>
         <blaze-target>//examples/kotlin/hello_world:hello_envoy_kt</blaze-target>
         <Profilers>


### PR DESCRIPTION
Description: Per our documentation, the following should be true "While breaking on a C++ function, Android Studio should present the source file and highlight the line where the breakpoint hit with all scope information". That feature did not work - I didn't confirm this but it's possible that the functionality was broken when https://github.com/envoyproxy/envoy-mobile/pull/2184 was merged. Anyway, the issue was that https://github.com/envoyproxy/envoy-mobile/blob/581ba40f2f8597243efccb2bdccade8193ff4559/.bazelrc#L44 config setting was not applied when Envoy Mobile was built for the runs of example apps. This has been fixed by making run configurations that are used by Envoy Mobile example apps specify `--config=dbg` setting explicitly.
Risk Level: None
Testing: Confirmed that Android Studio opens the right file (and highlights the right line) when EnvoyMobile breakpoint is hit.
Docs Changes: N/A
Release Notes: N/A

Signed-off-by: Rafal Augustyniak <raugustyniak@lyft.com>