### PR TITLE
jni: release strings after they are no longer needed

### DIFF
--- a/library/common/jni/jni_interface.cc
+++ b/library/common/jni/jni_interface.cc
@@ -120,8 +120,12 @@ extern "C" JNIEXPORT jlong JNICALL Java_io_envoyproxy_envoymobile_engine_JniLibr
 
 extern "C" JNIEXPORT jint JNICALL Java_io_envoyproxy_envoymobile_engine_JniLibrary_runEngine(
     JNIEnv* env, jclass, jlong engine, jstring config, jstring log_level) {
-  return run_engine(engine, env->GetStringUTFChars(config, nullptr),
-                    env->GetStringUTFChars(log_level, nullptr), "");
+  const char* string_config = env->GetStringUTFChars(config, nullptr);
+  const char* string_log_level = env->GetStringUTFChars(log_level, nullptr);
+  jint result = run_engine(engine, string_config, string_log_level, "");
+  env->ReleaseStringUTFChars(config, string_config);
+  env->ReleaseStringUTFChars(log_level, string_log_level);
+  return result;
 }
 
 extern "C" JNIEXPORT void JNICALL Java_io_envoyproxy_envoymobile_engine_JniLibrary_terminateEngine(


### PR DESCRIPTION
Description: Avoid leaking config/log_level related strings. The leak happens during engine initialization.
Risk Level: Low
Testing: Manual
Docs Changes:  N/A
Release Notes: N/A

Signed-off-by: Rafal Augustyniak <raugustyniak@lyft.com>
