### PR TITLE
key_value: Use known registered name to create global PlatformInterfaceImpl

### DIFF
--- a/library/common/api/external.cc
+++ b/library/common/api/external.cc
@@ -22,6 +22,8 @@ void registerApi(std::string name, void* api) {
 
 // TODO(goaway): This is not thread-safe, but the assumption here is that all writes will complete
 // before any reads occur.
+// TODO(alyssawilk, abeyad): gracefully handle the case where an Api by the given name is not
+// registered.
 void* retrieveApi(std::string name) {
   void* api = registry_[name];
   RELEASE_ASSERT(api != nullptr, fmt::format("{} not registered", name));

--- a/library/common/extensions/key_value/platform/config.cc
+++ b/library/common/extensions/key_value/platform/config.cc
@@ -12,7 +12,7 @@ namespace Envoy {
 namespace Extensions {
 namespace KeyValue {
 
-class PlatformInterfaceImpl : PlatformInterface, public Logger::Loggable<Logger::Id::filter> {
+class PlatformInterfaceImpl : public PlatformInterface, public Logger::Loggable<Logger::Id::filter> {
 public:
   PlatformInterfaceImpl(const std::string& name)
       : bridged_store_(*static_cast<envoy_kv_store*>(Api::External::retrieveApi(name))) {}
@@ -35,13 +35,13 @@ private:
   envoy_kv_store bridged_store_;
 };
 
-PlatformKeyValueStore::PlatformKeyValueStore(Event::Dispatcher& dispatcher,
-                                             std::chrono::milliseconds save_interval,
-                                             PlatformInterface& platform_interface,
-                                             uint64_t max_entries, const std::string& key)
+PlatformKeyValueStore::PlatformKeyValueStore(
+    Event::Dispatcher& dispatcher, std::chrono::milliseconds save_interval,
+    std::unique_ptr<PlatformInterface>&& platform_interface, uint64_t max_entries,
+    const std::string& key)
     : KeyValueStoreBase(dispatcher, save_interval, max_entries),
-      platform_interface_(platform_interface), key_(key) {
-  const std::string contents = platform_interface.read(key);
+      platform_interface_(std::move(platform_interface)), key_(key) {
+  const std::string contents = platform_interface_->read(key);
   if (!parseContents(contents)) {
     ENVOY_LOG(warn, "Failed to parse key value store contents {}", key);
   }
@@ -53,7 +53,7 @@ void PlatformKeyValueStore::flush() {
     absl::StrAppend(&output, it.first.length(), "\n", it.first, it.second.length(), "\n",
                     it.second);
   }
-  platform_interface_.save(key_, output);
+  platform_interface_->save(key_, output);
 }
 
 KeyValueStorePtr
@@ -63,14 +63,16 @@ PlatformKeyValueStoreFactory::createStore(const Protobuf::Message& config,
   const auto& typed_config = MessageUtil::downcastAndValidate<
       const ::envoy::config::common::key_value::v3::KeyValueStoreConfig&>(config,
                                                                           validation_visitor);
-  const auto file_config = MessageUtil::anyConvertAndValidate<
+  const auto platform_kv_store_config = MessageUtil::anyConvertAndValidate<
       envoymobile::extensions::key_value::platform::PlatformKeyValueStoreConfig>(
       typed_config.config().typed_config(), validation_visitor);
-  auto milliseconds =
-      std::chrono::milliseconds(DurationUtil::durationToMilliseconds(file_config.save_interval()));
-  return std::make_unique<PlatformKeyValueStore>(dispatcher, milliseconds,
-                                                 platform_interface_.value().get(),
-                                                 file_config.max_entries(), file_config.key());
+  auto milliseconds = std::chrono::milliseconds(
+      DurationUtil::durationToMilliseconds(platform_kv_store_config.save_interval()));
+  std::unique_ptr<PlatformInterface> platform_interface =
+      std::make_unique<PlatformInterfaceImpl>(platform_kv_store_config.kv_store_name());
+  return std::make_unique<PlatformKeyValueStore>(
+      dispatcher, milliseconds, std::move(platform_interface),
+      platform_kv_store_config.max_entries(), platform_kv_store_config.key());
 }
 
 REGISTER_FACTORY(PlatformKeyValueStoreFactory, KeyValueStoreFactory);

--- a/library/common/extensions/key_value/platform/config.cc
+++ b/library/common/extensions/key_value/platform/config.cc
@@ -12,7 +12,8 @@ namespace Envoy {
 namespace Extensions {
 namespace KeyValue {
 
-class PlatformInterfaceImpl : public PlatformInterface, public Logger::Loggable<Logger::Id::filter> {
+class PlatformInterfaceImpl : public PlatformInterface,
+                              public Logger::Loggable<Logger::Id::filter> {
 public:
   PlatformInterfaceImpl(const std::string& name)
       : bridged_store_(*static_cast<envoy_kv_store*>(Api::External::retrieveApi(name))) {}

--- a/library/common/extensions/key_value/platform/config.cc
+++ b/library/common/extensions/key_value/platform/config.cc
@@ -13,8 +13,8 @@ namespace Extensions {
 namespace KeyValue {
 
 namespace {
+
 constexpr absl::string_view PlatformStoreName{"reserved.platform_store"};
-} // namespace
 
 class PlatformInterfaceImpl : public PlatformInterface,
                               public Logger::Loggable<Logger::Id::filter> {
@@ -38,16 +38,23 @@ public:
   }
 
 private:
-  envoy_kv_store bridged_store_;
+  envoy_kv_store& bridged_store_;
 };
 
-PlatformKeyValueStore::PlatformKeyValueStore(
-    Event::Dispatcher& dispatcher, std::chrono::milliseconds save_interval,
-    std::unique_ptr<PlatformInterface>&& platform_interface, uint64_t max_entries,
-    const std::string& key)
+PlatformInterfaceImpl& getPlatformInterfaceImplSingleton() {
+  static PlatformInterfaceImpl impl = PlatformInterfaceImpl();
+  return impl;
+}
+
+} // namespace
+
+PlatformKeyValueStore::PlatformKeyValueStore(Event::Dispatcher& dispatcher,
+                                             std::chrono::milliseconds save_interval,
+                                             PlatformInterface& platform_interface,
+                                             uint64_t max_entries, const std::string& key)
     : KeyValueStoreBase(dispatcher, save_interval, max_entries),
-      platform_interface_(std::move(platform_interface)), key_(key) {
-  const std::string contents = platform_interface_->read(key);
+      platform_interface_(platform_interface), key_(key) {
+  const std::string contents = platform_interface_.read(key);
   if (!parseContents(contents)) {
     ENVOY_LOG(warn, "Failed to parse key value store contents {}", key);
   }
@@ -59,7 +66,7 @@ void PlatformKeyValueStore::flush() {
     absl::StrAppend(&output, it.first.length(), "\n", it.first, it.second.length(), "\n",
                     it.second);
   }
-  platform_interface_->save(key_, output);
+  platform_interface_.save(key_, output);
 }
 
 KeyValueStorePtr
@@ -74,9 +81,8 @@ PlatformKeyValueStoreFactory::createStore(const Protobuf::Message& config,
       typed_config.config().typed_config(), validation_visitor);
   auto milliseconds = std::chrono::milliseconds(
       DurationUtil::durationToMilliseconds(platform_kv_store_config.save_interval()));
-  std::unique_ptr<PlatformInterface> platform_interface = std::make_unique<PlatformInterfaceImpl>();
   return std::make_unique<PlatformKeyValueStore>(
-      dispatcher, milliseconds, std::move(platform_interface),
+      dispatcher, milliseconds, getPlatformInterfaceImplSingleton(),
       platform_kv_store_config.max_entries(), platform_kv_store_config.key());
 }
 

--- a/library/common/extensions/key_value/platform/config.cc
+++ b/library/common/extensions/key_value/platform/config.cc
@@ -12,11 +12,16 @@ namespace Envoy {
 namespace Extensions {
 namespace KeyValue {
 
+namespace {
+constexpr absl::string_view PlatformStoreName{"reserved.platform_store"};
+} // namespace
+
 class PlatformInterfaceImpl : public PlatformInterface,
                               public Logger::Loggable<Logger::Id::filter> {
 public:
-  PlatformInterfaceImpl(const std::string& name)
-      : bridged_store_(*static_cast<envoy_kv_store*>(Api::External::retrieveApi(name))) {}
+  PlatformInterfaceImpl()
+      : bridged_store_(*static_cast<envoy_kv_store*>(
+            Api::External::retrieveApi(std::string(PlatformStoreName)))) {}
 
   ~PlatformInterfaceImpl() override {}
 
@@ -69,8 +74,7 @@ PlatformKeyValueStoreFactory::createStore(const Protobuf::Message& config,
       typed_config.config().typed_config(), validation_visitor);
   auto milliseconds = std::chrono::milliseconds(
       DurationUtil::durationToMilliseconds(platform_kv_store_config.save_interval()));
-  std::unique_ptr<PlatformInterface> platform_interface =
-      std::make_unique<PlatformInterfaceImpl>(platform_kv_store_config.kv_store_name());
+  std::unique_ptr<PlatformInterface> platform_interface = std::make_unique<PlatformInterfaceImpl>();
   return std::make_unique<PlatformKeyValueStore>(
       dispatcher, milliseconds, std::move(platform_interface),
       platform_kv_store_config.max_entries(), platform_kv_store_config.key());

--- a/library/common/extensions/key_value/platform/config.h
+++ b/library/common/extensions/key_value/platform/config.h
@@ -32,8 +32,6 @@ public:
   void flush() override;
 
 private:
-  // TODO(alyssawilk, goaway) the default PlatformInterface should do up calls through Java and this
-  // can be moved to a non-optional reference.
   PlatformInterface& platform_interface_;
   const std::string key_;
 };

--- a/library/common/extensions/key_value/platform/config.h
+++ b/library/common/extensions/key_value/platform/config.h
@@ -26,15 +26,15 @@ public:
 class PlatformKeyValueStore : public KeyValueStoreBase {
 public:
   PlatformKeyValueStore(Event::Dispatcher& dispatcher, std::chrono::milliseconds save_interval,
-                        std::unique_ptr<PlatformInterface>&& platform_interface,
-                        uint64_t max_entries, const std::string& key);
+                        PlatformInterface& platform_interface, uint64_t max_entries,
+                        const std::string& key);
   // KeyValueStore
   void flush() override;
 
 private:
   // TODO(alyssawilk, goaway) the default PlatformInterface should do up calls through Java and this
   // can be moved to a non-optional reference.
-  std::unique_ptr<PlatformInterface> platform_interface_;
+  PlatformInterface& platform_interface_;
   const std::string key_;
 };
 

--- a/library/common/extensions/key_value/platform/platform.proto
+++ b/library/common/extensions/key_value/platform/platform.proto
@@ -15,4 +15,8 @@ message PlatformKeyValueStoreConfig {
 
   // The maximum number of entries that can be stored in the cache.
   uint64 max_entries = 3;
+
+  // Platform key-value store name. This is the name of the KV store registered via the
+  // addKeyValueStore builder API.
+  string kv_store_name = 4 [(validate.rules).string = {min_len: 1}];
 }

--- a/library/common/extensions/key_value/platform/platform.proto
+++ b/library/common/extensions/key_value/platform/platform.proto
@@ -15,8 +15,4 @@ message PlatformKeyValueStoreConfig {
 
   // The maximum number of entries that can be stored in the cache.
   uint64 max_entries = 3;
-
-  // Platform key-value store name. This is the name of the KV store registered via the
-  // addKeyValueStore builder API.
-  string kv_store_name = 4 [(validate.rules).string = {min_len: 1}];
 }

--- a/test/common/extensions/key_value/platform/platform_store_test.cc
+++ b/test/common/extensions/key_value/platform/platform_store_test.cc
@@ -17,8 +17,6 @@ namespace {
 
 class TestPlatformInterface : public PlatformInterface {
 public:
-  TestPlatformInterface(absl::flat_hash_map<std::string, std::string>& store) : store_(store) {}
-
   virtual void save(const std::string& key, const std::string& contents) override {
     store_.erase(key);
     store_.emplace(key, contents);
@@ -33,7 +31,7 @@ public:
   }
 
 private:
-  absl::flat_hash_map<std::string, std::string>& store_;
+  absl::flat_hash_map<std::string, std::string> store_;
 };
 
 class PlatformStoreTest : public testing::Test {
@@ -42,9 +40,7 @@ protected:
 
   void createStore() {
     flush_timer_ = new NiceMock<Event::MockTimer>(&dispatcher_);
-    auto mock_platform = std::make_unique<TestPlatformInterface>(kv_backing_store_);
-    store_ = std::make_unique<PlatformKeyValueStore>(dispatcher_, save_interval_,
-                                                     std::move(mock_platform),
+    store_ = std::make_unique<PlatformKeyValueStore>(dispatcher_, save_interval_, mock_platform_,
                                                      std::numeric_limits<uint64_t>::max(), key_);
   }
   NiceMock<Event::MockDispatcher> dispatcher_;
@@ -52,7 +48,7 @@ protected:
   std::unique_ptr<PlatformKeyValueStore> store_{};
   std::chrono::seconds save_interval_{5};
   Event::MockTimer* flush_timer_ = nullptr;
-  absl::flat_hash_map<std::string, std::string> kv_backing_store_;
+  TestPlatformInterface mock_platform_;
 };
 
 TEST_F(PlatformStoreTest, Basic) {


### PR DESCRIPTION
The PlatformKeyValueStoreFactory used to take a PlatformInterfaceImpl where the registered KV store was found in the API registry and used to bridge the PlatformKeyValueStore with the native underlying store (e.g. SharedPrefs on Android).

However, registered factory classes only have their default constructor invoked, so the current PlatformKeyValueStoreFactory constructor taking in the PlatformInterfaceImpl would not have worked.

Instead, we use a globally known registered API name to fetch the registered KV store, and use it to create a static global PlatformInstanceImpl.

Signed-off-by: Ali Beyad <abeyad@google.com>