### PR TITLE
Add a binary build target for Cronvoy

### DIFF
--- a/library/java/org/chromium/net/BUILD
+++ b/library/java/org/chromium/net/BUILD
@@ -15,3 +15,17 @@ android_library(
         artifact("androidx.annotation:annotation"),
     ],
 )
+
+# A binary target that includes transitive dependencies.
+# Use this target along with libenvoy_jni.so to integrate
+# Cronvoy with Cronet-dependent apps.
+android_binary(
+    name = "cronet",
+    srcs = [],
+    manifest = "ChromiumNetManifest.xml",
+    visibility = ["//visibility:public"],
+    deps = [
+        ":net",
+        "//library/java/org/chromium/net/impl:cronvoy",
+    ],
+)

--- a/library/java/org/chromium/net/ChromiumNetManifest.xml
+++ b/library/java/org/chromium/net/ChromiumNetManifest.xml
@@ -2,7 +2,7 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
           package="org.chromium.net">
     <uses-sdk
-            android:minSdkVersion="9"
+            android:minSdkVersion="21"
             android:targetSdkVersion="27" />
 
 </manifest>

--- a/library/java/org/chromium/net/impl/CronvoyManifest.xml
+++ b/library/java/org/chromium/net/impl/CronvoyManifest.xml
@@ -2,7 +2,7 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
           package="org.cronvoy">
     <uses-sdk
-            android:minSdkVersion="9"
+            android:minSdkVersion="21"
             android:targetSdkVersion="27" />
 
 </manifest>

--- a/library/java/org/chromium/net/urlconnection/URLConnectionManifest.xml
+++ b/library/java/org/chromium/net/urlconnection/URLConnectionManifest.xml
@@ -2,6 +2,6 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
     package="org.urlconnection">
   <uses-sdk
-      android:minSdkVersion="9"
+      android:minSdkVersion="21"
       android:targetSdkVersion="29" />
 </manifest>


### PR DESCRIPTION
Signed-off-by: Renjie Tang <renjietang@chromium.org>

Description: Add a Cronvoy binary target for the integration of Cronet-dependent projects
Risk Level: Low
Testing: build file only.
Docs Changes: n/a
Release Notes: n/a
