### PR TITLE
Rename release_validator to validation_cleanup

### DIFF
--- a/library/common/extensions/cert_validator/platform_bridge/c_types.h
+++ b/library/common/extensions/cert_validator/platform_bridge/c_types.h
@@ -25,7 +25,7 @@ typedef envoy_cert_validation_result (*envoy_validate_cert_f)(const envoy_data* 
                                                               const char* host_name);
 
 /**
- * Function signature for calling into platform APIs to clean up after validation completion.
+ * Function signature for calling into platform APIs to clean up after validation is complete.
  */
 typedef void (*envoy_validation_cleanup_f)();
 

--- a/library/common/extensions/cert_validator/platform_bridge/c_types.h
+++ b/library/common/extensions/cert_validator/platform_bridge/c_types.h
@@ -27,7 +27,7 @@ typedef envoy_cert_validation_result (*envoy_validate_cert_f)(const envoy_data* 
 /**
  * Function signature for calling into platform APIs to clean up after validation completion.
  */
-typedef void (*envoy_release_validator_f)();
+typedef void (*envoy_validation_cleanup_f)();
 
 #ifdef __cplusplus
 } // function pointers
@@ -38,5 +38,5 @@ typedef void (*envoy_release_validator_f)();
  */
 typedef struct {
   envoy_validate_cert_f validate_cert;
-  envoy_release_validator_f release_validator;
+  envoy_validation_cleanup_f validation_cleanup;
 } envoy_cert_validator;

--- a/library/common/extensions/cert_validator/platform_bridge/platform_bridge_cert_validator.cc
+++ b/library/common/extensions/cert_validator/platform_bridge/platform_bridge_cert_validator.cc
@@ -141,8 +141,8 @@ void PlatformBridgeCertValidator::PendingValidation::postVerifyResultAndCleanUp(
             "Finished platform cert validation for {}, post result callback to network thread",
             host_name_);
 
-  if (parent_.platform_validator_->release_validator) {
-    parent_.platform_validator_->release_validator();
+  if (parent_.platform_validator_->validation_cleanup) {
+    parent_.platform_validator_->validation_cleanup();
   }
   std::weak_ptr<size_t> weak_alive_indicator(parent_.alive_indicator_);
 

--- a/library/common/jni/android_network_utility.cc
+++ b/library/common/jni/android_network_utility.cc
@@ -144,6 +144,6 @@ static envoy_cert_validation_result verify_x509_cert_chain(const envoy_data* cer
 envoy_cert_validator* get_android_cert_validator_api() {
   envoy_cert_validator* api = (envoy_cert_validator*)safe_malloc(sizeof(envoy_cert_validator));
   api->validate_cert = verify_x509_cert_chain;
-  api->release_validator = jvm_detach_thread;
+  api->validation_cleanup = jvm_detach_thread;
   return api;
 }

--- a/library/common/network/apple_platform_cert_verifier.cc
+++ b/library/common/network/apple_platform_cert_verifier.cc
@@ -111,7 +111,7 @@ extern "C" {
 void register_apple_platform_cert_verifier() {
   envoy_cert_validator* api = (envoy_cert_validator*)safe_malloc(sizeof(envoy_cert_validator));
   api->validate_cert = verify_cert;
-  api->release_validator = NULL;
+  api->validation_cleanup = NULL;
   register_platform_api("platform_cert_validator", api);
 }
 


### PR DESCRIPTION
Rename release_validator to validation_cleanup.
The release_validator function does not actually release the validator.
On iOS is does nothing and on Android it merely detaches the JVM from the current thread.
So "cleanup validation" is a better description of it's function than "release validator" and
matches the existing description "to clean up after validation completion."

Signed-off-by: Ryan Hamilton <rch@google.com>
