### PR TITLE
[docs]: Added --no-deps for pip install in docs/build.sh

### DIFF
--- a/docs/build.sh
+++ b/docs/build.sh
@@ -45,7 +45,7 @@ rm -rf "${GENERATED_RST_DIR}"
 mkdir -p "${GENERATED_RST_DIR}"
 
 source_venv "$BUILD_DIR"
-pip install -r "${SCRIPT_DIR}"/requirements.txt
+pip install -r "${SCRIPT_DIR}"/requirements.txt --no-deps
 
 rsync -av "${SCRIPT_DIR}"/root/ "${SCRIPT_DIR}"/conf.py "${GENERATED_RST_DIR}"
 sphinx-build -W --keep-going -b html "${GENERATED_RST_DIR}" "${DOCS_OUTPUT_DIR}"


### PR DESCRIPTION
Description: [docs]: Added --no-deps for pip install in docs/build.sh
Risk Level: Medium
Testing: The docs built successfully
Docs Changes: N/A
Release Notes:

Signed-off-by: Andrés Felipe Barco Santa <andres@engflow.com>