### PR TITLE
Correct version string for CronetUrlRequestContext

### DIFF
--- a/library/java/org/chromium/net/impl/CronetUrlRequestContext.java
+++ b/library/java/org/chromium/net/impl/CronetUrlRequestContext.java
@@ -159,7 +159,7 @@ public final class CronetUrlRequestContext extends CronetEngineBase {
 
   @Override
   public String getVersionString() {
-    return "CronetHttpURLConnection/" + ImplVersion.getCronetVersionWithLastChange();
+    return "Cronet/" + ImplVersion.getCronetVersionWithLastChange();
   }
 
   @Override

--- a/test/java/org/chromium/net/CronetUrlRequestContextTest.java
+++ b/test/java/org/chromium/net/CronetUrlRequestContextTest.java
@@ -1321,6 +1321,17 @@ public class CronetUrlRequestContextTest {
     assertFalse(loader.wasCalled());
   }
 
+  @Test
+  @SmallTest
+  @Feature({"Cronet"})
+  @OnlyRunNativeCronet
+  public void testNativeCronetEngineBuilderImplSetsCorrectVersionString() throws Exception {
+    CronetEngine.Builder builder =
+        new CronetEngine.Builder(new NativeCronetEngineBuilderImpl(getContext()));
+    CronetEngine engine = builder.build();
+    assertTrue(engine.getVersionString().startsWith("Cronet/"));
+  }
+
   // Creates a CronetEngine on another thread and then one on the main thread. This shouldn't
   // crash.
   @Test


### PR DESCRIPTION
Signed-off-by: Renjie Tang <renjietang@chromium.org>

Description: Modify version string of the Cronvoy native engine so that it matches https://source.chromium.org/chromium/chromium/src/+/main:components/cronet/android/java/src/org/chromium/net/impl/CronetUrlRequestContext.java;l=319?q=getversionstring&ss=chromium%2Fchromium%2Fsrc:components%2Fcronet%2F
Risk Level: Low
Testing: n/a
Docs Changes: n/a
Release Notes: n/a
