### PR TITLE
example apps: disable interface binding

### DIFF
--- a/examples/kotlin/hello_world/MainActivity.kt
+++ b/examples/kotlin/hello_world/MainActivity.kt
@@ -50,7 +50,6 @@ class MainActivity : Activity() {
 
     engine = AndroidEngineBuilder(application)
       .addLogLevel(LogLevel.DEBUG)
-      .enableInterfaceBinding(true)
       .addPlatformFilter(::DemoFilter)
       .addPlatformFilter(::BufferDemoFilter)
       .addPlatformFilter(::AsyncDemoFilter)


### PR DESCRIPTION
Description: Disable interface binding in Android Kotlin example app as we have no clear plans for enabling interface binding anytime soon and having it disabled makes debugging of the example app (and Envoy Mobile) easier. On top of that, the same feature is _not_ enabled in iOS example apps.
Risk Level: None, example app change only.
Testing: Example app run manually.
Docs Changes: N/A
Release Notes: N/A 

Signed-off-by: Rafal Augustyniak <raugustyniak@lyft.com>