### PR TITLE
ci: Only execute remotely if repo is owned by envoyproxy

### DIFF
--- a/.github/workflows/android_build.yml
+++ b/.github/workflows/android_build.yml
@@ -9,6 +9,7 @@ on:
 jobs:
   androidbuild:
     name: android_build
+    if: github.repository_owner == 'envoyproxy'
     runs-on: macos-12
     timeout-minutes: 90
     steps:
@@ -22,7 +23,7 @@ jobs:
           architecture: x64
       - name: 'Install dependencies'
         run: ./ci/mac_ci_setup.sh --android
-      - name: 'Build envoy.aar distributable'
+      - name: 'Build envoy.aar distributable remotely'
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
@@ -33,6 +34,7 @@ jobs:
             //:android_dist
   javahelloworld:
     name: java_helloworld
+    if: github.repository_owner == 'envoyproxy'
     needs: androidbuild
     runs-on: macos-12
     timeout-minutes: 25
@@ -52,7 +54,7 @@ jobs:
       # Return to using:
       #   ./bazelw mobile-install --fat_apk_cpu=x86_64 --start_app //examples/java/hello_world:hello_envoy
       # When https://github.com/envoyproxy/envoy-mobile/issues/853 is fixed.
-      - name: 'Start java app'
+      - name: 'Start java app (built remotely)'
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
@@ -67,6 +69,7 @@ jobs:
         run: adb logcat -e "received headers with status 200" -m 1
   kotlinhelloworld:
     name: kotlin_helloworld
+    if: github.repository_owner == 'envoyproxy'
     needs: androidbuild
     runs-on: macos-12
     timeout-minutes: 25
@@ -86,7 +89,7 @@ jobs:
       # Return to using:
       #   ./bazelw mobile-install --fat_apk_cpu=x86_64 --start_app //examples/kotlin/hello_world:hello_envoy_kt
       # When https://github.com/envoyproxy/envoy-mobile/issues/853 is fixed.
-      - name: 'Start kotlin app'
+      - name: 'Start kotlin app (built remotely)'
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
@@ -101,6 +104,7 @@ jobs:
         run: adb logcat -e "received headers with status 200" -m 1
   kotlinbaselineapp:
     name: kotlin_baseline_app
+    if: github.repository_owner == 'envoyproxy'
     needs: androidbuild
     runs-on: macos-12
     timeout-minutes: 25
@@ -120,7 +124,7 @@ jobs:
       # Return to using:
       #   ./bazelw mobile-install --fat_apk_cpu=x86_64 --start_app //examples/kotlin/hello_world:hello_envoy_kt
       # When https://github.com/envoyproxy/envoy-mobile/issues/853 is fixed.
-      - name: 'Start kotlin app'
+      - name: 'Start kotlin app (built remotely)'
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
@@ -135,6 +139,7 @@ jobs:
         run: adb logcat -e "received headers with status 301" -m 1
   kotlinexperimentalapp:
     name: kotlin_experimental_app
+    if: github.repository_owner == 'envoyproxy'
     needs: androidbuild
     runs-on: macos-12
     timeout-minutes: 25
@@ -154,7 +159,7 @@ jobs:
       # Return to using:
       #   ./bazelw mobile-install --fat_apk_cpu=x86_64 --start_app //examples/kotlin/hello_world:hello_envoy_kt
       # When https://github.com/envoyproxy/envoy-mobile/issues/853 is fixed.
-      - name: 'Start kotlin app'
+      - name: 'Start kotlin app (built remotely)'
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |

--- a/.github/workflows/android_tests.yml
+++ b/.github/workflows/android_tests.yml
@@ -11,6 +11,7 @@ jobs:
     # revert to //test/kotlin/... once fixed
     # https://github.com/envoyproxy/envoy-mobile/issues/1932
     name: kotlin_tests_mac
+    if: github.repository_owner == 'envoyproxy'
     runs-on: macos-12
     timeout-minutes: 90
     steps:
@@ -37,7 +38,7 @@ jobs:
       - name: 'Install dependencies'
         if: steps.check_context.outputs.run_tests == 'true'
         run: ./ci/mac_ci_setup.sh
-      - name: 'Run Kotlin library tests'
+      - name: 'Run Kotlin library tests remotely'
         if: steps.check_context.outputs.run_tests == 'true'
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -50,6 +51,7 @@ jobs:
             //test/kotlin/io/...
   javatestsmac:
     name: java_tests_mac
+    if: github.repository_owner == 'envoyproxy'
     runs-on: macos-12
     timeout-minutes: 120
     steps:
@@ -76,7 +78,7 @@ jobs:
       - name: 'Install dependencies'
         if: steps.check_context.outputs.run_tests == 'true'
         run: ./ci/mac_ci_setup.sh
-      - name: 'Run Java library tests'
+      - name: 'Run Java library tests remotely'
         if: steps.check_context.outputs.run_tests == 'true'
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -92,6 +94,7 @@ jobs:
     # Only kotlin tests are executed since with linux:
     # https://github.com/envoyproxy/envoy-mobile/issues/1418.
     name: kotlin_tests_linux
+    if: github.repository_owner == 'envoyproxy'
     runs-on: ubuntu-latest
     timeout-minutes: 90
     container:
@@ -125,7 +128,7 @@ jobs:
       - name: 'Install dependencies'
         if: steps.check_context.outputs.run_tests == 'true'
         run: ./ci/linux_ci_setup.sh
-      - name: 'Run Kotlin library integration tests'
+      - name: 'Run Kotlin library integration tests remotely'
         if: steps.check_context.outputs.run_tests == 'true'
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/asan.yml
+++ b/.github/workflows/asan.yml
@@ -9,6 +9,7 @@ on:
 jobs:
   asan:
     name: asan
+    if: github.repository_owner == 'envoyproxy'
     runs-on: ubuntu-latest
     timeout-minutes: 180
     container:
@@ -38,7 +39,7 @@ jobs:
           java-version: '8'
           java-package: jdk
           architecture: x64
-      - name: 'Run tests'
+      - name: 'Run tests remotely'
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         if: steps.check_context.outputs.run_tests == 'true'

--- a/.github/workflows/cc_tests.yml
+++ b/.github/workflows/cc_tests.yml
@@ -9,6 +9,7 @@ on:
 jobs:
   cctests:
     name: cc_tests
+    if: github.repository_owner == 'envoyproxy'
     runs-on: ubuntu-latest
     timeout-minutes: 120
     container:
@@ -21,5 +22,11 @@ jobs:
         run: git config --global --add safe.directory /__w/envoy-mobile/envoy-mobile
       - env:
             GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        name: 'Run tests'
-        run: ./bazelw test --action_env=LD_LIBRARY_PATH --test_output=all --config=remote-ci-linux --remote_header="Authorization=Bearer $GITHUB_TOKEN" //test/cc/...
+        name: 'Run tests remotely'
+        run: |
+          ./bazelw test \
+            --action_env=LD_LIBRARY_PATH \
+            --test_output=all \
+            --config=remote-ci-linux \
+            --remote_header="Authorization=Bearer $GITHUB_TOKEN" \
+            //test/cc/...

--- a/.github/workflows/core.yml
+++ b/.github/workflows/core.yml
@@ -9,6 +9,7 @@ on:
 jobs:
   unittests:
     name: unit_tests
+    if: github.repository_owner == 'envoyproxy'
     runs-on: macos-12
     timeout-minutes: 120
     steps:
@@ -20,4 +21,9 @@ jobs:
       - name: 'Run tests'
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: ./bazelw test --test_output=all --config=remote-ci-macos --remote_header="Authorization=Bearer $GITHUB_TOKEN"  //test/common/...
+        run: |
+          ./bazelw test \
+            --test_output=all \
+            --config=remote-ci-macos \
+            --remote_header="Authorization=Bearer $GITHUB_TOKEN"  \
+            //test/common/...

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -9,6 +9,7 @@ on:
 jobs:
   coverage:
     name: coverage
+    if: github.repository_owner == 'envoyproxy'
     runs-on: ubuntu-latest
     timeout-minutes: 120
     defaults:
@@ -32,7 +33,7 @@ jobs:
             echo "Skipping coverage."
             echo "::set-output name=run_coverage::false"
           fi
-      - name: 'Run coverage'
+      - name: 'Run coverage remotely'
         if: steps.check_context.outputs.run_coverage == 'true'
         continue-on-error: true
         run: |

--- a/.github/workflows/format.yml
+++ b/.github/workflows/format.yml
@@ -58,6 +58,7 @@ jobs:
         run: ./bazelw run @DrString//:drstring check
   kotlinlint:
     name: kotlin_lint
+    if: github.repository_owner == 'envoyproxy'
     runs-on: macos-12
     timeout-minutes: 45
     steps:
@@ -71,7 +72,7 @@ jobs:
           architecture: x64
       - run: ./ci/mac_ci_setup.sh
         name: 'Install dependencies'
-      - name: 'Run Kotlin Lint (Detekt)'
+      - name: 'Run Kotlin Lint remotely (Detekt)'
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |

--- a/.github/workflows/ios_build.yml
+++ b/.github/workflows/ios_build.yml
@@ -9,6 +9,7 @@ on:
 jobs:
   iosbuild:
     name: ios_build
+    if: github.repository_owner == 'envoyproxy'
     runs-on: macos-12
     timeout-minutes: 120
     steps:
@@ -21,10 +22,15 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           ./bazelw shutdown
-          ./bazelw build --config=ios --config=remote-ci-macos --remote_header="Authorization=Bearer $GITHUB_TOKEN" //library/swift:ios_framework
-        name: 'Build Envoy.framework distributable'
+          ./bazelw build \
+            --config=ios \
+            --config=remote-ci-macos \
+            --remote_header="Authorization=Bearer $GITHUB_TOKEN" \
+            //library/swift:ios_framework
+        name: 'Build Envoy.framework distributable remotely'
   swifthelloworld:
     name: swift_helloworld
+    if: github.repository_owner == 'envoyproxy'
     needs: iosbuild
     runs-on: macos-12
     timeout-minutes: 25
@@ -36,13 +42,24 @@ jobs:
         name: 'Install dependencies'
       - env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: ./bazelw build --config=ios --config=remote-ci-macos --remote_header="Authorization=Bearer $GITHUB_TOKEN" //examples/swift/hello_world:app
-        name: 'Build swift app'
+        run: |
+          ./bazelw build \
+          --config=ios \
+          --config=remote-ci-macos \
+          --remote_header="Authorization=Bearer $GITHUB_TOKEN" \
+          //examples/swift/hello_world:app
+        name: 'Build swift app remotely'
       # Run the app in the background and redirect logs.
-      - env:
+      - if: github.repository_owner == 'envoyproxy'
+        env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: ./bazelw run --config=ios --config=remote-ci-macos --remote_header="Authorization=Bearer $GITHUB_TOKEN" //examples/swift/hello_world:app &> /tmp/envoy.log &
-        name: 'Run swift app'
+        run: |
+          ./bazelw run \
+          --config=ios \
+          --config=remote-ci-macos \
+          --remote_header="Authorization=Bearer $GITHUB_TOKEN" \
+          //examples/swift/hello_world:app &> /tmp/envoy.log &
+        name: 'Run swift app (built remotely)'
       - run: sed '/received headers with status 200/q' <(touch /tmp/envoy.log && tail -F /tmp/envoy.log)
         name: 'Check connectivity'
       - run: cat /tmp/envoy.log
@@ -50,6 +67,7 @@ jobs:
         name: 'Log app run'
   swiftbaselineapp:
     name: swift_baseline_app
+    if: github.repository_owner == 'envoyproxy'
     needs: iosbuild
     runs-on: macos-12
     timeout-minutes: 25
@@ -61,13 +79,23 @@ jobs:
         name: 'Install dependencies'
       - env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: ./bazelw build --config=ios --config=remote-ci-macos --remote_header="Authorization=Bearer $GITHUB_TOKEN" //test/swift/apps/baseline:app
-        name: 'Build swift app'
+        run: |
+          ./bazelw build \
+          --config=ios \
+          --config=remote-ci-macos \
+          --remote_header="Authorization=Bearer $GITHUB_TOKEN" \
+          //test/swift/apps/baseline:app
+        name: 'Build swift app remotely'
       # Run the app in the background and redirect logs.
       - env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: ./bazelw run --config=ios --config=remote-ci-macos --remote_header="Authorization=Bearer $GITHUB_TOKEN" //test/swift/apps/baseline:app &> /tmp/envoy.log &
-        name: 'Run swift app'
+        run: |
+          ./bazelw run \
+          --config=ios \
+          --config=remote-ci-macos \
+          --remote_header="Authorization=Bearer $GITHUB_TOKEN" \
+          //test/swift/apps/baseline:app &> /tmp/envoy.log &
+        name: 'Run swift app (built remotely)'
       - run: sed '/received headers with status 301/q' <(touch /tmp/envoy.log && tail -F /tmp/envoy.log)
         name: 'Check connectivity'
       - run: cat /tmp/envoy.log
@@ -75,6 +103,7 @@ jobs:
         name: 'Log app run'
   swiftexperimentalapp:
     name: swift_experimental_app
+    if: github.repository_owner == 'envoyproxy'
     needs: iosbuild
     runs-on: macos-12
     timeout-minutes: 25
@@ -86,12 +115,22 @@ jobs:
         name: 'Install dependencies'
       - env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: ./bazelw build --config=ios --config=remote-ci-macos --remote_header="Authorization=Bearer $GITHUB_TOKEN" //test/swift/apps/experimental:app
+        run: |
+          ./bazelw build \
+          --config=ios \
+          --config=remote-ci-macos \
+          --remote_header="Authorization=Bearer $GITHUB_TOKEN" \
+          //test/swift/apps/experimental:app
         name: 'Build swift app'
       # Run the app in the background and redirect logs.
       - env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: ./bazelw run --config=ios --config=remote-ci-macos --remote_header="Authorization=Bearer $GITHUB_TOKEN" //test/swift/apps/experimental:app &> /tmp/envoy.log &
+        run: |
+          ./bazelw run \
+          --config=ios \
+          --config=remote-ci-macos \
+          --remote_header="Authorization=Bearer $GITHUB_TOKEN" \
+          //test/swift/apps/experimental:app &> /tmp/envoy.log &
         name: 'Run swift app'
       - run: sed '/received headers with status 200/q' <(touch /tmp/envoy.log && tail -F /tmp/envoy.log)
         name: 'Check connectivity'
@@ -100,6 +139,7 @@ jobs:
         name: 'Log app run'
   swiftasyncawait:
     name: swift_async_await
+    if: github.repository_owner == 'envoyproxy'
     needs: iosbuild
     runs-on: macos-12
     timeout-minutes: 25
@@ -111,12 +151,22 @@ jobs:
         name: 'Install dependencies'
       - env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: ./bazelw build --config=ios --config=remote-ci-macos --remote_header="Authorization=Bearer $GITHUB_TOKEN" //examples/swift/async_await:app
+        run: |
+          ./bazelw build \
+          --config=ios \
+          --config=remote-ci-macos \
+          --remote_header="Authorization=Bearer $GITHUB_TOKEN" \
+          //examples/swift/async_await:app
         name: 'Build swift app'
       # Run the app in the background and redirect logs.
       - env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: ./bazelw run --config=ios --config=remote-ci-macos --remote_header="Authorization=Bearer $GITHUB_TOKEN" //examples/swift/async_await:app &> /tmp/envoy.log &
+        run: |
+          ./bazelw run \
+          --config=ios \
+          --config=remote-ci-macos \
+          --remote_header="Authorization=Bearer $GITHUB_TOKEN" \
+          //examples/swift/async_await:app &> /tmp/envoy.log &
         name: 'Run swift app'
       - run: sed '/\[2\] Uploaded 7 MB of data/q' <(touch /tmp/envoy.log && tail -F /tmp/envoy.log)
         name: 'Check upload succeeded'
@@ -125,6 +175,7 @@ jobs:
         name: 'Log app run'
   objchelloworld:
     name: objc_helloworld
+    if: github.repository_owner == 'envoyproxy'
     needs: iosbuild
     runs-on: macos-12
     timeout-minutes: 25
@@ -136,13 +187,23 @@ jobs:
         name: 'Install dependencies'
       - env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: ./bazelw build --config=ios --config=remote-ci-macos --remote_header="Authorization=Bearer $GITHUB_TOKEN" //examples/objective-c/hello_world:app
-        name: 'Build objective-c app'
+        run: |
+          ./bazelw build \
+          --config=ios \
+          --config=remote-ci-macos \
+          --remote_header="Authorization=Bearer $GITHUB_TOKEN" \
+          //examples/objective-c/hello_world:app
+        name: 'Build objective-c app remotely'
       # Run the app in the background and redirect logs.
       - env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: ./bazelw run --config=ios --config=remote-ci-macos --remote_header="Authorization=Bearer $GITHUB_TOKEN" //examples/objective-c/hello_world:app &> /tmp/envoy.log &
-        name: 'Run objective-c app'
+        run: |
+          ./bazelw run \
+          --config=ios \
+          --config=remote-ci-macos \
+          --remote_header="Authorization=Bearer $GITHUB_TOKEN" \
+          //examples/objective-c/hello_world:app &> /tmp/envoy.log &
+        name: 'Run objective-c app (built remotely)'
       - run: sed '/received headers with status 200/q' <(touch /tmp/envoy.log && tail -F /tmp/envoy.log)
         name: 'Check connectivity'
       - run: cat /tmp/envoy.log

--- a/.github/workflows/ios_tests.yml
+++ b/.github/workflows/ios_tests.yml
@@ -9,6 +9,7 @@ on:
 jobs:
   swifttests:
     name: swift_tests
+    if: github.repository_owner == 'envoyproxy'
     runs-on: macos-12
     timeout-minutes: 120
     steps:
@@ -27,13 +28,21 @@ jobs:
           fi
       - name: 'Install dependencies'
         run: ./ci/mac_ci_setup.sh
-      - name: 'Run swift library tests'
-        if: steps.check_context.outputs.run_tests == 'true'
+      - name: 'Run swift library tests remotely'
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: ./bazelw test --experimental_ui_max_stdouterr_bytes=10485760 --test_output=all --config=ios --build_tests_only --config=remote-ci-macos --remote_header="Authorization=Bearer $GITHUB_TOKEN" //test/swift/...
+        run: |
+          ./bazelw test \
+            --experimental_ui_max_stdouterr_bytes=10485760 \
+            --test_output=all \
+            --config=ios \
+            --build_tests_only \
+            --config=remote-ci-macos \
+            --remote_header="Authorization=Bearer $GITHUB_TOKEN" \
+            //test/swift/...
   objctests:
     name: c_and_objc_tests
+    if: github.repository_owner == 'envoyproxy'
     runs-on: macos-12
     timeout-minutes: 120
     steps:
@@ -52,8 +61,15 @@ jobs:
           fi
       - name: 'Install dependencies'
         run: ./ci/mac_ci_setup.sh
-      - name: 'Run Objective-C library tests'
-        if: steps.check_context.outputs.run_tests == 'true'
+      - name: 'Run Objective-C library tests remotely'
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: ./bazelw test --test_output=all --config=ios --build_tests_only --config=remote-ci-macos --remote_header="Authorization=Bearer $GITHUB_TOKEN" //test/objective-c/...  //test/cc/unit:envoy_config_test
+        run: |
+          ./bazelw test \
+            --test_output=all \
+            --config=ios \
+            --build_tests_only \
+            --config=remote-ci-macos \
+            --remote_header="Authorization=Bearer $GITHUB_TOKEN" \
+            //test/objective-c/... \
+            //test/cc/unit:envoy_config_test

--- a/.github/workflows/perf.yml
+++ b/.github/workflows/perf.yml
@@ -9,6 +9,7 @@ on:
 jobs:
   sizecurrent:
     name: size_current
+    if: github.repository_owner == 'envoyproxy'
     runs-on: ubuntu-latest
     timeout-minutes: 120
     container:
@@ -22,7 +23,7 @@ jobs:
           submodules: true
       - name: Add safe directory
         run: git config --global --add safe.directory /__w/envoy-mobile/envoy-mobile
-      - name: 'Build test binary'
+      - name: 'Build test binary remotely'
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
@@ -37,6 +38,7 @@ jobs:
           path: bazel-bin/test/performance/test_binary_size
   sizemain:
     name: size_main
+    if: github.repository_owner == 'envoyproxy'
     runs-on: ubuntu-latest
     timeout-minutes: 90
     container:
@@ -52,7 +54,7 @@ jobs:
         run: |
           git config --global --add safe.directory /__w/envoy-mobile/envoy-mobile/envoy
           git config --global --add safe.directory /__w/envoy-mobile/envoy-mobile
-      - name: 'Build test binary'
+      - name: 'Build test binary remotely'
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |

--- a/.github/workflows/python_tests.yml
+++ b/.github/workflows/python_tests.yml
@@ -9,6 +9,7 @@ on:
 jobs:
   pythontests:
     name: python_tests
+    if: github.repository_owner == 'envoyproxy'
     runs-on: ubuntu-latest
     timeout-minutes: 90
     container:
@@ -29,8 +30,7 @@ jobs:
             echo "Skipping tests."
             echo "::set-output name=run_tests::false"
           fi
-      - name: 'Run tests'
-        if: steps.check_context.outputs.run_tests == 'true'
+      - name: 'Run tests remotely'
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,6 +11,7 @@ on:
 jobs:
   android_release_artifacts:
     name: android_release_artifacts
+    if: github.repository_owner == 'envoyproxy'
     runs-on: macos-12
     timeout-minutes: 120
     steps:
@@ -24,7 +25,7 @@ jobs:
           architecture: x64
       - run: ./ci/mac_ci_setup.sh --android
         name: 'Install dependencies'
-      - name: 'Build envoy.aar distributable'
+      - name: 'Build envoy.aar distributable remotely'
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
@@ -117,7 +118,8 @@ jobs:
           submodules: true
       - name: 'Install dependencies'
         run: ./ci/mac_ci_setup.sh
-      - name: 'Build Envoy.xcframework'
+      - name: 'Build Envoy.xcframework remotely'
+        if: github.repository_owner == 'envoyproxy'
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
@@ -132,7 +134,8 @@ jobs:
         with:
           name: ios_framework
           path: ./Envoy.xcframework.zip
-      - name: 'Build Envoy.doccarchive.zip'
+      - name: 'Build Envoy.doccarchive.zip remotely'
+        if: github.repository_owner == 'envoyproxy'
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |

--- a/.github/workflows/release_validation.yml
+++ b/.github/workflows/release_validation.yml
@@ -9,6 +9,7 @@ on:
 jobs:
   validate_swiftpm_example:
     name: validate_swiftpm_example
+    if: github.repository_owner == 'envoyproxy'
     runs-on: macos-12
     timeout-minutes: 120
     steps:
@@ -19,8 +20,13 @@ jobs:
         name: 'Install dependencies'
       - env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: ./bazelw build --config=ios --config=remote-ci-macos --remote_header="Authorization=Bearer $GITHUB_TOKEN" //:ios_xcframework
-        name: 'Build xcframework'
+        run: |
+          ./bazelw build \
+            --config=ios \
+            --config=remote-ci-macos \
+            --remote_header="Authorization=Bearer $GITHUB_TOKEN" \
+            //:ios_xcframework
+        name: 'Build xcframework remotely'
       # Ignore errors: Bad CRC when unzipping large files: https://bbs.archlinux.org/viewtopic.php?id=153011
       - run: unzip bazel-bin/library/swift/Envoy.xcframework.zip -d examples/swift/swiftpm/Packages || true
         name: 'Unzip xcframework'

--- a/.github/workflows/tsan.yml
+++ b/.github/workflows/tsan.yml
@@ -9,6 +9,7 @@ on:
 jobs:
   tsan:
     name: tsan
+    if: github.repository_owner == 'envoyproxy'
     runs-on: ubuntu-latest
     timeout-minutes: 90
     container:
@@ -38,7 +39,7 @@ jobs:
           java-version: '8'
           java-package: jdk
           architecture: x64
-      - name: 'Run tests'
+      - name: 'Run tests remotely'
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         if: steps.check_context.outputs.run_tests == 'true'


### PR DESCRIPTION

For an explanation of how to fill out the fields, please see the relevant section
in [PULL_REQUESTS.md](https://github.com/envoyproxy/envoy/blob/master/PULL_REQUESTS.md)

Description:
This restricts the use of remote execution only to the original envoyproxy/envoy-mobile repository such that forks don't try to use RE without a proper GITHUB_TOKEN.
Additional Description:
The [EngFlow cluster](https://envoy.cluster.engflow.com/) occasionally sees failed builds due to users without a GITHUB_TOKEN trying to execute against the remote cluster indicating that they are not a member of envoyproxy.
Risk Level: Medium
Testing: Manual
Docs Changes: None
Release Notes: None
