### PR TITLE
Disable flaky TestConfig.StringAccessors

### DIFF
--- a/test/cc/unit/envoy_config_test.cc
+++ b/test/cc/unit/envoy_config_test.cc
@@ -404,7 +404,8 @@ TEST(TestConfig, AddPlatformFilter) {
   TestUtility::loadFromYaml(absl::StrCat(config_header, config_str), bootstrap);
 }
 
-TEST(TestConfig, StringAccessors) {
+// TODO(RyanTheOptimist): This test seems to be flaky. #2641
+TEST(TestConfig, DISABLED_StringAccessors) {
   std::string name("accessor_name");
   EngineBuilder engine_builder;
   std::string data_string = "envoy string";


### PR DESCRIPTION
Disable flaky TestConfig.StringAccessors util the cause of flakiness is addressed.

#2641
Risk Level: Low
Testing: N/A
Docs Changes: N/A
Release Notes: N/A

Signed-off-by: Ryan Hamilton <rch@google.com>