### PR TITLE
build: disable guard dog

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -2,6 +2,7 @@
 try-import ./envoy/.bazelrc
 
 # Common flags for all builds
+build --@envoy//bazel:guarddog=False
 build --platform_mappings=envoy/bazel/platform_mappings
 build --define=google_grpc=disabled
 build --define=hot_restart=disabled

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "envoy"]
 	path = envoy
-	url = https://github.com/envoyproxy/envoy.git
+	url = https://github.com/jpsim/envoy.git


### PR DESCRIPTION
Commit Message: build: disable guard dog
Additional Description: Which Envoy Mobile should never enable, because terminating the Envoy process would mean terminating the host iOS or Android app. See https://github.com/envoyproxy/envoy-mobile/issues/2581 for more details.
Risk Level: Low, compile-time flag, no-op by default.
Testing: Building Envoy Mobile locally.
Docs Changes: None.
Release Notes: None.
Platform Specific Features: Will be disabled when building Envoy Mobile.
Fixes: https://github.com/envoyproxy/envoy-mobile/issues/2581

Signed-off-by: JP Simard <jp@jpsim.com>