### PR TITLE
prefer using onEngineRunning over setLogger

### DIFF
--- a/test/kotlin/integration/EngineApiTest.kt
+++ b/test/kotlin/integration/EngineApiTest.kt
@@ -30,7 +30,7 @@ class EngineApiTest {
     engine = EngineBuilder()
       .addLogLevel(LogLevel.INFO)
       .addStatsFlushSeconds(1)
-      .onEngineRunning { countDownLatch.countDown() }
+      .setOnEngineRunning { countDownLatch.countDown() }
       .build()
 
     assertThat(countDownLatch.await(30, TimeUnit.SECONDS)).isTrue()

--- a/test/kotlin/integration/EngineApiTest.kt
+++ b/test/kotlin/integration/EngineApiTest.kt
@@ -30,11 +30,7 @@ class EngineApiTest {
     engine = EngineBuilder()
       .addLogLevel(LogLevel.INFO)
       .addStatsFlushSeconds(1)
-      .setLogger { msg ->
-        if (msg.contains("starting main dispatch loop")) {
-          countDownLatch.countDown()
-        }
-      }
+      .onEngineRunning { countDownLatch.countDown() }
       .build()
 
     assertThat(countDownLatch.await(30, TimeUnit.SECONDS)).isTrue()

--- a/test/kotlin/integration/StatFlushIntegrationTest.kt
+++ b/test/kotlin/integration/StatFlushIntegrationTest.kt
@@ -30,11 +30,7 @@ class StatFlushIntegrationTest {
     engine = EngineBuilder()
       .addLogLevel(LogLevel.INFO)
       .addStatsFlushSeconds(1)
-      .setLogger { msg ->
-        if (msg.contains("starting main dispatch loop")) {
-          countDownLatch.countDown()
-        }
-      }
+      .onEngineRunning { countDownLatch.countDown() }
       .build()
 
     assertThat(countDownLatch.await(30, TimeUnit.SECONDS)).isTrue()
@@ -56,11 +52,7 @@ class StatFlushIntegrationTest {
       .addStatsDPort(8125)
       // Really high flush interval so it won't trigger during test execution.
       .addStatsFlushSeconds(100)
-      .setLogger { msg ->
-        if (msg.contains("starting main dispatch loop")) {
-          countDownLatch.countDown()
-        }
-      }
+      .onEngineRunning { countDownLatch.countDown() }
       .build()
 
     assertThat(countDownLatch.await(30, TimeUnit.SECONDS)).isTrue()

--- a/test/kotlin/integration/StatFlushIntegrationTest.kt
+++ b/test/kotlin/integration/StatFlushIntegrationTest.kt
@@ -30,7 +30,7 @@ class StatFlushIntegrationTest {
     engine = EngineBuilder()
       .addLogLevel(LogLevel.INFO)
       .addStatsFlushSeconds(1)
-      .onEngineRunning { countDownLatch.countDown() }
+      .setOnEngineRunning { countDownLatch.countDown() }
       .build()
 
     assertThat(countDownLatch.await(30, TimeUnit.SECONDS)).isTrue()
@@ -52,7 +52,7 @@ class StatFlushIntegrationTest {
       .addStatsDPort(8125)
       // Really high flush interval so it won't trigger during test execution.
       .addStatsFlushSeconds(100)
-      .onEngineRunning { countDownLatch.countDown() }
+      .setOnEngineRunning { countDownLatch.countDown() }
       .build()
 
     assertThat(countDownLatch.await(30, TimeUnit.SECONDS)).isTrue()


### PR DESCRIPTION
Using setLogger ends up routing all the logs to the callback, which drastically reduces visibility into why the test is failing. This moves tests that aren't specifically testing the logging callback to use the startup callback instead. 

Risk Level:  Low, test only
Testing: n/a
Docs Changes: n/a
Release Notes: n/a
