### PR TITLE
testing: make find_class method work in tests

### DIFF
--- a/library/common/jni/android_jni_utility.cc
+++ b/library/common/jni/android_jni_utility.cc
@@ -37,7 +37,7 @@ bool is_cleartext_permitted(absl::string_view hostname) {
 void tag_socket(int ifd, int uid, int tag) {
 #if defined(__ANDROID_API__)
   JNIEnv* env = get_env();
-  jclass jcls_AndroidNetworkLibrary = find_class("org/chromium/net/AndroidNetworkLibrary");
+  jclass jcls_AndroidNetworkLibrary = find_class("org.chromium.net.AndroidNetworkLibrary");
   jmethodID jmid_tagSocket =
       env->GetStaticMethodID(jcls_AndroidNetworkLibrary, "tagSocket", "(III)V");
   env->CallStaticVoidMethod(jcls_AndroidNetworkLibrary, jmid_tagSocket, ifd, uid, tag);

--- a/library/common/jni/android_test_jni_interface.cc
+++ b/library/common/jni/android_test_jni_interface.cc
@@ -10,7 +10,9 @@
 extern "C" JNIEXPORT jint JNICALL
 Java_io_envoyproxy_envoymobile_engine_AndroidJniLibrary_initialize(JNIEnv* env,
                                                                    jclass, // class
+                                                                   jobject class_loader,
                                                                    jobject connectivity_manager) {
+  set_class_loader(env->NewGlobalRef(class_loader));
 
   return 0;
 }

--- a/library/common/jni/jni_utility.h
+++ b/library/common/jni/jni_utility.h
@@ -21,12 +21,16 @@ void set_class_loader(jobject class_loader);
  * of `set_class_loader` function. The class loader is supposed to come from
  * application's context and should be associated with project's code - Java classes
  * defined by the project. For finding classes of Java built in-types use
- * `env->FindClass(...)` method instead as it is lighter to use.
+ * `env->FindClass(...)` method instead as it is lighter to use. 
  *
+ * Read more about why you cannot use `env->FindClass(...)` to look for Java classes 
+ * defined by the project and a pattern used by the implementation of `find_class` helper 
+ * method at https://developer.android.com/training/articles/perf-jni#native-libraries.
+ * 
  * The method works on Android targets only as the `set_class_loader` method is not
  * called by JVM-only targets.
  *
- * @param class_name, the name of the class to find (i.e. "org/chromium/net/AndroidNetworkLibrary").
+ * @param class_name, the name of the class to find (i.e. "org.chromium.net.AndroidNetworkLibrary").
  *
  * @return jclass, the class with a provided `class_name` or NULL if
  *         it couldn't be found.

--- a/library/common/jni/jni_utility.h
+++ b/library/common/jni/jni_utility.h
@@ -21,12 +21,12 @@ void set_class_loader(jobject class_loader);
  * of `set_class_loader` function. The class loader is supposed to come from
  * application's context and should be associated with project's code - Java classes
  * defined by the project. For finding classes of Java built in-types use
- * `env->FindClass(...)` method instead as it is lighter to use. 
+ * `env->FindClass(...)` method instead as it is lighter to use.
  *
- * Read more about why you cannot use `env->FindClass(...)` to look for Java classes 
- * defined by the project and a pattern used by the implementation of `find_class` helper 
+ * Read more about why you cannot use `env->FindClass(...)` to look for Java classes
+ * defined by the project and a pattern used by the implementation of `find_class` helper
  * method at https://developer.android.com/training/articles/perf-jni#native-libraries.
- * 
+ *
  * The method works on Android targets only as the `set_class_loader` method is not
  * called by JVM-only targets.
  *


### PR DESCRIPTION
Description: Update the implementation of `Java_io_envoyproxy_envoymobile_engine_AndroidJniLibrary_initialize` so that it takes a `class_loader` argument which was introduced in https://github.com/envoyproxy/envoy-mobile/pull/2483. It turns out that this method is implemented in two separate places - `android_jni_interface.cc` and  and `android_test_jni_interface.cc` files - and my previous PR updated only the former. This is needed to make `find_class` method work in tests as tests depend on  the implementation from `android_test_jni_interface.cc` file.
Risk Level: None, additive change for test targets only.
Testing: None, a follow up tests that depend on `find_class` method are being worked on.
Docs Changes: N/A
Release Notes: N/A

Signed-off-by: Rafal Augustyniak <raugustyniak@lyft.com>