### PR TITLE
core: enable more detailed virtual cluster stats

### DIFF
--- a/library/common/config/config.cc
+++ b/library/common/config/config.cc
@@ -480,7 +480,7 @@ stats_config:
         - safe_regex:
             regex: '^pulse.*'
         - safe_regex:
-            regex: '^vhost\.[\w]+\.vcluster\.[\w]+?\.upstream_rq_(?:[12345]xx|retry.*|time|timeout|total)'
+            regex: '^vhost\.[\w]+\.vcluster\.[\w]+?\.upstream_rq_(?:[12345]xx|[1-5][0-9][0-9]|retry.*|time|timeout|total)'
   use_all_default_tags:
     false
 watchdogs:

--- a/library/common/config/config.cc
+++ b/library/common/config/config.cc
@@ -480,7 +480,7 @@ stats_config:
         - safe_regex:
             regex: '^pulse.*'
         - safe_regex:
-            regex: '^vhost\.[\w]+\.vcluster\.[\w]+?\.upstream_rq_(?:[12345]xx|[1-5][0-9][0-9]|retry.*|time|timeout|total)'
+            regex: '^vhost\.[\w]+\.vcluster\.[\w]+?\.upstream_rq_(?:[12345]xx|[3-5][0-9][0-9]|retry.*|time|timeout|total)'
   use_all_default_tags:
     false
 watchdogs:


### PR DESCRIPTION
Description: Emit stats that include the specific error code for cases when a request fails with 3xx, 4xx or 5xx. These stats are created only when a failure with a given status code happens so most of them are never created which is great as it reduces the memory footprint that these stats have.
Risk Level: Low, more stats for cases where you have enabled virtual clusters only.
Testing: Manual
Docs Changes: N/A
Release Notes: N/A

Signed-off-by: Rafal Augustyniak <raugustyniak@lyft.com>

