### PR TITLE
test: Set initial_fetch_timeout on the xDS integration tests

### DIFF
--- a/test/common/integration/rtds_integration_test.cc
+++ b/test/common/integration/rtds_integration_test.cc
@@ -20,6 +20,10 @@ envoy::config::bootstrap::v3::LayeredRuntime layeredRuntimeConfig(const std::str
       rtds_layer:
         name: some_rtds_layer
         rtds_config:
+          # TODO(abeyad): Remove the initial_fetch_timeout when
+          # https://github.com/envoyproxy/envoy-mobile/issues/2678 is fixed.
+          initial_fetch_timeout:
+            seconds: 1
           resource_api_version: V3
           api_config_source:
             api_type: {}

--- a/test/common/integration/sds_integration_test.cc
+++ b/test/common/integration/sds_integration_test.cc
@@ -63,6 +63,9 @@ protected:
     api_config_source->set_transport_api_version(envoy::config::core::v3::V3);
     auto* grpc_service = api_config_source->add_grpc_services();
     setGrpcService(*grpc_service, std::string(XDS_CLUSTER), fake_upstreams_.back()->localAddress());
+    // TODO(abeyad): Remove the initial_fetch_timeout when
+    // https://github.com/envoyproxy/envoy-mobile/issues/2678 is fixed.
+    config_source->mutable_initial_fetch_timeout()->set_seconds(1);
   }
 
   envoy::extensions::transport_sockets::tls::v3::Secret getClientSecret() {


### PR DESCRIPTION
While we figure out and fix
https://github.com/envoyproxy/envoy-mobile/issues/2678, this commit reduces the initial_fetch_timeout on the xDS config sources in the integration tests from 15s to 1s, preventing issues like test timeouts.

Signed-off-by: Ali Beyad <abeyad@google.com>