### PR TITLE
bazel: define custom Xcode schemes

### DIFF
--- a/BUILD
+++ b/BUILD
@@ -120,7 +120,7 @@ xcodeproj(
     build_mode = "bazel",
     project_name = "Envoy",
     tags = ["manual"],
-    targets = [
+    top_level_targets = [
         # Libraries
         "//library/swift:ios_lib",
         "//library/objective-c:envoy_engine_objc_lib",

--- a/BUILD
+++ b/BUILD
@@ -123,7 +123,7 @@ xcodeproj(
     bazel_path = "./bazelw",
     build_mode = "bazel",
     project_name = "Envoy",
-    scheme_autogeneration_mode = "auto", # Switch to "all" to generate schemes for all deps
+    scheme_autogeneration_mode = "auto",  # Switch to "all" to generate schemes for all deps
     schemes = [
         xcode_schemes.scheme(
             name = "Async Await App",

--- a/BUILD
+++ b/BUILD
@@ -5,7 +5,11 @@ load(
     "@com_github_buildbuddy_io_rules_xcodeproj//xcodeproj:experimental.bzl",
     "device_and_simulator",
 )
-load("@com_github_buildbuddy_io_rules_xcodeproj//xcodeproj:xcodeproj.bzl", "xcodeproj")
+load(
+    "@com_github_buildbuddy_io_rules_xcodeproj//xcodeproj:xcodeproj.bzl",
+    "xcode_schemes",
+    "xcodeproj",
+)
 load("//bazel:framework_imports_extractor.bzl", "framework_imports_extractor")
 
 licenses(["notice"])  # Apache 2
@@ -119,12 +123,52 @@ xcodeproj(
     bazel_path = "./bazelw",
     build_mode = "bazel",
     project_name = "Envoy",
+    scheme_autogeneration_mode = "auto", # Switch to "all" to generate schemes for all deps
+    schemes = [
+        xcode_schemes.scheme(
+            name = "Async Await App",
+            launch_action = xcode_schemes.launch_action("//examples/swift/async_await:app"),
+        ),
+        xcode_schemes.scheme(
+            name = "Hello World App",
+            launch_action = xcode_schemes.launch_action("//examples/swift/hello_world:app"),
+        ),
+        # TODO(jpsim): Fix Objective-C app support
+        # xcode_schemes.scheme(
+        #     name = "Hello World App (ObjC)",
+        #     launch_action = xcode_schemes.launch_action("//examples/objective-c/hello_world:app"),
+        # ),
+        xcode_schemes.scheme(
+            name = "Baseline App",
+            launch_action = xcode_schemes.launch_action("//test/swift/apps/baseline:app"),
+        ),
+        xcode_schemes.scheme(
+            name = "Experimental App",
+            launch_action = xcode_schemes.launch_action("//test/swift/apps/experimental:app"),
+        ),
+        xcode_schemes.scheme(
+            name = "Swift Library",
+            build_action = xcode_schemes.build_action(["//library/swift:ios_lib"]),
+        ),
+        xcode_schemes.scheme(
+            name = "iOS Tests",
+            test_action = xcode_schemes.test_action([
+                "//experimental/swift:quic_stream_test.__internal__.__test_bundle",
+                "//test/objective-c:envoy_bridge_utility_test.__internal__.__test_bundle",
+                "//test/swift/integration:flatbuffer_test.__internal__.__test_bundle",
+                "//test/swift/integration:test.__internal__.__test_bundle",
+                "//test/swift/stats:test.__internal__.__test_bundle",
+                "//test/swift:test.__internal__.__test_bundle",
+            ]),
+        ),
+        xcode_schemes.scheme(
+            name = "Objective-C Library",
+            build_action = xcode_schemes.build_action(["//library/objective-c:envoy_engine_objc_lib"]),
+            test_action = xcode_schemes.test_action(["//test/objective-c:envoy_bridge_utility_test.__internal__.__test_bundle"]),
+        ),
+    ],
     tags = ["manual"],
     top_level_targets = [
-        # Libraries
-        "//library/swift:ios_lib",
-        "//library/objective-c:envoy_engine_objc_lib",
-        "//library/common:envoy_main_interface_lib",
         # Apps
         "//:ios_examples",
         # Tests

--- a/bazel/envoy_mobile_repositories.bzl
+++ b/bazel/envoy_mobile_repositories.bzl
@@ -99,8 +99,8 @@ def swift_repos():
 
     http_archive(
         name = "com_github_buildbuddy_io_rules_xcodeproj",
-        sha256 = "728cb6089ad2f4c4de2003ce23462be662bfdd250a8735dc590e61fb7401e7d2",
-        url = "https://github.com/buildbuddy-io/rules_xcodeproj/releases/download/0.5.0/release.tar.gz",
+        sha256 = "a647ad9ee6664a78377cf5707331966b6788be09d1fea48045a61bc450c8f1b1",
+        url = "https://github.com/buildbuddy-io/rules_xcodeproj/releases/download/0.7.0/release.tar.gz",
     )
 
 def kotlin_repos():

--- a/docs/root/development/debugging/ios_local.rst
+++ b/docs/root/development/debugging/ios_local.rst
@@ -28,7 +28,7 @@ and ``xed .`` to open it in Xcode (or double-click ``Envoy.xcodeproj``
 in Finder).
 
 In Xcode's scheme selector, pick the app target you want to build (e.g.
-``__examples_swift_hello_world_app``), pick a Simulator to run it on,
+``Hello World App``), pick a Simulator to run it on,
 then hit cmd-R to build and run.
 
 From there, most Xcode features should just work for all transitively


### PR DESCRIPTION
This makes it much easier to find relevant schemes (there were over 2,000 schemes before this) and labels them with more descriptive and human-readable names than `__examples_swift_hello_world_app`.

```console
# Before
$ ls Envoy.xcodeproj/xcshareddata/xcschemes | wc -l
  2231
# After
$ ls Envoy.xcodeproj/xcshareddata/xcschemes | wc -l
  7
```

New scheme picker looks like this:

<image  src=https://user-images.githubusercontent.com/474794/185428361-cb8b42a9-e7e1-4ddd-85db-a834b9796780.png width=250 />

I've separated the "Swift Library" scheme from the "iOS Tests" one because the Swift Library can be built for macOS too, but the tests only run on iOS.

If you want to build a scheme that's not in this list, you can quickly revert back to the previous behavior to generate schemes for all transitive dependencies by setting `scheme_autogeneration_mode = "all"`.

Depends on https://github.com/envoyproxy/envoy-mobile/pull/2475.

Risk Level: Low, local dev only
Testing: Local
Docs Changes: Updated
Release Notes: N/A

Signed-off-by: JP Simard <jp@jpsim.com>