### PR TITLE
repo: Switch `pip_install` -> `pip_parse`

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -66,6 +66,9 @@ python_configure(name = "local_config_python", python_version = "3")
 load("//bazel:python.bzl", "declare_python_abi")
 declare_python_abi(name = "python_abi", python_version = "3")
 
+load("@mobile_pip3//:requirements.bzl", pip_dependencies = "install_deps")
+pip_dependencies()
+
 load("//bazel:android_configure.bzl", "android_configure")
 android_configure(
     name = "local_config_android",

--- a/bazel/envoy_mobile_dependencies.bzl
+++ b/bazel/envoy_mobile_dependencies.bzl
@@ -6,7 +6,7 @@ load("@rules_detekt//detekt:dependencies.bzl", "rules_detekt_dependencies")
 load("@io_bazel_rules_kotlin//kotlin:repositories.bzl", "kotlin_repositories")
 load("@rules_proto_grpc//:repositories.bzl", "rules_proto_grpc_repos", "rules_proto_grpc_toolchains")
 load("@rules_proto//proto:repositories.bzl", "rules_proto_dependencies", "rules_proto_toolchains")
-load("@rules_python//python:pip.bzl", "pip_install")
+load("@rules_python//python:pip.bzl", "pip_parse")
 load("@robolectric//bazel:robolectric.bzl", "robolectric_repositories")
 load("@rules_java//java:repositories.bzl", "rules_java_dependencies")
 
@@ -110,7 +110,8 @@ def python_dependencies():
     # pip_install(
     #     requirements = ":dev_requirements.txt",
     # )
-    pip_install(
-        requirements = "//third_party/python:requirements.txt",
+    pip_parse(
+        name = "mobile_pip3",
+        requirements_lock = "//third_party/python:requirements.txt",
         timeout = 1000,
     )

--- a/library/python/BUILD
+++ b/library/python/BUILD
@@ -1,4 +1,4 @@
-load("@pip//:requirements.bzl", "requirement")
+load("@mobile_pip3//:requirements.bzl", "requirement")
 load("@pybind11_bazel//:build_defs.bzl", "pybind_extension", "pybind_library")
 load("@python_abi//:abi.bzl", "abi_tag", "python_tag")
 load("@rules_python//python:defs.bzl", "py_library")

--- a/test/python/BUILD
+++ b/test/python/BUILD
@@ -1,4 +1,4 @@
-load("@pip//:requirements.bzl", "requirement")
+load("@mobile_pip3//:requirements.bzl", "requirement")
 load("@rules_python//python:defs.bzl", "py_test")
 
 licenses(["notice"])  # Apache 2


### PR DESCRIPTION
This is a follow up to #2643 

`pip_install` has been deprecated and now points to `pip_parse` anyway so rather switch to using it directly

the benefit of `pip_parse` is that it dynamically figures out the transitive pip requirements of a particular target - ie it only installs/downloads the requirements that are needed and there is no need to maintain separate requirements files per target/s

Signed-off-by: Ryan Northey <ryan@synca.io>

For an explanation of how to fill out the fields, please see the relevant section
in [PULL_REQUESTS.md](https://github.com/envoyproxy/envoy/blob/master/PULL_REQUESTS.md)

Description:
Risk Level:
Testing:
Docs Changes:
Release Notes:
[Optional Fixes #Issue]
[Optional Deprecated:]
