### PR TITLE
android: put cronet files into final EM aar

### DIFF
--- a/bazel/android_artifacts.bzl
+++ b/bazel/android_artifacts.bzl
@@ -238,7 +238,7 @@ def _create_classes_jar(name, manifest, android_library):
         classes_dir=$$(mktemp -d)
         echo "Creating classes.jar from $(SRCS)"
         pushd $$classes_dir
-        unzip $$original_directory/$(SRCS) "io/envoyproxy/*" "META-INF/" > /dev/null
+        unzip $$original_directory/$(SRCS) "io/envoyproxy/*" "org/chromium/net/*" "META-INF/" > /dev/null
         zip -r classes.jar * > /dev/null
         popd
         cp $$classes_dir/classes.jar $@


### PR DESCRIPTION
Description: Change the script so that cronet files end up being a part of Envoy Mobile aar. Needed for https://github.com/envoyproxy/envoy-mobile/issues/2432.
Risk Level: Low, the change should be additive.
Testing: Manual testing
Docs Changes: N/A
Release Notes: N/A

Signed-off-by: Rafal Augustyniak <raugustyniak@lyft.com>
