### PR TITLE
[CI] Remove a lyft maintainer

### DIFF
--- a/.github/lyft_maintainers.yml
+++ b/.github/lyft_maintainers.yml
@@ -2,5 +2,4 @@ current: snowp
 maintainers:
   - Augustyniak
   - snowp
-  - goaway
   - jpsim


### PR DESCRIPTION
Description: Removing @goaway from the list of Lyft maintainers.
Risk Level: None
Testing: N/A
Docs Changes: N/A
Release Notes: N/A

Signed-off-by: Rafal Augustyniak <raugustyniak@lyft.com>