### PR TITLE
[Cronvoy] Remove hardcoded test url

### DIFF
--- a/test/java/org/chromium/net/impl/CronvoyEngineTest.java
+++ b/test/java/org/chromium/net/impl/CronvoyEngineTest.java
@@ -234,8 +234,8 @@ public class CronvoyEngineTest {
     assertThat(response.getBodyAsString()).isEqualTo("Everything is awesome");
     assertThat(response.getCronetException()).withFailMessage(response.getErrorMessage()).isNull();
     assertThat(response.getUrlResponseInfo().getUrlChain())
-        .contains("http://localhost:" + mockWebServer.getPort() + "/get/flowers",
-                  "http://localhost:" + mockWebServer.getPort() + "/get/chocolates");
+        .contains(mockWebServer.url("/get/flowers").toString(),
+                  mockWebServer.url("/get/chocolates").toString());
   }
 
   @Test
@@ -270,8 +270,8 @@ public class CronvoyEngineTest {
     assertThat(response.getBodyAsString()).isEqualTo("Everything is awesome");
     assertThat(response.getCronetException()).withFailMessage(response.getErrorMessage()).isNull();
     assertThat(response.getUrlResponseInfo().getUrlChain())
-        .contains("http://localhost:" + mockWebServer.getPort() + "/get/flowers",
-                  "http://localhost:" + mockWebServer.getPort() + "/get/chocolates");
+        .contains(mockWebServer.url("/get/flowers").toString(),
+                  mockWebServer.url("/get/chocolates").toString());
   }
 
   @Test
@@ -311,8 +311,8 @@ public class CronvoyEngineTest {
     assertThat(response.getBodyAsString()).isEqualTo("Everything is awesome");
     assertThat(response.getCronetException()).withFailMessage(response.getErrorMessage()).isNull();
     assertThat(response.getUrlResponseInfo().getUrlChain())
-        .contains("http://localhost:" + mockWebServer.getPort() + "/get/flowers",
-                  "http://localhost:" + mockWebServer.getPort() + "/get/chocolates");
+        .contains(mockWebServer.url("/get/flowers").toString(),
+                  mockWebServer.url("/get/chocolates").toString());
   }
 
   private Response sendRequest(RequestScenario requestScenario) {

--- a/test/java/org/chromium/net/urlconnection/CronetInputStreamTest.java
+++ b/test/java/org/chromium/net/urlconnection/CronetInputStreamTest.java
@@ -15,7 +15,6 @@ import org.junit.Rule;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.ArgumentMatchers;
-import org.mockito.Mock;
 import org.mockito.Mockito;
 import org.mockito.invocation.InvocationOnMock;
 import org.mockito.stubbing.Answer;
@@ -27,7 +26,7 @@ import org.mockito.stubbing.Answer;
 public class CronetInputStreamTest {
   @Rule public final CronetTestRule mTestRule = new CronetTestRule();
 
-  @Mock private CronetHttpURLConnection mMockConnection;
+  private CronetHttpURLConnection mMockConnection;
 
   @Before
   public void setUp() throws Exception {


### PR DESCRIPTION
Do not hard code MockWebServer url as it varies between "https://localhost:xxxx" or
"https://127.0.0.1:xxxx".

Signed-off-by: Chidera Olibie <colibie@google.com>

Description: For some reason, the mockwebserver url is not the same across board, so these tests were failing on my setup. So instead use the mockwebserver.url() method.
Risk Level: none: only touches Cronvoy
Testing: N/A
Docs Changes: N/A
Release Notes: N/A
[Optional Fixes #Issue]
[Optional Deprecated:]
