### PR TITLE
bazel: reorganize dbg configs

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -54,6 +54,14 @@ build:ios --define=manual_stamp=manual_stamp
 # Default flags for builds targeting Android
 build:android --define=logger=android --define=include_ifaddrs=true
 
+# Default flags for Android debug builds
+build:dbg-android --config=dbg
+build:dbg-android --config=android
+
+# Default flags for iOS debug builds
+build:dbg-ios --config=dbg
+build:dbg-ios --config=ios
+
 # Locally-runnable ASAN config for MacOS & Linux with standard dev environment
 # See also:
 # https://github.com/bazelbuild/bazel/issues/6932

--- a/.bazelrc
+++ b/.bazelrc
@@ -40,9 +40,9 @@ build --java_language_version=8
 # Override PGV validation with NOP functions
 build --@com_envoyproxy_protoc_gen_validate//bazel:template-flavor=nop
 
-build:dbg --compilation_mode=dbg
+build:dbg-common --compilation_mode=dbg
 # Enable source map for debugging in IDEs
-build:dbg --copt="-fdebug-compilation-dir" --copt="/proc/self/cwd"
+build:dbg-common --copt="-fdebug-compilation-dir" --copt="/proc/self/cwd"
 
 # Default flags for builds targeting iOS
 # Manual stamping is necessary in order to get versioning information in the iOS
@@ -55,11 +55,11 @@ build:ios --define=manual_stamp=manual_stamp
 build:android --define=logger=android --define=include_ifaddrs=true
 
 # Default flags for Android debug builds
-build:dbg-android --config=dbg
+build:dbg-android --config=dbg-common
 build:dbg-android --config=android
 
 # Default flags for iOS debug builds
-build:dbg-ios --config=dbg
+build:dbg-ios --config=dbg-common
 build:dbg-ios --config=ios
 
 # Locally-runnable ASAN config for MacOS & Linux with standard dev environment

--- a/examples/kotlin/hello_world/MainActivity.kt
+++ b/examples/kotlin/hello_world/MainActivity.kt
@@ -50,7 +50,6 @@ class MainActivity : Activity() {
 
     engine = AndroidEngineBuilder(application)
       .addLogLevel(LogLevel.DEBUG)
-      .enableInterfaceBinding(true)
       .addPlatformFilter(::DemoFilter)
       .addPlatformFilter(::BufferDemoFilter)
       .addPlatformFilter(::AsyncDemoFilter)

--- a/examples/kotlin/hello_world/MainActivity.kt
+++ b/examples/kotlin/hello_world/MainActivity.kt
@@ -50,6 +50,7 @@ class MainActivity : Activity() {
 
     engine = AndroidEngineBuilder(application)
       .addLogLevel(LogLevel.DEBUG)
+      .enableInterfaceBinding(true)
       .addPlatformFilter(::DemoFilter)
       .addPlatformFilter(::BufferDemoFilter)
       .addPlatformFilter(::AsyncDemoFilter)

--- a/examples/kotlin/hello_world/tools/android-studio-run-configurations/run_configuration_example_debug_arm64.xml
+++ b/examples/kotlin/hello_world/tools/android-studio-run-configurations/run_configuration_example_debug_arm64.xml
@@ -14,7 +14,7 @@
         use-work-profile-if-present="false"
         show-logcat-automatically="false"
         AM_START_OPTIONS="">
-        <blaze-user-flag>--config=dbg</blaze-user-flag>
+        <blaze-user-flag>--config=dbg-android</blaze-user-flag>
         <blaze-user-flag>--fat_apk_cpu=arm64-v8a</blaze-user-flag>
         <blaze-target>//examples/kotlin/hello_world:hello_envoy_kt</blaze-target>
         <Profilers>

--- a/examples/kotlin/hello_world/tools/android-studio-run-configurations/run_configuration_example_debug_x86.xml
+++ b/examples/kotlin/hello_world/tools/android-studio-run-configurations/run_configuration_example_debug_x86.xml
@@ -14,7 +14,7 @@
         use-work-profile-if-present="false"
         show-logcat-automatically="false"
         AM_START_OPTIONS="">
-        <blaze-user-flag>--config=dbg</blaze-user-flag>
+        <blaze-user-flag>--config=dbg-android</blaze-user-flag>
         <blaze-user-flag>--fat_apk_cpu=x86</blaze-user-flag>
         <blaze-target>//examples/kotlin/hello_world:hello_envoy_kt</blaze-target>
         <Profilers>


### PR DESCRIPTION
Description: After finding an interface binding related crash in https://github.com/envoyproxy/envoy-mobile/pull/2456 I noticed that our `dbg`  bazel config does not specify `--define=include_ifaddrs=true` which is supposed to ensure that we compile code that's required for proper functioning of Envoy Mobile on Android. Introduce `dbg-android` and `dbg-ios` which are intended to be platform specific `dbg` configurations.
Risk Level: None, does not impact release configurations.
Testing: Ran Kotlin example app manually.
Docs Changes: N/A
Release Notes: N/A

Signed-off-by: Rafal Augustyniak <raugustyniak@lyft.com>
