### PR TITLE
Honor the `-l` log level command line setting for C++ integration tests

### DIFF
--- a/test/common/integration/base_client_integration_test.cc
+++ b/test/common/integration/base_client_integration_test.cc
@@ -1,11 +1,13 @@
 #include "test/common/integration/base_client_integration_test.h"
 
+#include <cstdlib>
 #include <string>
 
 #include "test/common/http/common.h"
 
 #include "gtest/gtest.h"
 #include "library/cc/bridge_utility.h"
+#include "library/cc/log_level.h"
 #include "library/common/config/internal.h"
 #include "library/common/http/header_utility.h"
 
@@ -61,6 +63,10 @@ BaseClientIntegrationTest::BaseClientIntegrationTest(Network::Address::IpVersion
   use_lds_ = false;
   autonomous_upstream_ = true;
   defer_listener_finalization_ = true;
+
+  if (const char* log_level = std::getenv("LOG_LEVEL")) {
+    addLogLevel(Platform::logLevelFromString(std::string(log_level)));
+  }
 }
 
 void BaseClientIntegrationTest::initialize() {

--- a/test/common/integration/base_client_integration_test.cc
+++ b/test/common/integration/base_client_integration_test.cc
@@ -64,8 +64,8 @@ BaseClientIntegrationTest::BaseClientIntegrationTest(Network::Address::IpVersion
   autonomous_upstream_ = true;
   defer_listener_finalization_ = true;
 
-  if (const char* log_level = std::getenv("LOG_LEVEL")) {
-    addLogLevel(Platform::logLevelFromString(std::string(log_level)));
+  if (auto log_level = TestEnvironment::getOptionalEnvVar("LOG_LEVEL")) {
+    addLogLevel(Platform::logLevelFromString(*log_level));
   }
 }
 

--- a/test/common/integration/base_client_integration_test.cc
+++ b/test/common/integration/base_client_integration_test.cc
@@ -1,6 +1,5 @@
 #include "test/common/integration/base_client_integration_test.h"
 
-#include <cstdlib>
 #include <string>
 
 #include "test/common/http/common.h"


### PR DESCRIPTION
Instead of requiring adding the code `addLogLevel()` to an integration test to get finer-grained logging, now we can specify the log level on the command line via `--test_arg="-l LOG_LEVEL"`, just like for the Envoy integration tests.  For example:

`bazel test --test_arg="-l trace" //test/common/integration:rtds_integration_test`

Limitations:
 - This flag only applies to C++ integration tests (not unit tests or other language tests).

Signed-off-by: Ali Beyad <abeyad@google.com>