### PR TITLE
Add support for Platform and Native filters to C++ EngineBuilder

### DIFF
--- a/docs/root/intro/version_history.rst
+++ b/docs/root/intro/version_history.rst
@@ -22,6 +22,7 @@ Features:
 - kotlin: add a ``enableSkipDNSLookupForProxiedRequests(true)`` knob for controlling whether Envoy waits on DNS response in the dynamic forward proxy filter for proxied requests. (:issue:`#2602 <2602>`)
 - api: Add various methods to C++ EngineBuilder to bring it to parity with the Java and Obj-C builders. (:issue:`#2498 <2498>`)
 - api: Add support for String Accessors to the C++ EngineBuilder. (:issue:`#2498 <2498>`)
+- api: Add support for Native Filters and Platform Filters to the C++ EngineBuilder. (:issue:`#2498 <2498>`)
 - api: added upstream protocol to final stream intel. (:issue:`#2613 <2613>`)
 
 0.5.0 (September 2, 2022)

--- a/library/cc/engine_builder.cc
+++ b/library/cc/engine_builder.cc
@@ -212,6 +212,11 @@ EngineBuilder& EngineBuilder::addNativeFilter(const std::string& name, const std
   return *this;
 }
 
+EngineBuilder& EngineBuilder::addPlatformFilter(const std::string& name) {
+  platform_filters_.push_back(name);
+  return *this;
+}
+
 std::string EngineBuilder::generateConfigStr() const {
 #if defined(__APPLE__)
   std::string dns_resolver_name = "envoy.network.dns_resolver.apple";
@@ -312,7 +317,14 @@ std::string EngineBuilder::generateConfigStr() const {
             native_filter_template,
             {{"{{ native_filter_name }}", filter.name_},
              {"{{ native_filter_typed_config }}", filter.typed_config_}});
+    insertCustomFilter(filter_config, config_template);
+  }
 
+  for (const std::string& name : platform_filters_) {
+    std::string filter_config =
+        absl::StrReplaceAll(
+            platform_filter_template,
+            {{"{{ platform_filter_name }}", name}});
     insertCustomFilter(filter_config, config_template);
   }
 

--- a/library/cc/engine_builder.cc
+++ b/library/cc/engine_builder.cc
@@ -207,7 +207,8 @@ EngineBuilder& EngineBuilder::addStringAccessor(const std::string& name,
   return *this;
 }
 
-EngineBuilder& EngineBuilder::addNativeFilter(const std::string& name, const std::string& typed_config) {
+EngineBuilder& EngineBuilder::addNativeFilter(const std::string& name,
+                                              const std::string& typed_config) {
   native_filter_chain_.emplace_back(name, typed_config);
   return *this;
 }
@@ -312,19 +313,15 @@ std::string EngineBuilder::generateConfigStr() const {
   }
 
   for (const NativeFilterConfig& filter : native_filter_chain_) {
-    std::string filter_config =
-        absl::StrReplaceAll(
-            native_filter_template,
-            {{"{{ native_filter_name }}", filter.name_},
-             {"{{ native_filter_typed_config }}", filter.typed_config_}});
+    std::string filter_config = absl::StrReplaceAll(
+        native_filter_template, {{"{{ native_filter_name }}", filter.name_},
+                                 {"{{ native_filter_typed_config }}", filter.typed_config_}});
     insertCustomFilter(filter_config, config_template);
   }
 
   for (const std::string& name : platform_filters_) {
     std::string filter_config =
-        absl::StrReplaceAll(
-            platform_filter_template,
-            {{"{{ platform_filter_name }}", name}});
+        absl::StrReplaceAll(platform_filter_template, {{"{{ platform_filter_name }}", name}});
     insertCustomFilter(filter_config, config_template);
   }
 

--- a/library/cc/engine_builder.cc
+++ b/library/cc/engine_builder.cc
@@ -207,6 +207,11 @@ EngineBuilder& EngineBuilder::addStringAccessor(const std::string& name,
   return *this;
 }
 
+EngineBuilder& EngineBuilder::addNativeFilter(const std::string& name, const std::string& typed_config) {
+  native_filter_chain_.emplace_back(name, typed_config);
+  return *this;
+}
+
 std::string EngineBuilder::generateConfigStr() const {
 #if defined(__APPLE__)
   std::string dns_resolver_name = "envoy.network.dns_resolver.apple";
@@ -299,6 +304,16 @@ std::string EngineBuilder::generateConfigStr() const {
   }
   if (this->enable_http3_) {
     insertCustomFilter(alternate_protocols_cache_filter_insert, config_template);
+  }
+
+  for (const NativeFilterConfig& filter : native_filter_chain_) {
+    std::string filter_config =
+        absl::StrReplaceAll(
+            native_filter_template,
+            {{"{{ native_filter_name }}", filter.name_},
+             {"{{ native_filter_typed_config }}", filter.typed_config_}});
+
+    insertCustomFilter(filter_config, config_template);
   }
 
   config_builder << config_template;

--- a/library/cc/engine_builder.h
+++ b/library/cc/engine_builder.h
@@ -42,6 +42,7 @@ public:
   EngineBuilder& addKeyValueStore(const std::string& name, KeyValueStoreSharedPtr key_value_store);
   EngineBuilder& addStringAccessor(const std::string& name, StringAccessorSharedPtr accessor);
   EngineBuilder& addNativeFilter(const std::string& name, const std::string& typed_config);
+  EngineBuilder& addPlatformFilter(const std::string& name);
   EngineBuilder& setAppVersion(const std::string& app_version);
   EngineBuilder& setAppId(const std::string& app_id);
   EngineBuilder& setDeviceOs(const std::string& app_id);
@@ -64,12 +65,6 @@ public:
 
   EngineSharedPtr build();
 
-  // TODO(crockeo): add after filter integration
-  // EngineBuilder& addPlatformFilter(name: String = UUID.randomUUID().toString(), factory: () ->
-  // Filter):
-  // EngineBuilder& addNativeFilter(name: String = UUID.randomUUID().toString(),
-  // typedConfig: String):
-
 protected:
   void setOverrideConfigForTests(std::string config) { config_override_for_tests_ = config; }
   void setAdminAddressPathForTests(std::string admin) { admin_address_path_for_tests_ = admin; }
@@ -81,6 +76,7 @@ private:
     std::string name_;
     std::string typed_config_;
   };
+
   LogLevel log_level_ = LogLevel::info;
   EngineCallbacksSharedPtr callbacks_;
 
@@ -122,9 +118,8 @@ private:
   int max_connections_per_host_ = 7;
   std::vector<std::string> stat_sinks_;
 
-  // TODO(crockeo): add after filter integration
-  // std::vector<EnvoyHTTPFilterFactory> http_platform_filter_factories_;
   std::vector<NativeFilterConfig> native_filter_chain_;
+  std::vector<std::string>  platform_filters_;
   absl::flat_hash_map<std::string, StringAccessorSharedPtr> string_accessors_;
 };
 

--- a/library/cc/engine_builder.h
+++ b/library/cc/engine_builder.h
@@ -41,6 +41,7 @@ public:
   EngineBuilder& addVirtualClusters(const std::string& virtual_clusters);
   EngineBuilder& addKeyValueStore(const std::string& name, KeyValueStoreSharedPtr key_value_store);
   EngineBuilder& addStringAccessor(const std::string& name, StringAccessorSharedPtr accessor);
+  EngineBuilder& addNativeFilter(const std::string& name, const std::string& typed_config);
   EngineBuilder& setAppVersion(const std::string& app_version);
   EngineBuilder& setAppId(const std::string& app_id);
   EngineBuilder& setDeviceOs(const std::string& app_id);
@@ -74,6 +75,12 @@ protected:
   void setAdminAddressPathForTests(std::string admin) { admin_address_path_for_tests_ = admin; }
 
 private:
+  struct NativeFilterConfig {
+    NativeFilterConfig(const std::string& name, const std::string&  typed_config) : name_(name), typed_config_(typed_config) {}
+
+    std::string name_;
+    std::string typed_config_;
+  };
   LogLevel log_level_ = LogLevel::info;
   EngineCallbacksSharedPtr callbacks_;
 
@@ -117,7 +124,7 @@ private:
 
   // TODO(crockeo): add after filter integration
   // std::vector<EnvoyHTTPFilterFactory> http_platform_filter_factories_;
-  // std::vector<EnvoyNativeFilterConfig> native_filter_chain_;
+  std::vector<NativeFilterConfig> native_filter_chain_;
   absl::flat_hash_map<std::string, StringAccessorSharedPtr> string_accessors_;
 };
 

--- a/library/cc/engine_builder.h
+++ b/library/cc/engine_builder.h
@@ -71,7 +71,8 @@ protected:
 
 private:
   struct NativeFilterConfig {
-    NativeFilterConfig(const std::string& name, const std::string&  typed_config) : name_(name), typed_config_(typed_config) {}
+    NativeFilterConfig(const std::string& name, const std::string& typed_config)
+        : name_(name), typed_config_(typed_config) {}
 
     std::string name_;
     std::string typed_config_;
@@ -119,7 +120,7 @@ private:
   std::vector<std::string> stat_sinks_;
 
   std::vector<NativeFilterConfig> native_filter_chain_;
-  std::vector<std::string>  platform_filters_;
+  std::vector<std::string> platform_filters_;
   absl::flat_hash_map<std::string, StringAccessorSharedPtr> string_accessors_;
 };
 

--- a/test/cc/unit/envoy_config_test.cc
+++ b/test/cc/unit/envoy_config_test.cc
@@ -405,7 +405,7 @@ TEST(TestConfig, AddPlatformFilter) {
 
   std::string config_str = engine_builder.generateConfigStr();
   ASSERT_THAT(config_str, Not(HasSubstr("http.platform_bridge.PlatformBridge")));
-  ASSERT_THAT(config_str, Not(HasSubstr("platform_filter_name: "+ filter_name)));
+  ASSERT_THAT(config_str, Not(HasSubstr("platform_filter_name: " + filter_name)));
   envoy::config::bootstrap::v3::Bootstrap bootstrap;
   TestUtility::loadFromYaml(absl::StrCat(config_header, config_str), bootstrap);
 
@@ -413,7 +413,7 @@ TEST(TestConfig, AddPlatformFilter) {
 
   config_str = engine_builder.generateConfigStr();
   ASSERT_THAT(config_str, HasSubstr("http.platform_bridge.PlatformBridge"));
-  ASSERT_THAT(config_str, HasSubstr("platform_filter_name: "+ filter_name));
+  ASSERT_THAT(config_str, HasSubstr("platform_filter_name: " + filter_name));
   TestUtility::loadFromYaml(absl::StrCat(config_header, config_str), bootstrap);
 }
 

--- a/test/cc/unit/envoy_config_test.cc
+++ b/test/cc/unit/envoy_config_test.cc
@@ -376,7 +376,6 @@ private:
   mutable int count_ = 0;
 };
 
-
 TEST(TestConfig, AddNativeFilter) {
   EngineBuilder engine_builder;
 
@@ -396,6 +395,25 @@ TEST(TestConfig, AddNativeFilter) {
   config_str = engine_builder.generateConfigStr();
   ASSERT_THAT(config_str, HasSubstr("- name: " + filter_name));
   ASSERT_THAT(config_str, HasSubstr("  typed_config: " + filter_config));
+  TestUtility::loadFromYaml(absl::StrCat(config_header, config_str), bootstrap);
+}
+
+TEST(TestConfig, AddPlatformFilter) {
+  EngineBuilder engine_builder;
+
+  std::string filter_name = "test_platform_filter";
+
+  std::string config_str = engine_builder.generateConfigStr();
+  ASSERT_THAT(config_str, Not(HasSubstr("http.platform_bridge.PlatformBridge")));
+  ASSERT_THAT(config_str, Not(HasSubstr("platform_filter_name: "+ filter_name)));
+  envoy::config::bootstrap::v3::Bootstrap bootstrap;
+  TestUtility::loadFromYaml(absl::StrCat(config_header, config_str), bootstrap);
+
+  engine_builder.addPlatformFilter(filter_name);
+
+  config_str = engine_builder.generateConfigStr();
+  ASSERT_THAT(config_str, HasSubstr("http.platform_bridge.PlatformBridge"));
+  ASSERT_THAT(config_str, HasSubstr("platform_filter_name: "+ filter_name));
   TestUtility::loadFromYaml(absl::StrCat(config_header, config_str), bootstrap);
 }
 

--- a/test/cc/unit/envoy_config_test.cc
+++ b/test/cc/unit/envoy_config_test.cc
@@ -376,6 +376,29 @@ private:
   mutable int count_ = 0;
 };
 
+
+TEST(TestConfig, AddNativeFilter) {
+  EngineBuilder engine_builder;
+
+  std::string filter_name = "envoy.filters.http.buffer";
+  std::string filter_config =
+      "{\"@type\":\"type.googleapis.com/envoy.extensions.filters.http.buffer.v3.Buffer\","
+      "\"max_request_bytes\":5242880}";
+
+  std::string config_str = engine_builder.generateConfigStr();
+  ASSERT_THAT(config_str, Not(HasSubstr("- name: " + filter_name)));
+  ASSERT_THAT(config_str, Not(HasSubstr("  typed_config: " + filter_config)));
+  envoy::config::bootstrap::v3::Bootstrap bootstrap;
+  TestUtility::loadFromYaml(absl::StrCat(config_header, config_str), bootstrap);
+
+  engine_builder.addNativeFilter(filter_name, filter_config);
+
+  config_str = engine_builder.generateConfigStr();
+  ASSERT_THAT(config_str, HasSubstr("- name: " + filter_name));
+  ASSERT_THAT(config_str, HasSubstr("  typed_config: " + filter_config));
+  TestUtility::loadFromYaml(absl::StrCat(config_header, config_str), bootstrap);
+}
+
 TEST(TestConfig, StringAccessors) {
   std::string name("accessor_name");
   EngineBuilder engine_builder;


### PR DESCRIPTION
As discussed in the weekly meeting, this does not provide a C++ implementation of Platform filters, merely the ability to configure Envoy to use them.
    
Part of: #2498
    
Risk Level: Low
Testing: New unit tests
Docs Changes: N/A
Release Notes: Updated version_history.rst
    
Signed-off-by: Ryan Hamilton <rch@google.com>
