### PR TITLE
ci: fix `/retest` command

### DIFF
--- a/.github/actions/retest-action/entrypoint.sh
+++ b/.github/actions/retest-action/entrypoint.sh
@@ -1,45 +1,69 @@
-#!/bin/sh
+#!/bin/bash
 
-set -ex
+set -euo pipefail
 
-if ! jq -e '.issue.pull_request' ${GITHUB_EVENT_PATH}; then
-    echo "Not a PR... Exiting."
-    exit 0
+# Check if this is a PR event
+
+if ! jq -e '.issue.pull_request' "${GITHUB_EVENT_PATH}"; then
+  echo "Not a PR... Exiting."
+  exit 0
 fi
 
-if [ "$(jq -r '.comment.body' ${GITHUB_EVENT_PATH})" != "/retest" ]; then
-    echo "Nothing to do... Exiting."
-    exit 0
+# Check if the comment is "/retest"
+
+if [ "$(jq -r '.comment.body' "${GITHUB_EVENT_PATH}")" != "/retest" ]; then
+  echo "Nothing to do... Exiting."
+  exit 0
 fi
 
-PR_URL=$(jq -r '.issue.pull_request.url' ${GITHUB_EVENT_PATH})
+# Get the PR details
 
-curl --request GET \
-    --url "${PR_URL}" \
-    --header "authorization: Bearer ${GITHUB_TOKEN}" \
-    --header "content-type: application/json" > pr.json
+PR_URL=$(jq -r '.issue.pull_request.url' "${GITHUB_EVENT_PATH}")
 
-ACTOR=$(jq -r '.user.login' pr.json)
-BRANCH=$(jq -r '.head.ref' pr.json)
+curl --silent --request GET \
+  --url "${PR_URL}" \
+  --header "authorization: Bearer ${GITHUB_TOKEN}" \
+  --header "content-type: application/json" > pr.json
 
-curl --request GET \
-    --url "https://api.github.com/repos/${GITHUB_REPOSITORY}/actions/runs?event=pull_request&actor=${ACTOR}&branch=${BRANCH}" \
-    --header "authorization: Bearer ${GITHUB_TOKEN}" \
-    --header "content-type: application/json" | jq '.workflow_runs | max_by(.run_number)' > run.json
+# Extract useful PR info
 
-RUN_URL=$(jq -r '.url' run.json)
+PR_NUMBER=$(jq -r '.number' pr.json)
+PR_BRANCH=$(jq -r '.head.ref' pr.json)
+PR_COMMIT=$(jq -r '.head.sha' pr.json)
 
-curl --request POST \
+echo "Running /retest command for PR #${PR_NUMBER}"
+echo "PR branch: ${PR_BRANCH}"
+echo "Latest PR commit: ${PR_COMMIT}"
+
+# Get failed Workflow runs for the latest PR commit
+
+curl --silent --request GET \
+  --url "https://api.github.com/repos/envoyproxy/envoy-mobile/actions/runs?branch=${PR_BRANCH}" \
+  --header "authorization: Bearer ${GITHUB_TOKEN}" \
+  --header "content-type: application/json" > runs.json
+jq ".workflow_runs[] | select(.head_sha == \"${PR_COMMIT}\") | select(.conclusion == \"failure\")" runs.json > failed_runs.json
+jq -c ". | {name: .name, url: .url}" failed_runs.json > failed_runs_compact.json
+
+# Iterate over each failed run and retry its failed jobs
+
+while read -r failed_run; do
+  echo "$failed_run" > line.json
+  RUN_NAME="$(jq -r '.name' line.json)"
+  echo "Retrying failed job: ${RUN_NAME}"
+  RUN_URL="$(jq -r '.url' line.json)"
+  curl --silent --request POST \
     --url "${RUN_URL}/rerun-failed-jobs" \
     --header "authorization: Bearer ${GITHUB_TOKEN}" \
     --header "content-type: application/json"
+done < failed_runs_compact.json
 
+# Add a rocket emoji reaction to the "/retest" comment to inform that this script finished running
 
-REACTION_URL="$(jq -r '.comment.url' ${GITHUB_EVENT_PATH})/reactions"
+REACTION_URL="$(jq -r '.comment.url' "${GITHUB_EVENT_PATH}")/reactions"
 
-curl --request POST \
-    --url "${REACTION_URL}" \
-    --header "authorization: Bearer ${GITHUB_TOKEN}" \
-    --header "accept: application/vnd.github.squirrel-girl-preview+json" \
-    --header "content-type: application/json" \
-    --data '{ "content" : "rocket" }'
+curl --silent --request POST \
+  --url "${REACTION_URL}" \
+  --header "authorization: Bearer ${GITHUB_TOKEN}" \
+  --header "accept: application/vnd.github.squirrel-girl-preview+json" \
+  --header "content-type: application/json" \
+  --data '{ "content" : "rocket" }'


### PR DESCRIPTION
Previously it didn't retry all failed workflows, just one.

Risk Level: Low, CI automation only
Testing: I've verified locally that this works by running the script on this PR: https://github.com/envoyproxy/envoy-mobile/pull/2472
Docs Changes: N/A, not user facing
Release Notes: N/A, not user facing

Signed-off-by: JP Simard <jp@jpsim.com>