### PR TITLE
core: pass strings as references

### DIFF
--- a/library/common/engine.cc
+++ b/library/common/engine.cc
@@ -24,8 +24,8 @@ Engine::Engine(envoy_engine_callbacks callbacks, envoy_logger logger,
   Envoy::Api::External::registerApi(std::string(envoy_event_tracker_api_name), &event_tracker_);
 }
 
-envoy_status_t Engine::run(const std::string config, const std::string log_level,
-                           const std::string admin_address_path) {
+envoy_status_t Engine::run(const std::string& config, const std::string& log_level,
+                           const std::string& admin_address_path) {
   // Start the Envoy on the dedicated thread. Note: due to how the assignment operator works with
   // std::thread, main_thread_ is the same object after this call, but its state is replaced with
   // that of the temporary. The temporary object's state becomes the default state, which does
@@ -35,8 +35,8 @@ envoy_status_t Engine::run(const std::string config, const std::string log_level
   return ENVOY_SUCCESS;
 }
 
-envoy_status_t Engine::main(const std::string config, const std::string log_level,
-                            const std::string admin_address_path) {
+envoy_status_t Engine::main(const std::string& config, const std::string& log_level,
+                            const std::string& admin_address_path) {
   // Using unique_ptr ensures main_common's lifespan is strictly scoped to this function.
   std::unique_ptr<EngineCommon> main_common;
   const std::string name = "envoy";

--- a/library/common/engine.h
+++ b/library/common/engine.h
@@ -36,8 +36,8 @@ public:
    * @param log_level, the log level.
    * @param admin_address_path to set --admin-address-path, or an empty string if not needed.
    */
-  envoy_status_t run(std::string config, std::string log_level,
-                     const std::string admin_address_path);
+  envoy_status_t run(const std::string& config, const std::string& log_level,
+                     const std::string& admin_address_path);
 
   /**
    * Immediately terminate the engine, if running.
@@ -130,7 +130,7 @@ public:
   Upstream::ClusterManager& getClusterManager();
 
 private:
-  envoy_status_t main(std::string config, std::string log_level, std::string admin_address_path);
+  envoy_status_t main(const std::string& config, const std::string& log_level, const std::string& admin_address_path);
   static void logInterfaces(absl::string_view event,
                             std::vector<Network::InterfacePair>& interfaces);
 

--- a/library/common/engine_handle.cc
+++ b/library/common/engine_handle.cc
@@ -16,9 +16,12 @@ envoy_engine_t EngineHandle::initEngine(envoy_engine_callbacks callbacks, envoy_
   return reinterpret_cast<envoy_engine_t>(engine);
 }
 
-envoy_status_t EngineHandle::runEngine(envoy_engine_t handle, const char* config,
-                                       const char* log_level, const char* admin_address_path) {
+envoy_status_t EngineHandle::runEngine(envoy_engine_t handle, const char* c_config,
+                                       const char* c_log_level, const char* c_admin_address_path) {
   if (auto engine = reinterpret_cast<Envoy::Engine*>(handle)) {
+    const auto config = std::string(c_config);
+    const auto log_level = std::string(c_log_level);
+    const auto admin_address_path = std::string(c_admin_address_path);
     engine->run(config, log_level, admin_address_path);
     return ENVOY_SUCCESS;
   }


### PR DESCRIPTION
Description: Passing these strings as references may help us to avoid doing copying during initialization.
Risk Level: Low
Testing: Manual
Docs Changes: N/A
Release Notes: N/A

Signed-off-by: Rafal Augustyniak <raugustyniak@lyft.com>
