### PR TITLE
Various small cleanups to PlatformBridgeCertValidator

### DIFF
--- a/library/common/extensions/cert_validator/platform_bridge/platform_bridge_cert_validator.cc
+++ b/library/common/extensions/cert_validator/platform_bridge/platform_bridge_cert_validator.cc
@@ -15,7 +15,7 @@ PlatformBridgeCertValidator::PlatformBridgeCertValidator(
     const Envoy::Ssl::CertificateValidationContextConfig* config, SslStats& stats,
     const envoy_cert_validator* platform_validator)
     : allow_untrusted_certificate_(config != nullptr &&
-                                         config->trustChainVerification() ==
+                                   config->trustChainVerification() ==
                                        envoy::extensions::transport_sockets::tls::v3::
                                            CertificateValidationContext::ACCEPT_UNTRUSTED),
       platform_validator_(platform_validator), stats_(stats) {

--- a/library/common/extensions/cert_validator/platform_bridge/platform_bridge_cert_validator.cc
+++ b/library/common/extensions/cert_validator/platform_bridge/platform_bridge_cert_validator.cc
@@ -94,7 +94,6 @@ ValidationResults PlatformBridgeCertValidator::doVerifyCertChain(
   ASSERT(insert_result.second);
   PendingValidation& ref = const_cast<PendingValidation&>(*insert_result.first);
   std::thread verification_thread(&PendingValidation::verifyCertsByPlatform, &ref);
-
   std::thread::id thread_id = verification_thread.get_id();
   validation_threads_[thread_id] = std::move(verification_thread);
   return {ValidationResults::ValidationStatus::Pending, absl::nullopt, absl::nullopt};

--- a/library/common/extensions/cert_validator/platform_bridge/platform_bridge_cert_validator.h
+++ b/library/common/extensions/cert_validator/platform_bridge/platform_bridge_cert_validator.h
@@ -59,7 +59,7 @@ public:
                     absl::string_view hostname) override;
   // Return SSL_VERIFY_PEER so that doVerifyCertChain() will be called from the TLS stack.
   int initializeSslContexts(std::vector<SSL_CTX*> /*contexts*/,
-			    bool /*handshaker_provides_certificates*/) override {
+                            bool /*handshaker_provides_certificates*/) override {
     return SSL_VERIFY_PEER;
   }
 

--- a/library/common/extensions/cert_validator/platform_bridge/platform_bridge_cert_validator.h
+++ b/library/common/extensions/cert_validator/platform_bridge/platform_bridge_cert_validator.h
@@ -69,7 +69,8 @@ private:
                       absl::string_view hostname, std::vector<std::string> subject_alt_names,
                       Ssl::ValidateResultCallbackPtr result_callback)
         : parent_(parent), certs_(std::move(certs)), hostname_(hostname),
-          subject_alt_names_(std::move(subject_alt_names)), result_callback_(std::move(result_callback)) {}
+          subject_alt_names_(std::move(subject_alt_names)),
+          result_callback_(std::move(result_callback)) {}
 
     void verifyCertsByPlatform();
 

--- a/library/common/extensions/cert_validator/platform_bridge/platform_bridge_cert_validator.h
+++ b/library/common/extensions/cert_validator/platform_bridge/platform_bridge_cert_validator.h
@@ -57,7 +57,7 @@ public:
                     SSL_CTX& ssl_ctx,
                     const CertValidator::ExtraValidationContext& validation_context, bool is_server,
                     absl::string_view hostname) override;
-  // Return SSL_VERIFY_PEER so that doVerifyCertChain() will be called from the TLS stack.
+  // Returns SSL_VERIFY_PEER so that doVerifyCertChain() will be called from the TLS stack.
   int initializeSslContexts(std::vector<SSL_CTX*> /*contexts*/,
                             bool /*handshaker_provides_certificates*/) override {
     return SSL_VERIFY_PEER;
@@ -77,6 +77,9 @@ private:
     PendingValidation(const PendingValidation&) = delete;
     PendingValidation(PendingValidation&&) = delete;
 
+    // Calls into platform APIs in a stand-alone thread to verify the given certs.
+    // Once the validation is done, the result will be posted back to the current
+    // thread to trigger callback and update verify stats.
     void verifyCertsByPlatform();
 
     void postVerifyResultAndCleanUp(bool success, absl::string_view error_details,


### PR DESCRIPTION
Remove unused next_iteration_callback_ member.
Remove unused config_ member.
Make some members const.
Use hostname instead of host_name.
Pass in the list of subject alt names instead of passing in the transport socket options.

Risk Level: Low
Testing: No behavior change
Docs Changes: N/A
Release Notes: N/A

Signed-off-by: Ryan Hamilton <rch@google.com>

