### PR TITLE
ci: Conditionally run on remote execution

### DIFF
--- a/.github/workflows/android_build.yml
+++ b/.github/workflows/android_build.yml
@@ -27,7 +27,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           ./bazelw build \
-            --config=remote-ci-macos \
+            $([ -z $GITHUB_TOKEN ] || echo "--config=remote-ci-macos") \
             --remote_header="Authorization=Bearer $GITHUB_TOKEN" \
             --fat_apk_cpu=x86_64 \
             //:android_dist
@@ -57,7 +57,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           ./bazelw build \
-            --config=remote-ci-macos \
+            $([ -z $GITHUB_TOKEN ] || echo "--config=remote-ci-macos") \
             --remote_header="Authorization=Bearer $GITHUB_TOKEN" \
             --fat_apk_cpu=x86_64 \
             //examples/java/hello_world:hello_envoy
@@ -91,7 +91,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           ./bazelw build \
-            --config=remote-ci-macos \
+            $([ -z $GITHUB_TOKEN ] || echo "--config=remote-ci-macos") \
             --remote_header="Authorization=Bearer $GITHUB_TOKEN" \
             --fat_apk_cpu=x86_64 \
             //examples/kotlin/hello_world:hello_envoy_kt
@@ -125,7 +125,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           ./bazelw build \
-            --config=remote-ci-macos \
+            $([ -z $GITHUB_TOKEN ] || echo "--config=remote-ci-macos") \
             --remote_header="Authorization=Bearer $GITHUB_TOKEN" \
             --fat_apk_cpu=x86_64 \
             //test/kotlin/apps/baseline:hello_envoy_kt
@@ -159,7 +159,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           ./bazelw build \
-            --config=remote-ci-macos \
+            $([ -z $GITHUB_TOKEN ] || echo "--config=remote-ci-macos") \
             --remote_header="Authorization=Bearer $GITHUB_TOKEN" \
             --fat_apk_cpu=x86_64 \
             //test/kotlin/apps/experimental:hello_envoy_kt

--- a/.github/workflows/android_tests.yml
+++ b/.github/workflows/android_tests.yml
@@ -45,7 +45,7 @@ jobs:
           ./bazelw test \
             --test_output=all \
             --build_tests_only \
-            --config=remote-ci-macos \
+            $([ -z $GITHUB_TOKEN ] || echo "--config=remote-ci-macos") \
             --remote_header="Authorization=Bearer $GITHUB_TOKEN" \
             //test/kotlin/io/...
   javatestsmac:
@@ -84,7 +84,7 @@ jobs:
           ./bazelw test \
             --test_output=all \
             --build_tests_only \
-            --config=remote-ci-macos \
+            $([ -z $GITHUB_TOKEN ] || echo "--config=remote-ci-macos") \
             --remote_header="Authorization=Bearer $GITHUB_TOKEN" \
             --define=signal_trace=disabled \
             //test/java/...
@@ -133,6 +133,6 @@ jobs:
           ./bazelw test \
             --test_output=all \
             --build_tests_only \
-            --config=remote-ci-linux-clang \
+            $([ -z $GITHUB_TOKEN ] || echo "--config=remote-ci-linux-clang") \
             --remote_header="Authorization=Bearer $GITHUB_TOKEN" \
             //test/kotlin/...

--- a/.github/workflows/asan.yml
+++ b/.github/workflows/asan.yml
@@ -45,6 +45,6 @@ jobs:
         run: |
           ./bazelw test --test_output=all \
             --test_env=ENVOY_IP_TEST_VERSIONS=v4only \
+            $([ -z $GITHUB_TOKEN ] || echo "--config=remote-ci-linux-asan") \
             --remote_header="Authorization=Bearer $GITHUB_TOKEN" \
-            --config=remote-ci-linux-asan \
             //test/common/...

--- a/.github/workflows/cc_tests.yml
+++ b/.github/workflows/cc_tests.yml
@@ -26,6 +26,6 @@ jobs:
           ./bazelw test \
             --action_env=LD_LIBRARY_PATH \
             --test_output=all \
-            --config=remote-ci-linux \
+            $([ -z $GITHUB_TOKEN ] || echo "--config=remote-ci-linux") \
             --remote_header="Authorization=Bearer $GITHUB_TOKEN" \
             //test/cc/...

--- a/.github/workflows/core.yml
+++ b/.github/workflows/core.yml
@@ -23,6 +23,6 @@ jobs:
         run: |
           ./bazelw test \
             --test_output=all \
-            --config=remote-ci-macos \
+            $([ -z $GITHUB_TOKEN ] || echo "--config=remote-ci-macos") \
             --remote_header="Authorization=Bearer $GITHUB_TOKEN" \
             //test/common/...

--- a/.github/workflows/format.yml
+++ b/.github/workflows/format.yml
@@ -76,7 +76,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           ./bazelw build \
-            --config=remote-ci-macos \
+            $([ -z $GITHUB_TOKEN ] || echo "--config=remote-ci-macos") \
             --remote_header="Authorization=Bearer $GITHUB_TOKEN" \
             //library/kotlin/io/envoyproxy/envoymobile:envoy_lib_lint \
             //examples/kotlin/hello_world:hello_envoy_kt_lint

--- a/.github/workflows/ios_build.yml
+++ b/.github/workflows/ios_build.yml
@@ -23,7 +23,7 @@ jobs:
           ./bazelw shutdown
           ./bazelw build \
             --config=ios \
-            --config=remote-ci-macos \
+            $([ -z $GITHUB_TOKEN ] || echo "--config=remote-ci-macos") \
             --remote_header="Authorization=Bearer $GITHUB_TOKEN" \
             //library/swift:ios_framework
         name: 'Build Envoy.framework distributable'
@@ -43,7 +43,7 @@ jobs:
         run: |
           ./bazelw build \
             --config=ios \
-            --config=remote-ci-macos \
+            $([ -z $GITHUB_TOKEN ] || echo "--config=remote-ci-macos") \
             --remote_header="Authorization=Bearer $GITHUB_TOKEN" \
             //examples/swift/hello_world:app
         name: 'Build swift app'
@@ -53,7 +53,7 @@ jobs:
         run: |
           ./bazelw run \
             --config=ios \
-            --config=remote-ci-macos \
+            $([ -z $GITHUB_TOKEN ] || echo "--config=remote-ci-macos") \
             --remote_header="Authorization=Bearer $GITHUB_TOKEN" \
             //examples/swift/hello_world:app &> /tmp/envoy.log &
         name: 'Run swift app'
@@ -78,7 +78,7 @@ jobs:
         run: |
           ./bazelw build \
             --config=ios \
-            --config=remote-ci-macos \
+            $([ -z $GITHUB_TOKEN ] || echo "--config=remote-ci-macos") \
             --remote_header="Authorization=Bearer $GITHUB_TOKEN" \
             //test/swift/apps/baseline:app
         name: 'Build swift app'
@@ -88,7 +88,7 @@ jobs:
         run: |
           ./bazelw run \
             --config=ios \
-            --config=remote-ci-macos \
+            $([ -z $GITHUB_TOKEN ] || echo "--config=remote-ci-macos") \
             --remote_header="Authorization=Bearer $GITHUB_TOKEN" \
             //test/swift/apps/baseline:app &> /tmp/envoy.log &
         name: 'Run swift app'
@@ -113,7 +113,7 @@ jobs:
         run: |
           ./bazelw build \
             --config=ios \
-            --config=remote-ci-macos \
+            $([ -z $GITHUB_TOKEN ] || echo "--config=remote-ci-macos") \
             --remote_header="Authorization=Bearer $GITHUB_TOKEN" \
             //test/swift/apps/experimental:app
         name: 'Build swift app'
@@ -123,7 +123,7 @@ jobs:
         run: |
           ./bazelw run \
             --config=ios \
-            --config=remote-ci-macos \
+            $([ -z $GITHUB_TOKEN ] || echo "--config=remote-ci-macos") \
             --remote_header="Authorization=Bearer $GITHUB_TOKEN" \
             //test/swift/apps/experimental:app &> /tmp/envoy.log &
         name: 'Run swift app'
@@ -148,7 +148,7 @@ jobs:
         run: |
           ./bazelw build \
             --config=ios \
-            --config=remote-ci-macos \
+            $([ -z $GITHUB_TOKEN ] || echo "--config=remote-ci-macos") \
             --remote_header="Authorization=Bearer $GITHUB_TOKEN" \
             //examples/swift/async_await:app
         name: 'Build swift app'
@@ -158,7 +158,7 @@ jobs:
         run: |
           ./bazelw run \
             --config=ios \
-            --config=remote-ci-macos \
+            $([ -z $GITHUB_TOKEN ] || echo "--config=remote-ci-macos") \
             --remote_header="Authorization=Bearer $GITHUB_TOKEN" \
             //examples/swift/async_await:app &> /tmp/envoy.log &
         name: 'Run swift app'
@@ -183,7 +183,7 @@ jobs:
         run: |
           ./bazelw build \
             --config=ios \
-            --config=remote-ci-macos \
+            $([ -z $GITHUB_TOKEN ] || echo "--config=remote-ci-macos") \
             --remote_header="Authorization=Bearer $GITHUB_TOKEN" \
             //examples/objective-c/hello_world:app
         name: 'Build objective-c app'
@@ -193,7 +193,7 @@ jobs:
         run: |
           ./bazelw run \
             --config=ios \
-            --config=remote-ci-macos \
+            $([ -z $GITHUB_TOKEN ] || echo "--config=remote-ci-macos") \
             --remote_header="Authorization=Bearer $GITHUB_TOKEN" \
             //examples/objective-c/hello_world:app &> /tmp/envoy.log &
         name: 'Run objective-c app'

--- a/.github/workflows/ios_tests.yml
+++ b/.github/workflows/ios_tests.yml
@@ -37,7 +37,7 @@ jobs:
             --test_output=all \
             --config=ios \
             --build_tests_only \
-            --config=remote-ci-macos \
+            $([ -z $GITHUB_TOKEN ] || echo "--config=remote-ci-macos") \
             --remote_header="Authorization=Bearer $GITHUB_TOKEN" \
             //test/swift/...
   objctests:
@@ -69,7 +69,7 @@ jobs:
             --test_output=all \
             --config=ios \
             --build_tests_only \
-            --config=remote-ci-macos \
+            $([ -z $GITHUB_TOKEN ] || echo "--config=remote-ci-macos") \
             --remote_header="Authorization=Bearer $GITHUB_TOKEN" \
             //test/objective-c/...  \
             //test/cc/unit:envoy_config_test

--- a/.github/workflows/perf.yml
+++ b/.github/workflows/perf.yml
@@ -28,7 +28,7 @@ jobs:
         run: |
           ./bazelw build \
             --config=sizeopt \
-            --config=remote-ci-linux-clang \
+            $([ -z $GITHUB_TOKEN ] || echo "--config=remote-ci-linux-clang") \
             --remote_header="Authorization=Bearer $GITHUB_TOKEN" \
             //test/performance:test_binary_size
       - uses: actions/upload-artifact@v2
@@ -59,7 +59,7 @@ jobs:
           git checkout main && git pull origin main && git submodule update
           ./bazelw build \
             --config=sizeopt \
-            --config=remote-ci-linux-clang \
+            $([ -z $GITHUB_TOKEN ] || echo "--config=remote-ci-linux-clang") \
             --remote_header="Authorization=Bearer $GITHUB_TOKEN" \
             //test/performance:test_binary_size
       - uses: actions/upload-artifact@v2

--- a/.github/workflows/python_tests.yml
+++ b/.github/workflows/python_tests.yml
@@ -37,6 +37,6 @@ jobs:
           ./bazelw test \
             --action_env=LD_LIBRARY_PATH \
             --test_output=all \
-            --config=remote-ci-linux \
+            $([ -z $GITHUB_TOKEN ] || echo "--config=remote-ci-linux") \
             --remote_header="Authorization=Bearer $GITHUB_TOKEN" \
             //test/python/...

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -33,7 +33,7 @@ jobs:
               --config=release-android \
               --fat_apk_cpu=x86,x86_64,armeabi-v7a,arm64-v8a \
               --define=pom_version="${current_release_version:1}" \
-              --config=remote-ci-macos \
+              $([ -z $GITHUB_TOKEN ] || echo "--config=remote-ci-macos") \
               --remote_header="Authorization=Bearer $GITHUB_TOKEN" \
               //:android_dist
       - name: 'Tar artifacts'
@@ -123,7 +123,7 @@ jobs:
         run: |
           ./bazelw build \
             --config=release-ios \
-            --config=remote-ci-macos \
+            $([ -z $GITHUB_TOKEN ] || echo "--config=remote-ci-macos") \
             --remote_header="Authorization=Bearer $GITHUB_TOKEN" \
             //:ios_xcframework
       - name: 'Move Envoy.xcframework.zip'
@@ -139,7 +139,7 @@ jobs:
           ./bazelw build \
             --output_groups=+swift_symbol_graph \
             --config=release-ios \
-            --config=remote-ci-macos \
+            $([ -z $GITHUB_TOKEN ] || echo "--config=remote-ci-macos") \
             --remote_header="Authorization=Bearer $GITHUB_TOKEN" \
             //library/swift:ios_lib
           ./tools/docc.sh bazel-bin/library/swift/ios_lib.symbolgraph

--- a/.github/workflows/release_validation.yml
+++ b/.github/workflows/release_validation.yml
@@ -19,7 +19,12 @@ jobs:
         name: 'Install dependencies'
       - env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: ./bazelw build --config=ios --config=remote-ci-macos --remote_header="Authorization=Bearer $GITHUB_TOKEN" //:ios_xcframework
+        run: |
+          ./bazelw build \
+            --config=ios \
+            $([ -z $GITHUB_TOKEN ] || echo "--config=remote-ci-macos") \
+            --remote_header="Authorization=Bearer $GITHUB_TOKEN" \
+            //:ios_xcframework
         name: 'Build xcframework'
       # Ignore errors: Bad CRC when unzipping large files: https://bbs.archlinux.org/viewtopic.php?id=153011
       - run: unzip bazel-bin/library/swift/Envoy.xcframework.zip -d examples/swift/swiftpm/Packages || true

--- a/.github/workflows/tsan.yml
+++ b/.github/workflows/tsan.yml
@@ -47,5 +47,5 @@ jobs:
             --test_output=all \
             --test_env=ENVOY_IP_TEST_VERSIONS=v4only \
             --remote_header="Authorization=Bearer $GITHUB_TOKEN" \
-            --config=remote-ci-linux-tsan \
+            $([ -z $GITHUB_TOKEN ] || echo "--config=remote-ci-linux-tsan") \
             //test/common/...


### PR DESCRIPTION
For an explanation of how to fill out the fields, please see the relevant section
in [PULL_REQUESTS.md](https://github.com/envoyproxy/envoy/blob/master/PULL_REQUESTS.md)

Description:
Only configure Bazel to run against remote execution if the GITHUB_TOKEN environment variable is set. This should prevent forked repos (that do not have a valid GITHUB_TOKEN) from attempting to run against the remote execution cluster.

Risk Level: Medium
Testing: Manual
Docs Changes: N/A
Release Notes: N/A

Signed-off-by: Will Martin <will@engflow.com>