### PR TITLE
android: default to use the system DNS resolver

### DIFF
--- a/docs/root/intro/version_history.rst
+++ b/docs/root/intro/version_history.rst
@@ -45,7 +45,7 @@ Features:
 - android: create simple persistent SharedPreferencesStore (:issue: `#2319 <2319>`)
 - iOS: A documentation archive is now included in the GitHub release artifact (:issue: `#2335 <2335>`)
 - api: improved C++ APIs compatibility with Java / Kotlin / Swift (:issue `#2362 <2362>`)
-- api: add option to use the a ``getaddrinfo``-based system DNS resolver instead of c-ares (:issue: `#2419 <2419>`)
+- Android: default to use a ``getaddrinfo``-based system DNS resolver instead of c-ares (:issue: `#2419 <2419>`)
 - iOS: add ``KeyValueStore`` protocol conformance to ``UserDefaults`` (:issue: `#2452 <2452>`)
 
 0.4.6 (April 26, 2022)

--- a/library/cc/engine_builder.h
+++ b/library/cc/engine_builder.h
@@ -68,7 +68,7 @@ private:
   int dns_failure_refresh_seconds_max_ = 10;
   int dns_query_timeout_seconds_ = 25;
   std::string dns_preresolve_hostnames_ = "[]";
-  bool use_system_resolver_ = false;
+  bool use_system_resolver_ = true;
   int h2_connection_keepalive_idle_interval_milliseconds_ = 100000000;
   int h2_connection_keepalive_timeout_seconds_ = 10;
   int stats_flush_seconds_ = 60;

--- a/library/kotlin/io/envoyproxy/envoymobile/EngineBuilder.kt
+++ b/library/kotlin/io/envoyproxy/envoymobile/EngineBuilder.kt
@@ -49,7 +49,7 @@ open class EngineBuilder(
   private var dnsFailureRefreshSecondsMax = 10
   private var dnsFallbackNameservers = listOf<String>()
   private var dnsFilterUnroutableFamilies = true
-  private var dnsUseSystemResolver = false
+  private var dnsUseSystemResolver = true
   private var dnsQueryTimeoutSeconds = 25
   private var dnsMinRefreshSeconds = 60
   private var dnsPreresolveHostnames = "[]"
@@ -222,7 +222,7 @@ open class EngineBuilder(
 
   /**
    * Specify whether to use the getaddrinfo-based system DNS resolver or the c-ares resolver.
-   * Defaults to false.
+   * Defaults to true.
    *
    * Note that if this is set, the values of `dnsFallbackNameservers` and
    * `dnsFilterUnroutableFamilies` will be ignored.

--- a/test/cc/unit/envoy_config_test.cc
+++ b/test/cc/unit/envoy_config_test.cc
@@ -68,24 +68,24 @@ TEST(TestConfig, ConfigIsValid) {
 
   // Test per-platform DNS fixes.
 #if defined(__APPLE__)
-  ASSERT_THAT(bootstrap.DebugString(), Not(HasSubstr("envoy.network.dns_resolver.cares")));
+  ASSERT_THAT(bootstrap.DebugString(), Not(HasSubstr("envoy.network.dns_resolver.getaddrinfo")));
   ASSERT_THAT(bootstrap.DebugString(), HasSubstr("envoy.network.dns_resolver.apple"));
 #else
-  ASSERT_THAT(bootstrap.DebugString(), HasSubstr("envoy.network.dns_resolver.cares"));
+  ASSERT_THAT(bootstrap.DebugString(), HasSubstr("envoy.network.dns_resolver.getaddrinfo"));
   ASSERT_THAT(bootstrap.DebugString(), Not(HasSubstr("envoy.network.dns_resolver.apple")));
 #endif
 }
 
 #if !defined(__APPLE__)
-TEST(TestConfig, SetUseDnsSystemResolver) {
+TEST(TestConfig, SetUseDnsCAresResolver) {
   auto engine_builder = EngineBuilder();
-  engine_builder.useDnsSystemResolver(true);
+  engine_builder.useDnsSystemResolver(false);
   auto config_str = engine_builder.generateConfigStr();
   envoy::config::bootstrap::v3::Bootstrap bootstrap;
   TestUtility::loadFromYaml(absl::StrCat(config_header, config_str), bootstrap);
 
-  ASSERT_THAT(bootstrap.DebugString(), HasSubstr("envoy.network.dns_resolver.getaddrinfo"));
-  ASSERT_THAT(bootstrap.DebugString(), Not(HasSubstr("envoy.network.dns_resolver.cares")));
+  ASSERT_THAT(bootstrap.DebugString(), HasSubstr("envoy.network.dns_resolver.cares"));
+  ASSERT_THAT(bootstrap.DebugString(), Not(HasSubstr("envoy.network.dns_resolver.getaddrinfo")));
 }
 #endif
 

--- a/test/java/io/envoyproxy/envoymobile/engine/EnvoyConfigurationTest.kt
+++ b/test/java/io/envoyproxy/envoymobile/engine/EnvoyConfigurationTest.kt
@@ -290,7 +290,8 @@ class EnvoyConfigurationTest {
   @Test
   fun `resolving multiple dns fallback nameservers`() {
     val envoyConfiguration = buildTestEnvoyConfiguration(
-      dnsFallbackNameservers = listOf("8.8.8.8", "1.1.1.1")
+      dnsFallbackNameservers = listOf("8.8.8.8", "1.1.1.1"),
+      dnsUseSystemResolver = false
     )
 
     val resolvedTemplate = envoyConfiguration.resolveTemplate(

--- a/test/java/io/envoyproxy/envoymobile/engine/EnvoyConfigurationTest.kt
+++ b/test/java/io/envoyproxy/envoymobile/engine/EnvoyConfigurationTest.kt
@@ -197,6 +197,7 @@ class EnvoyConfigurationTest {
     val envoyConfiguration = buildTestEnvoyConfiguration(
       dnsFallbackNameservers = listOf("8.8.8.8"),
       enableDnsFilterUnroutableFamilies = false,
+      dnsUseSystemResolver = false,
       enableDrainPostDnsRefresh = true,
       enableHappyEyeballs = true,
       enableHttp3 = true,

--- a/test/java/io/envoyproxy/envoymobile/engine/EnvoyConfigurationTest.kt
+++ b/test/java/io/envoyproxy/envoymobile/engine/EnvoyConfigurationTest.kt
@@ -59,7 +59,7 @@ class EnvoyConfigurationTest {
     dnsPreresolveHostnames: String = "[hostname]",
     dnsFallbackNameservers: List<String> = emptyList(),
     enableDnsFilterUnroutableFamilies: Boolean = true,
-    dnsUseSystemResolver: Boolean = false,
+    dnsUseSystemResolver: Boolean = true,
     enableDrainPostDnsRefresh: Boolean = false,
     enableHttp3: Boolean = false,
     enableGzip: Boolean = true,
@@ -142,8 +142,8 @@ class EnvoyConfigurationTest {
     assertThat(resolvedTemplate).contains("&dns_multiple_addresses false")
     assertThat(resolvedTemplate).contains("&dns_min_refresh_rate 12s")
     assertThat(resolvedTemplate).contains("&dns_preresolve_hostnames [hostname]")
-    assertThat(resolvedTemplate).contains("&dns_resolver_name envoy.network.dns_resolver.cares")
-    assertThat(resolvedTemplate).contains("&dns_resolver_config {\"@type\":\"type.googleapis.com/envoy.extensions.network.dns_resolver.cares.v3.CaresDnsResolverConfig\",\"resolvers\":[],\"use_resolvers_as_fallback\": false, \"filter_unroutable_families\": true}")
+    assertThat(resolvedTemplate).contains("&dns_resolver_name envoy.network.dns_resolver.getaddrinfo")
+    assertThat(resolvedTemplate).contains("&dns_resolver_config {\"@type\":\"type.googleapis.com/envoy.extensions.network.dns_resolver.getaddrinfo.v3.GetAddrInfoDnsResolverConfig\"}")
     assertThat(resolvedTemplate).contains("&enable_drain_post_dns_refresh false")
 
     // Interface Binding
@@ -239,17 +239,17 @@ class EnvoyConfigurationTest {
   }
 
   @Test
-  fun `configuration resolves with system DNS resolver`() {
+  fun `configuration resolves with c ares DNS resolver`() {
     val envoyConfiguration = buildTestEnvoyConfiguration(
-      dnsUseSystemResolver = true
+      dnsUseSystemResolver = false
     )
 
     val resolvedTemplate = envoyConfiguration.resolveTemplate(
       TEST_CONFIG, PLATFORM_FILTER_CONFIG, NATIVE_FILTER_CONFIG, APCF_INSERT, GZIP_INSERT, BROTLI_INSERT, SOCKET_TAG_INSERT
     )
 
-    assertThat(resolvedTemplate).contains("&dns_resolver_config {\"@type\":\"type.googleapis.com/envoy.extensions.network.dns_resolver.getaddrinfo.v3.GetAddrInfoDnsResolverConfig\"}")
-    assertThat(resolvedTemplate).contains("&dns_resolver_name envoy.network.dns_resolver.getaddrinfo")
+    assertThat(resolvedTemplate).contains("&dns_resolver_name envoy.network.dns_resolver.cares")
+    assertThat(resolvedTemplate).contains("&dns_resolver_config {\"@type\":\"type.googleapis.com/envoy.extensions.network.dns_resolver.cares.v3.CaresDnsResolverConfig\",\"resolvers\":[],\"use_resolvers_as_fallback\": false, \"filter_unroutable_families\": true}")
   }
 
   @Test

--- a/test/kotlin/apps/experimental/MainActivity.kt
+++ b/test/kotlin/apps/experimental/MainActivity.kt
@@ -57,7 +57,7 @@ class MainActivity : Activity() {
       .addPlatformFilter(::AsyncDemoFilter)
       .h2ExtendKeepaliveTimeout(true)
       .enableInterfaceBinding(true)
-      .enableDNSUseSystemResolver(true)
+      .enableDNSUseSystemResolver(false)
       .forceIPv6(true)
       .enableSocketTagging(true)
       .addNativeFilter("envoy.filters.http.buffer", "{\"@type\":\"type.googleapis.com/envoy.extensions.filters.http.buffer.v3.Buffer\",\"max_request_bytes\":5242880}")


### PR DESCRIPTION
Description: Rather than c-ares. In our tests, the system DNS resolver consumes less CPU and memory while otherwise performing similarly overall.
Risk Level: Medium, although it's performed well in our tests, it's possible that some situations we haven't tested perform worse than c-ares. Users can still disable this in the engine builder though.
Testing: Lyft apps & unit tests
Docs Changes: Docstrings updated to reflect new default
Release Notes: Added

Signed-off-by: JP Simard <jp@jpsim.com>