### PR TITLE
Cleanup the state of PlatformBridgeCertValidator to clarify the threading semantics

### DIFF
--- a/docs/root/intro/version_history.rst
+++ b/docs/root/intro/version_history.rst
@@ -15,6 +15,7 @@ Bugfixes:
 
 - android: fix engine startup crash for when admin interface is enabled. (:issue:`#2520 <2520>`)
 - android: respect system security policy when determining whether clear text requests are allowed. (:issue:`#2528 <2528>`)
+- tls: fix a potential use-after-free with the platform cert validator. (:issue:`#2691 <2691>`)
 
 Features:
 

--- a/library/common/extensions/cert_validator/platform_bridge/platform_bridge.proto
+++ b/library/common/extensions/cert_validator/platform_bridge/platform_bridge.proto
@@ -2,4 +2,5 @@ syntax = "proto3";
 
 package envoy_mobile.extensions.cert_validator.platform_bridge;
 
-message PlatformBridgeCertValidator {}
+message PlatformBridgeCertValidator {
+}

--- a/library/common/extensions/cert_validator/platform_bridge/platform_bridge_cert_validator.h
+++ b/library/common/extensions/cert_validator/platform_bridge/platform_bridge_cert_validator.h
@@ -56,56 +56,74 @@ public:
                     const Network::TransportSocketOptionsConstSharedPtr& transport_socket_options,
                     SSL_CTX& ssl_ctx,
                     const CertValidator::ExtraValidationContext& validation_context, bool is_server,
-                    absl::string_view host_name) override;
+                    absl::string_view hostname) override;
   // As CA path will not be configured, make sure the return value won’t be SSL_VERIFY_NONE because
   // of that, so that doVerifyCertChain() will be called from the TLS stack.
   int initializeSslContexts(std::vector<SSL_CTX*> contexts,
                             bool handshaker_provides_certificates) override;
 
 private:
+  enum class ValidationFailureType {
+    SUCCESS,
+    FAIL_VERIFY_ERROR,
+    FAIL_VERIFY_SAN,
+
+  };
   class PendingValidation {
   public:
-    PendingValidation(PlatformBridgeCertValidator& parent, std::vector<envoy_data> certs,
-                      absl::string_view host_name,
-                      const Network::TransportSocketOptionsConstSharedPtr transport_socket_options,
-                      Ssl::ValidateResultCallbackPtr result_callback)
-        : parent_(parent), certs_(std::move(certs)), host_name_(host_name),
-          result_callback_(std::move(result_callback)),
-          transport_socket_options_(std::move(transport_socket_options)) {}
+    PendingValidation(Event::Dispatcher& dispatcher, std::weak_ptr<PlatformBridgeCertValidator> weak_validator, const envoy_cert_validator* platform_validator, bool allow_untrusted_certificate,
+		      const std::vector<envoy_data>& certs, absl::string_view hostname,
+		      const std::vector<std::string>& subject_alt_names)
+      : dispatcher_(dispatcher), weak_validator_(weak_validator), platform_validator_(platform_validator), allow_untrusted_certificate_(allow_untrusted_certificate), certs_(std::move(certs)), hostname_(hostname), subject_alt_names_(subject_alt_names) {}
 
     // Ensure that this class is never moved or copies to guarantee pointer stability.
     PendingValidation(const PendingValidation&) = delete;
     PendingValidation(PendingValidation&&) = delete;
 
-    void verifyCertsByPlatform();
-
     void postVerifyResultAndCleanUp(bool success, absl::string_view error_details,
-                                    uint8_t tls_alert, OptRef<Stats::Counter> error_counter);
+                                    uint8_t tls_alert, ValidationFailureType failure_type);
+
+    // Calls into platform APIs in a stand-alone thread to verify the given certs.
+    // Once the validation is done, the result will be posted back to the current
+    // thread to trigger callback and update verify stats.
+    void verifyCertChainByPlatform();
 
   private:
-    Event::SchedulableCallbackPtr next_iteration_callback_;
-    PlatformBridgeCertValidator& parent_;
-    std::vector<envoy_data> certs_;
-    std::string host_name_;
-    Ssl::ValidateResultCallbackPtr result_callback_;
-    const Network::TransportSocketOptionsConstSharedPtr transport_socket_options_;
+    Event::Dispatcher& dispatcher_;
+    std::weak_ptr<PlatformBridgeCertValidator> weak_validator_;
+    const envoy_cert_validator* platform_validator_;
+    const bool allow_untrusted_certificate_;
+    const std::vector<envoy_data> certs_;
+    const std::string hostname_;
+    const std::vector<std::string> subject_alt_names_;
   };
 
-  // Calls into platform APIs in a stand-alone thread to verify the given certs.
-  // Once the validation is done, the result will be posted back to the current
-  // thread to trigger callback and update verify stats.
-  void verifyCertChainByPlatform(std::vector<envoy_data>& cert_chain, const std::string& host_name,
-                                 const std::vector<std::string>& subject_alt_names,
-                                 PendingValidation& pending_validation);
+  // The complete state for handling a platform verification on a worker thread.
+  struct ValidationJob {
+    // Only touched by the main thread.
+    Ssl::ValidateResultCallbackPtr result_callback_;
+    // Worker thread on which to perform validation.
+    std::thread thread_;
+    // Runs on the worker and must not be touched by any other thread.
+    std::unique_ptr<PendingValidation> validation_;
+  };
+
+  // Called when a pending verification completes. Must be invoked on the main thread.
+  void onVerificationComplete(std::thread::id thread_id,
+			      std::string hostname,
+			      bool success,
+			      std::string error_details,
+			      uint8_t tls_alert,
+			      ValidationFailureType failure_type);
 
   const Envoy::Ssl::CertificateValidationContextConfig* config_;
+  const bool allow_untrusted_certificate_;
   SslStats& stats_;
-  bool allow_untrusted_certificate_ = false;
-  // latches the platform extension API.
+  // Latches the platform extension API.
   const envoy_cert_validator* platform_validator_;
-  absl::flat_hash_map<std::thread::id, std::thread> validation_threads_;
-  absl::flat_hash_set<std::unique_ptr<PendingValidation>> validations_;
-  std::shared_ptr<size_t> alive_indicator_{new size_t(1)};
+  absl::flat_hash_map<std::thread::id, std::unique_ptr<ValidationJob>> validation_jobs_;
+  // Used to vend weak pointers to worker threads.
+  std::shared_ptr<PlatformBridgeCertValidator> shared_this_;
 };
 
 } // namespace Tls

--- a/library/common/extensions/cert_validator/platform_bridge/platform_bridge_cert_validator.h
+++ b/library/common/extensions/cert_validator/platform_bridge/platform_bridge_cert_validator.h
@@ -73,21 +73,14 @@ private:
           result_callback_(std::move(result_callback)),
           transport_socket_options_(std::move(transport_socket_options)) {}
 
+    // Ensure that this class is never moved or copies to guarantee pointer stability.
+    PendingValidation(const PendingValidation&) = delete;
+    PendingValidation(PendingValidation&&) = delete;
+
     void verifyCertsByPlatform();
 
     void postVerifyResultAndCleanUp(bool success, absl::string_view error_details,
                                     uint8_t tls_alert, OptRef<Stats::Counter> error_counter);
-
-    struct Hash {
-      size_t operator()(const PendingValidation& p) const {
-        return reinterpret_cast<size_t>(p.result_callback_.get());
-      }
-    };
-    struct Eq {
-      bool operator()(const PendingValidation& a, const PendingValidation& b) const {
-        return a.result_callback_.get() == b.result_callback_.get();
-      }
-    };
 
   private:
     Event::SchedulableCallbackPtr next_iteration_callback_;
@@ -111,8 +104,7 @@ private:
   // latches the platform extension API.
   const envoy_cert_validator* platform_validator_;
   absl::flat_hash_map<std::thread::id, std::thread> validation_threads_;
-  absl::flat_hash_set<PendingValidation, PendingValidation::Hash, PendingValidation::Eq>
-      validations_;
+  absl::flat_hash_set<std::unique_ptr<PendingValidation>> validations_;
   std::shared_ptr<size_t> alive_indicator_{new size_t(1)};
 };
 

--- a/library/common/extensions/cert_validator/platform_bridge/platform_bridge_cert_validator.h
+++ b/library/common/extensions/cert_validator/platform_bridge/platform_bridge_cert_validator.h
@@ -71,10 +71,15 @@ private:
   };
   class PendingValidation {
   public:
-    PendingValidation(Event::Dispatcher& dispatcher, std::weak_ptr<PlatformBridgeCertValidator> weak_validator, const envoy_cert_validator* platform_validator, bool allow_untrusted_certificate,
-		      const std::vector<envoy_data>& certs, absl::string_view hostname,
-		      const std::vector<std::string>& subject_alt_names)
-      : dispatcher_(dispatcher), weak_validator_(weak_validator), platform_validator_(platform_validator), allow_untrusted_certificate_(allow_untrusted_certificate), certs_(std::move(certs)), hostname_(hostname), subject_alt_names_(subject_alt_names) {}
+    PendingValidation(Event::Dispatcher& dispatcher,
+                      std::weak_ptr<PlatformBridgeCertValidator> weak_validator,
+                      const envoy_cert_validator* platform_validator,
+                      bool allow_untrusted_certificate, const std::vector<envoy_data>& certs,
+                      absl::string_view hostname, const std::vector<std::string>& subject_alt_names)
+        : dispatcher_(dispatcher), weak_validator_(weak_validator),
+          platform_validator_(platform_validator),
+          allow_untrusted_certificate_(allow_untrusted_certificate), certs_(std::move(certs)),
+          hostname_(hostname), subject_alt_names_(subject_alt_names) {}
 
     // Ensure that this class is never moved or copies to guarantee pointer stability.
     PendingValidation(const PendingValidation&) = delete;
@@ -109,12 +114,9 @@ private:
   };
 
   // Called when a pending verification completes. Must be invoked on the main thread.
-  void onVerificationComplete(std::thread::id thread_id,
-			      std::string hostname,
-			      bool success,
-			      std::string error_details,
-			      uint8_t tls_alert,
-			      ValidationFailureType failure_type);
+  void onVerificationComplete(std::thread::id thread_id, std::string hostname, bool success,
+                              std::string error_details, uint8_t tls_alert,
+                              ValidationFailureType failure_type);
 
   const Envoy::Ssl::CertificateValidationContextConfig* config_;
   const bool allow_untrusted_certificate_;

--- a/test/java/org/chromium/net/impl/UrlRequestCallbackTester.java
+++ b/test/java/org/chromium/net/impl/UrlRequestCallbackTester.java
@@ -48,10 +48,10 @@ final class UrlRequestCallbackTester<R> {
     }
     if (throwable.get() != null) {
       if (throwable.get() instanceof Error) {
-        throw(Error) throwable.get();
+        throw (Error)throwable.get();
       }
       if (throwable.get() instanceof RuntimeException) {
-        throw(RuntimeException) throwable.get();
+        throw (RuntimeException)throwable.get();
       }
       throw new RuntimeException(throwable.get());
     }

--- a/test/java/org/chromium/net/testing/TestUrlRequestCallback.java
+++ b/test/java/org/chromium/net/testing/TestUrlRequestCallback.java
@@ -176,10 +176,10 @@ public class TestUrlRequestCallback extends UrlRequest.Callback {
     mDone.block();
     if (mThrowableRef.get() != null) {
       if (mThrowableRef.get() instanceof Error) {
-        throw(Error) mThrowableRef.get();
+        throw (Error)mThrowableRef.get();
       }
       if (mThrowableRef.get() instanceof RuntimeException) {
-        throw(RuntimeException) mThrowableRef.get();
+        throw (RuntimeException)mThrowableRef.get();
       }
       throw new RuntimeException(mThrowableRef.get());
     }


### PR DESCRIPTION
Cleanup the state of PlatformBridgeCertValidator to clarify the threading semantics.
Make the PendingValidation object only accessed on the worker thread.
Make the PlatformBridgeCertValidator only accessed on the main thread.
