### PR TITLE
jni: release data to avoid memory leak

### DIFF
--- a/library/common/jni/jni_interface.cc
+++ b/library/common/jni/jni_interface.cc
@@ -58,6 +58,7 @@ static void jvm_on_log(envoy_data data, const void* context) {
   jmethodID jmid_onLog = env->GetMethodID(jcls_JvmLoggerContext, "log", "(Ljava/lang/String;)V");
   env->CallVoidMethod(j_context, jmid_onLog, str);
 
+  release_envoy_data(data);
   env->DeleteLocalRef(str);
   env->DeleteLocalRef(jcls_JvmLoggerContext);
 }


### PR DESCRIPTION
Description: Release passed data to avoid a mem leak.
Risk Level: Low, proper handling of memory
Testing: Manual
Docs Changes: N/A 
Release Notes: N/A

Signed-off-by: Rafal Augustyniak <raugustyniak@lyft.com>