### PR TITLE
test: Wait for RTDS updates to be applied in the integration test

### DIFF
--- a/test/common/integration/rtds_integration_test.cc
+++ b/test/common/integration/rtds_integration_test.cc
@@ -85,7 +85,6 @@ TEST_P(RtdsIntegrationTest, RtdsReload) {
   EXPECT_EQ("yar", getRuntimeKey("bar"));
   EXPECT_EQ("", getRuntimeKey("baz"));
 
-  const uint64_t initial_load_success = getCounterValue("runtime.load_success");
   // Send a RTDS request and get back the RTDS response.
   EXPECT_TRUE(compareDiscoveryRequest(Config::TypeUrl::get().Runtime, "", {"some_rtds_layer"},
                                       {"some_rtds_layer"}, {}, true));
@@ -98,7 +97,7 @@ TEST_P(RtdsIntegrationTest, RtdsReload) {
   sendDiscoveryResponse<envoy::service::runtime::v3::Runtime>(
       Config::TypeUrl::get().Runtime, {some_rtds_layer}, {some_rtds_layer}, {}, "1");
   // Wait until the RTDS updates from the DiscoveryResponse have been applied.
-  ASSERT_TRUE(waitForCounterGe("runtime.load_success", initial_load_success + 1));
+  ASSERT_TRUE(waitForCounterGe("runtime.load_success", 1));
 
   // Verify that the Runtime config values are from the RTDS response.
   EXPECT_EQ("bar", getRuntimeKey("foo"));


### PR DESCRIPTION
This fixes a bug where sometimes the RtdsIntegrationTest would fail because we would check the updates after the DiscoveryResponse was sent but before ensuring the RTDS updates in the response have been applied by the Envoy engine.

Signed-off-by: Ali Beyad <abeyad@google.com>