### PR TITLE
Switch to using new-style Bazel platform constraints.

### DIFF
--- a/third_party/rbe_configs/config/BUILD
+++ b/third_party/rbe_configs/config/BUILD
@@ -21,13 +21,13 @@ package(default_visibility = ["//visibility:public"])
 toolchain(
     name = "cc-toolchain",
     exec_compatible_with = [
-        "@bazel_tools//platforms:linux",
-        "@bazel_tools//platforms:x86_64",
+        "@platforms//os:linux",
+        "@platforms//cpu:x86_64",
         "@bazel_tools//tools/cpp:clang",
     ],
     target_compatible_with = [
-        "@bazel_tools//platforms:linux",
-        "@bazel_tools//platforms:x86_64",
+        "@platforms//os:linux",
+        "@platforms//cpu:x86_64",
     ],
     toolchain = "//third_party/rbe_configs/cc:cc-compiler-k8",
     toolchain_type = "@bazel_tools//tools/cpp:toolchain_type",
@@ -37,8 +37,8 @@ platform(
     name = "platform",
     parents = ["@local_config_platform//:host"],
     constraint_values = [
-        "@bazel_tools//platforms:linux",
-        "@bazel_tools//platforms:x86_64",
+        "@platforms//os:linux",
+        "@platforms//cpu:x86_64",
         "@bazel_tools//tools/cpp:clang",
     ],
     exec_properties = {
@@ -52,8 +52,8 @@ platform(
     name = "platform-asan",
     parents = ["@local_config_platform//:host"],
     constraint_values = [
-        "@bazel_tools//platforms:linux",
-        "@bazel_tools//platforms:x86_64",
+        "@platforms//os:linux",
+        "@platforms//cpu:x86_64",
         "@bazel_tools//tools/cpp:clang",
     ],
     exec_properties = {


### PR DESCRIPTION
The old style will stop working in Bazel 6.0 (see https://github.com/bazelbuild/bazel/commit/3469784a4935c91b4ac22bcfed6be52e6dfec878)

Signed-off-by: Benjamin Peterson <benjamin@engflow.com>

For an explanation of how to fill out the fields, please see the relevant section
in [PULL_REQUESTS.md](https://github.com/envoyproxy/envoy/blob/master/PULL_REQUESTS.md)

Description:
Risk Level:
Testing:
Docs Changes:
Release Notes:
[Optional Fixes #Issue]
[Optional Deprecated:]
