### PR TITLE
android proxy: add support for PAC proxies

### DIFF
--- a/library/java/io/envoyproxy/envoymobile/engine/AndroidProxyMonitor.java
+++ b/library/java/io/envoyproxy/envoymobile/engine/AndroidProxyMonitor.java
@@ -62,7 +62,7 @@ class AndroidProxyMonitor extends BroadcastReceiver {
   private ProxyInfo extractProxyInfo(final Intent intent) {
     ProxyInfo info = connectivityManager.getDefaultProxy();
 
-    // If proxy is configured using the PAC file use the
+    // If a proxy is configured using the PAC file use
     // Android's injected localhost HTTP proxy.
     //
     // Android's injected localhost proxy can be accessed using a proxy host

--- a/library/java/io/envoyproxy/envoymobile/engine/AndroidProxyMonitor.java
+++ b/library/java/io/envoyproxy/envoymobile/engine/AndroidProxyMonitor.java
@@ -8,16 +8,17 @@ import android.content.IntentFilter;
 import android.net.ConnectivityManager;
 import android.net.Proxy;
 import android.net.ProxyInfo;
+import android.net.Uri;
 import android.os.Build;
 import android.os.Bundle;
 
 @TargetApi(Build.VERSION_CODES.LOLLIPOP)
-public class AndroidProxyMonitor extends BroadcastReceiver {
-  private static volatile AndroidProxyMonitor instance = null;
+class AndroidProxyMonitor extends BroadcastReceiver {
+  static volatile AndroidProxyMonitor instance = null;
   private ConnectivityManager connectivityManager;
   private EnvoyEngine envoyEngine;
 
-  public static void load(Context context, EnvoyEngine envoyEngine) {
+  static void load(Context context, EnvoyEngine envoyEngine) {
     if (instance != null) {
       return;
     }
@@ -61,7 +62,17 @@ public class AndroidProxyMonitor extends BroadcastReceiver {
   private ProxyInfo extractProxyInfo(final Intent intent) {
     ProxyInfo info = connectivityManager.getDefaultProxy();
 
-    if (info.getPacFileUrl() != null) {
+    // If proxy is configured using the PAC file use the
+    // Android's injected localhost HTTP proxy.
+    //
+    // Android's injected localhost proxy can be accessed using a proxy host
+    // equal to `localhost` and a proxy port retrieved from intent's 'extras'.
+    // We cannot take a proxy port from the ProxyInfo object that's exposed by
+    // the connectivity manager as it's always equal to -1 for cases when PAC
+    // proxy is configured.
+    //
+    // See https://github.com/envoyproxy/envoy-mobile/issues/2531 for more details.
+    if (info.getPacFileUrl() != null && info.getPacFileUrl() != Uri.EMPTY) {
       Bundle extras = intent.getExtras();
       if (extras == null) {
         return null;

--- a/library/java/io/envoyproxy/envoymobile/engine/AndroidProxyMonitor.java
+++ b/library/java/io/envoyproxy/envoymobile/engine/AndroidProxyMonitor.java
@@ -61,6 +61,9 @@ class AndroidProxyMonitor extends BroadcastReceiver {
 
   private ProxyInfo extractProxyInfo(final Intent intent) {
     ProxyInfo info = connectivityManager.getDefaultProxy();
+    if (info == null) {
+      return null;
+    }
 
     // If a proxy is configured using the PAC file use
     // Android's injected localhost HTTP proxy.

--- a/test/kotlin/integration/proxying/PerformHTTPRequestUsingProxyTest.kt
+++ b/test/kotlin/integration/proxying/PerformHTTPRequestUsingProxyTest.kt
@@ -1,7 +1,10 @@
 package test.kotlin.integration.proxying
 
+import android.content.Intent
 import android.content.Context
+import android.os.UserHandle
 import android.net.ConnectivityManager
+import android.net.Proxy
 import android.net.ProxyInfo
 import androidx.test.core.app.ApplicationProvider
 
@@ -47,17 +50,16 @@ class PerformHTTPRequestUsingProxy {
   fun `performs an HTTP request through a proxy`() {
     val port = (10001..11000).random()
 
-    val mockContext = Mockito.mock(Context::class.java)
-    Mockito.`when`(mockContext.getApplicationContext()).thenReturn(mockContext)
-    val mockConnectivityManager = Mockito.mock(ConnectivityManager::class.java)
-    Mockito.`when`(mockContext.getSystemService(Mockito.anyString())).thenReturn(mockConnectivityManager)
-    Mockito.`when`(mockConnectivityManager.getDefaultProxy()).thenReturn(ProxyInfo.buildDirectProxy("127.0.0.1", port))
+    val context = Mockito.spy(ApplicationProvider.getApplicationContext<Context>())
+    val connectivityManager: ConnectivityManager = Mockito.mock(ConnectivityManager::class.java)
+    Mockito.doReturn(connectivityManager).`when`(context).getSystemService(Context.CONNECTIVITY_SERVICE)
+    Mockito.`when`(connectivityManager.getDefaultProxy()).thenReturn(ProxyInfo.buildDirectProxy("127.0.0.1", port))
 
     val onProxyEngineRunningLatch = CountDownLatch(1)
     val onEngineRunningLatch = CountDownLatch(1)
     val onRespondeHeadersLatch = CountDownLatch(1)
 
-    val proxyEngineBuilder = Proxy(ApplicationProvider.getApplicationContext(), port)
+    val proxyEngineBuilder = Proxy(context, port)
       .http()
     val proxyEngine = proxyEngineBuilder
       .addLogLevel(LogLevel.DEBUG)
@@ -67,7 +69,9 @@ class PerformHTTPRequestUsingProxy {
     onProxyEngineRunningLatch.await(10, TimeUnit.SECONDS)
     assertThat(onProxyEngineRunningLatch.count).isEqualTo(0)
 
-    val builder = AndroidEngineBuilder(mockContext)
+    context.sendStickyBroadcast(Intent(Proxy.PROXY_CHANGE_ACTION))
+
+    val builder = AndroidEngineBuilder(context)
     val engine = builder
       .addLogLevel(LogLevel.DEBUG)
       .enableProxying(true)

--- a/test/kotlin/integration/proxying/PerformHTTPRequestUsingProxyTest.kt
+++ b/test/kotlin/integration/proxying/PerformHTTPRequestUsingProxyTest.kt
@@ -2,7 +2,6 @@ package test.kotlin.integration.proxying
 
 import android.content.Intent
 import android.content.Context
-import android.os.UserHandle
 import android.net.ConnectivityManager
 import android.net.Proxy
 import android.net.ProxyInfo

--- a/test/kotlin/integration/proxying/PerformHTTPSRequestBadHostname.kt
+++ b/test/kotlin/integration/proxying/PerformHTTPSRequestBadHostname.kt
@@ -1,8 +1,10 @@
 package test.kotlin.integration.proxying
 
-
+import android.content.Intent
 import android.content.Context
+import android.os.UserHandle
 import android.net.ConnectivityManager
+import android.net.Proxy
 import android.net.ProxyInfo
 import androidx.test.core.app.ApplicationProvider
 
@@ -49,17 +51,16 @@ class PerformHTTPSRequestBadHostname {
   fun `attempts an HTTPs request through a proxy using an async DNS resolution that fails`() {
     val port = (10001..11000).random()
 
-    val mockContext = Mockito.mock(Context::class.java)
-    Mockito.`when`(mockContext.getApplicationContext()).thenReturn(mockContext)
-    val mockConnectivityManager = Mockito.mock(ConnectivityManager::class.java)
-    Mockito.`when`(mockContext.getSystemService(Mockito.anyString())).thenReturn(mockConnectivityManager)
-    Mockito.`when`(mockConnectivityManager.getDefaultProxy()).thenReturn(ProxyInfo.buildDirectProxy("loopback", port))
+    val context = Mockito.spy(ApplicationProvider.getApplicationContext<Context>())
+    val connectivityManager: ConnectivityManager = Mockito.mock(ConnectivityManager::class.java)
+    Mockito.doReturn(connectivityManager).`when`(context).getSystemService(Context.CONNECTIVITY_SERVICE)
+    Mockito.`when`(connectivityManager.getDefaultProxy()).thenReturn(ProxyInfo.buildDirectProxy("127.0.0.1", port))
 
     val onEngineRunningLatch = CountDownLatch(1)
     val onProxyEngineRunningLatch = CountDownLatch(1)
     val onErrorLatch = CountDownLatch(1)
 
-    val proxyEngineBuilder = Proxy(ApplicationProvider.getApplicationContext(), port).https()
+    val proxyEngineBuilder = Proxy(context, port).https()
     val proxyEngine = proxyEngineBuilder
       .addLogLevel(LogLevel.DEBUG)
       .addDNSQueryTimeoutSeconds(2)
@@ -69,7 +70,9 @@ class PerformHTTPSRequestBadHostname {
     onProxyEngineRunningLatch.await(10, TimeUnit.SECONDS)
     assertThat(onProxyEngineRunningLatch.count).isEqualTo(0)
 
-    val builder = AndroidEngineBuilder(mockContext)
+    context.sendStickyBroadcast(Intent(Proxy.PROXY_CHANGE_ACTION))
+
+    val builder = AndroidEngineBuilder(context)
     val engine = builder
       .addLogLevel(LogLevel.DEBUG)
       .enableProxying(true)

--- a/test/kotlin/integration/proxying/PerformHTTPSRequestBadHostname.kt
+++ b/test/kotlin/integration/proxying/PerformHTTPSRequestBadHostname.kt
@@ -53,7 +53,7 @@ class PerformHTTPSRequestBadHostname {
     val context = Mockito.spy(ApplicationProvider.getApplicationContext<Context>())
     val connectivityManager: ConnectivityManager = Mockito.mock(ConnectivityManager::class.java)
     Mockito.doReturn(connectivityManager).`when`(context).getSystemService(Context.CONNECTIVITY_SERVICE)
-    Mockito.`when`(connectivityManager.getDefaultProxy()).thenReturn(ProxyInfo.buildDirectProxy("127.0.0.1", port))
+    Mockito.`when`(connectivityManager.getDefaultProxy()).thenReturn(ProxyInfo.buildDirectProxy("loopback", port))
 
     val onEngineRunningLatch = CountDownLatch(1)
     val onProxyEngineRunningLatch = CountDownLatch(1)

--- a/test/kotlin/integration/proxying/PerformHTTPSRequestBadHostname.kt
+++ b/test/kotlin/integration/proxying/PerformHTTPSRequestBadHostname.kt
@@ -2,7 +2,6 @@ package test.kotlin.integration.proxying
 
 import android.content.Intent
 import android.content.Context
-import android.os.UserHandle
 import android.net.ConnectivityManager
 import android.net.Proxy
 import android.net.ProxyInfo

--- a/test/kotlin/integration/proxying/PerformHTTPSRequestUsingAsyncProxyTest.kt
+++ b/test/kotlin/integration/proxying/PerformHTTPSRequestUsingAsyncProxyTest.kt
@@ -1,8 +1,10 @@
 package test.kotlin.integration.proxying
 
-
+import android.content.Intent
 import android.content.Context
+import android.os.UserHandle
 import android.net.ConnectivityManager
+import android.net.Proxy
 import android.net.ProxyInfo
 import androidx.test.core.app.ApplicationProvider
 
@@ -49,11 +51,10 @@ class PerformHTTPSRequestUsingAsyncProxyTest {
   fun `performs an HTTPs request through a proxy using async DNS resolution`() {
     val port = (10001..11000).random()
 
-    val mockContext = Mockito.mock(Context::class.java)
-    Mockito.`when`(mockContext.getApplicationContext()).thenReturn(mockContext)
-    val mockConnectivityManager = Mockito.mock(ConnectivityManager::class.java)
-    Mockito.`when`(mockContext.getSystemService(Mockito.anyString())).thenReturn(mockConnectivityManager)
-    Mockito.`when`(mockConnectivityManager.getDefaultProxy()).thenReturn(ProxyInfo.buildDirectProxy("localhost", port))
+    val context = Mockito.spy(ApplicationProvider.getApplicationContext<Context>())
+    val connectivityManager: ConnectivityManager = Mockito.mock(ConnectivityManager::class.java)
+    Mockito.doReturn(connectivityManager).`when`(context).getSystemService(Context.CONNECTIVITY_SERVICE)
+    Mockito.`when`(connectivityManager.getDefaultProxy()).thenReturn(ProxyInfo.buildDirectProxy("127.0.0.1", port))
 
     val onEngineRunningLatch = CountDownLatch(1)
     val onProxyEngineRunningLatch = CountDownLatch(1)
@@ -68,7 +69,9 @@ class PerformHTTPSRequestUsingAsyncProxyTest {
     onProxyEngineRunningLatch.await(10, TimeUnit.SECONDS)
     assertThat(onProxyEngineRunningLatch.count).isEqualTo(0)
 
-    val builder = AndroidEngineBuilder(mockContext)
+    context.sendStickyBroadcast(Intent(Proxy.PROXY_CHANGE_ACTION))
+
+    val builder = AndroidEngineBuilder(context)
     val engine = builder
       .addLogLevel(LogLevel.DEBUG)
       .enableProxying(true)

--- a/test/kotlin/integration/proxying/PerformHTTPSRequestUsingAsyncProxyTest.kt
+++ b/test/kotlin/integration/proxying/PerformHTTPSRequestUsingAsyncProxyTest.kt
@@ -53,7 +53,7 @@ class PerformHTTPSRequestUsingAsyncProxyTest {
     val context = Mockito.spy(ApplicationProvider.getApplicationContext<Context>())
     val connectivityManager: ConnectivityManager = Mockito.mock(ConnectivityManager::class.java)
     Mockito.doReturn(connectivityManager).`when`(context).getSystemService(Context.CONNECTIVITY_SERVICE)
-    Mockito.`when`(connectivityManager.getDefaultProxy()).thenReturn(ProxyInfo.buildDirectProxy("127.0.0.1", port))
+    Mockito.`when`(connectivityManager.getDefaultProxy()).thenReturn(ProxyInfo.buildDirectProxy("localhost", port))
 
     val onEngineRunningLatch = CountDownLatch(1)
     val onProxyEngineRunningLatch = CountDownLatch(1)

--- a/test/kotlin/integration/proxying/PerformHTTPSRequestUsingAsyncProxyTest.kt
+++ b/test/kotlin/integration/proxying/PerformHTTPSRequestUsingAsyncProxyTest.kt
@@ -2,7 +2,6 @@ package test.kotlin.integration.proxying
 
 import android.content.Intent
 import android.content.Context
-import android.os.UserHandle
 import android.net.ConnectivityManager
 import android.net.Proxy
 import android.net.ProxyInfo

--- a/test/kotlin/integration/proxying/PerformHTTPSRequestUsingProxyTest.kt
+++ b/test/kotlin/integration/proxying/PerformHTTPSRequestUsingProxyTest.kt
@@ -1,8 +1,10 @@
 package test.kotlin.integration.proxying
 
-
+import android.content.Intent
 import android.content.Context
+import android.os.UserHandle
 import android.net.ConnectivityManager
+import android.net.Proxy
 import android.net.ProxyInfo
 import androidx.test.core.app.ApplicationProvider
 
@@ -49,17 +51,16 @@ class PerformHTTPSRequestUsingProxy {
   fun `performs an HTTPs request through a proxy`() {
     val port = (10001..11000).random()
 
-    val mockContext = Mockito.mock(Context::class.java)
-    Mockito.`when`(mockContext.getApplicationContext()).thenReturn(mockContext)
-    val mockConnectivityManager = Mockito.mock(ConnectivityManager::class.java)
-    Mockito.`when`(mockContext.getSystemService(Mockito.anyString())).thenReturn(mockConnectivityManager)
-    Mockito.`when`(mockConnectivityManager.getDefaultProxy()).thenReturn(ProxyInfo.buildDirectProxy("127.0.0.1", port))
+    val context = Mockito.spy(ApplicationProvider.getApplicationContext<Context>())
+    val connectivityManager: ConnectivityManager = Mockito.mock(ConnectivityManager::class.java)
+    Mockito.doReturn(connectivityManager).`when`(context).getSystemService(Context.CONNECTIVITY_SERVICE)
+    Mockito.`when`(connectivityManager.getDefaultProxy()).thenReturn(ProxyInfo.buildDirectProxy("127.0.0.1", port))
 
     val onEngineRunningLatch = CountDownLatch(1)
     val onProxyEngineRunningLatch = CountDownLatch(1)
     val onRespondeHeadersLatch = CountDownLatch(1)
 
-    val proxyEngineBuilder = Proxy(ApplicationProvider.getApplicationContext(), port).https()
+    val proxyEngineBuilder = Proxy(context, port).https()
     val proxyEngine = proxyEngineBuilder
       .addLogLevel(LogLevel.DEBUG)
       .setOnEngineRunning { onProxyEngineRunningLatch.countDown() }
@@ -68,7 +69,9 @@ class PerformHTTPSRequestUsingProxy {
     onProxyEngineRunningLatch.await(10, TimeUnit.SECONDS)
     assertThat(onProxyEngineRunningLatch.count).isEqualTo(0)
 
-    val builder = AndroidEngineBuilder(mockContext)
+    context.sendStickyBroadcast(Intent(Proxy.PROXY_CHANGE_ACTION))
+
+    val builder = AndroidEngineBuilder(context)
     val engine = builder
       .addLogLevel(LogLevel.DEBUG)
       .enableProxying(true)

--- a/test/kotlin/integration/proxying/PerformHTTPSRequestUsingProxyTest.kt
+++ b/test/kotlin/integration/proxying/PerformHTTPSRequestUsingProxyTest.kt
@@ -2,7 +2,6 @@ package test.kotlin.integration.proxying
 
 import android.content.Intent
 import android.content.Context
-import android.os.UserHandle
 import android.net.ConnectivityManager
 import android.net.Proxy
 import android.net.ProxyInfo


### PR DESCRIPTION
Description: Add support for PAC proxies. Fixes https://github.com/envoyproxy/envoy-mobile/issues/2531.
Risk Level: Low, the change should be additive and it's guarded with an engine builder flag (`enableProxying(true/false)` that's disabled by default.
Testing: Manual testing for PAC proxies, integrations tests for other types of proxies.
Docs Changes: N/A
Release Notes: WIP

Signed-off-by: Rafal Augustyniak <raugustyniak@lyft.com>