### PR TITLE
android: make it easy to run all example apps

### DIFF
--- a/.bazelproject
+++ b/.bazelproject
@@ -1,4 +1,7 @@
 # Uncomment the examples you'd like to use!
 import examples/kotlin/hello_world/.bazelproject
+import examples/java/hello_world/.bazelproject
+import test/kotlin/apps/baseline/.bazelproject
+import test/kotlin/apps/experimental/.bazelproject
 
 android_sdk_platform: android-31

--- a/docs/root/development/debugging/android_local.rst
+++ b/docs/root/development/debugging/android_local.rst
@@ -51,7 +51,7 @@ Entering a debugging session
 
 With the project ready, you can now start debugging with Android Studio.
 
-1. From Android Studio select one of the available configuration e.g., `Example App (Debug) [x86]` or `Example App (Debug) [arm64]`. Note: `x86` configurations don't work on ARM machines (i.e., M1 Macbooks).
+1. From Android Studio select one of the available configurations e.g., `Example App (Debug) [x86]` or `Example App (Debug) [arm64]`. Note: `x86` configurations don't work on ARM machines (i.e., M1 Macbooks).
 2. Hit the debug icon. Note: if you don't see this option go to "Add configuration" and it'll be there on the Bazel category, just select it and hit Ok.
 3. Optionally you could create symbolic breakpoints before running by going to the Debugger tab.
 

--- a/docs/root/development/debugging/android_local.rst
+++ b/docs/root/development/debugging/android_local.rst
@@ -51,7 +51,7 @@ Entering a debugging session
 
 With the project ready, you can now start debugging with Android Studio.
 
-1. From Android Studio select either `Example App (Debug) [x86]` or `Example App (Debug) [arm64]` configuration. Note: the `x86` configuration doesn't work on ARM machines (i.e., M1 Macbooks).
+1. From Android Studio select one of the available configuration e.g., `Example App (Debug) [x86]` or `Example App (Debug) [arm64]`. Note: `x86` configurations don't work on ARM machines (i.e., M1 Macbooks).
 2. Hit the debug icon. Note: if you don't see this option go to "Add configuration" and it'll be there on the Bazel category, just select it and hit Ok.
 3. Optionally you could create symbolic breakpoints before running by going to the Debugger tab.
 

--- a/examples/java/hello_world/.bazelproject
+++ b/examples/java/hello_world/.bazelproject
@@ -1,0 +1,25 @@
+workspace_type: android
+
+bazel_binary: bazelw
+
+directories:
+  -bazel-bin
+  -bazel-instant-android
+  -bazel-out
+  -bazel-testlogs
+  -buck-out
+  -build
+  examples/java/hello_world
+
+import_run_configurations:
+  examples/java/hello_world/tools/android-studio-run-configurations/run_configuration_example_debug_x86.xml
+  examples/java/hello_world/tools/android-studio-run-configurations/run_configuration_example_debug_arm64.xml
+
+targets:
+  //examples/java/hello_world:hello_envoy
+
+additional_languages:
+  kotlin
+  java
+  android
+  c

--- a/examples/java/hello_world/AndroidManifest.xml
+++ b/examples/java/hello_world/AndroidManifest.xml
@@ -15,7 +15,7 @@
             android:label="Hello Envoy Java">
         <activity
                 android:name=".MainActivity"
-                android:label="Hello Envoy">
+                android:label="Hello Envoy Java">
             <intent-filter>
                 <action android:name="android.intent.action.MAIN"/>
                 <category android:name="android.intent.category.LAUNCHER"/>

--- a/examples/java/hello_world/AndroidManifest.xml
+++ b/examples/java/hello_world/AndroidManifest.xml
@@ -12,7 +12,7 @@
             android:targetSdkVersion="27"/>
 
     <application
-            android:label="Hello Envoy">
+            android:label="Hello Envoy Java">
         <activity
                 android:name=".MainActivity"
                 android:label="Hello Envoy">

--- a/examples/java/hello_world/tools/android-studio-run-configurations/run_configuration_example_debug_arm64.xml
+++ b/examples/java/hello_world/tools/android-studio-run-configurations/run_configuration_example_debug_arm64.xml
@@ -1,4 +1,4 @@
-<configuration name="Experimental Test App (Debug) [x86]"
+<configuration name="Java Example App (Debug) [arm64]"
     type="BlazeCommandRunConfigurationType"
     factoryName="Bazel Command"
     nameIsGenerated="false">
@@ -15,8 +15,8 @@
         show-logcat-automatically="false"
         AM_START_OPTIONS="">
         <blaze-user-flag>--config=dbg-android</blaze-user-flag>
-        <blaze-user-flag>--fat_apk_cpu=x86</blaze-user-flag>
-        <blaze-target>//test/kotlin/apps/experimental:hello_envoy_kt</blaze-target>
+        <blaze-user-flag>--fat_apk_cpu=arm64-v8a</blaze-user-flag>
+        <blaze-target>//examples/java/hello_world:hello_envoy</blaze-target>
         <Profilers>
             <option name="ADVANCED_PROFILING_ENABLED"
                 value="false" />

--- a/examples/java/hello_world/tools/android-studio-run-configurations/run_configuration_example_debug_x86.xml
+++ b/examples/java/hello_world/tools/android-studio-run-configurations/run_configuration_example_debug_x86.xml
@@ -1,4 +1,4 @@
-<configuration name="Experimental Test App (Debug) [x86]"
+<configuration name="Java Example App (Debug) [x86]"
     type="BlazeCommandRunConfigurationType"
     factoryName="Bazel Command"
     nameIsGenerated="false">
@@ -16,7 +16,7 @@
         AM_START_OPTIONS="">
         <blaze-user-flag>--config=dbg-android</blaze-user-flag>
         <blaze-user-flag>--fat_apk_cpu=x86</blaze-user-flag>
-        <blaze-target>//test/kotlin/apps/experimental:hello_envoy_kt</blaze-target>
+        <blaze-target>//examples/java/hello_world:hello_envoy</blaze-target>
         <Profilers>
             <option name="ADVANCED_PROFILING_ENABLED"
                 value="false" />

--- a/test/kotlin/apps/baseline/.bazelproject
+++ b/test/kotlin/apps/baseline/.bazelproject
@@ -1,5 +1,7 @@
 workspace_type: android
 
+bazel_binary: bazelw
+
 directories:
   -bazel-bin
   -bazel-instant-android
@@ -7,13 +9,14 @@ directories:
   -bazel-testlogs
   -buck-out
   -build
-  examples/kotlin/hello_world
+  test/kotlin/apps/baseline/
 
 import_run_configurations:
-  examples/kotlin/hello_world/tools/android-studio-run-configurations/run_configuration_example_debug_x86.xml
+  test/kotlin/apps/baseline/tools/android-studio-run-configurations/run_configuration_example_debug_x86.xml
+  test/kotlin/apps/baseline/tools/android-studio-run-configurations/run_configuration_example_debug_arm64.xml
 
 targets:
-  //examples/kotlin/hello_world:hello_envoy_kt
+  //test/kotlin/apps/baseline:hello_envoy_kt
 
 additional_languages:
   kotlin

--- a/test/kotlin/apps/baseline/AndroidManifest.xml
+++ b/test/kotlin/apps/baseline/AndroidManifest.xml
@@ -1,5 +1,5 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
-          package="io.envoyproxy.envoymobile.helloenvoykotlin"
+          package="io.envoyproxy.envoymobile.helloenvoybaselinetest"
           android:versionCode="1"
           android:versionName="0.1">
     <uses-permission android:name="android.permission.INTERNET"/>
@@ -13,7 +13,7 @@
             android:label="Hello Envoy Baseline Test">
         <activity
                 android:name=".MainActivity"
-                android:label="Hello Envoy Kotlin">
+                android:label="Hello Envoy Baseline Test">
             <intent-filter>
                 <action android:name="android.intent.action.MAIN"/>
                 <category android:name="android.intent.category.LAUNCHER"/>

--- a/test/kotlin/apps/baseline/AndroidManifest.xml
+++ b/test/kotlin/apps/baseline/AndroidManifest.xml
@@ -10,7 +10,7 @@
             android:targetSdkVersion="27"/>
 
     <application
-            android:label="Hello Envoy">
+            android:label="Hello Envoy Baseline Test">
         <activity
                 android:name=".MainActivity"
                 android:label="Hello Envoy Kotlin">

--- a/test/kotlin/apps/baseline/AsyncDemoFilter.kt
+++ b/test/kotlin/apps/baseline/AsyncDemoFilter.kt
@@ -1,4 +1,4 @@
-package io.envoyproxy.envoymobile.helloenvoykotlin
+package io.envoyproxy.envoymobile.helloenvoybaselinetest
 
 import io.envoyproxy.envoymobile.AsyncResponseFilter
 import io.envoyproxy.envoymobile.EnvoyError

--- a/test/kotlin/apps/baseline/BUILD
+++ b/test/kotlin/apps/baseline/BUILD
@@ -7,7 +7,7 @@ licenses(["notice"])  # Apache 2
 
 android_binary(
     name = "hello_envoy_kt",
-    custom_package = "io.envoyproxy.envoymobile.helloenvoykotlin",
+    custom_package = "io.envoyproxy.envoymobile.helloenvoybaselinetest",
     manifest = "AndroidManifest.xml",
     proguard_specs = ["//library:proguard_rules"],
     deps = [
@@ -23,7 +23,7 @@ kt_android_library(
         "DemoFilter.kt",
         "MainActivity.kt",
     ],
-    custom_package = "io.envoyproxy.envoymobile.helloenvoykotlin",
+    custom_package = "io.envoyproxy.envoymobile.helloenvoybaselinetest",
     manifest = "AndroidManifest.xml",
     resource_files = [
         "res/layout/activity_main.xml",

--- a/test/kotlin/apps/baseline/BufferDemoFilter.kt
+++ b/test/kotlin/apps/baseline/BufferDemoFilter.kt
@@ -1,4 +1,4 @@
-package io.envoyproxy.envoymobile.helloenvoykotlin
+package io.envoyproxy.envoymobile.helloenvoybaselinetest
 
 import io.envoyproxy.envoymobile.EnvoyError
 import io.envoyproxy.envoymobile.FilterDataStatus

--- a/test/kotlin/apps/baseline/DemoFilter.kt
+++ b/test/kotlin/apps/baseline/DemoFilter.kt
@@ -1,4 +1,4 @@
-package io.envoyproxy.envoymobile.helloenvoykotlin
+package io.envoyproxy.envoymobile.helloenvoybaselinetest
 
 import android.util.Log
 import io.envoyproxy.envoymobile.EnvoyError

--- a/test/kotlin/apps/baseline/MainActivity.kt
+++ b/test/kotlin/apps/baseline/MainActivity.kt
@@ -1,4 +1,4 @@
-package io.envoyproxy.envoymobile.helloenvoykotlin
+package io.envoyproxy.envoymobile.helloenvoybaselinetest
 
 import android.app.Activity
 import android.os.Bundle

--- a/test/kotlin/apps/baseline/tools/android-studio-run-configurations/run_configuration_example_debug_arm64.xml
+++ b/test/kotlin/apps/baseline/tools/android-studio-run-configurations/run_configuration_example_debug_arm64.xml
@@ -1,4 +1,4 @@
-<configuration name="Experimental Test App (Debug) [x86]"
+<configuration name="Baseline Test App (Debug) [arm64]"
     type="BlazeCommandRunConfigurationType"
     factoryName="Bazel Command"
     nameIsGenerated="false">
@@ -15,8 +15,8 @@
         show-logcat-automatically="false"
         AM_START_OPTIONS="">
         <blaze-user-flag>--config=dbg-android</blaze-user-flag>
-        <blaze-user-flag>--fat_apk_cpu=x86</blaze-user-flag>
-        <blaze-target>//test/kotlin/apps/experimental:hello_envoy_kt</blaze-target>
+        <blaze-user-flag>--fat_apk_cpu=arm64-v8a</blaze-user-flag>
+        <blaze-target>//test/kotlin/apps/baseline:hello_envoy_kt</blaze-target>
         <Profilers>
             <option name="ADVANCED_PROFILING_ENABLED"
                 value="false" />

--- a/test/kotlin/apps/baseline/tools/android-studio-run-configurations/run_configuration_example_debug_x86.xml
+++ b/test/kotlin/apps/baseline/tools/android-studio-run-configurations/run_configuration_example_debug_x86.xml
@@ -1,4 +1,4 @@
-<configuration name="Example App x86 (Debug)"
+<configuration name="Baseline Test App (Debug) [x86]"
     type="BlazeCommandRunConfigurationType"
     factoryName="Bazel Command"
     nameIsGenerated="false">
@@ -14,8 +14,9 @@
         use-work-profile-if-present="false"
         show-logcat-automatically="false"
         AM_START_OPTIONS="">
+        <blaze-user-flag>--config=dbg-android</blaze-user-flag>
         <blaze-user-flag>--fat_apk_cpu=x86</blaze-user-flag>
-        <blaze-target>//examples/kotlin/hello_world:hello_envoy_kt</blaze-target>
+        <blaze-target>//test/kotlin/apps/baseline:hello_envoy_kt</blaze-target>
         <Profilers>
             <option name="ADVANCED_PROFILING_ENABLED"
                 value="false" />

--- a/test/kotlin/apps/experimental/.bazelproject
+++ b/test/kotlin/apps/experimental/.bazelproject
@@ -7,13 +7,14 @@ directories:
   -bazel-testlogs
   -buck-out
   -build
-  examples/kotlin/hello_world
+  test/kotlin/apps/experimental
 
 import_run_configurations:
-  examples/kotlin/hello_world/tools/android-studio-run-configurations/run_configuration_example_debug_x86.xml
+  test/kotlin/apps/experimental/tools/android-studio-run-configurations/run_configuration_example_debug_x86.xml
+  test/kotlin/apps/experimental/tools/android-studio-run-configurations/run_configuration_example_debug_arm64.xml
 
 targets:
-  //examples/kotlin/hello_world:hello_envoy_kt
+  //test/kotlin/apps/experimental:hello_envoy_kt
 
 additional_languages:
   kotlin

--- a/test/kotlin/apps/experimental/AndroidManifest.xml
+++ b/test/kotlin/apps/experimental/AndroidManifest.xml
@@ -10,7 +10,7 @@
             android:targetSdkVersion="27"/>
 
     <application
-            android:label="Hello Envoy">
+            android:label="Hello Envoy Experimental Test">
         <activity
                 android:name=".MainActivity"
                 android:label="Hello Envoy Kotlin">

--- a/test/kotlin/apps/experimental/AndroidManifest.xml
+++ b/test/kotlin/apps/experimental/AndroidManifest.xml
@@ -1,5 +1,5 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
-          package="io.envoyproxy.envoymobile.helloenvoykotlin"
+          package="io.envoyproxy.envoymobile.helloenvoyexperimentaltest"
           android:versionCode="1"
           android:versionName="0.1">
     <uses-permission android:name="android.permission.INTERNET"/>
@@ -13,7 +13,7 @@
             android:label="Hello Envoy Experimental Test">
         <activity
                 android:name=".MainActivity"
-                android:label="Hello Envoy Kotlin">
+                android:label="Hello Envoy Experimental Test">
             <intent-filter>
                 <action android:name="android.intent.action.MAIN"/>
                 <category android:name="android.intent.category.LAUNCHER"/>

--- a/test/kotlin/apps/experimental/AsyncDemoFilter.kt
+++ b/test/kotlin/apps/experimental/AsyncDemoFilter.kt
@@ -1,4 +1,4 @@
-package io.envoyproxy.envoymobile.helloenvoykotlin
+package io.envoyproxy.envoymobile.helloenvoyexperimentaltest
 
 import io.envoyproxy.envoymobile.AsyncResponseFilter
 import io.envoyproxy.envoymobile.EnvoyError

--- a/test/kotlin/apps/experimental/BUILD
+++ b/test/kotlin/apps/experimental/BUILD
@@ -7,7 +7,7 @@ licenses(["notice"])  # Apache 2
 
 android_binary(
     name = "hello_envoy_kt",
-    custom_package = "io.envoyproxy.envoymobile.helloenvoykotlin",
+    custom_package = "io.envoyproxy.envoymobile.helloenvoyexperimentaltest",
     manifest = "AndroidManifest.xml",
     proguard_specs = ["//library:proguard_rules"],
     deps = [
@@ -23,7 +23,7 @@ kt_android_library(
         "DemoFilter.kt",
         "MainActivity.kt",
     ],
-    custom_package = "io.envoyproxy.envoymobile.helloenvoykotlin",
+    custom_package = "io.envoyproxy.envoymobile.helloenvoyexperimentaltest",
     manifest = "AndroidManifest.xml",
     resource_files = [
         "res/layout/activity_main.xml",

--- a/test/kotlin/apps/experimental/BufferDemoFilter.kt
+++ b/test/kotlin/apps/experimental/BufferDemoFilter.kt
@@ -1,4 +1,4 @@
-package io.envoyproxy.envoymobile.helloenvoykotlin
+package io.envoyproxy.envoymobile.helloenvoyexperimentaltest
 
 import io.envoyproxy.envoymobile.EnvoyError
 import io.envoyproxy.envoymobile.FilterDataStatus

--- a/test/kotlin/apps/experimental/DemoFilter.kt
+++ b/test/kotlin/apps/experimental/DemoFilter.kt
@@ -1,4 +1,4 @@
-package io.envoyproxy.envoymobile.helloenvoykotlin
+package io.envoyproxy.envoymobile.helloenvoyexperimentaltest
 
 import android.util.Log
 import io.envoyproxy.envoymobile.EnvoyError

--- a/test/kotlin/apps/experimental/MainActivity.kt
+++ b/test/kotlin/apps/experimental/MainActivity.kt
@@ -1,4 +1,4 @@
-package io.envoyproxy.envoymobile.helloenvoykotlin
+package io.envoyproxy.envoymobile.helloenvoyexperimentaltest
 
 import android.app.Activity
 import android.content.Context

--- a/test/kotlin/apps/experimental/tools/android-studio-run-configurations/run_configuration_example_debug_arm64.xml
+++ b/test/kotlin/apps/experimental/tools/android-studio-run-configurations/run_configuration_example_debug_arm64.xml
@@ -1,4 +1,4 @@
-<configuration name="Experimental Test App (Debug) [x86]"
+<configuration name="Experimental Test App (Debug) [arm64]"
     type="BlazeCommandRunConfigurationType"
     factoryName="Bazel Command"
     nameIsGenerated="false">
@@ -15,7 +15,7 @@
         show-logcat-automatically="false"
         AM_START_OPTIONS="">
         <blaze-user-flag>--config=dbg-android</blaze-user-flag>
-        <blaze-user-flag>--fat_apk_cpu=x86</blaze-user-flag>
+        <blaze-user-flag>--fat_apk_cpu=arm64-v8a</blaze-user-flag>
         <blaze-target>//test/kotlin/apps/experimental:hello_envoy_kt</blaze-target>
         <Profilers>
             <option name="ADVANCED_PROFILING_ENABLED"


### PR DESCRIPTION
Description: Make it easy to run all of the example apps. Previously it was possible to use Android Studio to run Kotlin example app. This PR adds support for: Java example app, baseline test example app and experimental test example app.
Risk Level: None, touches example apps only
Testing: Manual
Docs Changes: N/A
Release Notes: N/A

Signed-off-by: Rafal Augustyniak <raugustyniak@lyft.com>
