### PR TITLE
build: Add MOBILE_PACKAGE_VISIBILITY to the build config

### DIFF
--- a/envoy_build_config/extensions_build_config.bzl
+++ b/envoy_build_config/extensions_build_config.bzl
@@ -1,4 +1,5 @@
 CONTRIB_EXTENSION_PACKAGE_VISIBILITY = ["@envoy//:contrib_library"]
+MOBILE_PACKAGE_VISIBILITY = ["@envoy//:mobile_library"]
 EXTENSION_CONFIG_VISIBILITY = ["//visibility:public"]
 EXTENSION_PACKAGE_VISIBILITY = ["//visibility:public"]
 EXTENSIONS = {


### PR DESCRIPTION
The variable is required by the `envoy_mobile_package` build package declared in Envoy:
https://github.com/envoyproxy/envoy/blob/91eccaf7d75161676e90adae58722c4bfa7d0c2e/bazel/envoy_build_system.bzl#L74

Signed-off-by: Ali Beyad <abeyad@google.com>