### PR TITLE
bazel: update rules_kotlin to v1.7.0-RC-2

### DIFF
--- a/bazel/envoy_mobile_repositories.bzl
+++ b/bazel/envoy_mobile_repositories.bzl
@@ -119,8 +119,8 @@ def kotlin_repos():
 
     http_archive(
         name = "io_bazel_rules_kotlin",
-        sha256 = "f1a4053eae0ea381147f5056bb51e396c5c494c7f8d50d0dee4cc2f9d5c701b0",
-        urls = ["https://github.com/bazelbuild/rules_kotlin/releases/download/1.6.0-RC-1/rules_kotlin_release.tgz"],
+        sha256 = "946747acdbeae799b085d12b240ec346f775ac65236dfcf18aa0cd7300f6de78",
+        urls = ["https://github.com/bazelbuild/rules_kotlin/releases/download/v1.7.0-RC-2/rules_kotlin_release.tgz"],
     )
 
     http_archive(


### PR DESCRIPTION
Which will be needed when we update to the latest version of bazel: https://github.com/envoyproxy/envoy/pull/22295

Risk Level: Low
Testing: CI
Docs Changes: N/A
Release Notes: N/A

Signed-off-by: JP Simard <jp@jpsim.com>