### PR TITLE
xcode: update to 14.1

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -17,10 +17,10 @@ build --host_force_python=PY3
 build --macos_minimum_os=10.14
 build --ios_minimum_os=12.0
 build --ios_simulator_device="iPhone 13"
-build --ios_simulator_version=16.0
+build --ios_simulator_version=16.1
 build --verbose_failures
 build --workspace_status_command=envoy/bazel/get_workspace_status
-build --xcode_version=14.0
+build --xcode_version=14.1
 build --use_top_level_targets_for_symlinks
 build --experimental_repository_downloader_retries=2
 # https://github.com/bazelbuild/rules_jvm_external/issues/445

--- a/.github/workflows/format.yml
+++ b/.github/workflows/format.yml
@@ -54,7 +54,7 @@ jobs:
           submodules: true
       - name: 'Run DrString'
         env:
-          DEVELOPER_DIR: /Applications/Xcode_14.0.app
+          DEVELOPER_DIR: /Applications/Xcode_14.1.app
         run: ./bazelw run @DrString//:drstring check
   kotlinlint:
     name: kotlin_lint

--- a/.github/workflows/release_validation.yml
+++ b/.github/workflows/release_validation.yml
@@ -29,6 +29,6 @@ jobs:
       # Ignore errors: Bad CRC when unzipping large files: https://bbs.archlinux.org/viewtopic.php?id=153011
       - run: unzip bazel-bin/library/swift/Envoy.xcframework.zip -d examples/swift/swiftpm/Packages || true
         name: 'Unzip xcframework'
-      - run: xcodebuild -project examples/swift/swiftpm/EnvoySwiftPMExample.xcodeproj -scheme EnvoySwiftPMExample -destination platform="iOS Simulator,name=iPhone 13 Pro Max,OS=16.0"
+      - run: xcodebuild -project examples/swift/swiftpm/EnvoySwiftPMExample.xcodeproj -scheme EnvoySwiftPMExample -destination platform="iOS Simulator,name=iPhone 13 Pro Max,OS=16.1"
         name: 'Build app'
       # TODO(jpsim): Run app and inspect logs to validate

--- a/ci/BUILD
+++ b/ci/BUILD
@@ -1,27 +1,27 @@
 licenses(["notice"])  # Apache 2
 
 xcode_version(
-    name = "xcode_14_0_0",
-    default_ios_sdk_version = "16.0",
-    default_macos_sdk_version = "12.3",
-    default_tvos_sdk_version = "16.0",
-    default_watchos_sdk_version = "9.0",
-    version = "14.0",
+    name = "xcode_14_1_0",
+    default_ios_sdk_version = "16.1",
+    default_macos_sdk_version = "13.0",
+    default_tvos_sdk_version = "16.1",
+    default_watchos_sdk_version = "9.1",
+    version = "14.1",
 )
 
 available_xcodes(
     name = "local_xcodes",
-    default = ":xcode_14_0_0",
+    default = ":xcode_14_1_0",
     versions = [
-        ":xcode_14_0_0",
+        ":xcode_14_1_0",
     ],
 )
 
 available_xcodes(
     name = "remote_xcodes",
-    default = ":xcode_14_0_0",
+    default = ":xcode_14_1_0",
     versions = [
-        ":xcode_14_0_0",
+        ":xcode_14_1_0",
     ],
 )
 

--- a/ci/mac_ci_setup.sh
+++ b/ci/mac_ci_setup.sh
@@ -45,7 +45,7 @@ fi
 
 pip3 install slackclient
 # https://github.com/actions/runner-images/blob/main/images/macos/macos-12-Readme.md#xcode
-sudo xcode-select --switch /Applications/Xcode_14.0.app
+sudo xcode-select --switch /Applications/Xcode_14.1.app
 
 if [[ "${1:-}" == "--android" ]]; then
   # Download and set up ndk 21 after GitHub update

--- a/docs/root/intro/version_history.rst
+++ b/docs/root/intro/version_history.rst
@@ -7,7 +7,7 @@ Pending Release
 Breaking changes:
 
 - ios/android: remove ``addH2RawDomains`` method. (:issue: `#2590 <2590>`)
-- build: building on macOS now requires Xcode 14.0. (:issue:`#2544 <2544>`)
+- build: building on macOS now requires Xcode 14.1. (:issue:`#2664 <2664>`)
 - iOS: remove experimental option to force all connections to use IPv6.
 - kotlin: always use ``getaddrinfo`` DNS resolver. Remove ``addDNSFallbackNameservers``, ``enableDNSFilterUnroutableFamilies``, and ``enableDNSUseSystemResolver`` methods from the Kotlin engine builder. (:issue:`#2618 <2618>`)
 

--- a/docs/root/start/building/building.rst
+++ b/docs/root/start/building/building.rst
@@ -58,7 +58,7 @@ See `ci/mac_ci_setup.sh` for the specific NDK version used during builds.
 iOS requirements
 ----------------
 
-- Xcode 14.0
+- Xcode 14.1
 - iOS 12.0 or later
 - Note: Requirements are listed in the :repo:`.bazelrc file <.bazelrc>` and CI scripts
 


### PR DESCRIPTION
Updates the version of Xcode Envoy Mobile is compatible with to the latest stable version.

Risk Level: Low.
Testing: Local & CI.
Docs Changes: Done.
Release Notes: Done.
Fixes #2664

Signed-off-by: JP Simard <jp@jpsim.com>