### PR TITLE
ci: Allow BES uploads to complete before shutting down VMs

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -136,7 +136,7 @@ build:remote-ci-common --remote_executor=grpcs://envoy.cluster.engflow.com
 build:remote-ci-common --bes_backend=grpcs://envoy.cluster.engflow.com/
 build:remote-ci-common --bes_results_url=https://envoy.cluster.engflow.com/invocation/
 build:remote-ci-common --bes_lifecycle_events
-build:remote-ci-common --bes_upload_mode=fully_async
+build:remote-ci-common --bes_upload_mode=wait_for_upload_complete
 build:remote-ci-common --jobs=40
 build:remote-ci-common --verbose_failures
 build:remote-ci-common --spawn_strategy=remote,sandboxed,local


### PR DESCRIPTION
This change makes it so the Bazel process waits for BEP to upload before returning rather shutting down the VM before the BEP background processes have completed

https://bazel.build/reference/command-line-reference#flag--bes_upload_mode

For an explanation of how to fill out the fields, please see the relevant section
in [PULL_REQUESTS.md](https://github.com/envoyproxy/envoy/blob/master/PULL_REQUESTS.md)

Description:
Risk Level:
Testing:
Docs Changes:
Release Notes:
[Optional Fixes #Issue]
[Optional Deprecated:]
