### PR TITLE
repo: Shellcheck cleanups

### DIFF
--- a/bazelw
+++ b/bazelw
@@ -10,7 +10,8 @@ else
   readonly bazel_os="linux"
 fi
 
-readonly raw_arch="$(uname -m)"
+raw_arch="$(uname -m)"
+readonly raw_arch
 if [[ "$raw_arch" == "aarch64" || "$raw_arch" == "arm64" ]]; then
   readonly bazel_arch="arm64"
 else

--- a/ci/linux_ci_setup.sh
+++ b/ci/linux_ci_setup.sh
@@ -24,6 +24,8 @@ echo "y" | $SDKMANAGER --install "ndk;21.4.7075529"
 $SDKMANAGER --install "platforms;android-30"
 $SDKMANAGER --install "build-tools;30.0.2"
 
-echo "ANDROID_HOME=$ANDROID_HOME" >> $GITHUB_ENV
-echo "ANDROID_SDK_ROOT=$ANDROID_HOME" >> $GITHUB_ENV
-echo "ANDROID_NDK_HOME=$ANDROID_HOME/ndk/21.4.7075529" >> $GITHUB_ENV
+{
+    echo "ANDROID_HOME=${ANDROID_HOME}"
+    echo "ANDROID_SDK_ROOT=${ANDROID_HOME}"
+    echo "ANDROID_NDK_HOME=${ANDROID_HOME}/ndk/21.4.7075529"
+}  >> "$GITHUB_ENV"

--- a/ci/mac_ci_setup.sh
+++ b/ci/mac_ci_setup.sh
@@ -54,9 +54,9 @@ if [[ "${1:-}" == "--android" ]]; then
   SDKMANAGER="${ANDROID_SDK_ROOT}/cmdline-tools/latest/bin/sdkmanager"
   $SDKMANAGER --uninstall "ndk-bundle"
   echo "y" | $SDKMANAGER "ndk;21.4.7075529"
-  ln -sfn $ANDROID_SDK_ROOT/ndk/21.4.7075529 "${ANDROID_SDK_ROOT}/ndk-bundle"
+  ln -sfn "${ANDROID_SDK_ROOT}/ndk/21.4.7075529" "${ANDROID_SDK_ROOT}/ndk-bundle"
 
   # Download and set up build-tools 30.0.3, 31.0.0 is missing dx.jar.
   $SDKMANAGER --install "build-tools;30.0.3"
-  echo "ANDROID_NDK_HOME=$ANDROID_HOME/ndk/21.4.7075529" >> $GITHUB_ENV
+  echo "ANDROID_NDK_HOME=${ANDROID_HOME}/ndk/21.4.7075529" >> "$GITHUB_ENV"
 fi

--- a/ci/mac_start_emulator.sh
+++ b/ci/mac_start_emulator.sh
@@ -2,7 +2,11 @@
 
 set -e
 
-echo "y" | $ANDROID_HOME/tools/bin/sdkmanager --install 'system-images;android-29;google_apis;x86_64' --channel=3
-echo "no" | $ANDROID_HOME/tools/bin/avdmanager create avd -n test_android_emulator -k 'system-images;android-29;google_apis;x86_64' --force
-ls $ANDROID_HOME/tools/bin/
-nohup $ANDROID_HOME/emulator/emulator -partition-size 1024 -avd test_android_emulator -no-snapshot > /dev/null 2>&1 & $ANDROID_HOME/platform-tools/adb wait-for-device shell 'while [[ -z $(getprop sys.boot_completed | tr -d '\r') ]]; do sleep 1; done; input keyevent 82'
+echo "y" | "${ANDROID_HOME}/tools/bin/sdkmanager" --install 'system-images;android-29;google_apis;x86_64' --channel=3
+echo "no" | "${ANDROID_HOME}/tools/bin/avdmanager" create avd -n test_android_emulator -k 'system-images;android-29;google_apis;x86_64' --force
+ls "${ANDROID_HOME}/tools/bin/"
+
+nohup "${ANDROID_HOME}/emulator/emulator" -partition-size 1024 -avd test_android_emulator -no-snapshot > /dev/null 2>&1 & {
+    # shellcheck disable=SC2016
+    "${ANDROID_HOME}/platform-tools/adb" wait-for-device shell 'while [[ -z $(getprop sys.boot_completed | tr -d '\''\r'\'') ]]; do sleep 1; done; input keyevent 82'
+}

--- a/ci/test_size_regression.sh
+++ b/ci/test_size_regression.sh
@@ -5,7 +5,7 @@
 MAX_SIZE=7300000 # 7.3MB
 MAX_PERC=2.0
 
-if [ `uname` == "Darwin" ]
+if [ "$(uname)" == "Darwin" ]
 then
     SIZE1=$(stat -f "%z" "$1")
     SIZE2=$(stat -f "%z" "$2")
@@ -18,13 +18,13 @@ PERC=$(bc <<< "scale=2; ($SIZE2 - $SIZE1)/$SIZE1 * 100")
 echo "The new binary is $PERC % different in size compared to main."
 echo "The new binary is $SIZE2 bytes."
 
-if [ $SIZE2 -gt $MAX_SIZE ]
+if [ "$SIZE2" -gt $MAX_SIZE ]
 then
     echo "The current size ($SIZE2) is larger than the maximum size ($MAX_SIZE)."
     exit 1
 fi
 
-if [ $(bc <<< "scale=2; $PERC >= $MAX_PERC") -eq 1 ]
+if [ "$(bc <<< "scale=2; $PERC >= $MAX_PERC")" -eq 1 ]
 then
     echo "The percentage increase ($PERC) is larger then the maximum percentage increase ($MAX_PERC)."
     exit 1

--- a/docs/build.sh
+++ b/docs/build.sh
@@ -2,6 +2,7 @@
 
 set -e
 
+# shellcheck disable=SC1091
 . envoy/tools/shell_utils.sh
 
 # We need to set ENVOY_DOCS_VERSION_STRING and ENVOY_DOCS_RELEASE_LEVEL for Sphinx.

--- a/docs/publish.sh
+++ b/docs/publish.sh
@@ -11,7 +11,7 @@ set -e
 
 DOCS_DIR=generated/docs
 CHECKOUT_DIR=../envoy-mobile-docs
-BUILD_SHA=`git rev-parse HEAD`
+BUILD_SHA="$(git rev-parse HEAD)"
 
 if [ -n "$CIRCLE_TAG" ]
 then

--- a/tools/bump_lyft_support_rotation.sh
+++ b/tools/bump_lyft_support_rotation.sh
@@ -48,7 +48,7 @@ previous=${first_line#"current: "}
 next="$(next_maintainer "$previous" "$maintainers_file")"
 set_maintainer "$next" "$maintainers_file"
 
-echo "PREVIOUS_MAINTAINER=$previous" >> $GITHUB_OUTPUT
-echo "NEXT_MAINTAINER=$next" >> $GITHUB_OUTPUT
+echo "PREVIOUS_MAINTAINER=$previous" >> "$GITHUB_OUTPUT"
+echo "NEXT_MAINTAINER=$next" >> "$GITHUB_OUTPUT"
 
 echo "Lyft support maintainer changing from $previous to $next"

--- a/tools/check_format.sh
+++ b/tools/check_format.sh
@@ -25,6 +25,6 @@ TARGET_PATH="$2"
 ENVOY_BAZEL_PREFIX=@envoy envoy/tools/code_format/check_format.py \
     --config_path envoy/tools/code_format/config.yaml \
     --add-excluded-prefixes ./envoy/ ./envoy_build_config/extensions_build_config.bzl ./WORKSPACE ./Envoy.xcodeproj/ ./dist/ ./library/common/config_template.cc ./bazel/envoy_mobile_swift_bazel_support.bzl ./bazel/envoy_mobile_repositories.bzl ./examples/swift/swiftpm/Packages/Envoy.xcframework \
-    --skip_envoy_build_rule_check "$ENVOY_FORMAT_ACTION" $TARGET_PATH \
+    --skip_envoy_build_rule_check "$ENVOY_FORMAT_ACTION" "$TARGET_PATH" \
     --namespace_check_excluded_paths ./envoy ./examples/ ./library/java/ ./library/kotlin ./library/objective-c ./test/java ./test/java ./test/objective-c ./test/swift ./experimental/swift \
     --build_fixer_check_excluded_paths ./envoy ./BUILD ./dist ./examples ./library/java ./library/kotlin ./library/objective-c ./library/swift ./library/common/extensions ./test/java ./test/kotlin ./test/objective-c ./test/swift ./experimental/swift


### PR DESCRIPTION
This resolves shellcheck errors - which would trigger when the envoy linter runs against the code

For an explanation of how to fill out the fields, please see the relevant section
in [PULL_REQUESTS.md](https://github.com/envoyproxy/envoy/blob/master/PULL_REQUESTS.md)

Description:
Risk Level:
Testing:
Docs Changes:
Release Notes:
[Optional Fixes #Issue]
[Optional Deprecated:]
