### PR TITLE
test: Remove obsolete comments

### DIFF
--- a/test/common/integration/rtds_integration_test.cc
+++ b/test/common/integration/rtds_integration_test.cc
@@ -20,8 +20,6 @@ envoy::config::bootstrap::v3::LayeredRuntime layeredRuntimeConfig(const std::str
       rtds_layer:
         name: some_rtds_layer
         rtds_config:
-          # TODO(abeyad): Remove the initial_fetch_timeout when
-          # https://github.com/envoyproxy/envoy-mobile/issues/2678 is fixed.
           initial_fetch_timeout:
             seconds: 1
           resource_api_version: V3

--- a/test/common/integration/sds_integration_test.cc
+++ b/test/common/integration/sds_integration_test.cc
@@ -63,8 +63,6 @@ protected:
     api_config_source->set_transport_api_version(envoy::config::core::v3::V3);
     auto* grpc_service = api_config_source->add_grpc_services();
     setGrpcService(*grpc_service, std::string(XDS_CLUSTER), fake_upstreams_.back()->localAddress());
-    // TODO(abeyad): Remove the initial_fetch_timeout when
-    // https://github.com/envoyproxy/envoy-mobile/issues/2678 is fixed.
     config_source->mutable_initial_fetch_timeout()->set_seconds(1);
   }
 


### PR DESCRIPTION
The `initial_fetch_timeout` is needed in the tests, as described in https://github.com/envoyproxy/envoy-mobile/issues/2678#issuecomment-1322948208.

Signed-off-by: Ali Beyad <abeyad@google.com>