### PR TITLE
bazel: update rules_xcodeproj to 0.7.0 release

### DIFF
--- a/BUILD
+++ b/BUILD
@@ -120,7 +120,7 @@ xcodeproj(
     build_mode = "bazel",
     project_name = "Envoy",
     tags = ["manual"],
-    targets = [
+    top_level_targets = [
         # Libraries
         "//library/swift:ios_lib",
         "//library/objective-c:envoy_engine_objc_lib",

--- a/bazel/envoy_mobile_repositories.bzl
+++ b/bazel/envoy_mobile_repositories.bzl
@@ -99,8 +99,8 @@ def swift_repos():
 
     http_archive(
         name = "com_github_buildbuddy_io_rules_xcodeproj",
-        sha256 = "728cb6089ad2f4c4de2003ce23462be662bfdd250a8735dc590e61fb7401e7d2",
-        url = "https://github.com/buildbuddy-io/rules_xcodeproj/releases/download/0.5.0/release.tar.gz",
+        sha256 = "a647ad9ee6664a78377cf5707331966b6788be09d1fea48045a61bc450c8f1b1",
+        url = "https://github.com/buildbuddy-io/rules_xcodeproj/releases/download/0.7.0/release.tar.gz",
     )
 
 def kotlin_repos():


### PR DESCRIPTION
This will make it possible for us to define custom schemes.

Release info: https://github.com/buildbuddy-io/rules_xcodeproj/releases/tag/0.7.0

Risk Level: Low, local dev only
Testing: Local
Docs Changes: N/A
Release Notes: N/A

Signed-off-by: JP Simard <jp@jpsim.com>