### PR TITLE
ci: update GitHub Actions Linux runners to run on `ubuntu-latest`

### DIFF
--- a/.github/workflows/android_tests.yml
+++ b/.github/workflows/android_tests.yml
@@ -92,7 +92,7 @@ jobs:
     # Only kotlin tests are executed since with linux:
     # https://github.com/envoyproxy/envoy-mobile/issues/1418.
     name: kotlin_tests_linux
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-latest
     timeout-minutes: 90
     container:
       image: envoyproxy/envoy-build-ubuntu:0a02a76af5951bf7f4c7029c0ea6d29d96c0f682

--- a/.github/workflows/asan.yml
+++ b/.github/workflows/asan.yml
@@ -9,7 +9,7 @@ on:
 jobs:
   asan:
     name: asan
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-latest
     timeout-minutes: 180
     container:
       image: envoyproxy/envoy-build-ubuntu:0a02a76af5951bf7f4c7029c0ea6d29d96c0f682

--- a/.github/workflows/cc_tests.yml
+++ b/.github/workflows/cc_tests.yml
@@ -9,7 +9,7 @@ on:
 jobs:
   cctests:
     name: cc_tests
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-latest
     timeout-minutes: 120
     container:
       image: envoyproxy/envoy-build-ubuntu:0a02a76af5951bf7f4c7029c0ea6d29d96c0f682

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -9,7 +9,7 @@ on:
 jobs:
   coverage:
     name: coverage
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-latest
     timeout-minutes: 120
     defaults:
       run:

--- a/.github/workflows/format.yml
+++ b/.github/workflows/format.yml
@@ -9,7 +9,7 @@ on:
 jobs:
   formatall:
     name: format_all
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-latest
     timeout-minutes: 45
     container:
       image: envoyproxy/envoy-build-ubuntu:0a02a76af5951bf7f4c7029c0ea6d29d96c0f682
@@ -36,7 +36,7 @@ jobs:
         run: pre-commit run --all-files
   swiftlint:
     name: swift_lint
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-latest
     timeout-minutes: 5
     container:
       image: ghcr.io/realm/swiftlint:0.47.1

--- a/.github/workflows/perf.yml
+++ b/.github/workflows/perf.yml
@@ -9,7 +9,7 @@ on:
 jobs:
   sizecurrent:
     name: size_current
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-latest
     timeout-minutes: 120
     container:
       image: envoyproxy/envoy-build-ubuntu:0a02a76af5951bf7f4c7029c0ea6d29d96c0f682
@@ -37,7 +37,7 @@ jobs:
           path: bazel-bin/test/performance/test_binary_size
   sizemain:
     name: size_main
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-latest
     timeout-minutes: 90
     container:
       image: envoyproxy/envoy-build-ubuntu:0a02a76af5951bf7f4c7029c0ea6d29d96c0f682
@@ -69,7 +69,7 @@ jobs:
   sizecompare:
     name: size_compare
     needs: [sizecurrent, sizemain]
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-latest
     timeout-minutes: 30
     container:
       image: envoyproxy/envoy-build-ubuntu:0a02a76af5951bf7f4c7029c0ea6d29d96c0f682

--- a/.github/workflows/python_tests.yml
+++ b/.github/workflows/python_tests.yml
@@ -9,7 +9,7 @@ on:
 jobs:
   pythontests:
     name: python_tests
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-latest
     timeout-minutes: 90
     container:
       image: envoyproxy/envoy-build-ubuntu:0a02a76af5951bf7f4c7029c0ea6d29d96c0f682

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -47,7 +47,7 @@ jobs:
     name: android_release_deploy
     if: startsWith(github.ref, 'refs/tags/v')
     needs: android_release_artifacts
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-latest
     timeout-minutes: 240
     steps:
       - uses: actions/checkout@v1

--- a/.github/workflows/tsan.yml
+++ b/.github/workflows/tsan.yml
@@ -9,7 +9,7 @@ on:
 jobs:
   tsan:
     name: tsan
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-latest
     timeout-minutes: 90
     container:
       image: envoyproxy/envoy-build-ubuntu:0a02a76af5951bf7f4c7029c0ea6d29d96c0f682


### PR DESCRIPTION
The `ubuntu-18.04` image has been deprecated: https://github.com/actions/runner-images/issues/6002

May explain why our Linux CI jobs started being cancelled before even starting. https://envoyproxy.slack.com/archives/C02F93EEJCE/p1661181247759129

Signed-off-by: JP Simard <jp@jpsim.com>