### PR TITLE
android: fix admin interface

### DIFF
--- a/docs/root/intro/version_history.rst
+++ b/docs/root/intro/version_history.rst
@@ -10,7 +10,7 @@ Breaking changes:
 
 Bugfixes:
 
-- android: fix app launch crash for when admin interface is enabled. (:issue:`#2520 <2520>`)
+- android: fix engine startup crash for when admin interface is enabled. (:issue:`#2520 <2520>`)
 
 Features:
 

--- a/docs/root/intro/version_history.rst
+++ b/docs/root/intro/version_history.rst
@@ -10,7 +10,7 @@ Breaking changes:
 
 Bugfixes:
 
--
+- android: fix app launch crash for when admin interface is enabled. (:issue:`#2520 <2520>`)
 
 Features:
 

--- a/library/common/config/config.cc
+++ b/library/common/config/config.cc
@@ -143,7 +143,7 @@ R"(- &enable_drain_post_dns_refresh false
 !ignore admin_interface_defs: &admin_interface
     address:
       socket_address:
-        address: 127.0.0.1
+        address: ::1
         port_value: 9901
 
 !ignore tls_root_ca_defs: &tls_root_certs |

--- a/test/kotlin/apps/experimental/MainActivity.kt
+++ b/test/kotlin/apps/experimental/MainActivity.kt
@@ -56,6 +56,7 @@ class MainActivity : Activity() {
       .addPlatformFilter(::BufferDemoFilter)
       .addPlatformFilter(::AsyncDemoFilter)
       .h2ExtendKeepaliveTimeout(true)
+      .enableAdminInterface()
       .enableInterfaceBinding(true)
       .enableDNSUseSystemResolver(false)
       .enableSocketTagging(true)

--- a/test/swift/apps/experimental/ViewController.swift
+++ b/test/swift/apps/experimental/ViewController.swift
@@ -23,6 +23,7 @@ final class ViewController: UITableViewController {
       .addPlatformFilter(BufferDemoFilter.init)
       .addPlatformFilter(AsyncDemoFilter.init)
       .h2ExtendKeepaliveTimeout(true)
+      .enabledAdminInterface()
       .enableInterfaceBinding(true)
       .addNativeFilter(
         name: "envoy.filters.http.buffer",

--- a/test/swift/apps/experimental/ViewController.swift
+++ b/test/swift/apps/experimental/ViewController.swift
@@ -23,7 +23,7 @@ final class ViewController: UITableViewController {
       .addPlatformFilter(BufferDemoFilter.init)
       .addPlatformFilter(AsyncDemoFilter.init)
       .h2ExtendKeepaliveTimeout(true)
-      .enabledAdminInterface()
+      .enableAdminInterface()
       .enableInterfaceBinding(true)
       .addNativeFilter(
         name: "envoy.filters.http.buffer",


### PR DESCRIPTION
Description: Fix admin interface on Android. Enable admin interface in experimental example app.
Risk Level: low, admin interface is disabled by default and it's crashing on app launch on Android without the change from this PR anyway.
Testing: manual on iOS and Android
Docs Changes: none
Release Notes: updated

Signed-off-by: Rafal Augustyniak <raugustyniak@lyft.com>