### PR TITLE
docs: update website URL to envoymobile.io

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,11 +4,11 @@ Multiplatform client HTTP/networking library built on the [Envoy](https://www.en
 
 ## Documentation
 
-- **[Official documentation](https://envoy-mobile.github.io/docs/envoy-mobile/latest/index.html)**
-- [Project website](https://envoy-mobile.github.io)
-- [Getting started demos](https://envoy-mobile.github.io/docs/envoy-mobile/latest/start/start.html)
-- [API and usage](https://envoy-mobile.github.io/docs/envoy-mobile/latest/api/api.html)
-- [Additional resources](https://envoy-mobile.github.io/docs/envoy-mobile/latest/intro/additional_resources.html)
+- **[Official documentation](https://envoymobile.io/docs/envoy-mobile/latest/index.html)**
+- [Project website](https://envoymobile.io)
+- [Getting started demos](https://envoymobile.io/docs/envoy-mobile/latest/start/start.html)
+- [API and usage](https://envoymobile.io/docs/envoy-mobile/latest/api/api.html)
+- [Additional resources](https://envoymobile.io/docs/envoy-mobile/latest/intro/additional_resources.html)
 
 ## Contact
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -2,7 +2,7 @@
 
 Envoy Mobile's docs are generated using [Sphinx](http://www.sphinx-doc.org),
 and are published
-[here](https://envoy-mobile.github.io/docs/envoy-mobile/latest/index.html).
+[here](https://envoymobile.io/docs/envoy-mobile/latest/index.html).
 
 ## Generating docs locally
 

--- a/docs/publish.sh
+++ b/docs/publish.sh
@@ -3,7 +3,7 @@
 # This is run on every commit that CircleCI picks up. It assumes that docs have already been built
 # via docs/build.sh. The push behavior differs depending on the nature of the commit:
 # * Tag commit (e.g. v1.6.0): pushes docs to versioned location.
-# * Main commit: pushes docs to latest. Note that envoy-mobile.github.io uses `master` rather than
+# * Main commit: pushes docs to latest. Note that envoymobile.io uses `master` rather than
 #                `main` because using `main` as the default branch currently results in 404s.
 # * Otherwise: noop.
 
@@ -25,7 +25,7 @@ else
 fi
 
 echo 'cloning'
-git clone git@github.com:envoy-mobile/envoy-mobile.github.io "$CHECKOUT_DIR"
+git clone git@github.com:envoy-mobile/envoymobile.io "$CHECKOUT_DIR"
 
 git -C "$CHECKOUT_DIR" fetch
 git -C "$CHECKOUT_DIR" checkout -B master origin/master

--- a/docs/publish.sh
+++ b/docs/publish.sh
@@ -3,7 +3,7 @@
 # This is run on every commit that CircleCI picks up. It assumes that docs have already been built
 # via docs/build.sh. The push behavior differs depending on the nature of the commit:
 # * Tag commit (e.g. v1.6.0): pushes docs to versioned location.
-# * Main commit: pushes docs to latest. Note that envoymobile.io uses `master` rather than
+# * Main commit: pushes docs to latest. Note that envoy-mobile.github.io uses `master` rather than
 #                `main` because using `main` as the default branch currently results in 404s.
 # * Otherwise: noop.
 
@@ -25,7 +25,7 @@ else
 fi
 
 echo 'cloning'
-git clone git@github.com:envoy-mobile/envoymobile.io "$CHECKOUT_DIR"
+git clone git@github.com:envoy-mobile/envoy-mobile.github.io "$CHECKOUT_DIR"
 
 git -C "$CHECKOUT_DIR" fetch
 git -C "$CHECKOUT_DIR" checkout -B master origin/master

--- a/examples/java/hello_world/README.md
+++ b/examples/java/hello_world/README.md
@@ -1,1 +1,1 @@
-For instructions on how to use this demo, please head over to our [docs](https://envoy-mobile.github.io/docs/envoy-mobile/latest/start/examples/hello_world.html).
+For instructions on how to use this demo, please head over to our [docs](https://envoymobile.io/docs/envoy-mobile/latest/start/examples/hello_world.html).

--- a/examples/kotlin/hello_world/README.md
+++ b/examples/kotlin/hello_world/README.md
@@ -1,1 +1,1 @@
-For instructions on how to use this demo, please head over to our [docs](https://envoy-mobile.github.io/docs/envoy-mobile/latest/start/examples/hello_world.html).
+For instructions on how to use this demo, please head over to our [docs](https://envoymobile.io/docs/envoy-mobile/latest/start/examples/hello_world.html).

--- a/examples/objective-c/hello_world/README.md
+++ b/examples/objective-c/hello_world/README.md
@@ -1,1 +1,1 @@
-For instructions on how to use this demo, please head over to our [docs](https://envoy-mobile.github.io/docs/envoy-mobile/latest/start/examples/hello_world.html).
+For instructions on how to use this demo, please head over to our [docs](https://envoymobile.io/docs/envoy-mobile/latest/start/examples/hello_world.html).

--- a/examples/swift/hello_world/README.md
+++ b/examples/swift/hello_world/README.md
@@ -1,1 +1,1 @@
-For instructions on how to use this demo, please head over to our [docs](https://envoy-mobile.github.io/docs/envoy-mobile/latest/start/examples/hello_world.html).
+For instructions on how to use this demo, please head over to our [docs](https://envoymobile.io/docs/envoy-mobile/latest/start/examples/hello_world.html).

--- a/test/kotlin/apps/baseline/README.md
+++ b/test/kotlin/apps/baseline/README.md
@@ -1,1 +1,1 @@
-For instructions on how to use this demo, please head over to our [docs](https://envoy-mobile.github.io/docs/envoy-mobile/latest/start/examples/hello_world.html).
+For instructions on how to use this demo, please head over to our [docs](https://envoymobile.io/docs/envoy-mobile/latest/start/examples/hello_world.html).

--- a/test/kotlin/apps/experimental/README.md
+++ b/test/kotlin/apps/experimental/README.md
@@ -1,1 +1,1 @@
-For instructions on how to use this demo, please head over to our [docs](https://envoy-mobile.github.io/docs/envoy-mobile/latest/start/examples/hello_world.html).
+For instructions on how to use this demo, please head over to our [docs](https://envoymobile.io/docs/envoy-mobile/latest/start/examples/hello_world.html).

--- a/test/performance/test_binary_size.cc
+++ b/test/performance/test_binary_size.cc
@@ -4,5 +4,5 @@
 
 // This binary is used to perform stripped down binary size investigations of the Envoy codebase.
 // Please refer to the development docs for more information:
-// https://envoy-mobile.github.io/docs/envoy-mobile/latest/development/performance/binary_size.html
+// https://envoymobile.io/docs/envoy-mobile/latest/development/performance/binary_size.html
 int main() { return run_engine(0, nullptr, nullptr, nullptr); }

--- a/test/swift/apps/baseline/README.md
+++ b/test/swift/apps/baseline/README.md
@@ -1,1 +1,1 @@
-For instructions on how to use this demo, please head over to our [docs](https://envoy-mobile.github.io/docs/envoy-mobile/latest/start/examples/hello_world.html).
+For instructions on how to use this demo, please head over to our [docs](https://envoymobile.io/docs/envoy-mobile/latest/start/examples/hello_world.html).

--- a/test/swift/apps/experimental/README.md
+++ b/test/swift/apps/experimental/README.md
@@ -1,1 +1,1 @@
-For instructions on how to use this demo, please head over to our [docs](https://envoy-mobile.github.io/docs/envoy-mobile/latest/start/examples/hello_world.html).
+For instructions on how to use this demo, please head over to our [docs](https://envoymobile.io/docs/envoy-mobile/latest/start/examples/hello_world.html).


### PR DESCRIPTION
New URL: https://envoymobile.io
Old URLs from https://envoy-mobile.github.io should redirect transparently.