### PR TITLE
Remove unnecessary google_re2 messages from config.cc

### DIFF
--- a/library/common/config/config.cc
+++ b/library/common/config/config.cc
@@ -462,40 +462,28 @@ stats_config:
     inclusion_list:
       patterns:
         - safe_regex:
-            google_re2: {}
             regex: '^cluster\.[\w]+?\.upstream_cx_[\w]+'
         - safe_regex:
-            google_re2: {}
             regex: '^cluster\.[\w]+?\.upstream_rq_[\w]+'
         - safe_regex:
-            google_re2: {}
             regex: '^cluster\.[\w]+?\.update_(attempt|success|failure)'
         - safe_regex:
-            google_re2: {}
             regex: '^cluster\.[\w]+?\.http2.keepalive_timeout'
         - safe_regex:
-            google_re2: {}
             regex: '^dns.apple.*'
         - safe_regex:
-            google_re2: {}
             regex: '^http.client.*'
         - safe_regex:
-            google_re2: {}
             regex: '^http.dispatcher.*'
         - safe_regex:
-            google_re2: {}
             regex: '^http.hcm.decompressor.*'
         - safe_regex:
-            google_re2: {}
             regex: '^http.hcm.downstream_rq_[\w]+'
         - safe_regex:
-            google_re2: {}
             regex: '^pbf_filter.*'
         - safe_regex:
-            google_re2: {}
             regex: '^pulse.*'
         - safe_regex:
-            google_re2: {}
             regex: '^vhost.api.vcluster\.[\w]+?\.upstream_rq_(?:[12345]xx|retry.*|time|timeout|total)'
   use_all_default_tags:
     false


### PR DESCRIPTION
Remove unnecessary google_re2 messages from config.cc in order to squelch runtime warnings about google_re2 being deprecated.

Risk Level: Low since this field is no longer needed after https://github.com/envoyproxy/envoy/pull/21633
Testing: Existing
Docs Changes: None
Release Notes: None

Signed-off-by: Ryan Hamilton <rch@google.com>
