### PR TITLE
Add Typed_config for PlatformBridgeCertValidator

### DIFF
--- a/library/common/config/config.cc
+++ b/library/common/config/config.cc
@@ -86,6 +86,7 @@ const char* platform_cert_validation_context_template = R"(
 - &validation_context
   custom_validator_config:
     name: "envoy_mobile.cert_validator.platform_bridge_cert_validator"
+    "@type": type.googleapis.com/envoy_mobile.extensions.cert_validator.platform_bridge.PlatformBridgeCertValidator
   trust_chain_verification: *trust_chain_verification
 )";
 

--- a/library/common/config/config.cc
+++ b/library/common/config/config.cc
@@ -86,7 +86,8 @@ const char* platform_cert_validation_context_template = R"(
 - &validation_context
   custom_validator_config:
     name: "envoy_mobile.cert_validator.platform_bridge_cert_validator"
-    "@type": type.googleapis.com/envoy_mobile.extensions.cert_validator.platform_bridge.PlatformBridgeCertValidator
+    typed_config:
+      "@type": type.googleapis.com/envoy_mobile.extensions.cert_validator.platform_bridge.PlatformBridgeCertValidator
   trust_chain_verification: *trust_chain_verification
 )";
 

--- a/library/common/extensions/cert_validator/platform_bridge/BUILD
+++ b/library/common/extensions/cert_validator/platform_bridge/BUILD
@@ -3,11 +3,17 @@ load(
     "envoy_cc_extension",
     "envoy_cc_library",
     "envoy_extension_package",
+    "envoy_proto_library",
 )
 
 licenses(["notice"])  # Apache 2
 
 envoy_extension_package()
+
+envoy_proto_library(
+    name = "platform_bridge",
+    srcs = ["platform_bridge.proto"],
+)
 
 envoy_cc_library(
     name = "c_types_lib",
@@ -27,6 +33,7 @@ envoy_cc_library(
     repository = "@envoy",
     deps = [
         ":c_types_lib",
+        ":platform_bridge_cc_proto",
         "@envoy//source/extensions/transport_sockets/tls/cert_validator:cert_validator_lib",
     ],
 )

--- a/library/common/extensions/cert_validator/platform_bridge/platform_bridge.proto
+++ b/library/common/extensions/cert_validator/platform_bridge/platform_bridge.proto
@@ -1,0 +1,5 @@
+syntax = "proto3";
+
+package envoy_mobile.extensions.cert_validator.platform_bridge;
+
+message PlatformBridgeCertValidator {}


### PR DESCRIPTION
Signed-off-by: Renjie Tang <renjietang@chromium.org>

Description:
I got this error message when running Envoy-mobile with platform cert validator:
`error initializing configuration '': Proto constraint validation failed (UpstreamTlsContextValidationError.CommonTlsContext: embedded message failed validation | caused by CommonTlsContextValidationError.ValidationContext: embedded message failed validation | caused by CertificateValidationContextValidationError.CustomValidatorConfig: embedded message failed validation | caused by TypedExtensionConfigValidationError.TypedConfig: value is required):`
For the other extensions, I notice they all have a typed_config field. So I guess I need to add one for PlatformBridgeCertValidator too?

Risk Level: Low
Testing: n/a
Docs Changes: n/a
Release Notes: n/a
