### PR TITLE
ci: automatically cancel old ci job on push

### DIFF
--- a/.github/workflows/android_tests.yml
+++ b/.github/workflows/android_tests.yml
@@ -13,7 +13,7 @@ jobs:
     name: kotlin_tests_mac
     runs-on: macos-12
     timeout-minutes: 90
-    concurrency: 
+    concurrency:
       group: ${{ github.head_ref || github.run_id }}
       cancel-in-progress: true
     steps:
@@ -55,7 +55,7 @@ jobs:
     name: java_tests_mac
     runs-on: macos-12
     timeout-minutes: 120
-    concurrency: 
+    concurrency:
       group: ${{ github.head_ref || github.run_id }}
       cancel-in-progress: true
     steps:
@@ -100,7 +100,7 @@ jobs:
     name: kotlin_tests_linux
     runs-on: ubuntu-latest
     timeout-minutes: 90
-    concurrency: 
+    concurrency:
       group: ${{ github.head_ref || github.run_id }}
       cancel-in-progress: true
     container:

--- a/.github/workflows/android_tests.yml
+++ b/.github/workflows/android_tests.yml
@@ -6,6 +6,10 @@ on:
       - main
   pull_request:
 
+concurrency:
+  group: ${{ github.action }}-${{ github.head_ref || github.run_id }}
+  cancel-in-progress: true
+
 jobs:
   kotlintestsmac:
     # revert to //test/kotlin/... once fixed
@@ -13,9 +17,6 @@ jobs:
     name: kotlin_tests_mac
     runs-on: macos-12
     timeout-minutes: 90
-    concurrency:
-      group: ${{ github.action }}-${{ github.head_ref || github.run_id }}
-      cancel-in-progress: true
     steps:
       - uses: actions/checkout@v1
         with:
@@ -55,9 +56,6 @@ jobs:
     name: java_tests_mac
     runs-on: macos-12
     timeout-minutes: 120
-    concurrency:
-      group: ${{ github.action }}-${{ github.head_ref || github.run_id }}
-      cancel-in-progress: true
     steps:
       - uses: actions/checkout@v1
         with:
@@ -100,9 +98,6 @@ jobs:
     name: kotlin_tests_linux
     runs-on: ubuntu-latest
     timeout-minutes: 90
-    concurrency:
-      group: ${{ github.action }}-${{ github.head_ref || github.run_id }}
-      cancel-in-progress: true
     container:
       image: envoyproxy/envoy-build-ubuntu:0a02a76af5951bf7f4c7029c0ea6d29d96c0f682
       env:

--- a/.github/workflows/android_tests.yml
+++ b/.github/workflows/android_tests.yml
@@ -13,6 +13,9 @@ jobs:
     name: kotlin_tests_mac
     runs-on: macos-12
     timeout-minutes: 90
+    concurrency: 
+      group: ${{ github.head_ref || github.run_id }}
+      cancel-in-progress: true
     steps:
       - uses: actions/checkout@v1
         with:
@@ -52,6 +55,9 @@ jobs:
     name: java_tests_mac
     runs-on: macos-12
     timeout-minutes: 120
+    concurrency: 
+      group: ${{ github.head_ref || github.run_id }}
+      cancel-in-progress: true
     steps:
       - uses: actions/checkout@v1
         with:
@@ -94,6 +100,9 @@ jobs:
     name: kotlin_tests_linux
     runs-on: ubuntu-latest
     timeout-minutes: 90
+    concurrency: 
+      group: ${{ github.head_ref || github.run_id }}
+      cancel-in-progress: true
     container:
       image: envoyproxy/envoy-build-ubuntu:0a02a76af5951bf7f4c7029c0ea6d29d96c0f682
       env:

--- a/.github/workflows/android_tests.yml
+++ b/.github/workflows/android_tests.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: macos-12
     timeout-minutes: 90
     concurrency:
-      group: ${{ github.head_ref || github.run_id }}
+      group: ${{ github.action }}-${{ github.head_ref || github.run_id }}
       cancel-in-progress: true
     steps:
       - uses: actions/checkout@v1
@@ -56,7 +56,7 @@ jobs:
     runs-on: macos-12
     timeout-minutes: 120
     concurrency:
-      group: ${{ github.head_ref || github.run_id }}
+      group: ${{ github.action }}-${{ github.head_ref || github.run_id }}
       cancel-in-progress: true
     steps:
       - uses: actions/checkout@v1
@@ -101,7 +101,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 90
     concurrency:
-      group: ${{ github.head_ref || github.run_id }}
+      group: ${{ github.action }}-${{ github.head_ref || github.run_id }}
       cancel-in-progress: true
     container:
       image: envoyproxy/envoy-build-ubuntu:0a02a76af5951bf7f4c7029c0ea6d29d96c0f682


### PR DESCRIPTION
Signed-off-by: Rafal Augustyniak <raugustyniak@lyft.com>

For an explanation of how to fill out the fields, please see the relevant section
in [PULL_REQUESTS.md](https://github.com/envoyproxy/envoy/blob/master/PULL_REQUESTS.md)

Description:
Risk Level:
Testing:
Docs Changes:
Release Notes:
[Optional Fixes #Issue]
[Optional Deprecated:]
