### PR TITLE
Fix Android certificate validation JNI calling convention

### DIFF
--- a/library/common/jni/android_network_utility.cc
+++ b/library/common/jni/android_network_utility.cc
@@ -8,7 +8,7 @@
 // NOLINT(namespace-envoy)
 
 // Helper functions call into AndroidNetworkLibrary, but they are not platform dependent
-// because AndroidNetworkLibray can be called in non-Android platform with mock interfaces.
+// because AndroidNetworkLibrary can be called in non-Android platform with mock interfaces.
 
 bool jvm_cert_is_issued_by_known_root(JNIEnv* env, jobject result) {
   jclass jcls_AndroidCertVerifyResult = find_class("org.chromium.net.AndroidCertVerifyResult");

--- a/library/common/jni/android_network_utility.h
+++ b/library/common/jni/android_network_utility.h
@@ -18,4 +18,16 @@ jobject call_jvm_verify_x509_cert_chain(JNIEnv* env, const std::vector<std::stri
  */
 envoy_cert_validator* get_android_cert_validator_api();
 
+/* Extracts the certificate verification status from the Java object return by
+ * call_jvm_verify_x509_cert_chain.
+ * Used only for testing.
+ */
+envoy_cert_verify_status_t jvm_cert_get_status(JNIEnv* env, jobject j_result);
+
+/* Extracts whether the certificate was issued by a known root from the Java
+ * returned by call_jvm_verify_x509_cert_chain.
+ * Used only for testing.
+ */
+bool jvm_cert_is_issued_by_known_root(JNIEnv* env, jobject result);
+
 static constexpr const char* cert_validator_name = "platform_cert_validator";

--- a/library/common/jni/jni_interface.cc
+++ b/library/common/jni/jni_interface.cc
@@ -1209,3 +1209,15 @@ Java_io_envoyproxy_envoymobile_engine_JniLibrary_callClearTestRootCertificateFro
                                                                                         jclass) {
   jvm_clear_test_root_certificate();
 }
+
+extern "C" JNIEXPORT envoy_cert_verify_status_t JNICALL
+Java_io_envoyproxy_envoymobile_engine_JniLibrary_callAndroidCertVerifyResultGetStatusFromNative(
+    JNIEnv* env, jclass, jobject result) {
+  return jvm_cert_get_status(env, result);
+}
+
+extern "C" JNIEXPORT bool JNICALL
+Java_io_envoyproxy_envoymobile_engine_JniLibrary_callAndroidCertVerifyResultIsIssuedByKnownRootFromNative(
+    JNIEnv* env, jclass, jobject result) {
+  return jvm_cert_is_issued_by_known_root(env, result);
+}

--- a/library/java/io/envoyproxy/envoymobile/engine/JniLibrary.java
+++ b/library/java/io/envoyproxy/envoymobile/engine/JniLibrary.java
@@ -381,7 +381,7 @@ public class JniLibrary {
    * @param certChain The ASN.1 DER encoded bytes for certificates.
    * @param authType The key exchange algorithm name (e.g. RSA).
    * @param host The hostname of the server.
-   * @return Android certificate verification result code.
+   * @return AndroidCertVerifyResult representing the certificate verification result.
    */
   public static native Object callCertificateVerificationFromNative(byte[][] certChain,
                                                                     byte[] authType, byte[] host);
@@ -396,7 +396,23 @@ public class JniLibrary {
   /**
    * Mimic a call to AndroidNetworkLibrary#clearTestRootCertificate from native code.
    * To be used for testing only.
-   *
    */
   public static native void callClearTestRootCertificateFromNative();
+
+  /**
+   * Mimic a call to AndroidCertVerifyResult#getStatus from native code.
+   * To be used for testing only.
+   *
+   * @param result AndroidCertVerifyResult to call getStatus onto.
+   */
+  public static native int callAndroidCertVerifyResultGetStatusFromNative(Object result);
+
+  /**
+   * Mimic a call to AndroidCertVerifyResult#isIssuedByKnownRoot from native code.
+   * To be used for testing only.
+   *
+   * @param result AndroidCertVerifyResult to call isIssuedByKnownRoot onto.
+   */
+  public static native boolean
+  callAndroidCertVerifyResultIsIssuedByKnownRootFromNative(Object result);
 }

--- a/library/java/org/chromium/net/AndroidCertVerifyResult.java
+++ b/library/java/org/chromium/net/AndroidCertVerifyResult.java
@@ -14,7 +14,7 @@ public final class AndroidCertVerifyResult {
   /**
    * The verification status. One of the values in CertVerifyStatusAndroid.
    */
-  private final int mStatus;
+  @CertVerifyStatusAndroid private final int mStatus;
 
   /**
    * True if the root CA in the chain is in the system store.
@@ -26,29 +26,35 @@ public final class AndroidCertVerifyResult {
    */
   private final List<X509Certificate> mCertificateChain;
 
-  public AndroidCertVerifyResult(int status, boolean isIssuedByKnownRoot,
+  public AndroidCertVerifyResult(@CertVerifyStatusAndroid int status, boolean isIssuedByKnownRoot,
                                  List<X509Certificate> certificateChain) {
     mStatus = status;
     mIsIssuedByKnownRoot = isIssuedByKnownRoot;
     mCertificateChain = new ArrayList<X509Certificate>(certificateChain);
   }
 
-  public AndroidCertVerifyResult(int status) {
+  public AndroidCertVerifyResult(@CertVerifyStatusAndroid int status) {
     mStatus = status;
     mIsIssuedByKnownRoot = false;
     mCertificateChain = Collections.<X509Certificate>emptyList();
   }
 
-  // TODO(stefanoduo): Hook envoy-mobile JNI.
-  //@CalledByNative
-  public int getStatus() { return mStatus; }
+  /**
+   * Called from native.
+   */
+  @CertVerifyStatusAndroid
+  public int getStatus() {
+    return mStatus;
+  }
 
-  // TODO(stefanoduo): Hook envoy-mobile JNI.
-  //@CalledByNative
+  /**
+   * Called from native.
+   */
   public boolean isIssuedByKnownRoot() { return mIsIssuedByKnownRoot; }
 
-  // TODO(stefanoduo): Hook envoy-mobile JNI.
-  //@CalledByNative
+  /**
+   * Called from native.
+   */
   public byte[][] getCertificateChainEncoded() {
     byte[][] verifiedChainArray = new byte[mCertificateChain.size()][];
     try {

--- a/test/java/org/chromium/net/BUILD
+++ b/test/java/org/chromium/net/BUILD
@@ -49,6 +49,7 @@ envoy_mobile_android_test(
         "//library/java/io/envoyproxy/envoymobile/engine:envoy_base_engine_lib",
         "//library/java/io/envoyproxy/envoymobile/engine:envoy_engine_lib",
         "//library/java/org/chromium/net",
+        "//test/java/org/chromium/net/testing",
     ],
 )
 


### PR DESCRIPTION
Use JNI parameter ordering defined for instance methods (instead of the
static methods one).
Add tests to avoid regressions.

#1575