### PR TITLE
[Cronvoy]Allow Cronvoy to build with proguard.

### DIFF
--- a/library/java/org/chromium/net/BUILD
+++ b/library/java/org/chromium/net/BUILD
@@ -23,6 +23,7 @@ android_binary(
     name = "cronet",
     srcs = [],
     manifest = "ChromiumNetManifest.xml",
+    proguard_specs = ["//library:proguard_rules"],
     visibility = ["//visibility:public"],
     deps = [
         ":net",


### PR DESCRIPTION
Signed-off-by: Renjie Tang <renjietang@chromium.org>

Description: Add proguard specs to Cronvoy build target. This will produce a cronet_proguard.jar(51k) which is a lot smaller than the original cronet_deploy.jar(2.6m)
Risk Level: Low
Testing: manual test
Docs Changes: n/a
Release Notes: n/a
