### PR TITLE
proguard: update rules to account for AndroidNetworkLibrary

### DIFF
--- a/library/proguard.txt
+++ b/library/proguard.txt
@@ -11,6 +11,10 @@
     native <methods>;
 }
 
+-keep, includedescriptorclasses class org.chromium.net.AndroidNetworkLibrary {
+   <methods>;
+}
+
 -keep, includedescriptorclasses class io.envoyproxy.envoymobile.engine.types.EnvoyEventTracker {
    <methods>;
 }


### PR DESCRIPTION
Description: Update proguard so that AndroidNetworkLibrary is not stripped/obfuscated by proguard. Needed to fix https://github.com/envoyproxy/envoy-mobile/issues/2432.
Risk Level: Low, the change should be additive.
Testing: Manual.
Docs Changes: N/A
Release Notes: N/A
Signed-off-by: Rafal Augustyniak <raugustyniak@lyft.com>