### PR TITLE
android: enable forceIPv6 by default

### DIFF
--- a/library/java/io/envoyproxy/envoymobile/engine/EnvoyConfiguration.java
+++ b/library/java/io/envoyproxy/envoymobile/engine/EnvoyConfiguration.java
@@ -44,7 +44,6 @@ public class EnvoyConfiguration {
   public final Boolean enableSocketTagging;
   public final Boolean enableHappyEyeballs;
   public final Boolean enableInterfaceBinding;
-  public final Boolean forceIPv6;
   public final Integer h2ConnectionKeepaliveIdleIntervalMilliseconds;
   public final Integer h2ConnectionKeepaliveTimeoutSeconds;
   public final Boolean h2ExtendKeepaliveTimeout;
@@ -88,7 +87,6 @@ public class EnvoyConfiguration {
    * @param enableSocketTagging          whether to enable socket tagging.
    * @param enableHappyEyeballs          whether to enable RFC 6555 handling for IPv4/IPv6.
    * @param enableInterfaceBinding       whether to allow interface binding.
-   * @param forceIPv6                    whether to force connections to use IPv6.
    * @param h2ConnectionKeepaliveIdleIntervalMilliseconds rate in milliseconds seconds to send h2
    *     pings on stream creation.
    * @param h2ConnectionKeepaliveTimeoutSeconds rate in seconds to timeout h2 pings.
@@ -116,7 +114,7 @@ public class EnvoyConfiguration {
       boolean dnsFilterUnroutableFamilies, boolean dnsUseSystemResolver,
       boolean enableDrainPostDnsRefresh, boolean enableHttp3, boolean enableGzip,
       boolean enableBrotli, boolean enableSocketTagging, boolean enableHappyEyeballs,
-      boolean enableInterfaceBinding, boolean forceIPv6,
+      boolean enableInterfaceBinding,
       int h2ConnectionKeepaliveIdleIntervalMilliseconds, int h2ConnectionKeepaliveTimeoutSeconds,
       boolean h2ExtendKeepaliveTimeout, List<String> h2RawDomains, int maxConnectionsPerHost,
       int statsFlushSeconds, int streamIdleTimeoutSeconds, int perTryIdleTimeoutSeconds,
@@ -145,7 +143,6 @@ public class EnvoyConfiguration {
     this.enableSocketTagging = enableSocketTagging;
     this.enableHappyEyeballs = enableHappyEyeballs;
     this.enableInterfaceBinding = enableInterfaceBinding;
-    this.forceIPv6 = forceIPv6;
     this.h2ConnectionKeepaliveIdleIntervalMilliseconds =
         h2ConnectionKeepaliveIdleIntervalMilliseconds;
     this.h2ConnectionKeepaliveTimeoutSeconds = h2ConnectionKeepaliveTimeoutSeconds;
@@ -274,7 +271,7 @@ public class EnvoyConfiguration {
                               enableDrainPostDnsRefresh ? "true" : "false"))
         .append(String.format("- &enable_interface_binding %s\n",
                               enableInterfaceBinding ? "true" : "false"))
-        .append(String.format("- &force_ipv6 %s\n", forceIPv6 ? "true" : "false"))
+        .append("- &force_ipv6 true\n")
         .append(String.format("- &h2_connection_keepalive_idle_interval %ss\n",
                               h2ConnectionKeepaliveIdleIntervalMilliseconds / 1000.0))
         .append(String.format("- &h2_connection_keepalive_timeout %ss\n",

--- a/library/kotlin/io/envoyproxy/envoymobile/EngineBuilder.kt
+++ b/library/kotlin/io/envoyproxy/envoymobile/EngineBuilder.kt
@@ -60,7 +60,6 @@ open class EngineBuilder(
   private var enableBrotli = false
   private var enableSocketTagging = false
   private var enableInterfaceBinding = false
-  private var forceIPv6 = false
   private var h2ConnectionKeepaliveIdleIntervalMilliseconds = 1
   private var h2ConnectionKeepaliveTimeoutSeconds = 10
   private var h2ExtendKeepaliveTimeout = false
@@ -324,19 +323,6 @@ open class EngineBuilder(
    */
   fun enableInterfaceBinding(enableInterfaceBinding: Boolean): EngineBuilder {
     this.enableInterfaceBinding = enableInterfaceBinding
-    return this
-  }
-
-  /**
-   * Specify whether to remap IPv4 addresses to the IPv6 space and always force connections
-   * to use IPv6. Note this is an experimental option and should be enabled with caution.
-   *
-   * @param forceIPv6 whether to force connections to use IPv6.
-   *
-   * @return This builder.
-   */
-  fun forceIPv6(forceIPv6: Boolean): EngineBuilder {
-    this.forceIPv6 = forceIPv6
     return this
   }
 
@@ -629,7 +615,6 @@ open class EngineBuilder(
       enableSocketTagging,
       enableHappyEyeballs,
       enableInterfaceBinding,
-      forceIPv6,
       h2ConnectionKeepaliveIdleIntervalMilliseconds,
       h2ConnectionKeepaliveTimeoutSeconds,
       h2ExtendKeepaliveTimeout,

--- a/test/java/io/envoyproxy/envoymobile/engine/EnvoyConfigurationTest.kt
+++ b/test/java/io/envoyproxy/envoymobile/engine/EnvoyConfigurationTest.kt
@@ -67,7 +67,6 @@ class EnvoyConfigurationTest {
     enableSocketTagging: Boolean = false,
     enableHappyEyeballs: Boolean = false,
     enableInterfaceBinding: Boolean = false,
-    forceIPv6: Boolean = false,
     h2ConnectionKeepaliveIdleIntervalMilliseconds: Int = 222,
     h2ConnectionKeepaliveTimeoutSeconds: Int = 333,
     h2ExtendKeepaliveTimeout: Boolean = false,
@@ -102,7 +101,6 @@ class EnvoyConfigurationTest {
       enableSocketTagging,
       enableHappyEyeballs,
       enableInterfaceBinding,
-      forceIPv6,
       h2ConnectionKeepaliveIdleIntervalMilliseconds,
       h2ConnectionKeepaliveTimeoutSeconds,
       h2ExtendKeepaliveTimeout,
@@ -150,7 +148,7 @@ class EnvoyConfigurationTest {
     assertThat(resolvedTemplate).contains("&enable_interface_binding false")
 
     // Forcing IPv6
-    assertThat(resolvedTemplate).contains("&force_ipv6 false")
+    assertThat(resolvedTemplate).contains("&force_ipv6 true")
 
     // H2 Ping
     assertThat(resolvedTemplate).contains("&h2_connection_keepalive_idle_interval 0.222s")
@@ -205,7 +203,6 @@ class EnvoyConfigurationTest {
       enableGzip = false,
       enableBrotli = true,
       enableInterfaceBinding = true,
-      forceIPv6 = true,
       h2ExtendKeepaliveTimeout = true
     )
 
@@ -233,9 +230,6 @@ class EnvoyConfigurationTest {
 
     // Interface Binding
     assertThat(resolvedTemplate).contains("&enable_interface_binding true")
-
-    // Forcing IPv6
-    assertThat(resolvedTemplate).contains("&force_ipv6 true")
   }
 
   @Test


### PR DESCRIPTION
Description: Forcing the use of IPv6 socket addresses is required to make Envoy Mobile work with some carriers when running on an Android device. The option was introduced upstream in https://github.com/envoyproxy/envoy/pull/21803.
Risk Level: Low, enabled a well tested option.
Testing: Manual, launched the example app
Docs Changes: Updated
Release Notes: Updated

Signed-off-by: Rafal Augustyniak <raugustyniak@lyft.com>