### PR TITLE
ci: migrate from `set-output` to `GITHUB_OUTPUT`

### DIFF
--- a/.github/workflows/android_tests.yml
+++ b/.github/workflows/android_tests.yml
@@ -22,10 +22,10 @@ jobs:
         run: |
           if git rev-parse --abbrev-ref HEAD | grep -q ^main$ || git diff --name-only origin/main | grep -qe common/ -e java/ -e kotlin/ -e bazel/ -e ^\.bazelrc$ -e ^envoy$ -e ^WORKSPACE$ -e ^.github/workflows/android_tests.yml$ ; then
             echo "Tests will run."
-            echo "::set-output name=run_tests::true"
+            echo "run_tests=true" >> $GITHUB_OUTPUT
           else
             echo "Skipping tests."
-            echo "::set-output name=run_tests::false"
+            echo "run_tests=false" >> $GITHUB_OUTPUT
           fi
       - name: 'Java setup'
         if: steps.check_context.outputs.run_tests == 'true'
@@ -61,10 +61,10 @@ jobs:
         run: |
           if git rev-parse --abbrev-ref HEAD | grep -q ^main$ || git diff --name-only origin/main | grep -qe common/ -e java/ -e kotlin/ -e bazel/ -e ^\.bazelrc$ -e ^envoy$ -e ^WORKSPACE$ -e ^.github/workflows/android_tests.yml$ ; then
             echo "Tests will run."
-            echo "::set-output name=run_tests::true"
+            echo "run_tests=true" >> $GITHUB_OUTPUT
           else
             echo "Skipping tests."
-            echo "::set-output name=run_tests::false"
+            echo "run_tests=false" >> $GITHUB_OUTPUT
           fi
       - name: 'Java setup'
         if: steps.check_context.outputs.run_tests == 'true'
@@ -110,10 +110,10 @@ jobs:
         run: |
           if git rev-parse --abbrev-ref HEAD | grep -q ^main$ || git diff --name-only origin/main | grep -qe common/ -e java/ -e kotlin/ -e bazel/ -e ^\.bazelrc$ -e ^envoy$ -e ^WORKSPACE$ -e ^.github/workflows/android_tests.yml$ ; then
             echo "Tests will run."
-            echo "::set-output name=run_tests::true"
+            echo "run_tests=true" >> $GITHUB_OUTPUT
           else
             echo "Skipping tests."
-            echo "::set-output name=run_tests::false"
+            echo "run_tests=false" >> $GITHUB_OUTPUT
           fi
       - name: 'Java setup'
         if: steps.check_context.outputs.run_tests == 'true'

--- a/.github/workflows/asan.yml
+++ b/.github/workflows/asan.yml
@@ -27,10 +27,10 @@ jobs:
         run: |
           if git rev-parse --abbrev-ref HEAD | grep -q ^main$ || git diff --name-only origin/main | grep -qe common/ -e bazel/ -e ^\.bazelrc$ -e ^envoy$ -e ^WORKSPACE$ -e ^.github/workflows/asan.yml$ ; then
             echo "Tests will run."
-            echo "::set-output name=run_tests::true"
+            echo "run_tests=true" >> $GITHUB_OUTPUT
           else
             echo "Skipping tests."
-            echo "::set-output name=run_tests::false"
+            echo "run_tests=false" >> $GITHUB_OUTPUT
           fi
       - uses: actions/setup-java@v1
         if: steps.check-cache.outputs.cache-hit != 'true'

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -27,10 +27,10 @@ jobs:
         run: |
           if git rev-parse --abbrev-ref HEAD | grep -q ^main$ || git diff --name-only origin/main | grep -qe common/ -e ^.github/workflows/coverage.yml ; then
             echo "Coverage will run."
-            echo "::set-output name=run_coverage::true"
+            echo "run_coverage=true" >> $GITHUB_OUTPUT
           else
             echo "Skipping coverage."
-            echo "::set-output name=run_coverage::false"
+            echo "run_coverage=false" >> $GITHUB_OUTPUT
           fi
       - name: 'Run coverage'
         if: steps.check_context.outputs.run_coverage == 'true'

--- a/.github/workflows/ios_tests.yml
+++ b/.github/workflows/ios_tests.yml
@@ -20,10 +20,10 @@ jobs:
         run: |
           if git rev-parse --abbrev-ref HEAD | grep -q ^main$ || git diff --name-only origin/main | grep -qe common/ -e objective-c/ -e swift/ -e bazel/ -e ^\.bazelrc$ -e ^envoy$ -e ^WORKSPACE$ -e ^.github/workflows/ios_tests.yml$ ; then
             echo "Tests will run."
-            echo "::set-output name=run_tests::true"
+            echo "run_tests=true" >> $GITHUB_OUTPUT
           else
             echo "Skipping tests."
-            echo "::set-output name=run_tests::false"
+            echo "run_tests=false" >> $GITHUB_OUTPUT
           fi
       - name: 'Install dependencies'
         run: ./ci/mac_ci_setup.sh
@@ -53,10 +53,10 @@ jobs:
         run: |
           if git rev-parse --abbrev-ref HEAD | grep -q ^main$ || git diff --name-only origin/main | grep -qe common/ -e objective-c/ -e swift/ -e bazel/ -e ^\.bazelrc$ -e ^envoy$ -e ^WORKSPACE$ -e ^.github/workflows/ios_tests.yml$ ; then
             echo "Tests will run."
-            echo "::set-output name=run_tests::true"
+            echo "run_tests=true" >> $GITHUB_OUTPUT
           else
             echo "Skipping tests."
-            echo "::set-output name=run_tests::false"
+            echo "run_tests=false" >> $GITHUB_OUTPUT
           fi
       - name: 'Install dependencies'
         run: ./ci/mac_ci_setup.sh

--- a/.github/workflows/python_tests.yml
+++ b/.github/workflows/python_tests.yml
@@ -24,10 +24,10 @@ jobs:
         run: |
           if git rev-parse --abbrev-ref HEAD | grep -q ^main$ || git diff --name-only origin/main | grep -qe common/ -e cc/ -e python/ -e bazel/ -e ^\.bazelrc$ -e ^envoy$ -e ^WORKSPACE$ -e ^.github/workflows/python_tests.yml$ ; then
             echo "Tests will run."
-            echo "::set-output name=run_tests::true"
+            echo "run_tests=true" >> $GITHUB_OUTPUT
           else
             echo "Skipping tests."
-            echo "::set-output name=run_tests::false"
+            echo "run_tests=false" >> $GITHUB_OUTPUT
           fi
       - name: 'Run tests'
         if: steps.check_context.outputs.run_tests == 'true'

--- a/.github/workflows/submodule_update.yml
+++ b/.github/workflows/submodule_update.yml
@@ -22,7 +22,7 @@ jobs:
       run: |
         if ! git diff-index --quiet HEAD --; then
           echo "Detected changes..."
-          echo "::set-output name=dirty::true"
+          echo "dirty=true" >> $GITHUB_OUTPUT
         fi
     - name: Get current support maintainer
       if: steps.state.outputs.dirty == 'true'
@@ -31,7 +31,7 @@ jobs:
         maintainers_file=".github/lyft_maintainers.yml"
         first_line="$(head -n 1 "$maintainers_file")"
         current=${first_line#"current: "}
-        echo "::set-output name=maintainer::$current"
+        echo "maintainer=$current" >> $GITHUB_OUTPUT
     - name: Create PR
       if: steps.state.outputs.dirty == 'true'
       uses: peter-evans/create-pull-request@923ad837f191474af6b1721408744feb989a4c27

--- a/.github/workflows/tsan.yml
+++ b/.github/workflows/tsan.yml
@@ -27,10 +27,10 @@ jobs:
         run: |
           if git rev-parse --abbrev-ref HEAD | grep -q ^main$ || git diff --name-only origin/main | grep -qe common/ -e bazel/ -e ^\.bazelrc$ -e ^envoy$ -e ^WORKSPACE$ -e ^.github/workflows/tsan.yml$ ; then
             echo "Tests will run."
-            echo "::set-output name=run_tests::true"
+            echo "run_tests=true" >> $GITHUB_OUTPUT
           else
             echo "Skipping tests."
-            echo "::set-output name=run_tests::false"
+            echo "run_tests=false" >> $GITHUB_OUTPUT
           fi
       - uses: actions/setup-java@v1
         if: steps.check-cache.outputs.cache-hit != 'true'

--- a/tools/bump_lyft_support_rotation.sh
+++ b/tools/bump_lyft_support_rotation.sh
@@ -48,7 +48,7 @@ previous=${first_line#"current: "}
 next="$(next_maintainer "$previous" "$maintainers_file")"
 set_maintainer "$next" "$maintainers_file"
 
-echo "::set-output name=PREVIOUS_MAINTAINER::$previous"
-echo "::set-output name=NEXT_MAINTAINER::$next"
+echo "PREVIOUS_MAINTAINER=$previous" >> $GITHUB_OUTPUT
+echo "NEXT_MAINTAINER=$next" >> $GITHUB_OUTPUT
 
 echo "Lyft support maintainer changing from $previous to $next"


### PR DESCRIPTION
The former is deprecated and will stop working soon: https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/

Signed-off-by: JP Simard <jp@jpsim.com>