### PR TITLE
ci: remove Snow from Lyft EM rotation

### DIFF
--- a/.github/lyft_maintainers.yml
+++ b/.github/lyft_maintainers.yml
@@ -1,5 +1,4 @@
 current: Augustyniak
 maintainers:
   - Augustyniak
-  - snowp
   - jpsim


### PR DESCRIPTION
Remove @snowp from the Lyft Envoy Mobile rotation (@snowp is not leaving Lyft).

Signed-off-by: Rafal Augustyniak <raugustyniak@lyft.com>

