### PR TITLE
stats: disable virtual cluster histograms

### DIFF
--- a/library/common/config/config.cc
+++ b/library/common/config/config.cc
@@ -495,7 +495,7 @@ stats_config:
         - safe_regex:
             regex: '^pulse.*'
         - safe_regex:
-            regex: '^vhost\.[\w]+\.vcluster\.[\w]+?\.upstream_rq_(?:[12345]xx|[3-5][0-9][0-9]|retry.*|time|timeout|total)'
+            regex: '^vhost\.[\w]+\.vcluster\.[\w]+?\.upstream_rq_(?:[12345]xx|[3-5][0-9][0-9]|retry.*|timeout|total)'
   use_all_default_tags:
     false
 watchdogs:


### PR DESCRIPTION
Description: Disable histograms used to track the duration of time requests routed to a given virtual cluster take. That's to reduce the potential impact of adding a lot of virtual cluster stats to Envoy Mobile.
Risk Level: Low
Testing: 
Docs Changes:
Release Notes:

Signed-off-by: Rafal Augustyniak <raugustyniak@lyft.com>

