### PR TITLE
Do not strip AndroidCertVerifyResult methods with proguard

### DIFF
--- a/library/proguard.txt
+++ b/library/proguard.txt
@@ -15,6 +15,10 @@
    <methods>;
 }
 
+-keep, includedescriptorclasses class org.chromium.net.AndroidCertVerifyResult {
+   <methods>;
+}
+
 -keep, includedescriptorclasses class io.envoyproxy.envoymobile.engine.types.EnvoyEventTracker {
    <methods>;
 }


### PR DESCRIPTION
Do not strip AndroidCertVerifyResult methods with proguard

Signed-off-by: Ryan Hamilton <rch@google.com>

Risk Level: Low
Testing: Manual with Kotlin Hello World App
Docs Changes: N/A
Release Notes: N/A
