### PR TITLE
Fix typo in starting_envoy.rst

### DIFF
--- a/docs/root/api/starting_envoy.rst
+++ b/docs/root/api/starting_envoy.rst
@@ -484,7 +484,7 @@ Specify whether to use platform provided certificate validation interfaces. Curr
 ``enableProxying``
 ~~~~~~~~~~~~~~~~~~~~~~~~~~
 Specify whether to respect system Proxy settings when establishing connections.
-Available on Andorid only.
+Available on Android only.
 
 **Example**::
 


### PR DESCRIPTION
Fix typo in starting_envoy.rst
Backport of https://github.com/envoyproxy/envoy/pull/24187/files

Signed-off-by: Ryan Hamilton <rch@google.com>