### PR TITLE
ci: update mac_start_emulator.sh to launch arm64-v8a emulators on arm64

### DIFF
--- a/ci/mac_start_emulator.sh
+++ b/ci/mac_start_emulator.sh
@@ -2,7 +2,14 @@
 
 set -e
 
-echo "y" | $ANDROID_HOME/tools/bin/sdkmanager --install 'system-images;android-29;google_apis;x86_64' --channel=3
-echo "no" | $ANDROID_HOME/tools/bin/avdmanager create avd -n test_android_emulator -k 'system-images;android-29;google_apis;x86_64' --force
+if [[ "$(/usr/bin/uname -m)" == "arm64" ]]
+then
+  arch="arm64-v8a"
+else
+  arch="x86_64"
+fi
+
+echo "y" | $ANDROID_HOME/cmdline-tools/7.0/bin/sdkmanager --install "system-images;android-29;google_apis;$arch"
+echo "no" | $ANDROID_HOME/cmdline-tools/7.0/bin/avdmanager create avd -n test_android_emulator -k "system-images;android-29;google_apis;$arch" --force
 ls $ANDROID_HOME/tools/bin/
 nohup $ANDROID_HOME/emulator/emulator -partition-size 1024 -avd test_android_emulator -no-snapshot > /dev/null 2>&1 & $ANDROID_HOME/platform-tools/adb wait-for-device shell 'while [[ -z $(getprop sys.boot_completed | tr -d '\r') ]]; do sleep 1; done; input keyevent 82'


### PR DESCRIPTION
Signed-off-by: JP Simard <jp@jpsim.com>

For an explanation of how to fill out the fields, please see the relevant section
in [PULL_REQUESTS.md](https://github.com/envoyproxy/envoy/blob/master/PULL_REQUESTS.md)

Description:
Risk Level:
Testing:
Docs Changes:
Release Notes:
[Optional Fixes #Issue]
[Optional Deprecated:]
