### PR TITLE
config: update stats regex

### DIFF
--- a/library/common/config/config.cc
+++ b/library/common/config/config.cc
@@ -484,7 +484,7 @@ stats_config:
         - safe_regex:
             regex: '^pulse.*'
         - safe_regex:
-            regex: '^vhost.*.vcluster\.[\w]+?\.upstream_rq_(?:[12345]xx|retry.*|time|timeout|total)'
+            regex: '^vhost\.[\w]+\.vcluster\.[\w]+?\.upstream_rq_(?:[12345]xx|retry.*|time|timeout|total)'
   use_all_default_tags:
     false
 watchdogs:

--- a/library/common/config/config.cc
+++ b/library/common/config/config.cc
@@ -484,7 +484,7 @@ stats_config:
         - safe_regex:
             regex: '^pulse.*'
         - safe_regex:
-            regex: '^vhost.api.vcluster\.[\w]+?\.upstream_rq_(?:[12345]xx|retry.*|time|timeout|total)'
+            regex: '^vhost.*.vcluster\.[\w]+?\.upstream_rq_(?:[12345]xx|retry.*|time|timeout|total)'
   use_all_default_tags:
     false
 watchdogs:


### PR DESCRIPTION
Description: The change is needed for EM to emit virtual cluster stats. It used to work but was broken as part of https://github.com/envoyproxy/envoy-mobile/issues/2530 where we increase the number of virtual hosts from 1 to 2 and changed the name of the existing virtual host (which used to be called `api`).
Risk Level: Low, enables additional instrumentation
Testing: Manual using admin interface and curling `stats` endpoint.
Docs Changes: N/A
Release Notes: N/A

Signed-off-by: Rafal Augustyniak <raugustyniak@lyft.com>
