### PR TITLE
support configuring multiple stat sinks

### DIFF
--- a/library/common/config/config.cc
+++ b/library/common/config/config.cc
@@ -115,8 +115,6 @@ R"(- &enable_drain_post_dns_refresh false
 - &stats_domain 127.0.0.1
 - &stats_flush_interval 60s
 - &stats_sinks []
-- &statsd_host 127.0.0.1
-- &statsd_port 8125
 - &stream_idle_timeout 15s
 - &per_try_idle_timeout 15s
 - &trust_chain_verification VERIFY_TRUST_CHAIN
@@ -133,12 +131,6 @@ R"(- &enable_drain_post_dns_refresh false
       grpc_service:
         envoy_grpc:
           cluster_name: stats
-  base_statsd: &base_statsd
-    name: envoy.stat_sinks.statsd
-    typed_config:
-      "@type": type.googleapis.com/envoy.config.metrics.v3.StatsdSink
-      address:
-        socket_address: { address: *statsd_host, port_value: *statsd_port }
 
 !ignore admin_interface_defs: &admin_interface
     address:

--- a/library/java/io/envoyproxy/envoymobile/engine/EnvoyConfiguration.java
+++ b/library/java/io/envoyproxy/envoymobile/engine/EnvoyConfiguration.java
@@ -1,6 +1,7 @@
 package io.envoyproxy.envoymobile.engine;
 
 import java.util.List;
+import java.util.ArrayList;
 import java.util.Map;
 import java.util.regex.Pattern;
 import java.util.regex.Matcher;
@@ -26,7 +27,6 @@ public class EnvoyConfiguration {
 
   public final Boolean adminInterfaceEnabled;
   public final String grpcStatsDomain;
-  public final Integer statsdPort;
   public final Integer connectTimeoutSeconds;
   public final Integer dnsRefreshSeconds;
   public final Integer dnsFailureRefreshSecondsBase;
@@ -60,6 +60,7 @@ public class EnvoyConfiguration {
   public final List<EnvoyNativeFilterConfig> nativeFilterChain;
   public final Map<String, EnvoyStringAccessor> stringAccessors;
   public final Map<String, EnvoyKeyValueStore> keyValueStores;
+  public final List<String> statSinks;
 
   private static final Pattern UNRESOLVED_KEY_PATTERN = Pattern.compile("\\{\\{ (.+) \\}\\}");
 
@@ -107,25 +108,23 @@ public class EnvoyConfiguration {
    * @param keyValueStores               platform key-value store implementations.
    */
   public EnvoyConfiguration(
-      boolean adminInterfaceEnabled, String grpcStatsDomain, @Nullable Integer statsdPort,
-      int connectTimeoutSeconds, int dnsRefreshSeconds, int dnsFailureRefreshSecondsBase,
-      int dnsFailureRefreshSecondsMax, int dnsQueryTimeoutSeconds, int dnsMinRefreshSeconds,
-      String dnsPreresolveHostnames, List<String> dnsFallbackNameservers,
-      boolean dnsFilterUnroutableFamilies, boolean dnsUseSystemResolver,
-      boolean enableDrainPostDnsRefresh, boolean enableHttp3, boolean enableGzip,
-      boolean enableBrotli, boolean enableSocketTagging, boolean enableHappyEyeballs,
-      boolean enableInterfaceBinding, int h2ConnectionKeepaliveIdleIntervalMilliseconds,
-      int h2ConnectionKeepaliveTimeoutSeconds, boolean h2ExtendKeepaliveTimeout,
-      List<String> h2RawDomains, int maxConnectionsPerHost, int statsFlushSeconds,
-      int streamIdleTimeoutSeconds, int perTryIdleTimeoutSeconds, String appVersion, String appId,
-      TrustChainVerification trustChainVerification, String virtualClusters,
-      List<EnvoyNativeFilterConfig> nativeFilterChain,
+      boolean adminInterfaceEnabled, String grpcStatsDomain, int connectTimeoutSeconds,
+      int dnsRefreshSeconds, int dnsFailureRefreshSecondsBase, int dnsFailureRefreshSecondsMax,
+      int dnsQueryTimeoutSeconds, int dnsMinRefreshSeconds, String dnsPreresolveHostnames,
+      List<String> dnsFallbackNameservers, boolean dnsFilterUnroutableFamilies,
+      boolean dnsUseSystemResolver, boolean enableDrainPostDnsRefresh, boolean enableHttp3,
+      boolean enableGzip, boolean enableBrotli, boolean enableSocketTagging,
+      boolean enableHappyEyeballs, boolean enableInterfaceBinding,
+      int h2ConnectionKeepaliveIdleIntervalMilliseconds, int h2ConnectionKeepaliveTimeoutSeconds,
+      boolean h2ExtendKeepaliveTimeout, List<String> h2RawDomains, int maxConnectionsPerHost,
+      int statsFlushSeconds, int streamIdleTimeoutSeconds, int perTryIdleTimeoutSeconds,
+      String appVersion, String appId, TrustChainVerification trustChainVerification,
+      String virtualClusters, List<EnvoyNativeFilterConfig> nativeFilterChain,
       List<EnvoyHTTPFilterFactory> httpPlatformFilterFactories,
       Map<String, EnvoyStringAccessor> stringAccessors,
-      Map<String, EnvoyKeyValueStore> keyValueStores) {
+      Map<String, EnvoyKeyValueStore> keyValueStores, List<String> statSinks) {
     this.adminInterfaceEnabled = adminInterfaceEnabled;
     this.grpcStatsDomain = grpcStatsDomain;
-    this.statsdPort = statsdPort;
     this.connectTimeoutSeconds = connectTimeoutSeconds;
     this.dnsRefreshSeconds = dnsRefreshSeconds;
     this.dnsFailureRefreshSecondsBase = dnsFailureRefreshSecondsBase;
@@ -160,6 +159,7 @@ public class EnvoyConfiguration {
     this.httpPlatformFilterFactories = httpPlatformFilterFactories;
     this.stringAccessors = stringAccessors;
     this.keyValueStores = keyValueStores;
+    this.statSinks = statSinks;
   }
 
   /**
@@ -287,16 +287,18 @@ public class EnvoyConfiguration {
         .append(virtualClusters)
         .append("\n");
 
-    // TODO(goaway): enable support for both types of sinks, since it's now much easier.
-    if (statsdPort != null && grpcStatsDomain != null) {
-      throw new ConfigurationException("cannot enable both statsD and gRPC metrics sink");
-    } else if (grpcStatsDomain != null) {
+    configBuilder.append(String.format("- &stats_flush_interval %ss\n", statsFlushSeconds));
+
+    List<String> stat_sinks_config = new ArrayList<>(statSinks);
+    if (grpcStatsDomain != null) {
+      stat_sinks_config.add("*base_metrics_service");
       configBuilder.append("- &stats_domain ").append(grpcStatsDomain).append("\n");
-      configBuilder.append(String.format("- &stats_flush_interval %ss\n", statsFlushSeconds));
-      configBuilder.append("- &stats_sinks [ *base_metrics_service ]\n");
-    } else if (statsdPort != null) {
-      configBuilder.append("- &statsd_port ").append(statsdPort).append("\n");
-      configBuilder.append("- &stats_sinks [ *base_statsd ]\n");
+    }
+
+    if (!stat_sinks_config.isEmpty()) {
+      configBuilder.append("- &stats_sinks [");
+      configBuilder.append(String.join(",", stat_sinks_config));
+      configBuilder.append("] \n");
     }
 
     if (adminInterfaceEnabled) {

--- a/library/java/org/chromium/net/impl/NativeCronetEngineBuilderImpl.java
+++ b/library/java/org/chromium/net/impl/NativeCronetEngineBuilderImpl.java
@@ -33,7 +33,6 @@ public class NativeCronetEngineBuilderImpl extends CronetEngineBuilderImpl {
   private final EnvoyEventTracker mEnvoyEventTracker = null;
   private boolean mAdminInterfaceEnabled = false;
   private String mGrpcStatsDomain = null;
-  private Integer mStatsDPort = null;
   private int mConnectTimeoutSeconds = 30;
   private int mDnsRefreshSeconds = 60;
   private int mDnsFailureRefreshSecondsBase = 2;
@@ -100,21 +99,21 @@ public class NativeCronetEngineBuilderImpl extends CronetEngineBuilderImpl {
 
   private EnvoyConfiguration createEnvoyConfiguration() {
     List<EnvoyHTTPFilterFactory> platformFilterChain = Collections.emptyList();
-    List<EnvoyNativeFilterConfig> nativeFilterChain = new ArrayList<>();
+    List<EnvoyNativeFilterConfig> nativeFilterChain = Collections.emptyList();
     Map<String, EnvoyStringAccessor> stringAccessors = Collections.emptyMap();
     Map<String, EnvoyKeyValueStore> keyValueStores = Collections.emptyMap();
+    List<String> statSinks = Collections.emptyList();
 
     return new EnvoyConfiguration(
-        mAdminInterfaceEnabled, mGrpcStatsDomain, mStatsDPort, mConnectTimeoutSeconds,
-        mDnsRefreshSeconds, mDnsFailureRefreshSecondsBase, mDnsFailureRefreshSecondsMax,
-        mDnsQueryTimeoutSeconds, mDnsMinRefreshSeconds, mDnsPreresolveHostnames,
-        mDnsFallbackNameservers, mEnableDnsFilterUnroutableFamilies, mDnsUseSystemResolver,
-        mEnableDrainPostDnsRefresh, quicEnabled(), mEnableGzip, brotliEnabled(), mEnableSocketTag,
-        mEnableHappyEyeballs, mEnableInterfaceBinding,
-        mH2ConnectionKeepaliveIdleIntervalMilliseconds, mH2ConnectionKeepaliveTimeoutSeconds,
-        mH2ExtendKeepaliveTimeout, mH2RawDomains, mMaxConnectionsPerHost, mStatsFlushSeconds,
-        mStreamIdleTimeoutSeconds, mPerTryIdleTimeoutSeconds, mAppVersion, mAppId,
-        mTrustChainVerification, mVirtualClusters, nativeFilterChain, platformFilterChain,
-        stringAccessors, keyValueStores);
+        mAdminInterfaceEnabled, mGrpcStatsDomain, mConnectTimeoutSeconds, mDnsRefreshSeconds,
+        mDnsFailureRefreshSecondsBase, mDnsFailureRefreshSecondsMax, mDnsQueryTimeoutSeconds,
+        mDnsMinRefreshSeconds, mDnsPreresolveHostnames, mDnsFallbackNameservers,
+        mEnableDnsFilterUnroutableFamilies, mDnsUseSystemResolver, mEnableDrainPostDnsRefresh,
+        quicEnabled(), mEnableGzip, brotliEnabled(), mEnableSocketTag, mEnableHappyEyeballs,
+        mEnableInterfaceBinding, mH2ConnectionKeepaliveIdleIntervalMilliseconds,
+        mH2ConnectionKeepaliveTimeoutSeconds, mH2ExtendKeepaliveTimeout, mH2RawDomains,
+        mMaxConnectionsPerHost, mStatsFlushSeconds, mStreamIdleTimeoutSeconds,
+        mPerTryIdleTimeoutSeconds, mAppVersion, mAppId, mTrustChainVerification, mVirtualClusters,
+        nativeFilterChain, platformFilterChain, stringAccessors, keyValueStores, statSinks);
   }
 }

--- a/library/kotlin/io/envoyproxy/envoymobile/EngineBuilder.kt
+++ b/library/kotlin/io/envoyproxy/envoymobile/EngineBuilder.kt
@@ -91,7 +91,7 @@ open class EngineBuilder(
   }
 
   /**
-   * Specifies the the domain (e.g. `example.com`) to use in the default gRPC stat sink to flush
+   * Specifies the domain (e.g. `example.com`) to use in the default gRPC stat sink to flush
    * stats.
    *
    * Setting this value enables the gRPC stat sink, which periodically flushes stats via the gRPC

--- a/library/kotlin/io/envoyproxy/envoymobile/EngineBuilder.kt
+++ b/library/kotlin/io/envoyproxy/envoymobile/EngineBuilder.kt
@@ -76,7 +76,7 @@ open class EngineBuilder(
   private var nativeFilterChain = mutableListOf<EnvoyNativeFilterConfig>()
   private var stringAccessors = mutableMapOf<String, EnvoyStringAccessor>()
   private var keyValueStores = mutableMapOf<String, EnvoyKeyValueStore>()
-  private var statSinks = listOf<String>()
+  private var statsSinks = listOf<String>()
 
   /**
    * Add a log level to use with Envoy.
@@ -91,7 +91,8 @@ open class EngineBuilder(
   }
 
   /**
-   * Specifies the the domain (e.g. `example.com`) to use in the default gRPC stat sink to flush stats.
+   * Specifies the the domain (e.g. `example.com`) to use in the default gRPC stat sink to flush
+   * stats.
    *
    * Setting this value enables the gRPC stat sink, which periodically flushes stats via the gRPC
    * MetricsService API. The flush interval is specified via addStatsFlushSeconds.
@@ -114,8 +115,8 @@ open class EngineBuilder(
    *
    * @return this builder.
    */
-  fun addStatsSinks(statSinks: List<String>): EngineBuilder {
-    this.statSinks = statSinks
+  fun addStatsSinks(statsSinks: List<String>): EngineBuilder {
+    this.statsSinks = statsSinks
     return this
   }
 
@@ -648,7 +649,7 @@ open class EngineBuilder(
       platformFilterChain,
       stringAccessors,
       keyValueStores,
-      statSinks
+      statsSinks
     )
 
     return when (configuration) {

--- a/library/kotlin/io/envoyproxy/envoymobile/EngineBuilder.kt
+++ b/library/kotlin/io/envoyproxy/envoymobile/EngineBuilder.kt
@@ -43,7 +43,6 @@ open class EngineBuilder(
   private var logLevel = LogLevel.INFO
   private var adminInterfaceEnabled = false
   private var grpcStatsDomain: String? = null
-  private var statsDPort: Int? = null
   private var connectTimeoutSeconds = 30
   private var dnsRefreshSeconds = 60
   private var dnsFailureRefreshSecondsBase = 2
@@ -77,6 +76,7 @@ open class EngineBuilder(
   private var nativeFilterChain = mutableListOf<EnvoyNativeFilterConfig>()
   private var stringAccessors = mutableMapOf<String, EnvoyStringAccessor>()
   private var keyValueStores = mutableMapOf<String, EnvoyKeyValueStore>()
+  private var statSinks = listOf<String>()
 
   /**
    * Add a log level to use with Envoy.
@@ -91,12 +91,12 @@ open class EngineBuilder(
   }
 
   /**
-   * Add a domain to flush stats to.
-   * Passing nil disables stats emission via the gRPC stat sink.
+   * Specifies the the domain (e.g. `example.com`) to use in the default gRPC stat sink to flush stats.
    *
-   * Only one of the statsd and gRPC stat sink can be enabled.
+   * Setting this value enables the gRPC stat sink, which periodically flushes stats via the gRPC
+   * MetricsService API. The flush interval is specified via addStatsFlushSeconds.
    *
-   * @param grpcStatsDomain The domain to use for stats.
+   * @param grpcStatsDomain The domain to use for the gRPC stats sink.
    *
    * @return this builder.
    */
@@ -106,17 +106,16 @@ open class EngineBuilder(
   }
 
   /**
-   * Add a loopback port to emit statsD stats to.
-   * Passing nil disables stats emission via the statsD stat sink.
+   * Adds additional stats sinks, in the form of the raw YAML/JSON configuration.
+   * Sinks added in this fashion will be included in addition to the gRPC stats sink
+   * that may be enabled via addGrpcStatsDomain.
    *
-   * Only one of the statsD and gRPC stat sink can be enabled.
-   *
-   * @param port The port to send statsD UDP packets to via loopback
+   * @param statsSinks Configurations of stat sinks to add.
    *
    * @return this builder.
    */
-  fun addStatsDPort(port: Int): EngineBuilder {
-    this.statsDPort = port
+  fun addStatsSinks(statSinks: List<String>): EngineBuilder {
+    this.statSinks = statSinks
     return this
   }
 
@@ -616,7 +615,6 @@ open class EngineBuilder(
     val engineConfiguration = EnvoyConfiguration(
       adminInterfaceEnabled,
       grpcStatsDomain,
-      statsDPort,
       connectTimeoutSeconds,
       dnsRefreshSeconds,
       dnsFailureRefreshSecondsBase,
@@ -649,7 +647,8 @@ open class EngineBuilder(
       nativeFilterChain,
       platformFilterChain,
       stringAccessors,
-      keyValueStores
+      keyValueStores,
+      statSinks
     )
 
     return when (configuration) {

--- a/library/objective-c/EnvoyEngine.h
+++ b/library/objective-c/EnvoyEngine.h
@@ -379,6 +379,7 @@ extern const int kEnvoyFilterResumeStatusResumeIteration;
 @property (nonatomic, strong) NSArray<EnvoyHTTPFilterFactory *> *httpPlatformFilterFactories;
 @property (nonatomic, strong) NSDictionary<NSString *, EnvoyStringAccessor *> *stringAccessors;
 @property (nonatomic, strong) NSDictionary<NSString *, id<EnvoyKeyValueStore>> *keyValueStores;
+@property (nonatomic, strong) NSArray<NSString *> *statsSinks;
 
 /**
  Create a new instance of the configuration.
@@ -422,7 +423,8 @@ extern const int kEnvoyFilterResumeStatusResumeIteration;
                                           stringAccessors
                                    keyValueStores:
                                        (NSDictionary<NSString *, id<EnvoyKeyValueStore>> *)
-                                           keyValueStores;
+                                           keyValueStores
+                                       statsSinks:(NSArray<NSString *> *)statsSinks;
 
 /**
  Resolves the provided configuration template using properties on this configuration.

--- a/library/swift/EngineBuilder.swift
+++ b/library/swift/EngineBuilder.swift
@@ -49,6 +49,7 @@ open class EngineBuilder: NSObject {
   private var stringAccessors: [String: EnvoyStringAccessor] = [:]
   private var keyValueStores: [String: EnvoyKeyValueStore] = [:]
   private var directResponses: [DirectResponse] = []
+  private var statsSinks: [String] = []
 
   // MARK: - Public
 
@@ -74,6 +75,19 @@ open class EngineBuilder: NSObject {
   @discardableResult
   public func addGrpcStatsDomain(_ grpcStatsDomain: String?) -> Self {
     self.grpcStatsDomain = grpcStatsDomain
+    return self
+  }
+
+  /// Adds additional stats sink, in the form of the raw YAML/JSON configuration.
+  /// Sinks added in this fashion will be included in addition to the gRPC stats sink
+  /// that may be enabled via addGrpcStatsDomain.
+  ///
+  /// - parameter statsSinks: Configurations of stat sinks to add.
+  ///
+  /// - returns: This builder.
+  @discardableResult
+  public func addStatsSinks(_ statsSinks: [String]) -> Self {
+    self.statsSinks = statsSinks
     return self
   }
 
@@ -541,7 +555,8 @@ open class EngineBuilder: NSObject {
       nativeFilterChain: self.nativeFilterChain,
       platformFilterChain: self.platformFilterChain,
       stringAccessors: self.stringAccessors,
-      keyValueStores: self.keyValueStores
+      keyValueStores: self.keyValueStores,
+      statsSinks: self.statsSinks
     )
 
     switch self.base {

--- a/test/java/io/envoyproxy/envoymobile/engine/EnvoyConfigurationTest.kt
+++ b/test/java/io/envoyproxy/envoymobile/engine/EnvoyConfigurationTest.kt
@@ -49,7 +49,6 @@ class EnvoyConfigurationTest {
   fun buildTestEnvoyConfiguration(
     adminInterfaceEnabled: Boolean = false,
     grpcStatsDomain: String = "stats.example.com",
-    statsDPort: Int? = null,
     connectTimeoutSeconds: Int = 123,
     dnsRefreshSeconds: Int = 234,
     dnsFailureRefreshSecondsBase: Int = 345,
@@ -83,7 +82,6 @@ class EnvoyConfigurationTest {
     return EnvoyConfiguration(
       adminInterfaceEnabled,
       grpcStatsDomain,
-      statsDPort,
       connectTimeoutSeconds,
       dnsRefreshSeconds,
       dnsFailureRefreshSecondsBase,
@@ -116,7 +114,8 @@ class EnvoyConfigurationTest {
       listOf(EnvoyNativeFilterConfig("filter_name", "test_config")),
       emptyList(),
       emptyMap(),
-      emptyMap()
+      emptyMap(),
+      emptyList()
     )
   }
 
@@ -256,21 +255,6 @@ class EnvoyConfigurationTest {
       fail("Unresolved configuration keys should trigger exception.")
     } catch (e: EnvoyConfiguration.ConfigurationException) {
       assertThat(e.message).contains("missing")
-    }
-  }
-
-  @Test
-  fun `cannot configure both statsD and gRPC stat sink`() {
-    val envoyConfiguration = buildTestEnvoyConfiguration(
-      grpcStatsDomain = "stats.example.com",
-      statsDPort = 5050
-    )
-
-    try {
-      envoyConfiguration.resolveTemplate("", "", "", "", "", "", "")
-      fail("Conflicting stats keys should trigger exception.")
-    } catch (e: EnvoyConfiguration.ConfigurationException) {
-      assertThat(e.message).contains("cannot enable both statsD and gRPC metrics sink")
     }
   }
 

--- a/test/kotlin/integration/StatFlushIntegrationTest.kt
+++ b/test/kotlin/integration/StatFlushIntegrationTest.kt
@@ -28,7 +28,7 @@ class StatFlushIntegrationTest {
   fun `concurrent flushes with histograms`() {
     val countDownLatch = CountDownLatch(1)
     engine = EngineBuilder()
-      .addLogLevel(LogLevel.INFO)
+      .addLogLevel(LogLevel.DEBUG)
       .addStatsFlushSeconds(1)
       .setOnEngineRunning { countDownLatch.countDown() }
       .build()
@@ -45,13 +45,28 @@ class StatFlushIntegrationTest {
   }
 
   @Test
+  fun `multipe stat sinks configured`() {
+    val countDownLatch = CountDownLatch(1)
+    engine = EngineBuilder()
+      .addLogLevel(LogLevel.DEBUG)
+      // Really high flush interval so it won't trigger during test execution.
+      .addStatsFlushSeconds(100)
+      .addStatsSinks(listOf(statsdSinkConfig(8125), statsdSinkConfig(5000)))
+      .addGrpcStatsDomain("example.com")
+      .setOnEngineRunning { countDownLatch.countDown() }
+      .build()
+
+    assertThat(countDownLatch.await(30, TimeUnit.SECONDS)).isTrue()
+  }
+
+  @Test
   fun `flush flushes to stats sink`() {
     val countDownLatch = CountDownLatch(1)
     engine = EngineBuilder()
       .addLogLevel(LogLevel.DEBUG)
-      .addStatsDPort(8125)
       // Really high flush interval so it won't trigger during test execution.
       .addStatsFlushSeconds(100)
+      .addStatsSinks(listOf(statsdSinkConfig(8125), statsdSinkConfig(5000)))
       .setOnEngineRunning { countDownLatch.countDown() }
       .build()
 
@@ -59,11 +74,22 @@ class StatFlushIntegrationTest {
 
     engine!!.pulseClient().counter(Element("foo"), Element("bar")).increment(1)
 
-    val statsdServer = TestStatsdServer()
-    statsdServer.runAsync(8125)
+    val statsdServer1 = TestStatsdServer()
+    statsdServer1.runAsync(8125)
+
+    val statsdServer2 = TestStatsdServer()
+    statsdServer2.runAsync(5000)
 
     engine!!.flushStats()
 
-    statsdServer.awaitStatMatching { s -> s == "envoy.pulse.foo.bar:1|c" }
+    statsdServer1.awaitStatMatching { s -> s == "envoy.pulse.foo.bar:1|c" }
+    statsdServer2.awaitStatMatching { s -> s == "envoy.pulse.foo.bar:1|c" }
+  }
+
+  fun statsdSinkConfig(port: Int): String {
+return """{ name: envoy.stat_sinks.statsd,
+      typed_config: {
+        "@type": type.googleapis.com/envoy.config.metrics.v3.StatsdSink,
+        address: { socket_address: { address: 127.0.0.1, port_value: $port } } } }"""
   }
 }

--- a/test/kotlin/integration/StatFlushIntegrationTest.kt
+++ b/test/kotlin/integration/StatFlushIntegrationTest.kt
@@ -45,7 +45,7 @@ class StatFlushIntegrationTest {
   }
 
   @Test
-  fun `multipe stat sinks configured`() {
+  fun `multiple stat sinks configured`() {
     val countDownLatch = CountDownLatch(1)
     engine = EngineBuilder()
       .addLogLevel(LogLevel.DEBUG)
@@ -86,7 +86,7 @@ class StatFlushIntegrationTest {
     statsdServer2.awaitStatMatching { s -> s == "envoy.pulse.foo.bar:1|c" }
   }
 
-  fun statsdSinkConfig(port: Int): String {
+  private fun statsdSinkConfig(port: Int): String {
 return """{ name: envoy.stat_sinks.statsd,
       typed_config: {
         "@type": type.googleapis.com/envoy.config.metrics.v3.StatsdSink,

--- a/test/swift/EngineBuilderTests.swift
+++ b/test/swift/EngineBuilderTests.swift
@@ -506,7 +506,8 @@ final class EngineBuilderTests: XCTestCase {
         EnvoyHTTPFilterFactory(filterName: "TestFilter", factory: TestFilter.init),
       ],
       stringAccessors: [:],
-      keyValueStores: [:]
+      keyValueStores: [:],
+      statsSinks: []
     )
     let resolvedYAML = try XCTUnwrap(config.resolveTemplate(kMockTemplate))
     XCTAssertTrue(resolvedYAML.contains("&connect_timeout 200s"))
@@ -594,7 +595,8 @@ final class EngineBuilderTests: XCTestCase {
         EnvoyHTTPFilterFactory(filterName: "TestFilter", factory: TestFilter.init),
       ],
       stringAccessors: [:],
-      keyValueStores: [:]
+      keyValueStores: [:],
+      statsSinks: []
     )
     let resolvedYAML = try XCTUnwrap(config.resolveTemplate(kMockTemplate))
     XCTAssertTrue(resolvedYAML.contains("&dns_lookup_family V4_PREFERRED"))
@@ -643,7 +645,8 @@ final class EngineBuilderTests: XCTestCase {
       nativeFilterChain: [],
       platformFilterChain: [],
       stringAccessors: [:],
-      keyValueStores: [:]
+      keyValueStores: [:],
+      statsSinks: []
     )
     XCTAssertNil(config.resolveTemplate("{{ missing }}"))
   }


### PR DESCRIPTION
This introduces a `addExtraStatSinks(List<String>)` function to the builders, allowing for the injection of arbitrary stat sink configuration to use. The function accepts a list of YAML strings, which allows callers to inject any stat sink compiled into the Envoy configuration.

The motivation for this YAML-based API is to support injecting stat sinks that aren't available in the OSS.

One plus of this is that we are able to deprecate the statsd API on the JVM side (only used for test) and instead use this more flexible API.

Description:
Risk Level:
Testing:
Docs Changes:
Release Notes:
[Optional Fixes #Issue]
[Optional Deprecated:]
