### PR TITLE
Slight cleanup of C++ EngineBuilder

### DIFF
--- a/library/cc/engine_builder.cc
+++ b/library/cc/engine_builder.cc
@@ -12,6 +12,16 @@
 namespace Envoy {
 namespace Platform {
 
+namespace {
+// Inserts `filter_config` into the "custom_filters" target in `config_template`.
+void insertCustomFilter(const std::string& filter_config, std::string& config_template) {
+    absl::StrReplaceAll(
+        {{"#{custom_filters}",
+           absl::StrCat("#{custom_filters}\n", filter_config)}},
+        &config_template);
+}
+}  // namespace
+
 EngineBuilder::EngineBuilder(std::string config_template)
     : callbacks_(std::make_shared<EngineCallbacks>()), config_template_(config_template) {}
 EngineBuilder::EngineBuilder() : EngineBuilder(std::string(config_template)) {}
@@ -193,7 +203,7 @@ EngineBuilder::enablePlatformCertificatesValidation(bool platform_certificates_v
   return *this;
 }
 
-std::string EngineBuilder::generateConfigStr() {
+std::string EngineBuilder::generateConfigStr() const {
 #if defined(__APPLE__)
   std::string dns_resolver_name = "envoy.network.dns_resolver.apple";
   std::string dns_resolver_config =
@@ -273,29 +283,21 @@ std::string EngineBuilder::generateConfigStr() {
                                                   : default_cert_validation_context_template);
   config_builder << cert_validation_template << std::endl;
 
+  std::string config_template = config_template_;
   if (this->gzip_filter_) {
-    absl::StrReplaceAll(
-        {{"#{custom_filters}", absl::StrCat("#{custom_filters}\n", gzip_config_insert)}},
-        &config_template_);
+    insertCustomFilter(gzip_config_insert, config_template);
   }
   if (this->brotli_filter_) {
-    absl::StrReplaceAll(
-        {{"#{custom_filters}", absl::StrCat("#{custom_filters}\n", brotli_config_insert)}},
-        &config_template_);
+    insertCustomFilter(brotli_config_insert, config_template);
   }
   if (this->socket_tagging_filter_) {
-    absl::StrReplaceAll(
-        {{"#{custom_filters}", absl::StrCat("#{custom_filters}\n", socket_tag_config_insert)}},
-        &config_template_);
+    insertCustomFilter(socket_tag_config_insert, config_template);
   }
   if (this->enable_http3_) {
-    absl::StrReplaceAll(
-        {{"#{custom_filters}",
-          absl::StrCat("#{custom_filters}\n", alternate_protocols_cache_filter_insert)}},
-        &config_template_);
+    insertCustomFilter(alternate_protocols_cache_filter_insert, config_template);
   }
 
-  config_builder << config_template_;
+  config_builder << config_template;
 
   if (admin_interface_enabled_) {
     config_builder << "admin: *admin_interface" << std::endl;

--- a/library/cc/engine_builder.cc
+++ b/library/cc/engine_builder.cc
@@ -15,12 +15,10 @@ namespace Platform {
 namespace {
 // Inserts `filter_config` into the "custom_filters" target in `config_template`.
 void insertCustomFilter(const std::string& filter_config, std::string& config_template) {
-    absl::StrReplaceAll(
-        {{"#{custom_filters}",
-           absl::StrCat("#{custom_filters}\n", filter_config)}},
-        &config_template);
+  absl::StrReplaceAll({{"#{custom_filters}", absl::StrCat("#{custom_filters}\n", filter_config)}},
+                      &config_template);
 }
-}  // namespace
+} // namespace
 
 EngineBuilder::EngineBuilder(std::string config_template)
     : callbacks_(std::make_shared<EngineCallbacks>()), config_template_(config_template) {}

--- a/library/cc/engine_builder.h
+++ b/library/cc/engine_builder.h
@@ -57,7 +57,7 @@ public:
   EngineBuilder& enablePlatformCertificatesValidation(bool platform_certificates_validation_on);
 
   // this is separated from build() for the sake of testability
-  std::string generateConfigStr();
+  std::string generateConfigStr() const;
 
   EngineSharedPtr build();
 


### PR DESCRIPTION
Make generateConfigStr() const (to ensure that it produces the same output if called multiple times).
Add a small helper method for inserting custom filter configs into the template.

Risk Level: Low
Testing: No behavior change
Docs Changes: N/A
Release Notes: N/A