### PR TITLE
bazel: update rules-proto-grpc to 4.1.1

### DIFF
--- a/bazel/envoy_mobile_dependencies.bzl
+++ b/bazel/envoy_mobile_dependencies.bzl
@@ -4,9 +4,8 @@ load("@build_bazel_apple_support//lib:repositories.bzl", "apple_support_dependen
 load("@rules_jvm_external//:defs.bzl", "maven_install")
 load("@rules_detekt//detekt:dependencies.bzl", "rules_detekt_dependencies")
 load("@io_bazel_rules_kotlin//kotlin:repositories.bzl", "kotlin_repositories")
-load("@io_grpc_grpc_java//:repositories.bzl", "grpc_java_repositories")
-load("@rules_proto_grpc//protobuf:repositories.bzl", "protobuf_repos")
-load("@rules_proto_grpc//java:repositories.bzl", rules_proto_grpc_java_repos = "java_repos")
+load("@rules_proto_grpc//:repositories.bzl", "rules_proto_grpc_repos", "rules_proto_grpc_toolchains")
+load("@rules_proto//proto:repositories.bzl", "rules_proto_dependencies", "rules_proto_toolchains")
 load("@rules_python//python:pip.bzl", "pip_install")
 load("@robolectric//bazel:robolectric.bzl", "robolectric_repositories")
 load("@rules_java//java:repositories.bzl", "rules_java_dependencies")
@@ -102,14 +101,10 @@ def kotlin_dependencies(extra_maven_dependencies = []):
     rules_detekt_dependencies()
     robolectric_repositories()
 
-    grpc_java_repositories(
-        omit_bazel_skylib = True,
-        omit_com_google_protobuf = True,
-        omit_com_google_protobuf_javalite = True,
-        omit_net_zlib = True,
-    )
-    protobuf_repos()
-    rules_proto_grpc_java_repos()
+    rules_proto_grpc_toolchains()
+    rules_proto_grpc_repos()
+    rules_proto_dependencies()
+    rules_proto_toolchains()
 
 def python_dependencies():
     # TODO: bifurcate dev deps vs. prod deps

--- a/bazel/envoy_mobile_repositories.bzl
+++ b/bazel/envoy_mobile_repositories.bzl
@@ -130,23 +130,11 @@ def kotlin_repos():
         url = "https://github.com/buildfoundation/bazel_rules_detekt/archive/v0.6.0.tar.gz",
     )
 
-    # gRPC java for @rules_proto_grpc
-    # The current 0.2.0 uses v1.23.0 of gRPC java which has a buggy version of the grpc_java_repositories
-    # where it tries to bind the zlib and errors out
-    # The fix went in on this commit:
-    # https://github.com/grpc/grpc-java/commit/57e7bd394e92015d2891adc74af0eaf9cd347ea8#diff-515bc54a0cbb4b12fb4a7c465758b011L128-L131
-    http_archive(
-        name = "io_grpc_grpc_java",
-        sha256 = "8b495f58aaf75138b24775600a062bbdaa754d85f7ab2a47b2c9ecb432836dd1",
-        strip_prefix = "grpc-java-1.24.0",
-        urls = ["https://github.com/grpc/grpc-java/archive/v1.24.0.tar.gz"],
-    )
-
     http_archive(
         name = "rules_proto_grpc",
-        sha256 = "1e08cd6c61f893417b14930ca342950f5f22f71f929a38a8c4bbfeae2a80d03e",
-        strip_prefix = "rules_proto_grpc-0.2.0",
-        urls = ["https://github.com/rules-proto-grpc/rules_proto_grpc/archive/0.2.0.tar.gz"],
+        sha256 = "507e38c8d95c7efa4f3b1c0595a8e8f139c885cb41a76cab7e20e4e67ae87731",
+        strip_prefix = "rules_proto_grpc-4.1.1",
+        urls = ["https://github.com/rules-proto-grpc/rules_proto_grpc/archive/4.1.1.tar.gz"],
     )
 
     http_file(


### PR DESCRIPTION
We were on a very old release. This is also going to be needed to update to the latest bazel 6.x release which we need to do to update Envoy.

Risk Level: Medium
Testing: CI, Lyft apps
Docs Changes: N/A
Release Notes: N/A

Signed-off-by: JP Simard <jp@jpsim.com>
