### PR TITLE
bridge: fix up proto registration

### DIFF
--- a/library/common/extensions/cert_validator/platform_bridge/config.h
+++ b/library/common/extensions/cert_validator/platform_bridge/config.h
@@ -2,6 +2,7 @@
 
 #include "source/extensions/transport_sockets/tls/cert_validator/factory.h"
 
+#include "library/common/extensions/cert_validator/platform_bridge/platform_bridge.pb.h"
 #include "library/common/extensions/cert_validator/platform_bridge/platform_bridge_cert_validator.h"
 
 namespace Envoy {
@@ -9,7 +10,8 @@ namespace Extensions {
 namespace TransportSockets {
 namespace Tls {
 
-class PlatformBridgeCertValidatorFactory : public CertValidatorFactory {
+class PlatformBridgeCertValidatorFactory : public CertValidatorFactory,
+                                           public Config::TypedFactory {
 public:
   CertValidatorPtr createCertValidator(const Envoy::Ssl::CertificateValidationContextConfig* config,
                                        SslStats& stats, TimeSource& time_source) override;
@@ -17,6 +19,11 @@ public:
   std::string name() const override {
     return "envoy_mobile.cert_validator.platform_bridge_cert_validator";
   }
+  ProtobufTypes::MessagePtr createEmptyConfigProto() override {
+    return std::make_unique<
+        envoy_mobile::extensions::cert_validator::platform_bridge::PlatformBridgeCertValidator>();
+  }
+  std::string category() const override { return "envoy.tls.cert_validator"; }
 
 private:
   const envoy_cert_validator* platform_validator_ = nullptr;


### PR DESCRIPTION
This fixes up issues exposed in https://github.com/envoyproxy/envoy/pull/24151 where the PlatformBridgeCertValidatorFactory was not associated with the PlatformBridgeCertValidator proto.

Risk Level: low
Testing:  https://github.com/envoyproxy/envoy/pull/24151
Docs Changes: n/a
Release Notes: n/a
