### PR TITLE
test: use TestRequestHeaderMapImpl for building custom headers

### DIFF
--- a/library/cc/bridge_utility.cc
+++ b/library/cc/bridge_utility.cc
@@ -1,5 +1,6 @@
 #include "bridge_utility.h"
 
+#include <iostream>
 #include <sstream>
 
 #include "library/common/data/utility.h"
@@ -38,7 +39,6 @@ RawHeaderMap envoyHeadersAsRawHeaderMap(envoy_headers raw_headers) {
   for (auto i = 0; i < raw_headers.length; i++) {
     auto key = Data::Utility::copyToString(raw_headers.entries[i].key);
     auto value = Data::Utility::copyToString(raw_headers.entries[i].value);
-
     if (!headers.contains(key)) {
       headers.emplace(key, std::vector<std::string>());
     }

--- a/library/cc/bridge_utility.cc
+++ b/library/cc/bridge_utility.cc
@@ -1,6 +1,5 @@
 #include "bridge_utility.h"
 
-#include <iostream>
 #include <sstream>
 
 #include "library/common/data/utility.h"
@@ -39,6 +38,7 @@ RawHeaderMap envoyHeadersAsRawHeaderMap(envoy_headers raw_headers) {
   for (auto i = 0; i < raw_headers.length; i++) {
     auto key = Data::Utility::copyToString(raw_headers.entries[i].key);
     auto value = Data::Utility::copyToString(raw_headers.entries[i].value);
+
     if (!headers.contains(key)) {
       headers.emplace(key, std::vector<std::string>());
     }

--- a/library/common/http/header_utility.cc
+++ b/library/common/http/header_utility.cc
@@ -9,14 +9,14 @@ namespace Envoy {
 namespace Http {
 namespace Utility {
 
-void toEnvoyHeaders(HeaderMap& transformed_headers, envoy_headers headers) {
-  Envoy::Http::StatefulHeaderKeyFormatter& formatter = transformed_headers.formatter().value();
+void toEnvoyHeaders(HeaderMap& envoy_result_headers, envoy_headers headers) {
+  Envoy::Http::StatefulHeaderKeyFormatter& formatter = envoy_result_headers.formatter().value();
   for (envoy_map_size_t i = 0; i < headers.length; i++) {
     std::string key = Data::Utility::copyToString(headers.entries[i].key);
     // Make sure the formatter knows the original case.
     formatter.processKey(key);
-    transformed_headers.addCopy(LowerCaseString(key),
-                                Data::Utility::copyToString(headers.entries[i].value));
+    envoy_result_headers.addCopy(LowerCaseString(key),
+                                 Data::Utility::copyToString(headers.entries[i].value));
   }
   // The C envoy_headers struct can be released now because the headers have been copied.
   release_envoy_headers(headers);

--- a/library/common/http/header_utility.cc
+++ b/library/common/http/header_utility.cc
@@ -52,7 +52,7 @@ envoy_headers toBridgeHeaders(const HeaderMap& header_map, absl::string_view alp
   envoy_headers transformed_headers;
   transformed_headers.length = 0;
   transformed_headers.entries = headers;
-  
+
   header_map.iterate(
       [&transformed_headers, &header_map](const HeaderEntry& header) -> HeaderMap::Iterate {
         std::string key_val = std::string(header.key().getStringView());

--- a/library/common/http/header_utility.cc
+++ b/library/common/http/header_utility.cc
@@ -62,6 +62,7 @@ envoy_headers toBridgeHeaders(const HeaderMap& header_map, absl::string_view alp
         }
         envoy_data key = Data::Utility::copyToBridgeData(key_val);
         envoy_data value = Data::Utility::copyToBridgeData(header.value().getStringView());
+        
         transformed_headers.entries[transformed_headers.length] = {key, value};
         transformed_headers.length++;
 

--- a/library/common/http/header_utility.cc
+++ b/library/common/http/header_utility.cc
@@ -62,7 +62,7 @@ envoy_headers toBridgeHeaders(const HeaderMap& header_map, absl::string_view alp
         }
         envoy_data key = Data::Utility::copyToBridgeData(key_val);
         envoy_data value = Data::Utility::copyToBridgeData(header.value().getStringView());
-        
+
         transformed_headers.entries[transformed_headers.length] = {key, value};
         transformed_headers.length++;
 

--- a/library/common/http/header_utility.cc
+++ b/library/common/http/header_utility.cc
@@ -52,7 +52,7 @@ envoy_headers toBridgeHeaders(const HeaderMap& header_map, absl::string_view alp
   envoy_headers transformed_headers;
   transformed_headers.length = 0;
   transformed_headers.entries = headers;
-
+  
   header_map.iterate(
       [&transformed_headers, &header_map](const HeaderEntry& header) -> HeaderMap::Iterate {
         std::string key_val = std::string(header.key().getStringView());
@@ -62,7 +62,6 @@ envoy_headers toBridgeHeaders(const HeaderMap& header_map, absl::string_view alp
         }
         envoy_data key = Data::Utility::copyToBridgeData(key_val);
         envoy_data value = Data::Utility::copyToBridgeData(header.value().getStringView());
-
         transformed_headers.entries[transformed_headers.length] = {key, value};
         transformed_headers.length++;
 

--- a/test/common/integration/base_client_integration_test.cc
+++ b/test/common/integration/base_client_integration_test.cc
@@ -108,20 +108,20 @@ std::shared_ptr<Platform::RequestHeaders> BaseClientIntegrationTest::envoyToMobi
   Platform::RequestHeadersBuilder builder(
       Platform::RequestMethod::GET,
       std::string(default_request_headers_.Scheme()->value().getStringView()),
-      std::string(default_request_headers_.Host()->value().getStringView()), "/");
+      std::string(default_request_headers_.Host()->value().getStringView()),
+      std::string(default_request_headers_.Path()->value().getStringView()));
   if (upstreamProtocol() == Http::CodecType::HTTP2) {
     builder.addUpstreamHttpProtocol(Platform::UpstreamHttpProtocol::HTTP2);
   }
 
   request_headers.iterate(
       [&request_headers, &builder](const Http::HeaderEntry& header) -> Http::HeaderMap::Iterate {
-        std::string key_val = std::string(header.key().getStringView());
+        std::string key = std::string(header.key().getStringView());
         if (request_headers.formatter().has_value()) {
           const Envoy::Http::StatefulHeaderKeyFormatter& formatter =
               request_headers.formatter().value();
-          key_val = formatter.format(key_val);
+          key = formatter.format(key);
         }
-        auto key = std::string(key_val);
         auto value = std::vector<std::string>();
         value.push_back(std::string(header.value().getStringView()));
         builder.set(key, value);
@@ -131,8 +131,7 @@ std::shared_ptr<Platform::RequestHeaders> BaseClientIntegrationTest::envoyToMobi
   for (const auto& pair : rawHeaderMap) {
     builder.set(pair.first, pair.second);
   }
-  auto mobile_headers = std::make_shared<Platform::RequestHeaders>(builder.build());
-  return mobile_headers;
+  return std::make_shared<Platform::RequestHeaders>(builder.build());
 }
 
 void BaseClientIntegrationTest::threadRoutine(absl::Notification& engine_running) {

--- a/test/common/integration/base_client_integration_test.cc
+++ b/test/common/integration/base_client_integration_test.cc
@@ -102,9 +102,6 @@ void BaseClientIntegrationTest::initialize() {
 std::shared_ptr<Platform::RequestHeaders> BaseClientIntegrationTest::envoyToMobileHeaders(
     const Http::TestRequestHeaderMapImpl& request_headers) {
 
-  envoy_headers envoyHeaders = Http::Utility::toBridgeHeaders(request_headers);
-  Platform::RawHeaderMap rawHeaderMap = Platform::envoyHeadersAsRawHeaderMap(envoyHeaders);
-
   Platform::RequestHeadersBuilder builder(
       Platform::RequestMethod::GET,
       std::string(default_request_headers_.Scheme()->value().getStringView()),
@@ -128,9 +125,6 @@ std::shared_ptr<Platform::RequestHeaders> BaseClientIntegrationTest::envoyToMobi
         return Http::HeaderMap::Iterate::Continue;
       });
 
-  for (const auto& pair : rawHeaderMap) {
-    builder.set(pair.first, pair.second);
-  }
   return std::make_shared<Platform::RequestHeaders>(builder.build());
 }
 

--- a/test/common/integration/base_client_integration_test.cc
+++ b/test/common/integration/base_client_integration_test.cc
@@ -99,14 +99,14 @@ void BaseClientIntegrationTest::initialize() {
 }
 
 std::shared_ptr<Platform::RequestHeaders>
-BaseClientIntegrationTest::envoyToMobileHeaders(Http::TestRequestHeaderMapImpl request_headers) {
+BaseClientIntegrationTest::envoyToMobileHeaders(Http::TestRequestHeaderMapImpl *request_headers) {
   std::string host(fake_upstreams_[0]->localAddress()->asStringView());
 
-  envoy_headers eh = Http::Utility::toBridgeHeaders(request_headers);
-  Platform::RawHeaderMap rhm = Platform::envoyHeadersAsRawHeaderMap(eh);
+  envoy_headers envoyHeaders = Http::Utility::toBridgeHeaders(*request_headers);
+  Platform::RawHeaderMap rawHeaderMap = Platform::envoyHeadersAsRawHeaderMap(envoyHeaders);
 
   Platform::RequestHeadersBuilder builder(Platform::RequestMethod::GET, scheme_, host, "/");
-  for (const auto& pair : rhm) {
+  for (const auto& pair : rawHeaderMap) {
     builder.set(pair.first, pair.second);
   }
   if (upstreamProtocol() == Http::CodecType::HTTP2) {

--- a/test/common/integration/base_client_integration_test.cc
+++ b/test/common/integration/base_client_integration_test.cc
@@ -98,11 +98,11 @@ void BaseClientIntegrationTest::initialize() {
   default_request_headers_ = std::make_shared<Platform::RequestHeaders>(builder.build());
 }
 
-std::shared_ptr<Platform::RequestHeaders>
-BaseClientIntegrationTest::envoyToMobileHeaders(Http::TestRequestHeaderMapImpl* request_headers) {
+std::shared_ptr<Platform::RequestHeaders> BaseClientIntegrationTest::envoyToMobileHeaders(
+    const Http::TestRequestHeaderMapImpl& request_headers) {
   std::string host(fake_upstreams_[0]->localAddress()->asStringView());
 
-  envoy_headers envoyHeaders = Http::Utility::toBridgeHeaders(*request_headers);
+  envoy_headers envoyHeaders = Http::Utility::toBridgeHeaders(request_headers);
   Platform::RawHeaderMap rawHeaderMap = Platform::envoyHeadersAsRawHeaderMap(envoyHeaders);
 
   Platform::RequestHeadersBuilder builder(Platform::RequestMethod::GET, scheme_, host, "/");

--- a/test/common/integration/base_client_integration_test.cc
+++ b/test/common/integration/base_client_integration_test.cc
@@ -99,7 +99,7 @@ void BaseClientIntegrationTest::initialize() {
 }
 
 std::shared_ptr<Platform::RequestHeaders>
-BaseClientIntegrationTest::envoyToMobileHeaders(Http::TestRequestHeaderMapImpl *request_headers) {
+BaseClientIntegrationTest::envoyToMobileHeaders(Http::TestRequestHeaderMapImpl* request_headers) {
   std::string host(fake_upstreams_[0]->localAddress()->asStringView());
 
   envoy_headers envoyHeaders = Http::Utility::toBridgeHeaders(*request_headers);

--- a/test/common/integration/base_client_integration_test.cc
+++ b/test/common/integration/base_client_integration_test.cc
@@ -1,14 +1,13 @@
 #include "test/common/integration/base_client_integration_test.h"
 
+#include <string>
+
 #include "test/common/http/common.h"
 
 #include "gtest/gtest.h"
-#include <string>
 #include "library/cc/bridge_utility.h"
 #include "library/common/config/internal.h"
 #include "library/common/http/header_utility.h"
-#include "library/common/data/utility.h"
-#include "source/common/http/header_map_impl.h"
 
 namespace Envoy {
 namespace {
@@ -115,18 +114,19 @@ std::shared_ptr<Platform::RequestHeaders> BaseClientIntegrationTest::envoyToMobi
   }
 
   request_headers.iterate(
-  [&request_headers, &builder](const Http::HeaderEntry& header) -> Http::HeaderMap::Iterate {
-      std::string key_val = std::string(header.key().getStringView());
-      if (request_headers.formatter().has_value()) {
-        const Envoy::Http::StatefulHeaderKeyFormatter& formatter = request_headers.formatter().value();
-        key_val = formatter.format(key_val);
-      }
-      auto key = std::string(key_val);
-      auto value = std::vector<std::string>();
-      value.push_back(std::string(header.value().getStringView()));
-      builder.set(key, value);
-      return Http::HeaderMap::Iterate::Continue;
-    });
+      [&request_headers, &builder](const Http::HeaderEntry& header) -> Http::HeaderMap::Iterate {
+        std::string key_val = std::string(header.key().getStringView());
+        if (request_headers.formatter().has_value()) {
+          const Envoy::Http::StatefulHeaderKeyFormatter& formatter =
+              request_headers.formatter().value();
+          key_val = formatter.format(key_val);
+        }
+        auto key = std::string(key_val);
+        auto value = std::vector<std::string>();
+        value.push_back(std::string(header.value().getStringView()));
+        builder.set(key, value);
+        return Http::HeaderMap::Iterate::Continue;
+      });
 
   for (const auto& pair : rawHeaderMap) {
     builder.set(pair.first, pair.second);

--- a/test/common/integration/base_client_integration_test.h
+++ b/test/common/integration/base_client_integration_test.h
@@ -44,13 +44,14 @@ protected:
   void threadRoutine(absl::Notification& engine_running);
   // Must be called manually by subclasses in their TearDown();
   void TearDown();
+  std::shared_ptr<Platform::RequestHeaders>
+  envoyToMobileHeaders(Http::TestRequestHeaderMapImpl request_headers);
 
   Event::ProvisionalDispatcherPtr dispatcher_ = std::make_unique<Event::ProvisionalDispatcher>();
   envoy_http_callbacks bridge_callbacks_;
   ConditionalInitializer terminal_callback_;
   callbacks_called cc_{0, 0, 0, 0, 0, 0, 0, "", &terminal_callback_, {}};
   std::shared_ptr<Platform::RequestHeaders> default_request_headers_;
-  absl::flat_hash_map<std::string, std::string> custom_headers_;
   Event::DispatcherPtr full_dispatcher_;
   Platform::StreamPrototypeSharedPtr stream_prototype_;
   Platform::StreamSharedPtr stream_;

--- a/test/common/integration/base_client_integration_test.h
+++ b/test/common/integration/base_client_integration_test.h
@@ -45,7 +45,7 @@ protected:
   // Must be called manually by subclasses in their TearDown();
   void TearDown();
   std::shared_ptr<Platform::RequestHeaders>
-  envoyToMobileHeaders(Http::TestRequestHeaderMapImpl *request_headers);
+  envoyToMobileHeaders(Http::TestRequestHeaderMapImpl* request_headers);
 
   Event::ProvisionalDispatcherPtr dispatcher_ = std::make_unique<Event::ProvisionalDispatcher>();
   envoy_http_callbacks bridge_callbacks_;

--- a/test/common/integration/base_client_integration_test.h
+++ b/test/common/integration/base_client_integration_test.h
@@ -45,7 +45,7 @@ protected:
   // Must be called manually by subclasses in their TearDown();
   void TearDown();
   std::shared_ptr<Platform::RequestHeaders>
-  envoyToMobileHeaders(Http::TestRequestHeaderMapImpl* request_headers);
+  envoyToMobileHeaders(const Http::TestRequestHeaderMapImpl& request_headers);
 
   Event::ProvisionalDispatcherPtr dispatcher_ = std::make_unique<Event::ProvisionalDispatcher>();
   envoy_http_callbacks bridge_callbacks_;

--- a/test/common/integration/base_client_integration_test.h
+++ b/test/common/integration/base_client_integration_test.h
@@ -44,20 +44,19 @@ protected:
   void threadRoutine(absl::Notification& engine_running);
   // Must be called manually by subclasses in their TearDown();
   void TearDown();
-  std::shared_ptr<Platform::RequestHeaders>
+  // Converts TestRequestHeaderMapImpl to Envoy::Platform::RequestHeadersSharedPtr
+  Envoy::Platform::RequestHeadersSharedPtr
   envoyToMobileHeaders(const Http::TestRequestHeaderMapImpl& request_headers);
-
   Event::ProvisionalDispatcherPtr dispatcher_ = std::make_unique<Event::ProvisionalDispatcher>();
   envoy_http_callbacks bridge_callbacks_;
   ConditionalInitializer terminal_callback_;
   callbacks_called cc_{0, 0, 0, 0, 0, 0, 0, "", &terminal_callback_, {}};
-  std::shared_ptr<Platform::RequestHeaders> default_request_headers_;
+  Http::TestRequestHeaderMapImpl default_request_headers_;
   Event::DispatcherPtr full_dispatcher_;
   Platform::StreamPrototypeSharedPtr stream_prototype_;
   Platform::StreamSharedPtr stream_;
   Platform::EngineSharedPtr engine_;
   Thread::ThreadPtr envoy_thread_;
-  std::string scheme_ = "http";
   bool explicit_flow_control_ = false;
   bool expect_dns_ = true;
   bool override_builder_config_ = false;

--- a/test/common/integration/base_client_integration_test.h
+++ b/test/common/integration/base_client_integration_test.h
@@ -45,7 +45,7 @@ protected:
   // Must be called manually by subclasses in their TearDown();
   void TearDown();
   std::shared_ptr<Platform::RequestHeaders>
-  envoyToMobileHeaders(Http::TestRequestHeaderMapImpl request_headers);
+  envoyToMobileHeaders(Http::TestRequestHeaderMapImpl *request_headers);
 
   Event::ProvisionalDispatcherPtr dispatcher_ = std::make_unique<Event::ProvisionalDispatcher>();
   envoy_http_callbacks bridge_callbacks_;

--- a/test/common/integration/client_integration_test.cc
+++ b/test/common/integration/client_integration_test.cc
@@ -1,15 +1,10 @@
 #include "source/extensions/http/header_formatters/preserve_case/config.h"
 #include "source/extensions/http/header_formatters/preserve_case/preserve_case_formatter.h"
 
-#include "test/common/http/common.h"
 #include "test/common/integration/base_client_integration_test.h"
 #include "test/integration/autonomous_upstream.h"
 
-#include "gmock/gmock.h"
-#include "gtest/gtest.h"
 #include "library/common/data/utility.h"
-#include "library/common/engine.h"
-#include "library/common/http/header_utility.h"
 #include "library/common/types/c_types.h"
 
 using testing::ReturnRef;
@@ -245,7 +240,6 @@ TEST_P(ClientIntegrationTest, CaseSensitive) {
   std::string upstream_request;
   EXPECT_TRUE(upstream_connection->waitForData(FakeRawConnection::waitForInexactMatch("GET /"),
                                                &upstream_request));
-
   EXPECT_TRUE(absl::StrContains(upstream_request, "FoO: bar")) << upstream_request;
 
   // Send mixed case headers, and verify via setOnHeaders they are received correctly.

--- a/test/common/integration/client_integration_test.cc
+++ b/test/common/integration/client_integration_test.cc
@@ -245,8 +245,6 @@ TEST_P(ClientIntegrationTest, CaseSensitive) {
   EXPECT_TRUE(upstream_connection->waitForData(FakeRawConnection::waitForInexactMatch("GET /"),
                                                &upstream_request));
 
-  std::cout << "debug1";
-  std::cout << upstream_request;
   EXPECT_TRUE(absl::StrContains(upstream_request, "FoO: bar")) << upstream_request;
 
   // Send mixed case headers, and verify via setOnHeaders they are received correctly.

--- a/test/common/integration/client_integration_test.cc
+++ b/test/common/integration/client_integration_test.cc
@@ -48,7 +48,7 @@ TEST_P(ClientIntegrationTest, Basic) {
   custom_headers.addCopy(AutonomousStream::EXPECT_REQUEST_SIZE_BYTES,
                          std::to_string(request_data.length()));
   std::shared_ptr<Platform::RequestHeaders> custom_request_headers =
-      envoyToMobileHeaders(&custom_headers);
+      envoyToMobileHeaders(custom_headers);
 
   stream_prototype_->setOnData([this](envoy_data c_data, bool end_stream) {
     if (end_stream) {
@@ -104,7 +104,7 @@ TEST_P(ClientIntegrationTest, BasicReset) {
   HttpTestUtility::addDefaultHeaders(custom_headers);
   custom_headers.addCopy(AutonomousStream::RESET_AFTER_REQUEST, "yes");
   std::shared_ptr<Platform::RequestHeaders> custom_request_headers =
-      envoyToMobileHeaders(&custom_headers);
+      envoyToMobileHeaders(custom_headers);
 
   stream_->sendHeaders(custom_request_headers, true);
   terminal_callback_.waitReady();
@@ -240,7 +240,7 @@ TEST_P(ClientIntegrationTest, CaseSensitive) {
   custom_headers.header_map_->formatter().value().get().processKey("FoO");
 
   std::shared_ptr<Platform::RequestHeaders> custom_request_headers =
-      envoyToMobileHeaders(&custom_headers);
+      envoyToMobileHeaders(custom_headers);
 
   stream_prototype_->setOnHeaders(
       [this](Platform::ResponseHeadersSharedPtr headers, bool, envoy_stream_intel) {

--- a/test/common/integration/client_integration_test.cc
+++ b/test/common/integration/client_integration_test.cc
@@ -1,4 +1,3 @@
-#include "source/extensions/http/header_formatters/preserve_case/config.h"
 #include "source/extensions/http/header_formatters/preserve_case/preserve_case_formatter.h"
 
 #include "test/common/integration/base_client_integration_test.h"
@@ -197,21 +196,6 @@ TEST_P(ClientIntegrationTest, CancelWithPartialStream) {
 // Test header key case sensitivity.
 TEST_P(ClientIntegrationTest, CaseSensitive) {
   autonomous_upstream_ = false;
-  Envoy::Extensions::Http::HeaderFormatters::PreserveCase::
-      forceRegisterPreserveCaseFormatterFactoryConfig();
-  config_helper_.addConfigModifier([](envoy::config::bootstrap::v3::Bootstrap& bootstrap) {
-    ConfigHelper::HttpProtocolOptions protocol_options;
-    auto typed_extension_config = protocol_options.mutable_explicit_http_config()
-                                      ->mutable_http_protocol_options()
-                                      ->mutable_header_key_format()
-                                      ->mutable_stateful_formatter();
-    typed_extension_config->set_name("preserve_case");
-    typed_extension_config->mutable_typed_config()->set_type_url(
-        "type.googleapis.com/"
-        "envoy.extensions.http.header_formatters.preserve_case.v3.PreserveCaseFormatterConfig");
-    ConfigHelper::setProtocolOptions(*bootstrap.mutable_static_resources()->mutable_clusters(0),
-                                     protocol_options);
-  });
   initialize();
 
   default_request_headers_.header_map_->setFormatter(

--- a/test/common/integration/rtds_integration_test.cc
+++ b/test/common/integration/rtds_integration_test.cc
@@ -52,7 +52,7 @@ public:
   }
 
   void initialize() override {
-    BaseClientIntegrationTest::initialize();
+    XdsIntegrationTest::initialize();
     initializeXdsStream();
   }
 };
@@ -64,7 +64,7 @@ TEST_P(RtdsIntegrationTest, RtdsReload) {
   initialize();
 
   // Send a request on the data plane.
-  stream_->sendHeaders(default_request_headers_, true);
+  stream_->sendHeaders(envoyToMobileHeaders(default_request_headers_), true);
   terminal_callback_.waitReady();
 
   EXPECT_EQ(cc_.on_headers_calls, 1);

--- a/test/common/integration/sds_integration_test.cc
+++ b/test/common/integration/sds_integration_test.cc
@@ -95,7 +95,7 @@ TEST_P(SdsIntegrationTest, SdsForUpstreamCluster) {
   ASSERT_TRUE(
       waitForCounterGe("cluster.base_h2.client_ssl_socket_factory.ssl_context_update_by_sds", 1));
 
-  stream_->sendHeaders(default_request_headers_, true);
+  stream_->sendHeaders(envoyToMobileHeaders(default_request_headers_), true);
   terminal_callback_.waitReady();
 
   EXPECT_EQ(cc_.on_headers_calls, 1);

--- a/test/common/integration/xds_integration_test.cc
+++ b/test/common/integration/xds_integration_test.cc
@@ -22,7 +22,6 @@ XdsIntegrationTest::XdsIntegrationTest() : BaseClientIntegrationTest(ipVersion()
   expect_dns_ = false;             // TODO(alyssawilk) debug.
   create_xds_upstream_ = true;
   sotw_or_delta_ = sotwOrDelta();
-  scheme_ = "https";
 
   if (sotw_or_delta_ == Grpc::SotwOrDelta::UnifiedSotw ||
       sotw_or_delta_ == Grpc::SotwOrDelta::UnifiedDelta) {
@@ -53,6 +52,11 @@ XdsIntegrationTest::XdsIntegrationTest() : BaseClientIntegrationTest(ipVersion()
   });
   admin_filename_ = TestEnvironment::temporaryPath("admin_address.txt");
   setAdminAddressPathForTests(admin_filename_);
+}
+
+void XdsIntegrationTest::initialize() {
+  BaseClientIntegrationTest::initialize();
+  default_request_headers_.setScheme("https");
 }
 
 Network::Address::IpVersion XdsIntegrationTest::ipVersion() const {

--- a/test/common/integration/xds_integration_test.h
+++ b/test/common/integration/xds_integration_test.h
@@ -20,6 +20,7 @@ class XdsIntegrationTest : public BaseClientIntegrationTest,
 public:
   XdsIntegrationTest();
   virtual ~XdsIntegrationTest() = default;
+  void initialize() override;
 
 protected:
   void SetUp() override;


### PR DESCRIPTION
In the commit https://github.com/envoyproxy/envoy-mobile/pull/2362 we added a `custom_headers_` field on the `BaseClientIntegrationTest` class to use for custom headers.  

This commit replaces that class field by instead instantiating a `custom_headers` object inside tests when necessary. Then adds a helper function to convert it from the `TestRequestHeaderMapImpl` (an easy to edit type) to `RequestHeaders` (envoy header type).

Signed-off-by: caschoener <schoener@google.com>
