### PR TITLE
android: fix engine builder crash on Android 6/7

### DIFF
--- a/docs/root/intro/version_history.rst
+++ b/docs/root/intro/version_history.rst
@@ -12,7 +12,6 @@ Breaking changes:
 Bugfixes:
 
 - android: fix engine startup crash for when admin interface is enabled. (:issue:`#2520 <2520>`)
-- android: fix engine builder crash on Android 6/7 when using stats sinks. (:issue:`#2622 <2622>`)
 - android: respect system security policy when determining whether clear text requests are allowed. (:issue:`#2528 <2528>`)
 
 Features:

--- a/docs/root/intro/version_history.rst
+++ b/docs/root/intro/version_history.rst
@@ -12,6 +12,7 @@ Breaking changes:
 Bugfixes:
 
 - android: fix engine startup crash for when admin interface is enabled. (:issue:`#2520 <2520>`)
+- android: fix engine builder crash on Android 6/7 when using stats sinks. (:issue:`#2622 <2622>`)
 - android: respect system security policy when determining whether clear text requests are allowed. (:issue:`#2528 <2528>`)
 
 Features:

--- a/library/java/io/envoyproxy/envoymobile/engine/EnvoyConfiguration.java
+++ b/library/java/io/envoyproxy/envoymobile/engine/EnvoyConfiguration.java
@@ -309,7 +309,10 @@ public class EnvoyConfiguration {
 
     if (!stat_sinks_config.isEmpty()) {
       configBuilder.append("- &stats_sinks [");
-      configBuilder.append(String.join(",", stat_sinks_config));
+      configBuilder.append(stat_sinks_config[0]);
+      for (int i = 1; i < stat_sinks_config.length; i++) {
+        configBuilder.append(',').append(stat_sinks_config[i]);
+      }
       configBuilder.append("] \n");
     }
 

--- a/library/java/io/envoyproxy/envoymobile/engine/EnvoyConfiguration.java
+++ b/library/java/io/envoyproxy/envoymobile/engine/EnvoyConfiguration.java
@@ -309,9 +309,9 @@ public class EnvoyConfiguration {
 
     if (!stat_sinks_config.isEmpty()) {
       configBuilder.append("- &stats_sinks [");
-      configBuilder.append(stat_sinks_config[0]);
-      for (int i = 1; i < stat_sinks_config.length; i++) {
-        configBuilder.append(',').append(stat_sinks_config[i]);
+      configBuilder.append(stat_sinks_config.get(0));
+      for (int i = 1; i < stat_sinks_config.size(); i++) {
+        configBuilder.append(',').append(stat_sinks_config.get(i));
       }
       configBuilder.append("] \n");
     }


### PR DESCRIPTION
Description: `String.join` is only available in Android 8 and later.
Risk Level: Low.
Testing: Unit tests.
Docs Changes: N/A.
Release Notes: Added.
Fixes #2622

Signed-off-by: JP Simard <jp@jpsim.com>