### PR TITLE
Update rules_xcodeproj to 0.9.0

### DIFF
--- a/BUILD
+++ b/BUILD
@@ -2,8 +2,8 @@ load("@build_bazel_rules_android//android:rules.bzl", "aar_import")
 load("@build_bazel_rules_apple//apple:apple.bzl", "apple_static_framework_import")
 load("@io_bazel_rules_kotlin//kotlin/internal:toolchains.bzl", "define_kt_toolchain")
 load(
-    "@com_github_buildbuddy_io_rules_xcodeproj//xcodeproj:xcodeproj.bzl",
-    "top_level_target",
+    "@com_github_buildbuddy_io_rules_xcodeproj//xcodeproj:defs.bzl",
+    "top_level_targets",
     "xcode_schemes",
     "xcodeproj",
 )
@@ -151,36 +151,14 @@ xcodeproj(
     tags = ["manual"],
     top_level_targets = [
         # Apps
-        top_level_target(
-            "//examples/objective-c/hello_world:app",
-            target_environments = [
-                "device",
-                "simulator",
+        top_level_targets(
+            labels = [
+                "//examples/objective-c/hello_world:app",
+                "//examples/swift/async_await:app",
+                "//examples/swift/hello_world:app",
+                "//test/swift/apps/baseline:app",
+                "//test/swift/apps/experimental:app",
             ],
-        ),
-        top_level_target(
-            "//examples/swift/async_await:app",
-            target_environments = [
-                "device",
-                "simulator",
-            ],
-        ),
-        top_level_target(
-            "//examples/swift/hello_world:app",
-            target_environments = [
-                "device",
-                "simulator",
-            ],
-        ),
-        top_level_target(
-            "//test/swift/apps/baseline:app",
-            target_environments = [
-                "device",
-                "simulator",
-            ],
-        ),
-        top_level_target(
-            "//test/swift/apps/experimental:app",
             target_environments = [
                 "device",
                 "simulator",

--- a/bazel/envoy_mobile_repositories.bzl
+++ b/bazel/envoy_mobile_repositories.bzl
@@ -98,8 +98,8 @@ def swift_repos():
 
     http_archive(
         name = "com_github_buildbuddy_io_rules_xcodeproj",
-        sha256 = "663bf83d8725f39694125d790eacd373e4c063bf80be4e6b5daa0a5dbe74df1f",
-        url = "https://github.com/buildbuddy-io/rules_xcodeproj/releases/download/0.8.0/release.tar.gz",
+        sha256 = "564381b33261ba29e3c8f505de82fc398452700b605d785ce3e4b9dd6c73b623",
+        url = "https://github.com/buildbuddy-io/rules_xcodeproj/releases/download/0.9.0/release.tar.gz",
     )
 
 def kotlin_repos():

--- a/examples/BUILD
+++ b/examples/BUILD
@@ -1,6 +1,6 @@
 load("@build_bazel_rules_apple//apple:apple.bzl", "local_provisioning_profile")
 load(
-    "@com_github_buildbuddy_io_rules_xcodeproj//xcodeproj:xcodeproj.bzl",
+    "@com_github_buildbuddy_io_rules_xcodeproj//xcodeproj:defs.bzl",
     "xcode_provisioning_profile",
 )
 


### PR DESCRIPTION
Relevant to us are:

* a nicer API for simulator+device apps
* performance improvements
* support for runtime sanitizers
* support for pre-build run scripts

I tried getting SwiftLint and DrString set up as pre-build scripts but couldn't get that to work, so I'll add that in the future when I figure it out.

Signed-off-by: JP Simard <jp@jpsim.com>