### PR TITLE
android: add an empty implementation of isCleartextTrafficPermitted

### DIFF
--- a/library/common/jni/android_jni_utility.cc
+++ b/library/common/jni/android_jni_utility.cc
@@ -20,7 +20,7 @@ bool is_cleartext_permitted(absl::string_view hostname) {
   envoy_data host = Envoy::Data::Utility::copyToBridgeData(hostname);
   JNIEnv* env = get_env();
   jstring java_host = native_data_to_string(env, host);
-  jclass jcls_AndroidNetworkLibrary = env->FindClass("org/chromium/net/AndroidNetworkLibrary");
+  jclass jcls_AndroidNetworkLibrary = find_class("org.chromium.net.AndroidNetworkLibrary");
   jmethodID jmid_isCleartextTrafficPermitted = env->GetStaticMethodID(
       jcls_AndroidNetworkLibrary, "isCleartextTrafficPermitted", "(Ljava/lang/String;)Z");
   jboolean result = env->CallStaticBooleanMethod(jcls_AndroidNetworkLibrary,

--- a/library/java/org/chromium/net/AndroidNetworkLibrary.java
+++ b/library/java/org/chromium/net/AndroidNetworkLibrary.java
@@ -104,6 +104,14 @@ public final class AndroidNetworkLibrary {
     }
   }
 
+  /*
+   * Returns true if cleartext traffic to a given host is allowed by the current app.
+   */ 
+  public static boolean isCleartextTrafficPermitted(String host) {
+    // TODO(Augustyniak): Implement this method.
+    return true;
+  }
+
   /**
    * Class to wrap FileDescriptor.setInt$() which is hidden and so must be accessed via
    * reflection.

--- a/library/java/org/chromium/net/AndroidNetworkLibrary.java
+++ b/library/java/org/chromium/net/AndroidNetworkLibrary.java
@@ -108,7 +108,7 @@ public final class AndroidNetworkLibrary {
    * Returns true if cleartext traffic to a given host is allowed by the current app.
    */
   public static boolean isCleartextTrafficPermitted(String host) {
-    // TODO(Augustyniak): Implement this method.
+    // TODO(alyssawilk) Implement this method.
     return true;
   }
 

--- a/library/java/org/chromium/net/AndroidNetworkLibrary.java
+++ b/library/java/org/chromium/net/AndroidNetworkLibrary.java
@@ -106,7 +106,7 @@ public final class AndroidNetworkLibrary {
 
   /*
    * Returns true if cleartext traffic to a given host is allowed by the current app.
-   */ 
+   */
   public static boolean isCleartextTrafficPermitted(String host) {
     // TODO(Augustyniak): Implement this method.
     return true;


### PR DESCRIPTION
Description: Fixes a crash https://github.com/envoyproxy/envoy-mobile/issues/2432
Risk Level: Low, it effectively does nothing other than returning `true` and should prevent the app from crashing
Testing: Manual
Docs Changes: N/A
Release Notes: N/A

Signed-off-by: Rafal Augustyniak <raugustyniak@lyft.com>