### PR TITLE
docs: update find_class documentation

### DIFF
--- a/library/common/jni/jni_utility.h
+++ b/library/common/jni/jni_utility.h
@@ -26,7 +26,7 @@ void set_class_loader(jobject class_loader);
  * The method works on Android targets only as the `set_class_loader` method is not
  * called by JVM-only targets.
  *
- * @param class_name, the name of the class to find (i.e. "org.chromium.net.AndroidNetworkLibrary").
+ * @param class_name, the name of the class to find (i.e. "org/chromium/net/AndroidNetworkLibrary").
  *
  * @return jclass, the class with a provided `class_name` or NULL if
  *         it couldn't be found.


### PR DESCRIPTION
Description: Update the documentation of `find_class` method as it seems to accept `/` and `.` and using `/` should be less confusing as this is what `env->findClass` expects.
Risk Level: None
Testing: Manual confirmed that the current implementing of tagging works and it does uses `/` as opposed to `.`.
Docs Changes: N/A
Release Notes: N/A

Signed-off-by: Rafał Augustyniak <Augustyniak@users.noreply.github.com>