### PR TITLE
Remove note about DWARF patch being required

### DIFF
--- a/docs/root/development/performance/binary_size.rst
+++ b/docs/root/development/performance/binary_size.rst
@@ -49,17 +49,6 @@ necessary tools::
   make -j6
   cp bloaty /usr/local/bin/bloaty
 
-.. attention::
-
-    After this `change <https://github.com/envoyproxy/envoy/pull/12569>`_ Envoy started
-    using split DWARF capabilities to reduce link time and binary size when compiling debug symbols.
-    However, Bloaty (the analysis tool described below)
-    does not support using ``.dwp`` files as a source for debug symbols
-    (tracked in this `issue <https://github.com/google/bloaty/issues/156>`_). Therefore, a patch
-    `like this <https://github.com/envoyproxy/envoy-mobile/issues/1274#issuecomment-788345216>`_
-    must be applied to the Envoy submodule before compiling the binary described
-    below.
-
 The binary being compiled is ``//test/performance:test_binary_size``.
 The binary is getting built with the following build command::
 


### PR DESCRIPTION
As per https://github.com/envoyproxy/envoy-mobile/issues/1274#issuecomment-954305795, this patch is no longer required.

Signed-off-by: Ryan Hamilton <rch@google.com>

For an explanation of how to fill out the fields, please see the relevant section
in [PULL_REQUESTS.md](https://github.com/envoyproxy/envoy/blob/master/PULL_REQUESTS.md)