### PR TITLE
remove the use of deprecated flag

### DIFF
--- a/test/swift/integration/IdleTimeoutTest.swift
+++ b/test/swift/integration/IdleTimeoutTest.swift
@@ -126,7 +126,7 @@ static_resources:
       }
 
       func onError(_ error: EnvoyError, streamIntel: FinalStreamIntel) {
-        XCTAssertEqual(error.errorCode, 4)
+        XCTAssertEqual(error.errorCode, 0)
         timeoutExpectation.fulfill()
       }
 
@@ -159,7 +159,7 @@ static_resources:
     client
       .newStreamPrototype()
       .setOnError { error, _ in
-        XCTAssertEqual(error.errorCode, 4)
+        XCTAssertEqual(error.errorCode, 0)
         callbackExpectation.fulfill()
       }
       .setOnCancel { _ in

--- a/test/swift/integration/IdleTimeoutTest.swift
+++ b/test/swift/integration/IdleTimeoutTest.swift
@@ -81,13 +81,6 @@ static_resources:
         - endpoint:
             address:
               socket_address: { address: 127.0.0.1, port_value: \(remotePort) }
-layered_runtime:
-  layers:
-    - name: static_layer_0
-      static_layer:
-        envoy:
-          reloadable_features:
-            override_request_timeout_by_gateway_timeout: false
 """
 
     class IdleTimeoutValidationFilter: AsyncResponseFilter, ResponseFilter {


### PR DESCRIPTION
Description: Remove the use of removed `override_request_timeout_by_gateway_timeout` upstream Envoy flag from Swift tests. The flag was removed from the main `config.cc` as part of https://github.com/envoyproxy/envoy-mobile/pull/2296 file months ago. The original removal introduced a bug as filter's `onError` callback started being called twice - this PR fixes this issue. Update EM code to correctly handle stream idle. See https://github.com/envoyproxy/envoy-mobile/pull/2639 for more details. Fixes https://github.com/envoyproxy/envoy-mobile/issues/2108.
Risk Level: Medium, touches stream onDestroy code.
Testing: Unit/Integration tests.
Docs Changes: N/A
Release Notes: N/A


