### PR TITLE
set enablePlatformCertificateValidation to false on iOS by default

### DIFF
--- a/library/swift/EngineBuilder.swift
+++ b/library/swift/EngineBuilder.swift
@@ -27,7 +27,7 @@ open class EngineBuilder: NSObject {
   private var enableBrotli: Bool = false
   private var enableInterfaceBinding: Bool = false
   private var enforceTrustChainVerification: Bool = true
-  private var enablePlatformCertificateValidation: Bool = true
+  private var enablePlatformCertificateValidation: Bool = false
   private var enableDrainPostDnsRefresh: Bool = false
   private var forceIPv6: Bool = false
   private var h2ConnectionKeepaliveIdleIntervalMilliseconds: UInt32 = 1


### PR DESCRIPTION
Signed-off-by: Ryan Hamilton <rch@google.com>

Was set to true inadvertently in #2638.
