### PR TITLE
jni: introduce custom find_class method

### DIFF
--- a/library/common/jni/android_jni_interface.cc
+++ b/library/common/jni/android_jni_interface.cc
@@ -15,7 +15,7 @@ Java_io_envoyproxy_envoymobile_engine_AndroidJniLibrary_initialize(JNIEnv* env,
                                                                    jobject class_loader,
                                                                    jobject connectivity_manager) {
 
-  set_class_loader(env->NewGlobalRef(class_loader));                                                                    
+  set_class_loader(env->NewGlobalRef(class_loader));
   // See note above about c-ares.
   // c-ares jvm init is necessary in order to let c-ares perform DNS resolution in Envoy.
   // More information can be found at:

--- a/library/common/jni/android_jni_interface.cc
+++ b/library/common/jni/android_jni_interface.cc
@@ -14,7 +14,6 @@ Java_io_envoyproxy_envoymobile_engine_AndroidJniLibrary_initialize(JNIEnv* env,
                                                                    jclass, // class
                                                                    jobject class_loader,
                                                                    jobject connectivity_manager) {
-
   set_class_loader(env->NewGlobalRef(class_loader));
   // See note above about c-ares.
   // c-ares jvm init is necessary in order to let c-ares perform DNS resolution in Envoy.

--- a/library/common/jni/android_jni_interface.cc
+++ b/library/common/jni/android_jni_interface.cc
@@ -12,7 +12,10 @@
 extern "C" JNIEXPORT jint JNICALL
 Java_io_envoyproxy_envoymobile_engine_AndroidJniLibrary_initialize(JNIEnv* env,
                                                                    jclass, // class
+                                                                   jobject class_loader,
                                                                    jobject connectivity_manager) {
+
+  set_class_loader(env->NewGlobalRef(class_loader));                                                                    
   // See note above about c-ares.
   // c-ares jvm init is necessary in order to let c-ares perform DNS resolution in Envoy.
   // More information can be found at:

--- a/library/common/jni/jni_utility.cc
+++ b/library/common/jni/jni_utility.cc
@@ -11,11 +11,26 @@
 // NOLINT(namespace-envoy)
 
 static JavaVM* static_jvm = nullptr;
+static jobject static_class_loader = nullptr;
 static thread_local JNIEnv* local_env = nullptr;
 
 void set_vm(JavaVM* vm) { static_jvm = vm; }
 
 JavaVM* get_vm() { return static_jvm; }
+
+void set_class_loader(jobject class_loader) { static_class_loader = class_loader; }
+
+jclass find_class(const char* class_name) {
+  JNIEnv* env = get_env();
+  jclass class_loader = env->FindClass("java/lang/ClassLoader");
+  jmethodID find_class_method = env->GetMethodID(class_loader, "loadClass", "(Ljava/lang/String;)Ljava/lang/Class;");
+  jstring str_class_name = env->NewStringUTF(class_name);
+  jclass clazz = (jclass)(env->CallObjectMethod(static_class_loader, find_class_method, str_class_name));
+  env->DeleteLocalRef(str_class_name);
+  return clazz;
+}
+
+jobject get_class_loader() { return static_class_loader; } 
 
 JNIEnv* get_env() {
   if (local_env) {

--- a/library/common/jni/jni_utility.cc
+++ b/library/common/jni/jni_utility.cc
@@ -20,6 +20,8 @@ JavaVM* get_vm() { return static_jvm; }
 
 void set_class_loader(jobject class_loader) { static_class_loader = class_loader; }
 
+jobject get_class_loader() { return static_class_loader; }
+
 jclass find_class(const char* class_name) {
   JNIEnv* env = get_env();
   jclass class_loader = env->FindClass("java/lang/ClassLoader");
@@ -27,12 +29,10 @@ jclass find_class(const char* class_name) {
       env->GetMethodID(class_loader, "loadClass", "(Ljava/lang/String;)Ljava/lang/Class;");
   jstring str_class_name = env->NewStringUTF(class_name);
   jclass clazz =
-      (jclass)(env->CallObjectMethod(static_class_loader, find_class_method, str_class_name));
+      (jclass)(env->CallObjectMethod(get_class_loader(), find_class_method, str_class_name));
   env->DeleteLocalRef(str_class_name);
   return clazz;
 }
-
-jobject get_class_loader() { return static_class_loader; }
 
 JNIEnv* get_env() {
   if (local_env) {

--- a/library/common/jni/jni_utility.cc
+++ b/library/common/jni/jni_utility.cc
@@ -23,14 +23,16 @@ void set_class_loader(jobject class_loader) { static_class_loader = class_loader
 jclass find_class(const char* class_name) {
   JNIEnv* env = get_env();
   jclass class_loader = env->FindClass("java/lang/ClassLoader");
-  jmethodID find_class_method = env->GetMethodID(class_loader, "loadClass", "(Ljava/lang/String;)Ljava/lang/Class;");
+  jmethodID find_class_method =
+      env->GetMethodID(class_loader, "loadClass", "(Ljava/lang/String;)Ljava/lang/Class;");
   jstring str_class_name = env->NewStringUTF(class_name);
-  jclass clazz = (jclass)(env->CallObjectMethod(static_class_loader, find_class_method, str_class_name));
+  jclass clazz =
+      (jclass)(env->CallObjectMethod(static_class_loader, find_class_method, str_class_name));
   env->DeleteLocalRef(str_class_name);
   return clazz;
 }
 
-jobject get_class_loader() { return static_class_loader; } 
+jobject get_class_loader() { return static_class_loader; }
 
 JNIEnv* get_env() {
   if (local_env) {

--- a/library/common/jni/jni_utility.h
+++ b/library/common/jni/jni_utility.h
@@ -22,7 +22,7 @@ void set_class_loader(jobject class_loader);
  * application's context and should be associated with project's code - Java classes
  * defined by the project. For finding classes of Java built in-types use
  * `env->FindClass(...)` method instead as it is lighter to use.
- * 
+ *
  * The method works on Android targets only as the `set_class_loader` method is not
  * called by JVM-only targets.
  *

--- a/library/common/jni/jni_utility.h
+++ b/library/common/jni/jni_utility.h
@@ -14,6 +14,22 @@ JavaVM* get_vm();
 
 JNIEnv* get_env();
 
+void set_class_loader(jobject class_loader);
+
+/**
+ * Finds a class with a given name using a class loader provided with the use
+ * of `set_class_loader` function. The class loader is supposed to come from 
+ * application's context and should be associated with project's code - Java classes
+ * defined by the project. For finding classes of Java built in-types use 
+ * `env->FindClass(...)` method instead as it is lighter to use.
+ * 
+ * @param class_name, the name of the class to find (i.e. "org.chromium.net.AndroidNetworkLibrary").
+ * 
+ * @return jclass, the class with a provided `class_name` or NULL if 
+ *         it couldn't be found.
+ */
+jclass find_class(const char* class_name);
+
 void jvm_detach_thread();
 
 void jni_delete_global_ref(void* context);

--- a/library/common/jni/jni_utility.h
+++ b/library/common/jni/jni_utility.h
@@ -18,14 +18,14 @@ void set_class_loader(jobject class_loader);
 
 /**
  * Finds a class with a given name using a class loader provided with the use
- * of `set_class_loader` function. The class loader is supposed to come from 
+ * of `set_class_loader` function. The class loader is supposed to come from
  * application's context and should be associated with project's code - Java classes
- * defined by the project. For finding classes of Java built in-types use 
+ * defined by the project. For finding classes of Java built in-types use
  * `env->FindClass(...)` method instead as it is lighter to use.
- * 
+ *
  * @param class_name, the name of the class to find (i.e. "org.chromium.net.AndroidNetworkLibrary").
- * 
- * @return jclass, the class with a provided `class_name` or NULL if 
+ *
+ * @return jclass, the class with a provided `class_name` or NULL if
  *         it couldn't be found.
  */
 jclass find_class(const char* class_name);

--- a/library/common/jni/jni_utility.h
+++ b/library/common/jni/jni_utility.h
@@ -22,6 +22,9 @@ void set_class_loader(jobject class_loader);
  * application's context and should be associated with project's code - Java classes
  * defined by the project. For finding classes of Java built in-types use
  * `env->FindClass(...)` method instead as it is lighter to use.
+ * 
+ * The method works on Android targets only as the `set_class_loader` method is not
+ * called by JVM-only targets.
  *
  * @param class_name, the name of the class to find (i.e. "org.chromium.net.AndroidNetworkLibrary").
  *

--- a/library/java/io/envoyproxy/envoymobile/engine/AndroidJniLibrary.java
+++ b/library/java/io/envoyproxy/envoymobile/engine/AndroidJniLibrary.java
@@ -45,5 +45,6 @@ public class AndroidJniLibrary {
    * @param connectivityManager Android's ConnectivityManager.
    * @return The resulting status of the initialization.
    */
-  protected static native int initialize(ClassLoader classLoader, ConnectivityManager connectivityManager);
+  protected static native int initialize(ClassLoader classLoader,
+                                         ConnectivityManager connectivityManager);
 }

--- a/library/java/io/envoyproxy/envoymobile/engine/AndroidJniLibrary.java
+++ b/library/java/io/envoyproxy/envoymobile/engine/AndroidJniLibrary.java
@@ -33,6 +33,7 @@ public class AndroidJniLibrary {
   private static class AndroidLoader {
     private AndroidLoader(Context context) {
       AndroidJniLibrary.initialize(
+          context.getClassLoader(),
           (ConnectivityManager)context.getSystemService(Context.CONNECTIVITY_SERVICE));
     }
   }
@@ -40,8 +41,9 @@ public class AndroidJniLibrary {
   /**
    * Native binding to register the ConnectivityManager to C-Ares.
    *
+   * @param classLoader Application's class loader.
    * @param connectivityManager Android's ConnectivityManager.
    * @return The resulting status of the initialization.
    */
-  protected static native int initialize(ConnectivityManager connectivityManager);
+  protected static native int initialize(ClassLoader classLoader, ConnectivityManager connectivityManager);
 }


### PR DESCRIPTION
Description: The change is needed in order for JNI to be able to find classes which are defined in our repository (as opposed to built in Java types). Google documents in [here](https://developer.android.com/training/articles/perf-jni#native-libraries) touches on this issue. The implementation could be improved by adding some caching to it but I am inclined to keep it simple unless we find out that its performance is an issue. Needed  for https://github.com/envoyproxy/envoy-mobile/issues/2432.
Risk Level: None, not used anywhere as of now.
Testing: Manual
Docs Changes: N/A
Release Notes: N/A

Signed-off-by: Rafal Augustyniak <raugustyniak@lyft.com>